### PR TITLE
Leo gadgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "from-pest",
  "hex",
  "lazy_static",
+ "leo-gadgets",
  "log",
  "pest",
  "pest-ast",
@@ -530,6 +531,18 @@ dependencies = [
  "snarkos-models",
  "snarkos-utilities",
  "thiserror",
+]
+
+[[package]]
+name = "leo-gadgets"
+version = "0.1.0"
+dependencies = [
+ "rand",
+ "rand_xorshift",
+ "snarkos-errors",
+ "snarkos-gadgets",
+ "snarkos-models",
+ "snarkos-utilities",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "leo"
 path = "leo/main.rs"
 
 [workspace]
-members = [ "benchmark", "compiler" ]
+members = [ "benchmark", "compiler", "gadgets"]
 
 [dependencies]
 leo-compiler = { path = "compiler", version = "0.1.0" }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -5,6 +5,8 @@ authors = ["The Aleo Team <hello@aleo.org>"]
 edition = "2018"
 
 [dependencies]
+leo-gadgets = { path = "../gadgets", version = "0.1.0" }
+
 snarkos-algorithms = { path = "../../snarkOS/algorithms", version = "0.8.0" }
 snarkos-curves = { path = "../../snarkOS/curves", version = "0.8.0" }
 snarkos-errors = { path = "../../snarkOS/errors", version = "0.8.0" }

--- a/compiler/src/constraints/integer/integer.rs
+++ b/compiler/src/constraints/integer/integer.rs
@@ -6,16 +6,16 @@ use crate::{
     types::{InputValue, Integer},
     IntegerType,
 };
+use leo_gadgets::integers::{
+    uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64, uint8::UInt8,
+};
 
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
     gadgets::{
         r1cs::ConstraintSystem,
-        utilities::{
-            boolean::Boolean, select::CondSelectGadget, uint128::UInt128, uint16::UInt16,
-            uint32::UInt32, uint64::UInt64, uint8::UInt8,
-        },
+        utilities::{boolean::Boolean, select::CondSelectGadget},
     },
 };
 

--- a/compiler/src/constraints/integer/uint128.rs
+++ b/compiler/src/constraints/integer/uint128.rs
@@ -5,13 +5,14 @@ use crate::{
     errors::IntegerError,
     types::Integer,
 };
+use leo_gadgets::integers::uint128::UInt128;
 
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
     gadgets::{
         r1cs::ConstraintSystem,
-        utilities::{alloc::AllocGadget, eq::EqGadget, uint128::UInt128},
+        utilities::{alloc::AllocGadget, eq::EqGadget},
     },
 };
 

--- a/compiler/src/constraints/integer/uint16.rs
+++ b/compiler/src/constraints/integer/uint16.rs
@@ -5,13 +5,14 @@ use crate::{
     errors::IntegerError,
     types::Integer,
 };
+use leo_gadgets::integers::uint16::UInt16;
 
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
     gadgets::{
         r1cs::ConstraintSystem,
-        utilities::{alloc::AllocGadget, eq::EqGadget, uint16::UInt16},
+        utilities::{alloc::AllocGadget, eq::EqGadget},
     },
 };
 

--- a/compiler/src/constraints/integer/uint32.rs
+++ b/compiler/src/constraints/integer/uint32.rs
@@ -5,13 +5,14 @@ use crate::{
     errors::IntegerError,
     types::Integer,
 };
+use leo_gadgets::integers::uint32::UInt32;
 
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
     gadgets::{
         r1cs::ConstraintSystem,
-        utilities::{alloc::AllocGadget, eq::EqGadget, uint32::UInt32},
+        utilities::{alloc::AllocGadget, eq::EqGadget},
     },
 };
 

--- a/compiler/src/constraints/integer/uint64.rs
+++ b/compiler/src/constraints/integer/uint64.rs
@@ -5,13 +5,14 @@ use crate::{
     errors::IntegerError,
     types::Integer,
 };
+use leo_gadgets::integers::uint64::UInt64;
 
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
     gadgets::{
         r1cs::ConstraintSystem,
-        utilities::{alloc::AllocGadget, eq::EqGadget, uint64::UInt64},
+        utilities::{alloc::AllocGadget, eq::EqGadget},
     },
 };
 

--- a/compiler/src/constraints/integer/uint8.rs
+++ b/compiler/src/constraints/integer/uint8.rs
@@ -5,13 +5,14 @@ use crate::{
     errors::IntegerError,
     types::Integer,
 };
+use leo_gadgets::integers::uint8::UInt8;
 
 use snarkos_errors::gadgets::SynthesisError;
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
     gadgets::{
         r1cs::ConstraintSystem,
-        utilities::{alloc::AllocGadget, eq::EqGadget, uint8::UInt8},
+        utilities::{alloc::AllocGadget, eq::EqGadget},
     },
 };
 

--- a/compiler/src/constraints/statement.rs
+++ b/compiler/src/constraints/statement.rs
@@ -10,10 +10,11 @@ use crate::{
     },
     Variable,
 };
+use leo_gadgets::integers::uint32::UInt32;
 
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
-    gadgets::{r1cs::ConstraintSystem, utilities::boolean::Boolean, utilities::uint32::UInt32},
+    gadgets::{r1cs::ConstraintSystem, utilities::boolean::Boolean},
 };
 
 impl<F: Field + PrimeField, G: Group, CS: ConstraintSystem<F>> ConstrainedProgram<F, G, CS> {

--- a/compiler/src/constraints/value.rs
+++ b/compiler/src/constraints/value.rs
@@ -4,13 +4,13 @@ use crate::{
     errors::ValueError,
     types::{Circuit, FieldElement, Function, Identifier, Integer, IntegerType, Type},
 };
+use leo_gadgets::integers::{
+    uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64, uint8::UInt8,
+};
 
 use snarkos_models::{
     curves::{Field, Group, PrimeField},
-    gadgets::utilities::{
-        boolean::Boolean, uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64,
-        uint8::UInt8,
-    },
+    gadgets::utilities::boolean::Boolean,
 };
 use std::fmt;
 

--- a/compiler/src/types.rs
+++ b/compiler/src/types.rs
@@ -2,15 +2,12 @@
 //! Each defined type consists of typed statements and expressions.
 
 use crate::Import;
+use leo_gadgets::integers::{
+    uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64, uint8::UInt8,
+};
 
 use snarkos_models::curves::{Field, Group, PrimeField};
-use snarkos_models::gadgets::{
-    r1cs::Variable as R1CSVariable,
-    utilities::{
-        boolean::Boolean, uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64,
-        uint8::UInt8,
-    },
-};
+use snarkos_models::gadgets::{r1cs::Variable as R1CSVariable, utilities::boolean::Boolean};
 use std::collections::HashMap;
 use std::marker::PhantomData;
 

--- a/compiler/src/types_from.rs
+++ b/compiler/src/types_from.rs
@@ -1,12 +1,12 @@
 //! Logic to convert from an abstract syntax tree (ast) representation to a Leo program.
 
 use crate::{ast, types, Import, ImportSymbol};
+use leo_gadgets::integers::{
+    uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64, uint8::UInt8,
+};
 
 use snarkos_models::curves::{Field, Group, PrimeField};
-use snarkos_models::gadgets::utilities::{
-    boolean::Boolean, uint128::UInt128, uint16::UInt16, uint32::UInt32, uint64::UInt64,
-    uint8::UInt8,
-};
+use snarkos_models::gadgets::utilities::boolean::Boolean;
 use std::collections::HashMap;
 
 /// pest ast -> types::Identifier

--- a/compiler/tests/array/mod.rs
+++ b/compiler/tests/array/mod.rs
@@ -6,8 +6,9 @@ use leo_compiler::{
     errors::{CompilerError, FunctionError},
     ConstrainedValue, InputValue, Integer,
 };
+use leo_gadgets::integers::uint32::UInt32;
+
 use snarkos_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective};
-use snarkos_models::gadgets::utilities::uint32::UInt32;
 
 const DIRECTORY_NAME: &str = "tests/array/";
 

--- a/compiler/tests/circuit/mod.rs
+++ b/compiler/tests/circuit/mod.rs
@@ -12,8 +12,9 @@ use leo_compiler::{
     ConstrainedCircuitMember, ConstrainedValue, Expression, Function, Identifier, Integer,
     Statement, Type,
 };
+use leo_gadgets::integers::uint32::UInt32;
+
 use snarkos_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective};
-use snarkos_models::gadgets::utilities::uint32::UInt32;
 
 const DIRECTORY_NAME: &str = "tests/circuit/";
 

--- a/compiler/tests/integer/u32/mod.rs
+++ b/compiler/tests/integer/u32/mod.rs
@@ -1,10 +1,10 @@
 use crate::{compile_program, get_error, get_output};
 
 use leo_compiler::{compiler::Compiler, types::Integer, ConstrainedValue, InputValue};
+use leo_gadgets::integers::uint32::UInt32;
 
 use leo_compiler::errors::{CompilerError, FunctionError, IntegerError};
 use snarkos_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective};
-use snarkos_models::gadgets::utilities::uint32::UInt32;
 
 const DIRECTORY_NAME: &str = "tests/integer/u32/";
 

--- a/compiler/tests/mutability/mod.rs
+++ b/compiler/tests/mutability/mod.rs
@@ -6,8 +6,10 @@ use leo_compiler::{
     types::{InputValue, Integer},
     ConstrainedValue,
 };
+use leo_gadgets::integers::uint32::UInt32;
+
 use snarkos_curves::{bls12_377::Fr, edwards_bls12::EdwardsProjective};
-use snarkos_models::gadgets::{r1cs::TestConstraintSystem, utilities::uint32::UInt32};
+use snarkos_models::gadgets::r1cs::TestConstraintSystem;
 
 const DIRECTORY_NAME: &str = "tests/mutability/";
 

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "leo-gadgets"
+version = "0.1.0"
+authors = ["The Aleo Team <hello@aleo.org>"]
+edition = "2018"
+
+[dependencies]
+snarkos-errors = { path = "../../snarkOS/errors", version = "0.8.0" }
+snarkos-gadgets = { path = "../../snarkOS/gadgets", version = "0.8.0" }
+snarkos-models = { path = "../../snarkOS/models", version = "0.8.0" }
+snarkos-utilities = { path = "../../snarkOS/utilities", version = "0.8.0" }
+
+rand = { version = "0.7" }
+rand_xorshift = { version = "0.2", default-features = false }

--- a/gadgets/src/integers/mod.rs
+++ b/gadgets/src/integers/mod.rs
@@ -1,0 +1,5 @@
+pub mod uint128;
+pub mod uint16;
+pub mod uint32;
+pub mod uint64;
+pub mod uint8;

--- a/gadgets/src/integers/uint128.rs
+++ b/gadgets/src/integers/uint128.rs
@@ -1,0 +1,1363 @@
+use snarkos_errors::gadgets::SynthesisError;
+use snarkos_models::{
+    curves::{Field, FpParameters, PrimeField},
+    gadgets::{
+        r1cs::{Assignment, ConstraintSystem, LinearCombination},
+        utilities::{
+            alloc::AllocGadget,
+            boolean::{AllocatedBit, Boolean},
+            eq::{ConditionalEqGadget, EqGadget},
+            select::CondSelectGadget,
+            uint8::UInt8,
+            ToBytesGadget,
+        },
+    },
+};
+use snarkos_utilities::{
+    biginteger::{BigInteger, BigInteger256},
+    bytes::ToBytes,
+};
+
+use std::borrow::Borrow;
+
+/// Represents an interpretation of 128 `Boolean` objects as an
+/// unsigned integer.
+#[derive(Clone, Debug)]
+pub struct UInt128 {
+    // Least significant bit_gadget first
+    pub bits: Vec<Boolean>,
+    pub negated: bool,
+    pub value: Option<u128>,
+}
+
+impl UInt128 {
+    /// Construct a constant `UInt128` from a `u128`
+    pub fn constant(value: u128) -> Self {
+        let mut bits = Vec::with_capacity(128);
+
+        let mut tmp = value;
+        for _ in 0..128 {
+            if tmp & 1 == 1 {
+                bits.push(Boolean::constant(true))
+            } else {
+                bits.push(Boolean::constant(false))
+            }
+
+            tmp >>= 1;
+        }
+
+        Self {
+            bits,
+            negated: false,
+            value: Some(value),
+        }
+    }
+
+    /// Turns this `UInt128` into its little-endian byte order representation.
+    pub fn to_bits_le(&self) -> Vec<Boolean> {
+        self.bits.clone()
+    }
+
+    /// Converts a little-endian byte order representation of bits into a
+    /// `UInt128`.
+    pub fn from_bits_le(bits: &[Boolean]) -> Self {
+        assert_eq!(bits.len(), 128);
+
+        let bits = bits.to_vec();
+
+        let mut value = Some(0u128);
+        for b in bits.iter().rev() {
+            value.as_mut().map(|v| *v <<= 1);
+
+            match b {
+                &Boolean::Constant(b) => {
+                    if b {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                }
+                &Boolean::Is(ref b) => match b.get_value() {
+                    Some(true) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(false) => {}
+                    None => value = None,
+                },
+                &Boolean::Not(ref b) => match b.get_value() {
+                    Some(false) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(true) => {}
+                    None => value = None,
+                },
+            }
+        }
+
+        Self {
+            value,
+            negated: false,
+            bits,
+        }
+    }
+
+    pub fn rotr(&self, by: usize) -> Self {
+        let by = by % 128;
+
+        let new_bits = self
+            .bits
+            .iter()
+            .skip(by)
+            .chain(self.bits.iter())
+            .take(128)
+            .cloned()
+            .collect();
+
+        Self {
+            bits: new_bits,
+            negated: false,
+            value: self.value.map(|v| v.rotate_right(by as u32) as u128),
+        }
+    }
+
+    /// XOR this `UInt128` with another `UInt128`
+    pub fn xor<F, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
+    where
+        F: Field,
+        CS: ConstraintSystem<F>,
+    {
+        let new_value = match (self.value, other.value) {
+            (Some(a), Some(b)) => Some(a ^ b),
+            _ => None,
+        };
+
+        let bits = self
+            .bits
+            .iter()
+            .zip(other.bits.iter())
+            .enumerate()
+            .map(|(i, (a, b))| Boolean::xor(cs.ns(|| format!("xor of bit_gadget {}", i)), a, b))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: new_value,
+        })
+    }
+
+    /// Returns the inverse UInt128
+    pub fn negate(&self) -> Self {
+        Self {
+            bits: self.bits.clone(),
+            negated: true,
+            value: self.value.clone(),
+        }
+    }
+
+    /// Returns true if all bits in this UInt128 are constant
+    fn is_constant(&self) -> bool {
+        let mut constant = true;
+
+        // If any bits of self are allocated bits, return false
+        for bit in &self.bits {
+            match *bit {
+                Boolean::Is(ref _bit) => constant = false,
+                Boolean::Not(ref _bit) => constant = false,
+                Boolean::Constant(_bit) => {}
+            }
+        }
+
+        constant
+    }
+
+    /// Returns true if both UInt128s have constant bits
+    fn result_is_constant(first: &Self, second: &Self) -> bool {
+        // If any bits of first are allocated bits, return false
+        if !first.is_constant() {
+            return false;
+        }
+
+        // If any bits of second are allocated bits, return false
+        second.is_constant()
+    }
+
+    /// Perform modular addition of several `UInt128` objects.
+    pub fn addmany<F, CS>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>
+    where
+        F: PrimeField,
+        CS: ConstraintSystem<F>,
+    {
+        // Make some arbitrary bounds for ourselves to avoid overflows
+        // in the scalar field
+        assert!(F::Params::MODULUS_BITS <= 253);
+        assert!(operands.len() >= 2); // Weird trivial cases that should never happen
+
+        // Compute the maximum value of the sum so we allocate enough bits for
+        // the result
+        let mut max_value = BigInteger256::from_u128(u128::max_value());
+        max_value.muln(operands.len() as u32);
+
+        // Keep track of the resulting value
+        let mut big_result_value = Some(BigInteger256::default());
+
+        // This is a linear combination that we will enforce to be "zero"
+        let mut lc = LinearCombination::zero();
+
+        let mut all_constants = true;
+
+        // Iterate over the operands
+        for op in operands {
+            // Accumulate the value
+            match op.value {
+                Some(val) => {
+                    // Subtract or add operand
+                    if op.negated {
+                        // Perform subtraction
+                        big_result_value
+                            .as_mut()
+                            .map(|v| v.sub_noborrow(&BigInteger256::from_u128(val)));
+                    } else {
+                        // Perform addition
+                        big_result_value
+                            .as_mut()
+                            .map(|v| v.add_nocarry(&BigInteger256::from_u128(val)));
+                    }
+                }
+                None => {
+                    // If any of our operands have unknown value, we won't
+                    // know the value of the result
+                    big_result_value = None;
+                }
+            }
+
+            // Iterate over each bit_gadget of the operand and add the operand to
+            // the linear combination
+            let mut coeff = F::one();
+            for bit in &op.bits {
+                match *bit {
+                    Boolean::Is(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // Subtract coeff * bit gadget
+                            lc = lc - (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * bit_gadget
+                            lc = lc + (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Not(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // subtract coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc - (coeff, CS::one()) + (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc + (coeff, CS::one()) - (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Constant(bit) => {
+                        if bit {
+                            if op.negated {
+                                lc = lc - (coeff, CS::one());
+                            } else {
+                                lc = lc + (coeff, CS::one());
+                            }
+                        }
+                    }
+                }
+
+                coeff.double_in_place();
+            }
+        }
+
+        // The value of the actual result is modulo 2^128
+        let modular_value = big_result_value.map(|v| v.to_u128());
+
+        if all_constants && modular_value.is_some() {
+            // We can just return a constant, rather than
+            // unpacking the result into allocated bits.
+
+            return Ok(Self::constant(modular_value.unwrap()));
+        }
+
+        // Storage area for the resulting bits
+        let mut result_bits = vec![];
+
+        // Allocate each bit_gadget of the result
+        let mut coeff = F::one();
+        let mut i = 0;
+        while !max_value.is_zero() {
+            // Allocate the bit_gadget
+            let b = AllocatedBit::alloc(cs.ns(|| format!("result bit_gadget {}", i)), || {
+                big_result_value.map(|v| v.get_bit(i)).get()
+            })?;
+
+            // Subtract this bit_gadget from the linear combination to ensure the sums
+            // balance out
+            lc = lc - (coeff, b.get_variable());
+
+            result_bits.push(b.into());
+
+            max_value.div2();
+            i += 1;
+            coeff.double_in_place();
+        }
+
+        // Enforce that the linear combination equals zero
+        cs.enforce(|| "modular addition", |lc| lc, |lc| lc, |_| lc);
+
+        // Discard carry bits that we don't care about
+        result_bits.truncate(128);
+
+        Ok(Self {
+            bits: result_bits,
+            negated: false,
+            value: modular_value,
+        })
+    }
+
+    /// Perform modular subtraction of two `UInt128` objects.
+    pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // a - b
+        // a + (-b)
+
+        Self::addmany(&mut cs.ns(|| "add_not"), &[self.clone(), other.negate()])
+    }
+
+    /// Perform unsafe subtraction of two `UInt128` objects which returns 0 if overflowed
+    fn sub_unsafe<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        match (self.value, other.value) {
+            (Some(val1), Some(val2)) => {
+                // Check for overflow
+                if val1 < val2 {
+                    // Instead of erroring, return 0
+
+                    if Self::result_is_constant(&self, &other) {
+                        // Return constant 0u128
+                        Ok(Self::constant(0u128))
+                    } else {
+                        // Return allocated 0u128
+                        let result_value = Some(0u128);
+                        let modular_value = result_value.map(|v| v as u128);
+
+                        // Storage area for the resulting bits
+                        let mut result_bits = vec![];
+
+                        // This is a linear combination that we will enforce to be "zero"
+                        let mut lc = LinearCombination::zero();
+
+                        // Allocate each bit_gadget of the result
+                        let mut coeff = F::one();
+                        for i in 0..128 {
+                            // Allocate the bit_gadget
+                            let b = AllocatedBit::alloc(
+                                cs.ns(|| format!("result bit_gadget {}", i)),
+                                || result_value.map(|v| (v >> i) & 1 == 1).get(),
+                            )?;
+
+                            // Subtract this bit_gadget from the linear combination to ensure the sums
+                            // balance out
+                            lc = lc - (coeff, b.get_variable());
+
+                            result_bits.push(b.into());
+
+                            coeff.double_in_place();
+                        }
+
+                        // Enforce that the linear combination equals zero
+                        cs.enforce(|| "unsafe subtraction", |lc| lc, |lc| lc, |_| lc);
+
+                        // Discard carry bits that we don't care about
+                        result_bits.truncate(128);
+
+                        Ok(Self {
+                            bits: result_bits,
+                            negated: false,
+                            value: modular_value,
+                        })
+                    }
+                } else {
+                    // Perform subtraction
+                    self.sub(&mut cs.ns(|| ""), &other)
+                }
+            }
+            (_, _) => {
+                // If either of our operands have unknown value, we won't
+                // know the value of the result
+                return Err(SynthesisError::AssignmentMissing);
+            }
+        }
+    }
+
+    /// Bitwise multiplication of two `UInt128` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
+    pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // res = 0;
+        // shifted_self = self;
+        // for bit in other.bits {
+        //   if bit {
+        //     res += shifted_self;
+        //   }
+        //   shifted_self = shifted_self << 1;
+        // }
+        // return res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(0u128);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u128"), || Ok(0u128))?;
+        let zero_result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        let mut left_shift = self.clone();
+
+        let partial_products = other
+            .bits
+            .iter()
+            .enumerate()
+            .map(|(i, bit)| {
+                let current_left_shift = left_shift.clone();
+                left_shift = Self::addmany(
+                    &mut cs.ns(|| format!("shift_left_{}", i)),
+                    &[left_shift.clone(), left_shift.clone()],
+                )
+                .unwrap();
+
+                Self::conditionally_select(
+                    &mut cs.ns(|| format!("calculate_product_{}", i)),
+                    &bit,
+                    &current_left_shift,
+                    &zero_result,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<Self>>();
+
+        Self::addmany(
+            &mut cs.ns(|| format!("partial_products")),
+            &partial_products,
+        )
+    }
+
+    /// Perform long division of two `UInt128` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Division_algorithm
+    pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // if D = 0 then error(DivisionByZeroException) end
+        // Q := 0                  -- Initialize quotient and remainder to zero
+        // R := 0
+        // for i := n − 1 .. 0 do  -- Where n is number of bits in N
+        //   R := R << 1           -- Left-shift R by 1 bit
+        //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
+        //   if R ≥ D then
+        //     R := R − D
+        //     Q(i) := 1
+        //   end
+        // end
+
+        if other.eq(&Self::constant(0u128)) {
+            return Err(SynthesisError::DivisionByZero);
+        }
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+
+        let allocated_true =
+            Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
+        let true_bit = Boolean::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_true"),
+            &is_constant,
+            &Boolean::constant(true),
+            &allocated_true,
+        )?;
+
+        let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1u128))?;
+        let one = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_1u128"),
+            &is_constant,
+            &Self::constant(1u128),
+            &allocated_one,
+        )?;
+
+        let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0u128))?;
+        let zero = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_0u128"),
+            &is_constant,
+            &Self::constant(0u128),
+            &allocated_zero,
+        )?;
+
+        let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0u128)));
+        let mut quotient = zero.clone();
+        let mut remainder = zero.clone();
+
+        for (i, bit) in self.bits.iter().rev().enumerate() {
+            // Left shift remainder by 1
+            remainder = Self::addmany(
+                &mut cs.ns(|| format!("shift_left_{}", i)),
+                &[remainder.clone(), remainder.clone()],
+            )?;
+
+            // Set the least-significant bit of remainder to bit i of the numerator
+            let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
+            let new_remainder = Self::addmany(
+                &mut cs.ns(|| format!("set_remainder_bit_{}", i)),
+                &[remainder.clone(), one.clone()],
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
+                &bit_is_true,
+                &new_remainder,
+                &remainder,
+            )?;
+
+            // Greater than or equal to:
+            //   R >= D
+            //   (R == D) || (R > D)
+            //   (R == D) || ((R !=D) && ((R - D) != 0))
+            //
+            //  (R > D)                     checks subtraction overflow before evaluation
+            //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
+
+            let no_remainder = Boolean::constant(remainder.eq(&other));
+            let subtraction =
+                remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
+            let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0)));
+            let cond1 = Boolean::and(
+                &mut cs.ns(|| format!("cond_1_{}", i)),
+                &no_remainder.not(),
+                &sub_is_zero.not(),
+            )?;
+            let cond2 = Boolean::or(
+                &mut cs.ns(|| format!("cond_2_{}", i)),
+                &no_remainder,
+                &cond1,
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("subtract_or_same_{}", i)),
+                &cond2,
+                &subtraction,
+                &remainder,
+            )?;
+
+            let index = 127 - i as usize;
+            let bit_value = 1u128 << (index as u128);
+            let mut new_quotient = quotient.clone();
+            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
+
+            quotient = Self::conditionally_select(
+                &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
+                &cond2,
+                &new_quotient,
+                &quotient,
+            )?;
+        }
+        Self::conditionally_select(
+            &mut cs.ns(|| "self_or_quotient"),
+            &self_is_zero,
+            self,
+            &quotient,
+        )
+    }
+
+    /// Bitwise multiplication of two `UInt128` objects.
+    /// Reference: /snarkOS/models/src/curves/field.rs
+    pub fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // let mut res = Self::one();
+        //
+        // let mut found_one = false;
+        //
+        // for i in BitIterator::new(exp) {
+        //     if !found_one {
+        //         if i {
+        //             found_one = true;
+        //         } else {
+        //             continue;
+        //         }
+        //     }
+        //
+        //     res.square_in_place();
+        //
+        //     if i {
+        //         res *= self;
+        //     }
+        // }
+        // res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(1u128);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u128"), || Ok(1u128))?;
+        let mut result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        for (i, bit) in other.bits.iter().rev().enumerate() {
+            let found_one = Boolean::Constant(result.eq(&Self::constant(1u128)));
+            let cond1 = Boolean::and(cs.ns(|| format!("found_one_{}", i)), &bit.not(), &found_one)?;
+            let square = result
+                .mul(cs.ns(|| format!("square_{}", i)), &result)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("result_or_sqaure_{}", i)),
+                &cond1,
+                &result,
+                &square,
+            )?;
+
+            let mul_by_self = result
+                .mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("mul_by_self_or_result_{}", i)),
+                &bit,
+                &mul_by_self,
+                &result,
+            )?;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<F: Field> ToBytesGadget<F> for UInt128 {
+    #[inline]
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let value_chunks = match self.value.map(|val| {
+            let mut bytes = [0u8; 16];
+            val.write(bytes.as_mut()).unwrap();
+            bytes
+        }) {
+            Some(chunks) => [
+                Some(chunks[0]),
+                Some(chunks[1]),
+                Some(chunks[2]),
+                Some(chunks[3]),
+            ],
+            None => [None, None, None, None],
+        };
+        let mut bytes = Vec::new();
+        for (i, chunk8) in self.to_bits_le().chunks(8).into_iter().enumerate() {
+            let byte = UInt8 {
+                bits: chunk8.to_vec(),
+                negated: false,
+                value: value_chunks[i],
+            };
+            bytes.push(byte);
+        }
+
+        Ok(bytes)
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(
+        &self,
+        cs: CS,
+    ) -> Result<Vec<UInt8>, SynthesisError> {
+        self.to_bytes(cs)
+    }
+}
+
+impl PartialEq for UInt128 {
+    fn eq(&self, other: &Self) -> bool {
+        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+    }
+}
+
+impl Eq for UInt128 {}
+
+impl<F: Field> EqGadget<F> for UInt128 {}
+
+impl<F: Field> ConditionalEqGadget<F> for UInt128 {
+    fn conditional_enforce_equal<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError> {
+        for (i, (a, b)) in self.bits.iter().zip(&other.bits).enumerate() {
+            a.conditional_enforce_equal(
+                &mut cs.ns(|| format!("uint128_equal_{}", i)),
+                b,
+                condition,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn cost() -> usize {
+        128 * <Boolean as ConditionalEqGadget<F>>::cost()
+    }
+}
+
+impl<F: PrimeField> CondSelectGadget<F> for UInt128 {
+    fn conditionally_select<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        cond: &Boolean,
+        first: &Self,
+        second: &Self,
+    ) -> Result<Self, SynthesisError> {
+        if let Boolean::Constant(cond) = *cond {
+            if cond {
+                Ok(first.clone())
+            } else {
+                Ok(second.clone())
+            }
+        } else {
+            let mut is_negated = false;
+
+            let result_val = cond.get_value().and_then(|c| {
+                if c {
+                    is_negated = first.negated;
+                    first.value
+                } else {
+                    is_negated = second.negated;
+                    second.value
+                }
+            });
+
+            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || {
+                result_val.get().map(|v| v)
+            })?;
+
+            result.negated = is_negated;
+
+            let expected_bits = first
+                .bits
+                .iter()
+                .zip(&second.bits)
+                .enumerate()
+                .map(|(i, (a, b))| {
+                    Boolean::conditionally_select(
+                        &mut cs.ns(|| format!("uint128_cond_select_{}", i)),
+                        cond,
+                        a,
+                        b,
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<Boolean>>();
+
+            for (i, (actual, expected)) in result
+                .to_bits_le()
+                .iter()
+                .zip(expected_bits.iter())
+                .enumerate()
+            {
+                actual.enforce_equal(
+                    &mut cs.ns(|| format!("selected_result_bit_{}", i)),
+                    expected,
+                )?;
+            }
+
+            Ok(result)
+        }
+    }
+
+    fn cost() -> usize {
+        128 * (<Boolean as ConditionalEqGadget<F>>::cost()
+            + <Boolean as CondSelectGadget<F>>::cost())
+    }
+}
+
+impl<F: Field> AllocGadget<u128, F> for UInt128 {
+    fn alloc<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u128>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(128);
+
+                for _ in 0..128 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 128],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+
+    fn alloc_input<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u128>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(128);
+
+                for _ in 0..128 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 128],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc_input(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use snarkos_models::{
+        curves::Field,
+        gadgets::{
+            r1cs::{Fr, TestConstraintSystem},
+            utilities::boolean::Boolean,
+        },
+    };
+
+    use rand::{Rng, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+    use std::convert::TryInto;
+
+    fn check_all_constant_bits(mut expected: u128, actual: UInt128) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(_) => panic!(),
+                &Boolean::Not(_) => panic!(),
+                &Boolean::Constant(b) => {
+                    assert!(b == (expected & 1 == 1));
+                }
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    fn check_all_allocated_bits(mut expected: u128, actual: UInt128) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(ref b) => {
+                    assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Not(ref b) => {
+                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Constant(_) => unreachable!(),
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    #[test]
+    fn test_uint128_from_bits() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let v = (0..128)
+                .map(|_| Boolean::constant(rng.gen()))
+                .collect::<Vec<_>>();
+
+            let b = UInt128::from_bits_le(&v);
+
+            for (i, bit_gadget) in b.bits.iter().enumerate() {
+                match bit_gadget {
+                    &Boolean::Constant(bit_gadget) => {
+                        assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            let expected_to_be_same = b.to_bits_le();
+
+            for x in v.iter().zip(expected_to_be_same.iter()) {
+                match x {
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint128_xor() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+            let c: u128 = rng.gen();
+
+            let mut expected = a ^ b ^ c;
+
+            let a_bit = UInt128::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt128::constant(b);
+            let c_bit = UInt128::alloc(cs.ns(|| "c_bit"), || Ok(c)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "first xor"), &b_bit).unwrap();
+            let r = r.xor(cs.ns(|| "second xor"), &c_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            for b in r.bits.iter() {
+                match b {
+                    &Boolean::Is(ref b) => {
+                        assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Not(ref b) => {
+                        assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Constant(b) => {
+                        assert!(b == (expected & 1 == 1));
+                    }
+                }
+
+                expected >>= 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint128_rotr() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        let mut num = rng.gen();
+
+        let a = UInt128::constant(num);
+
+        for i in 0..128 {
+            let b = a.rotr(i);
+
+            assert!(b.value.unwrap() == num);
+
+            let mut tmp = num;
+            for b in &b.bits {
+                match b {
+                    &Boolean::Constant(b) => {
+                        assert_eq!(b, tmp & 1 == 1);
+                    }
+                    _ => unreachable!(),
+                }
+
+                tmp >>= 1;
+            }
+
+            num = num.rotate_right(1);
+        }
+    }
+
+    #[test]
+    fn test_uint128_addmany_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+            let c: u128 = rng.gen();
+
+            let a_bit = UInt128::constant(a);
+            let b_bit = UInt128::constant(b);
+            let c_bit = UInt128::constant(c);
+
+            let expected = a.wrapping_add(b).wrapping_add(c);
+
+            let r = UInt128::addmany(cs.ns(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint128_addmany() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+
+            let expected = a.wrapping_add(b);
+
+            let a_bit = UInt128::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt128::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap();
+
+            let r = UInt128::addmany(cs.ns(|| "addition"), &[a_bit, b_bit]).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the addition constraint still works
+            if cs.get("addition/result bit_gadget 0/boolean").is_zero() {
+                cs.set("addition/result bit_gadget 0/boolean", Field::one());
+            } else {
+                cs.set("addition/result bit_gadget 0/boolean", Field::zero());
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint128_sub_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen_range(u128::max_value() / 2u128, u128::max_value());
+            let b: u128 = rng.gen_range(0u128, u128::max_value() / 2u128);
+
+            let a_bit = UInt128::constant(a);
+            let b_bit = UInt128::constant(b);
+
+            let expected = a.wrapping_sub(b);
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint128_sub() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen_range(u128::max_value() / 2u128, u128::max_value());
+            let b: u128 = rng.gen_range(0u128, u128::max_value() / 2u128);
+
+            let expected = a.wrapping_sub(b);
+
+            let a_bit = UInt128::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u128::max_value() / 4 {
+                UInt128::constant(b)
+            } else {
+                UInt128::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the subtraction constraint still works
+            if cs
+                .get("subtraction/add_not/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint128_mul_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+
+            let a_bit = UInt128::constant(a);
+            let b_bit = UInt128::constant(b);
+
+            let expected = a.wrapping_mul(b);
+
+            let r = a_bit.mul(cs.ns(|| "multiply"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint128_mul() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+
+            let expected = a.wrapping_mul(b);
+
+            let a_bit = UInt128::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > (u128::max_value() / 2) {
+                UInt128::constant(b)
+            } else {
+                UInt128::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.mul(cs.ns(|| "multiplication"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the multiplication constraint still works
+            if cs
+                .get("multiplication/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint128_div_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+
+            let a_bit = UInt128::constant(a);
+            let b_bit = UInt128::constant(b);
+
+            let expected = a.wrapping_div(b);
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint128_div() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..10 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen();
+            let b: u128 = rng.gen();
+
+            let expected = a.wrapping_div(b);
+
+            let a_bit = UInt128::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u128::max_value() / 2 {
+                UInt128::constant(b)
+            } else {
+                UInt128::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the division constraint still works
+            if cs
+                .get("division/subtract_divisor_0/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint128_pow_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u128 = rng.gen_range(0, u128::from(u32::max_value()));
+            let b: u128 = rng.gen_range(0, 4);
+
+            let a_bit = UInt128::constant(a);
+            let b_bit = UInt128::constant(b);
+
+            let expected = a.wrapping_pow(b.try_into().unwrap());
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint128_pow() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        let mut cs = TestConstraintSystem::<Fr>::new();
+
+        let a: u128 = rng.gen_range(0, u128::from(u32::max_value()));
+        let b: u128 = rng.gen_range(0, 4);
+
+        let expected = a.wrapping_pow(b.try_into().unwrap());
+
+        let a_bit = UInt128::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+        let b_bit = UInt128::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap();
+
+        println!("num constraints before {}", cs.num_constraints());
+
+        let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+        println!("num constraints after {}\n", cs.num_constraints());
+
+        assert!(cs.is_satisfied());
+
+        assert!(r.value == Some(expected));
+
+        check_all_allocated_bits(expected, r);
+
+        // Flip a bit_gadget and see if the exponentiation constraint still works
+        if cs
+            .get("exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean")
+            .is_zero()
+        {
+            cs.set(
+                "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                Field::one(),
+            );
+        } else {
+            cs.set(
+                "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                Field::zero(),
+            );
+        }
+
+        assert!(!cs.is_satisfied());
+    }
+}

--- a/gadgets/src/integers/uint16.rs
+++ b/gadgets/src/integers/uint16.rs
@@ -1,0 +1,1363 @@
+use snarkos_errors::gadgets::SynthesisError;
+use snarkos_models::{
+    curves::{Field, FpParameters, PrimeField},
+    gadgets::{
+        r1cs::{Assignment, ConstraintSystem, LinearCombination},
+        utilities::{
+            alloc::AllocGadget,
+            boolean::{AllocatedBit, Boolean},
+            eq::{ConditionalEqGadget, EqGadget},
+            select::CondSelectGadget,
+            uint8::UInt8,
+            ToBytesGadget,
+        },
+    },
+};
+use snarkos_utilities::bytes::ToBytes;
+
+use std::borrow::Borrow;
+
+/// Represents an interpretation of 16 `Boolean` objects as an
+/// unsigned integer.
+#[derive(Clone, Debug)]
+pub struct UInt16 {
+    // Least significant bit_gadget first
+    pub bits: Vec<Boolean>,
+    pub negated: bool,
+    pub value: Option<u16>,
+}
+
+impl UInt16 {
+    /// Construct a constant `UInt16` from a `u16`
+    pub fn constant(value: u16) -> Self {
+        let mut bits = Vec::with_capacity(16);
+
+        let mut tmp = value;
+        for _ in 0..16 {
+            if tmp & 1 == 1 {
+                bits.push(Boolean::constant(true))
+            } else {
+                bits.push(Boolean::constant(false))
+            }
+
+            tmp >>= 1;
+        }
+
+        Self {
+            bits,
+            negated: false,
+            value: Some(value),
+        }
+    }
+
+    /// Turns this `UInt16` into its little-endian byte order representation.
+    pub fn to_bits_le(&self) -> Vec<Boolean> {
+        self.bits.clone()
+    }
+
+    /// Converts a little-endian byte order representation of bits into a
+    /// `UInt16`.
+    pub fn from_bits_le(bits: &[Boolean]) -> Self {
+        assert_eq!(bits.len(), 16);
+
+        let bits = bits.to_vec();
+
+        let mut value = Some(0u16);
+        for b in bits.iter().rev() {
+            value.as_mut().map(|v| *v <<= 1);
+
+            match b {
+                &Boolean::Constant(b) => {
+                    if b {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                }
+                &Boolean::Is(ref b) => match b.get_value() {
+                    Some(true) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(false) => {}
+                    None => value = None,
+                },
+                &Boolean::Not(ref b) => match b.get_value() {
+                    Some(false) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(true) => {}
+                    None => value = None,
+                },
+            }
+        }
+
+        Self {
+            value,
+            negated: false,
+            bits,
+        }
+    }
+
+    pub fn rotr(&self, by: usize) -> Self {
+        let by = by % 16;
+
+        let new_bits = self
+            .bits
+            .iter()
+            .skip(by)
+            .chain(self.bits.iter())
+            .take(16)
+            .cloned()
+            .collect();
+
+        Self {
+            bits: new_bits,
+            negated: false,
+            value: self.value.map(|v| v.rotate_right(by as u32) as u16),
+        }
+    }
+
+    /// XOR this `UInt16` with another `UInt16`
+    pub fn xor<F, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
+    where
+        F: Field,
+        CS: ConstraintSystem<F>,
+    {
+        let new_value = match (self.value, other.value) {
+            (Some(a), Some(b)) => Some(a ^ b),
+            _ => None,
+        };
+
+        let bits = self
+            .bits
+            .iter()
+            .zip(other.bits.iter())
+            .enumerate()
+            .map(|(i, (a, b))| Boolean::xor(cs.ns(|| format!("xor of bit_gadget {}", i)), a, b))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: new_value,
+        })
+    }
+
+    /// Returns the inverse UInt16
+    pub fn negate(&self) -> Self {
+        Self {
+            bits: self.bits.clone(),
+            negated: true,
+            value: self.value.clone(),
+        }
+    }
+
+    /// Returns true if all bits in this UInt16 are constant
+    fn is_constant(&self) -> bool {
+        let mut constant = true;
+
+        // If any bits of self are allocated bits, return false
+        for bit in &self.bits {
+            match *bit {
+                Boolean::Is(ref _bit) => constant = false,
+                Boolean::Not(ref _bit) => constant = false,
+                Boolean::Constant(_bit) => {}
+            }
+        }
+
+        constant
+    }
+
+    /// Returns true if both UInt16s have constant bits
+    fn result_is_constant(first: &Self, second: &Self) -> bool {
+        // If any bits of first are allocated bits, return false
+        if !first.is_constant() {
+            return false;
+        }
+
+        // If any bits of second are allocated bits, return false
+        second.is_constant()
+    }
+
+    /// Perform modular addition of several `UInt16` objects.
+    pub fn addmany<F, CS>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>
+    where
+        F: PrimeField,
+        CS: ConstraintSystem<F>,
+    {
+        // Make some arbitrary bounds for ourselves to avoid overflows
+        // in the scalar field
+        assert!(F::Params::MODULUS_BITS >= 64);
+        assert!(operands.len() >= 2); // Weird trivial cases that should never happen
+
+        // Compute the maximum value of the sum so we allocate enough bits for
+        // the result
+        let mut max_value = (operands.len() as u64) * u64::from(u16::max_value());
+
+        // Keep track of the resulting value
+        let mut result_value = Some(0u64);
+
+        // This is a linear combination that we will enforce to be "zero"
+        let mut lc = LinearCombination::zero();
+
+        let mut all_constants = true;
+
+        // Iterate over the operands
+        for op in operands {
+            // Accumulate the value
+            match op.value {
+                Some(val) => {
+                    // Subtract or add operand
+                    if op.negated {
+                        // Perform subtraction
+                        result_value.as_mut().map(|v| *v -= u64::from(val));
+                    } else {
+                        // Perform addition
+                        result_value.as_mut().map(|v| *v += u64::from(val));
+                    }
+                }
+                None => {
+                    // If any of our operands have unknown value, we won't
+                    // know the value of the result
+                    result_value = None;
+                }
+            }
+
+            // Iterate over each bit_gadget of the operand and add the operand to
+            // the linear combination
+            let mut coeff = F::one();
+            for bit in &op.bits {
+                match *bit {
+                    Boolean::Is(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // Subtract coeff * bit gadget
+                            lc = lc - (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * bit_gadget
+                            lc = lc + (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Not(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // subtract coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc - (coeff, CS::one()) + (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc + (coeff, CS::one()) - (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Constant(bit) => {
+                        if bit {
+                            if op.negated {
+                                lc = lc - (coeff, CS::one());
+                            } else {
+                                lc = lc + (coeff, CS::one());
+                            }
+                        }
+                    }
+                }
+
+                coeff.double_in_place();
+            }
+        }
+
+        // The value of the actual result is modulo 2^16
+        let modular_value = result_value.map(|v| v as u16);
+
+        if all_constants && modular_value.is_some() {
+            // We can just return a constant, rather than
+            // unpacking the result into allocated bits.
+
+            return Ok(Self::constant(modular_value.unwrap()));
+        }
+
+        // Storage area for the resulting bits
+        let mut result_bits = vec![];
+
+        // Allocate each bit_gadget of the result
+        let mut coeff = F::one();
+        let mut i = 0;
+        while max_value != 0 {
+            // Allocate the bit_gadget
+            let b = AllocatedBit::alloc(cs.ns(|| format!("result bit_gadget {}", i)), || {
+                result_value.map(|v| (v >> i) & 1 == 1).get()
+            })?;
+
+            // Subtract this bit_gadget from the linear combination to ensure the sums
+            // balance out
+            lc = lc - (coeff, b.get_variable());
+
+            result_bits.push(b.into());
+
+            max_value >>= 1;
+            i += 1;
+            coeff.double_in_place();
+        }
+
+        // Enforce that the linear combination equals zero
+        cs.enforce(|| "modular addition", |lc| lc, |lc| lc, |_| lc);
+
+        // Discard carry bits that we don't care about
+        result_bits.truncate(16);
+
+        Ok(Self {
+            bits: result_bits,
+            negated: false,
+            value: modular_value,
+        })
+    }
+
+    /// Perform modular subtraction of two `UInt16` objects.
+    pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // a - b
+        // a + (-b)
+
+        Self::addmany(&mut cs.ns(|| "add_not"), &[self.clone(), other.negate()])
+    }
+
+    /// Perform unsafe subtraction of two `UInt16` objects which returns 0 if overflowed
+    fn sub_unsafe<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        match (self.value, other.value) {
+            (Some(val1), Some(val2)) => {
+                // Check for overflow
+                if val1 < val2 {
+                    // Instead of erroring, return 0
+
+                    if Self::result_is_constant(&self, &other) {
+                        // Return constant 0u16
+                        Ok(Self::constant(0u16))
+                    } else {
+                        // Return allocated 0u16
+                        let result_value = Some(0u64);
+                        let modular_value = result_value.map(|v| v as u16);
+
+                        // Storage area for the resulting bits
+                        let mut result_bits = vec![];
+
+                        // This is a linear combination that we will enforce to be "zero"
+                        let mut lc = LinearCombination::zero();
+
+                        // Allocate each bit_gadget of the result
+                        let mut coeff = F::one();
+                        for i in 0..16 {
+                            // Allocate the bit_gadget
+                            let b = AllocatedBit::alloc(
+                                cs.ns(|| format!("result bit_gadget {}", i)),
+                                || result_value.map(|v| (v >> i) & 1 == 1).get(),
+                            )?;
+
+                            // Subtract this bit_gadget from the linear combination to ensure the sums
+                            // balance out
+                            lc = lc - (coeff, b.get_variable());
+
+                            result_bits.push(b.into());
+
+                            coeff.double_in_place();
+                        }
+
+                        // Enforce that the linear combination equals zero
+                        cs.enforce(|| "unsafe subtraction", |lc| lc, |lc| lc, |_| lc);
+
+                        // Discard carry bits that we don't care about
+                        result_bits.truncate(16);
+
+                        Ok(Self {
+                            bits: result_bits,
+                            negated: false,
+                            value: modular_value,
+                        })
+                    }
+                } else {
+                    // Perform subtraction
+                    self.sub(&mut cs.ns(|| ""), &other)
+                }
+            }
+            (_, _) => {
+                // If either of our operands have unknown value, we won't
+                // know the value of the result
+                return Err(SynthesisError::AssignmentMissing);
+            }
+        }
+    }
+
+    /// Bitwise multiplication of two `UInt16` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
+    pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // res = 0;
+        // shifted_self = self;
+        // for bit in other.bits {
+        //   if bit {
+        //     res += shifted_self;
+        //   }
+        //   shifted_self = shifted_self << 1;
+        // }
+        // return res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(0u16);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u16"), || Ok(0u16))?;
+        let zero_result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        let mut left_shift = self.clone();
+
+        let partial_products = other
+            .bits
+            .iter()
+            .enumerate()
+            .map(|(i, bit)| {
+                let current_left_shift = left_shift.clone();
+                left_shift = Self::addmany(
+                    &mut cs.ns(|| format!("shift_left_{}", i)),
+                    &[left_shift.clone(), left_shift.clone()],
+                )
+                .unwrap();
+
+                Self::conditionally_select(
+                    &mut cs.ns(|| format!("calculate_product_{}", i)),
+                    &bit,
+                    &current_left_shift,
+                    &zero_result,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<Self>>();
+
+        Self::addmany(
+            &mut cs.ns(|| format!("partial_products")),
+            &partial_products,
+        )
+    }
+
+    /// Perform long division of two `UInt16` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Division_algorithm
+    pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // if D = 0 then error(DivisionByZeroException) end
+        // Q := 0                  -- Initialize quotient and remainder to zero
+        // R := 0
+        // for i := n − 1 .. 0 do  -- Where n is number of bits in N
+        //   R := R << 1           -- Left-shift R by 1 bit
+        //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
+        //   if R ≥ D then
+        //     R := R − D
+        //     Q(i) := 1
+        //   end
+        // end
+
+        if other.eq(&Self::constant(0u16)) {
+            return Err(SynthesisError::DivisionByZero);
+        }
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+
+        let allocated_true =
+            Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
+        let true_bit = Boolean::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_true"),
+            &is_constant,
+            &Boolean::constant(true),
+            &allocated_true,
+        )?;
+
+        let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1u16))?;
+        let one = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_1u16"),
+            &is_constant,
+            &Self::constant(1u16),
+            &allocated_one,
+        )?;
+
+        let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0u16))?;
+        let zero = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_0u16"),
+            &is_constant,
+            &Self::constant(0u16),
+            &allocated_zero,
+        )?;
+
+        let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0u16)));
+        let mut quotient = zero.clone();
+        let mut remainder = zero.clone();
+
+        for (i, bit) in self.bits.iter().rev().enumerate() {
+            // Left shift remainder by 1
+            remainder = Self::addmany(
+                &mut cs.ns(|| format!("shift_left_{}", i)),
+                &[remainder.clone(), remainder.clone()],
+            )?;
+
+            // Set the least-significant bit of remainder to bit i of the numerator
+            let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
+            let new_remainder = Self::addmany(
+                &mut cs.ns(|| format!("set_remainder_bit_{}", i)),
+                &[remainder.clone(), one.clone()],
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
+                &bit_is_true,
+                &new_remainder,
+                &remainder,
+            )?;
+
+            // Greater than or equal to:
+            //   R >= D
+            //   (R == D) || (R > D)
+            //   (R == D) || ((R !=D) && ((R - D) != 0))
+            //
+            //  (R > D)                     checks subtraction overflow before evaluation
+            //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
+
+            let no_remainder = Boolean::constant(remainder.eq(&other));
+            let subtraction =
+                remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
+            let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0)));
+            let cond1 = Boolean::and(
+                &mut cs.ns(|| format!("cond_1_{}", i)),
+                &no_remainder.not(),
+                &sub_is_zero.not(),
+            )?;
+            let cond2 = Boolean::or(
+                &mut cs.ns(|| format!("cond_2_{}", i)),
+                &no_remainder,
+                &cond1,
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("subtract_or_same_{}", i)),
+                &cond2,
+                &subtraction,
+                &remainder,
+            )?;
+
+            let index = 15 - i as usize;
+            let bit_value = 1u16 << (index as u16);
+            let mut new_quotient = quotient.clone();
+            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
+
+            quotient = Self::conditionally_select(
+                &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
+                &cond2,
+                &new_quotient,
+                &quotient,
+            )?;
+        }
+        Self::conditionally_select(
+            &mut cs.ns(|| "self_or_quotient"),
+            &self_is_zero,
+            self,
+            &quotient,
+        )
+    }
+
+    /// Bitwise multiplication of two `UInt16` objects.
+    /// Reference: /snarkOS/models/src/curves/field.rs
+    pub fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // let mut res = Self::one();
+        //
+        // let mut found_one = false;
+        //
+        // for i in BitIterator::new(exp) {
+        //     if !found_one {
+        //         if i {
+        //             found_one = true;
+        //         } else {
+        //             continue;
+        //         }
+        //     }
+        //
+        //     res.square_in_place();
+        //
+        //     if i {
+        //         res *= self;
+        //     }
+        // }
+        // res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(1u16);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u16"), || Ok(1u16))?;
+        let mut result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        for (i, bit) in other.bits.iter().rev().enumerate() {
+            let found_one = Boolean::Constant(result.eq(&Self::constant(1u16)));
+            let cond1 = Boolean::and(cs.ns(|| format!("found_one_{}", i)), &bit.not(), &found_one)?;
+            let square = result
+                .mul(cs.ns(|| format!("square_{}", i)), &result)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("result_or_sqaure_{}", i)),
+                &cond1,
+                &result,
+                &square,
+            )?;
+
+            let mul_by_self = result
+                .mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("mul_by_self_or_result_{}", i)),
+                &bit,
+                &mul_by_self,
+                &result,
+            )?;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<F: Field> ToBytesGadget<F> for UInt16 {
+    #[inline]
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let value_chunks = match self.value.map(|val| {
+            let mut bytes = [0u8; 4];
+            val.write(bytes.as_mut()).unwrap();
+            bytes
+        }) {
+            Some(chunks) => [
+                Some(chunks[0]),
+                Some(chunks[1]),
+                Some(chunks[2]),
+                Some(chunks[3]),
+            ],
+            None => [None, None, None, None],
+        };
+        let mut bytes = Vec::new();
+        for (i, chunk8) in self.to_bits_le().chunks(8).into_iter().enumerate() {
+            let byte = UInt8 {
+                bits: chunk8.to_vec(),
+                negated: false,
+                value: value_chunks[i],
+            };
+            bytes.push(byte);
+        }
+
+        Ok(bytes)
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(
+        &self,
+        cs: CS,
+    ) -> Result<Vec<UInt8>, SynthesisError> {
+        self.to_bytes(cs)
+    }
+}
+
+impl PartialEq for UInt16 {
+    fn eq(&self, other: &Self) -> bool {
+        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+    }
+}
+
+impl Eq for UInt16 {}
+
+impl<F: Field> EqGadget<F> for UInt16 {}
+
+impl<F: Field> ConditionalEqGadget<F> for UInt16 {
+    fn conditional_enforce_equal<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError> {
+        for (i, (a, b)) in self.bits.iter().zip(&other.bits).enumerate() {
+            a.conditional_enforce_equal(
+                &mut cs.ns(|| format!("uint16_equal_{}", i)),
+                b,
+                condition,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn cost() -> usize {
+        16 * <Boolean as ConditionalEqGadget<F>>::cost()
+    }
+}
+
+impl<F: PrimeField> CondSelectGadget<F> for UInt16 {
+    fn conditionally_select<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        cond: &Boolean,
+        first: &Self,
+        second: &Self,
+    ) -> Result<Self, SynthesisError> {
+        if let Boolean::Constant(cond) = *cond {
+            if cond {
+                Ok(first.clone())
+            } else {
+                Ok(second.clone())
+            }
+        } else {
+            let mut is_negated = false;
+
+            let result_val = cond.get_value().and_then(|c| {
+                if c {
+                    is_negated = first.negated;
+                    first.value
+                } else {
+                    is_negated = second.negated;
+                    second.value
+                }
+            });
+
+            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || {
+                result_val.get().map(|v| v)
+            })?;
+
+            result.negated = is_negated;
+
+            let expected_bits = first
+                .bits
+                .iter()
+                .zip(&second.bits)
+                .enumerate()
+                .map(|(i, (a, b))| {
+                    Boolean::conditionally_select(
+                        &mut cs.ns(|| format!("uint16_cond_select_{}", i)),
+                        cond,
+                        a,
+                        b,
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<Boolean>>();
+
+            for (i, (actual, expected)) in result
+                .to_bits_le()
+                .iter()
+                .zip(expected_bits.iter())
+                .enumerate()
+            {
+                actual.enforce_equal(
+                    &mut cs.ns(|| format!("selected_result_bit_{}", i)),
+                    expected,
+                )?;
+            }
+
+            Ok(result)
+        }
+    }
+
+    fn cost() -> usize {
+        16 * (<Boolean as ConditionalEqGadget<F>>::cost()
+            + <Boolean as CondSelectGadget<F>>::cost())
+    }
+}
+
+impl<F: Field> AllocGadget<u16, F> for UInt16 {
+    fn alloc<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u16>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(16);
+
+                for _ in 0..16 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 16],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+
+    fn alloc_input<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u16>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(16);
+
+                for _ in 0..16 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 16],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc_input(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use snarkos_models::{
+        curves::Field,
+        gadgets::{
+            r1cs::{Fr, TestConstraintSystem},
+            utilities::boolean::Boolean,
+        },
+    };
+
+    use rand::{Rng, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
+    fn check_all_constant_bits(mut expected: u16, actual: UInt16) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(_) => panic!(),
+                &Boolean::Not(_) => panic!(),
+                &Boolean::Constant(b) => {
+                    assert!(b == (expected & 1 == 1));
+                }
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    fn check_all_allocated_bits(mut expected: u16, actual: UInt16) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(ref b) => {
+                    assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Not(ref b) => {
+                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Constant(_) => unreachable!(),
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    #[test]
+    fn test_uint16_from_bits() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let v = (0..16)
+                .map(|_| Boolean::constant(rng.gen()))
+                .collect::<Vec<_>>();
+
+            let b = UInt16::from_bits_le(&v);
+
+            for (i, bit_gadget) in b.bits.iter().enumerate() {
+                match bit_gadget {
+                    &Boolean::Constant(bit_gadget) => {
+                        assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            let expected_to_be_same = b.to_bits_le();
+
+            for x in v.iter().zip(expected_to_be_same.iter()) {
+                match x {
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint16_xor() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen();
+            let b: u16 = rng.gen();
+            let c: u16 = rng.gen();
+
+            let mut expected = a ^ b ^ c;
+
+            let a_bit = UInt16::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt16::constant(b);
+            let c_bit = UInt16::alloc(cs.ns(|| "c_bit"), || Ok(c)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "first xor"), &b_bit).unwrap();
+            let r = r.xor(cs.ns(|| "second xor"), &c_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            for b in r.bits.iter() {
+                match b {
+                    &Boolean::Is(ref b) => {
+                        assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Not(ref b) => {
+                        assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Constant(b) => {
+                        assert!(b == (expected & 1 == 1));
+                    }
+                }
+
+                expected >>= 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint16_rotr() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        let mut num = rng.gen();
+
+        let a = UInt16::constant(num);
+
+        for i in 0..16 {
+            let b = a.rotr(i);
+
+            assert!(b.value.unwrap() == num);
+
+            let mut tmp = num;
+            for b in &b.bits {
+                match b {
+                    &Boolean::Constant(b) => {
+                        assert_eq!(b, tmp & 1 == 1);
+                    }
+                    _ => unreachable!(),
+                }
+
+                tmp >>= 1;
+            }
+
+            num = num.rotate_right(1);
+        }
+    }
+
+    #[test]
+    fn test_uint16_addmany_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen();
+            let b: u16 = rng.gen();
+            let c: u16 = rng.gen();
+
+            let a_bit = UInt16::constant(a);
+            let b_bit = UInt16::constant(b);
+            let c_bit = UInt16::constant(c);
+
+            let expected = a.wrapping_add(b).wrapping_add(c);
+
+            let r = UInt16::addmany(cs.ns(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint16_addmany() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen();
+            let b: u16 = rng.gen();
+            let c: u16 = rng.gen();
+            let d: u16 = rng.gen();
+
+            let expected = (a ^ b).wrapping_add(c).wrapping_add(d);
+
+            let a_bit = UInt16::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt16::constant(b);
+            let c_bit = UInt16::constant(c);
+            let d_bit = UInt16::alloc(cs.ns(|| "d_bit"), || Ok(d)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "xor"), &b_bit).unwrap();
+            let r = UInt16::addmany(cs.ns(|| "addition"), &[r, c_bit, d_bit]).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the addition constraint still works
+            if cs.get("addition/result bit_gadget 0/boolean").is_zero() {
+                cs.set("addition/result bit_gadget 0/boolean", Field::one());
+            } else {
+                cs.set("addition/result bit_gadget 0/boolean", Field::zero());
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint16_sub_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen_range(u16::max_value() / 2u16, u16::max_value());
+            let b: u16 = rng.gen_range(0u16, u16::max_value() / 2u16);
+
+            let a_bit = UInt16::constant(a);
+            let b_bit = UInt16::constant(b);
+
+            let expected = a.wrapping_sub(b);
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint16_sub() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen_range(u16::max_value() / 2u16, u16::max_value());
+            let b: u16 = rng.gen_range(0u16, u16::max_value() / 2u16);
+
+            let expected = a.wrapping_sub(b);
+
+            let a_bit = UInt16::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u16::max_value() / 4 {
+                UInt16::constant(b)
+            } else {
+                UInt16::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the subtraction constraint still works
+            if cs
+                .get("subtraction/add_not/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint16_mul_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen_range(0, u16::max_value());
+            let b: u16 = rng.gen_range(0, u16::max_value());
+
+            let a_bit = UInt16::constant(a);
+            let b_bit = UInt16::constant(b);
+
+            let expected = a.wrapping_mul(b);
+
+            let r = a_bit.mul(cs.ns(|| "multiply"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint16_mul() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen_range(0, u16::max_value());
+            let b: u16 = rng.gen_range(0, u16::max_value());
+
+            let expected = a.wrapping_mul(b);
+
+            let a_bit = UInt16::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u16::max_value() / 2 {
+                UInt16::constant(b)
+            } else {
+                UInt16::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.mul(cs.ns(|| "multiplication"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the multiplication constraint still works
+            if cs
+                .get("multiplication/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint16_div_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen();
+            let b: u16 = rng.gen_range(0u16, u16::max_value());
+
+            let a_bit = UInt16::constant(a);
+            let b_bit = UInt16::constant(b);
+
+            let expected = a.wrapping_div(b);
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint16_div() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen();
+            let b: u16 = rng.gen_range(0u16, u16::max_value());
+
+            let expected = a.wrapping_div(b);
+
+            let a_bit = UInt16::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u16::max_value() / 2 {
+                UInt16::constant(b)
+            } else {
+                UInt16::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the division constraint still works
+            if cs
+                .get("division/subtract_divisor_0/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint16_pow_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen();
+            let b: u16 = rng.gen();
+
+            let a_bit = UInt16::constant(a);
+            let b_bit = UInt16::constant(b);
+
+            let expected = a.wrapping_pow(b.into());
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint16_pow() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..10 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u16 = rng.gen_range(0, u16::from(u8::max_value()));
+            let b: u16 = rng.gen_range(0, 4);
+
+            let expected = a.wrapping_pow(b.into());
+
+            let a_bit = UInt16::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > 2 {
+                UInt16::constant(b)
+            } else {
+                UInt16::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the exponentiation constraint still works
+            if cs
+                .get("exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+}

--- a/gadgets/src/integers/uint32.rs
+++ b/gadgets/src/integers/uint32.rs
@@ -1,0 +1,1362 @@
+use snarkos_errors::gadgets::SynthesisError;
+use snarkos_models::{
+    curves::{Field, FpParameters, PrimeField},
+    gadgets::{
+        r1cs::{Assignment, ConstraintSystem, LinearCombination},
+        utilities::{
+            alloc::AllocGadget,
+            boolean::{AllocatedBit, Boolean},
+            eq::{ConditionalEqGadget, EqGadget},
+            select::CondSelectGadget,
+            uint8::UInt8,
+            ToBytesGadget,
+        },
+    },
+};
+use snarkos_utilities::bytes::ToBytes;
+use std::borrow::Borrow;
+
+/// Represents an interpretation of 32 `Boolean` objects as an
+/// unsigned integer.
+#[derive(Clone, Debug)]
+pub struct UInt32 {
+    // Least significant bit_gadget first
+    pub bits: Vec<Boolean>,
+    pub negated: bool,
+    pub value: Option<u32>,
+}
+
+impl UInt32 {
+    /// Construct a constant `UInt32` from a `u32`
+    pub fn constant(value: u32) -> Self {
+        let mut bits = Vec::with_capacity(32);
+
+        let mut tmp = value;
+        for _ in 0..32 {
+            if tmp & 1 == 1 {
+                bits.push(Boolean::constant(true))
+            } else {
+                bits.push(Boolean::constant(false))
+            }
+
+            tmp >>= 1;
+        }
+
+        Self {
+            bits,
+            negated: false,
+            value: Some(value),
+        }
+    }
+
+    /// Turns this `UInt32` into its little-endian byte order representation.
+    pub fn to_bits_le(&self) -> Vec<Boolean> {
+        self.bits.clone()
+    }
+
+    /// Converts a little-endian byte order representation of bits into a
+    /// `UInt32`.
+    pub fn from_bits_le(bits: &[Boolean]) -> Self {
+        assert_eq!(bits.len(), 32);
+
+        let bits = bits.to_vec();
+
+        let mut value = Some(0u32);
+        for b in bits.iter().rev() {
+            value.as_mut().map(|v| *v <<= 1);
+
+            match b {
+                &Boolean::Constant(b) => {
+                    if b {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                }
+                &Boolean::Is(ref b) => match b.get_value() {
+                    Some(true) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(false) => {}
+                    None => value = None,
+                },
+                &Boolean::Not(ref b) => match b.get_value() {
+                    Some(false) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(true) => {}
+                    None => value = None,
+                },
+            }
+        }
+
+        Self {
+            value,
+            negated: false,
+            bits,
+        }
+    }
+
+    pub fn rotr(&self, by: usize) -> Self {
+        let by = by % 32;
+
+        let new_bits = self
+            .bits
+            .iter()
+            .skip(by)
+            .chain(self.bits.iter())
+            .take(32)
+            .cloned()
+            .collect();
+
+        Self {
+            bits: new_bits,
+            negated: false,
+            value: self.value.map(|v| v.rotate_right(by as u32)),
+        }
+    }
+
+    /// XOR this `UInt32` with another `UInt32`
+    pub fn xor<F, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
+    where
+        F: Field,
+        CS: ConstraintSystem<F>,
+    {
+        let new_value = match (self.value, other.value) {
+            (Some(a), Some(b)) => Some(a ^ b),
+            _ => None,
+        };
+
+        let bits = self
+            .bits
+            .iter()
+            .zip(other.bits.iter())
+            .enumerate()
+            .map(|(i, (a, b))| Boolean::xor(cs.ns(|| format!("xor of bit_gadget {}", i)), a, b))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: new_value,
+        })
+    }
+
+    /// Returns the inverse UInt32
+    pub fn negate(&self) -> Self {
+        Self {
+            bits: self.bits.clone(),
+            negated: true,
+            value: self.value.clone(),
+        }
+    }
+
+    /// Returns true if all bits in this UInt32 are constant
+    fn is_constant(&self) -> bool {
+        let mut constant = true;
+
+        // If any bits of self are allocated bits, return false
+        for bit in &self.bits {
+            match *bit {
+                Boolean::Is(ref _bit) => constant = false,
+                Boolean::Not(ref _bit) => constant = false,
+                Boolean::Constant(_bit) => {}
+            }
+        }
+
+        constant
+    }
+
+    /// Returns true if both UInt32s have constant bits
+    fn result_is_constant(first: &Self, second: &Self) -> bool {
+        // If any bits of first are allocated bits, return false
+        if !first.is_constant() {
+            return false;
+        }
+
+        // If any bits of second are allocated bits, return false
+        second.is_constant()
+    }
+
+    /// Perform modular addition of several `UInt32` objects.
+    pub fn addmany<F, CS>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>
+    where
+        F: PrimeField,
+        CS: ConstraintSystem<F>,
+    {
+        // Make some arbitrary bounds for ourselves to avoid overflows
+        // in the scalar field
+        assert!(F::Params::MODULUS_BITS >= 64);
+        assert!(operands.len() >= 2); // Weird trivial cases that should never happen
+
+        // Compute the maximum value of the sum so we allocate enough bits for
+        // the result
+        let mut max_value = (operands.len() as u64) * u64::from(u32::max_value());
+
+        // Keep track of the resulting value
+        let mut result_value = Some(0u64);
+
+        // This is a linear combination that we will enforce to be "zero"
+        let mut lc = LinearCombination::zero();
+
+        let mut all_constants = true;
+
+        // Iterate over the operands
+        for op in operands {
+            // Accumulate the value
+            match op.value {
+                Some(val) => {
+                    // Subtract or add operand
+                    if op.negated {
+                        // Perform subtraction
+                        result_value.as_mut().map(|v| *v -= u64::from(val));
+                    } else {
+                        // Perform addition
+                        result_value.as_mut().map(|v| *v += u64::from(val));
+                    }
+                }
+                None => {
+                    // If any of our operands have unknown value, we won't
+                    // know the value of the result
+                    result_value = None;
+                }
+            }
+
+            // Iterate over each bit_gadget of the operand and add the operand to
+            // the linear combination
+            let mut coeff = F::one();
+            for bit in &op.bits {
+                match *bit {
+                    Boolean::Is(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // Subtract coeff * bit gadget
+                            lc = lc - (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * bit_gadget
+                            lc = lc + (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Not(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // subtract coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc - (coeff, CS::one()) + (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc + (coeff, CS::one()) - (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Constant(bit) => {
+                        if bit {
+                            if op.negated {
+                                lc = lc - (coeff, CS::one());
+                            } else {
+                                lc = lc + (coeff, CS::one());
+                            }
+                        }
+                    }
+                }
+
+                coeff.double_in_place();
+            }
+        }
+
+        // The value of the actual result is modulo 2^32
+        let modular_value = result_value.map(|v| v as u32);
+
+        if all_constants && modular_value.is_some() {
+            // We can just return a constant, rather than
+            // unpacking the result into allocated bits.
+
+            return Ok(Self::constant(modular_value.unwrap()));
+        }
+
+        // Storage area for the resulting bits
+        let mut result_bits = vec![];
+
+        // Allocate each bit_gadget of the result
+        let mut coeff = F::one();
+        let mut i = 0;
+        while max_value != 0 {
+            // Allocate the bit_gadget
+            let b = AllocatedBit::alloc(cs.ns(|| format!("result bit_gadget {}", i)), || {
+                result_value.map(|v| (v >> i) & 1 == 1).get()
+            })?;
+
+            // Subtract this bit_gadget from the linear combination to ensure the sums
+            // balance out
+            lc = lc - (coeff, b.get_variable());
+
+            result_bits.push(b.into());
+
+            max_value >>= 1;
+            i += 1;
+            coeff.double_in_place();
+        }
+
+        // Enforce that the linear combination equals zero
+        cs.enforce(|| "modular addition", |lc| lc, |lc| lc, |_| lc);
+
+        // Discard carry bits that we don't care about
+        result_bits.truncate(32);
+
+        Ok(Self {
+            bits: result_bits,
+            negated: false,
+            value: modular_value,
+        })
+    }
+
+    /// Perform modular subtraction of two `UInt32` objects.
+    pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // a - b
+        // a + (-b)
+
+        Self::addmany(&mut cs.ns(|| "add_not"), &[self.clone(), other.negate()])
+    }
+
+    /// Perform unsafe subtraction of two `UInt32` objects which returns 0 if overflowed
+    fn sub_unsafe<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        match (self.value, other.value) {
+            (Some(val1), Some(val2)) => {
+                // Check for overflow
+                if val1 < val2 {
+                    // Instead of erroring, return 0
+
+                    if Self::result_is_constant(&self, &other) {
+                        // Return constant 0u32
+                        Ok(Self::constant(0u32))
+                    } else {
+                        // Return allocated 0u32
+                        let result_value = Some(0u64);
+                        let modular_value = result_value.map(|v| v as u32);
+
+                        // Storage area for the resulting bits
+                        let mut result_bits = vec![];
+
+                        // This is a linear combination that we will enforce to be "zero"
+                        let mut lc = LinearCombination::zero();
+
+                        // Allocate each bit_gadget of the result
+                        let mut coeff = F::one();
+                        for i in 0..32 {
+                            // Allocate the bit_gadget
+                            let b = AllocatedBit::alloc(
+                                cs.ns(|| format!("result bit_gadget {}", i)),
+                                || result_value.map(|v| (v >> i) & 1 == 1).get(),
+                            )?;
+
+                            // Subtract this bit_gadget from the linear combination to ensure the sums
+                            // balance out
+                            lc = lc - (coeff, b.get_variable());
+
+                            result_bits.push(b.into());
+
+                            coeff.double_in_place();
+                        }
+
+                        // Enforce that the linear combination equals zero
+                        cs.enforce(|| "unsafe subtraction", |lc| lc, |lc| lc, |_| lc);
+
+                        // Discard carry bits that we don't care about
+                        result_bits.truncate(32);
+
+                        Ok(Self {
+                            bits: result_bits,
+                            negated: false,
+                            value: modular_value,
+                        })
+                    }
+                } else {
+                    // Perform subtraction
+                    self.sub(&mut cs.ns(|| ""), &other)
+                }
+            }
+            (_, _) => {
+                // If either of our operands have unknown value, we won't
+                // know the value of the result
+                return Err(SynthesisError::AssignmentMissing);
+            }
+        }
+    }
+
+    /// Bitwise multiplication of two `UInt32` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
+    pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // res = 0;
+        // shifted_self = self;
+        // for bit in other.bits {
+        //   if bit {
+        //     res += shifted_self;
+        //   }
+        //   shifted_self = shifted_self << 1;
+        // }
+        // return res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(0u32);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u32"), || Ok(0u32))?;
+        let zero_result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        let mut left_shift = self.clone();
+
+        let partial_products = other
+            .bits
+            .iter()
+            .enumerate()
+            .map(|(i, bit)| {
+                let current_left_shift = left_shift.clone();
+                left_shift = Self::addmany(
+                    &mut cs.ns(|| format!("shift_left_{}", i)),
+                    &[left_shift.clone(), left_shift.clone()],
+                )
+                .unwrap();
+
+                Self::conditionally_select(
+                    &mut cs.ns(|| format!("calculate_product_{}", i)),
+                    &bit,
+                    &current_left_shift,
+                    &zero_result,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<Self>>();
+
+        Self::addmany(
+            &mut cs.ns(|| format!("partial_products")),
+            &partial_products,
+        )
+    }
+
+    /// Perform long division of two `UInt32` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Division_algorithm
+    pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // if D = 0 then error(DivisionByZeroException) end
+        // Q := 0                  -- Initialize quotient and remainder to zero
+        // R := 0
+        // for i := n − 1 .. 0 do  -- Where n is number of bits in N
+        //   R := R << 1           -- Left-shift R by 1 bit
+        //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
+        //   if R ≥ D then
+        //     R := R − D
+        //     Q(i) := 1
+        //   end
+        // end
+
+        if other.eq(&Self::constant(0u32)) {
+            return Err(SynthesisError::DivisionByZero);
+        }
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+
+        let allocated_true =
+            Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
+        let true_bit = Boolean::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_true"),
+            &is_constant,
+            &Boolean::constant(true),
+            &allocated_true,
+        )?;
+
+        let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1u32))?;
+        let one = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_1u32"),
+            &is_constant,
+            &Self::constant(1u32),
+            &allocated_one,
+        )?;
+
+        let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0u32))?;
+        let zero = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_0u32"),
+            &is_constant,
+            &Self::constant(0u32),
+            &allocated_zero,
+        )?;
+
+        let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0u32)));
+        let mut quotient = zero.clone();
+        let mut remainder = zero.clone();
+
+        for (i, bit) in self.bits.iter().rev().enumerate() {
+            // Left shift remainder by 1
+            remainder = Self::addmany(
+                &mut cs.ns(|| format!("shift_left_{}", i)),
+                &[remainder.clone(), remainder.clone()],
+            )?;
+
+            // Set the least-significant bit of remainder to bit i of the numerator
+            let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
+            let new_remainder = Self::addmany(
+                &mut cs.ns(|| format!("set_remainder_bit_{}", i)),
+                &[remainder.clone(), one.clone()],
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
+                &bit_is_true,
+                &new_remainder,
+                &remainder,
+            )?;
+
+            // Greater than or equal to:
+            //   R >= D
+            //   (R == D) || (R > D)
+            //   (R == D) || ((R !=D) && ((R - D) != 0))
+            //
+            //  (R > D)                     checks subtraction overflow before evaluation
+            //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
+
+            let no_remainder = Boolean::constant(remainder.eq(&other));
+            let subtraction =
+                remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
+            let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0)));
+            let cond1 = Boolean::and(
+                &mut cs.ns(|| format!("cond_1_{}", i)),
+                &no_remainder.not(),
+                &sub_is_zero.not(),
+            )?;
+            let cond2 = Boolean::or(
+                &mut cs.ns(|| format!("cond_2_{}", i)),
+                &no_remainder,
+                &cond1,
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("subtract_or_same_{}", i)),
+                &cond2,
+                &subtraction,
+                &remainder,
+            )?;
+
+            let index = 31 - i as usize;
+            let bit_value = 1u32 << (index as u32);
+            let mut new_quotient = quotient.clone();
+            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
+
+            quotient = Self::conditionally_select(
+                &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
+                &cond2,
+                &new_quotient,
+                &quotient,
+            )?;
+        }
+        Self::conditionally_select(
+            &mut cs.ns(|| "self_or_quotient"),
+            &self_is_zero,
+            self,
+            &quotient,
+        )
+    }
+
+    /// Bitwise multiplication of two `UInt32` objects.
+    /// Reference: /snarkOS/models/src/curves/field.rs
+    pub fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // let mut res = Self::one();
+        //
+        // let mut found_one = false;
+        //
+        // for i in BitIterator::new(exp) {
+        //     if !found_one {
+        //         if i {
+        //             found_one = true;
+        //         } else {
+        //             continue;
+        //         }
+        //     }
+        //
+        //     res.square_in_place();
+        //
+        //     if i {
+        //         res *= self;
+        //     }
+        // }
+        // res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(1u32);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u32"), || Ok(1u32))?;
+        let mut result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        for (i, bit) in other.bits.iter().rev().enumerate() {
+            let found_one = Boolean::Constant(result.eq(&Self::constant(1u32)));
+            let cond1 = Boolean::and(cs.ns(|| format!("found_one_{}", i)), &bit.not(), &found_one)?;
+            let square = result
+                .mul(cs.ns(|| format!("square_{}", i)), &result)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("result_or_sqaure_{}", i)),
+                &cond1,
+                &result,
+                &square,
+            )?;
+
+            let mul_by_self = result
+                .mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("mul_by_self_or_result_{}", i)),
+                &bit,
+                &mul_by_self,
+                &result,
+            )?;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<F: Field> ToBytesGadget<F> for UInt32 {
+    #[inline]
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let value_chunks = match self.value.map(|val| {
+            let mut bytes = [0u8; 4];
+            val.write(bytes.as_mut()).unwrap();
+            bytes
+        }) {
+            Some(chunks) => [
+                Some(chunks[0]),
+                Some(chunks[1]),
+                Some(chunks[2]),
+                Some(chunks[3]),
+            ],
+            None => [None, None, None, None],
+        };
+        let mut bytes = Vec::new();
+        for (i, chunk8) in self.to_bits_le().chunks(8).into_iter().enumerate() {
+            let byte = UInt8 {
+                bits: chunk8.to_vec(),
+                negated: false,
+                value: value_chunks[i],
+            };
+            bytes.push(byte);
+        }
+
+        Ok(bytes)
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(
+        &self,
+        cs: CS,
+    ) -> Result<Vec<UInt8>, SynthesisError> {
+        self.to_bytes(cs)
+    }
+}
+
+impl PartialEq for UInt32 {
+    fn eq(&self, other: &Self) -> bool {
+        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+    }
+}
+
+impl Eq for UInt32 {}
+
+impl<F: Field> EqGadget<F> for UInt32 {}
+
+impl<F: Field> ConditionalEqGadget<F> for UInt32 {
+    fn conditional_enforce_equal<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError> {
+        for (i, (a, b)) in self.bits.iter().zip(&other.bits).enumerate() {
+            a.conditional_enforce_equal(
+                &mut cs.ns(|| format!("uint32_equal_{}", i)),
+                b,
+                condition,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn cost() -> usize {
+        32 * <Boolean as ConditionalEqGadget<F>>::cost()
+    }
+}
+
+impl<F: PrimeField> CondSelectGadget<F> for UInt32 {
+    fn conditionally_select<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        cond: &Boolean,
+        first: &Self,
+        second: &Self,
+    ) -> Result<Self, SynthesisError> {
+        if let Boolean::Constant(cond) = *cond {
+            if cond {
+                Ok(first.clone())
+            } else {
+                Ok(second.clone())
+            }
+        } else {
+            let mut is_negated = false;
+
+            let result_val = cond.get_value().and_then(|c| {
+                if c {
+                    is_negated = first.negated;
+                    first.value
+                } else {
+                    is_negated = second.negated;
+                    second.value
+                }
+            });
+
+            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || {
+                result_val.get().map(|v| v)
+            })?;
+
+            result.negated = is_negated;
+
+            let expected_bits = first
+                .bits
+                .iter()
+                .zip(&second.bits)
+                .enumerate()
+                .map(|(i, (a, b))| {
+                    Boolean::conditionally_select(
+                        &mut cs.ns(|| format!("uint32_cond_select_{}", i)),
+                        cond,
+                        a,
+                        b,
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<Boolean>>();
+
+            for (i, (actual, expected)) in result
+                .to_bits_le()
+                .iter()
+                .zip(expected_bits.iter())
+                .enumerate()
+            {
+                actual.enforce_equal(
+                    &mut cs.ns(|| format!("selected_result_bit_{}", i)),
+                    expected,
+                )?;
+            }
+
+            Ok(result)
+        }
+    }
+
+    fn cost() -> usize {
+        32 * (<Boolean as ConditionalEqGadget<F>>::cost()
+            + <Boolean as CondSelectGadget<F>>::cost())
+    }
+}
+
+impl<F: Field> AllocGadget<u32, F> for UInt32 {
+    fn alloc<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u32>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(32);
+
+                for _ in 0..32 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 32],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+
+    fn alloc_input<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u32>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(32);
+
+                for _ in 0..32 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 32],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc_input(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use snarkos_models::{
+        curves::Field,
+        gadgets::{
+            r1cs::{Fr, TestConstraintSystem},
+            utilities::boolean::Boolean,
+        },
+    };
+
+    use rand::{Rng, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
+    fn check_all_constant_bits(mut expected: u32, actual: UInt32) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(_) => panic!(),
+                &Boolean::Not(_) => panic!(),
+                &Boolean::Constant(b) => {
+                    assert!(b == (expected & 1 == 1));
+                }
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    fn check_all_allocated_bits(mut expected: u32, actual: UInt32) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(ref b) => {
+                    assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Not(ref b) => {
+                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Constant(_) => unreachable!(),
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    #[test]
+    fn test_uint32_from_bits() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let v = (0..32)
+                .map(|_| Boolean::constant(rng.gen()))
+                .collect::<Vec<_>>();
+
+            let b = UInt32::from_bits_le(&v);
+
+            for (i, bit_gadget) in b.bits.iter().enumerate() {
+                match bit_gadget {
+                    &Boolean::Constant(bit_gadget) => {
+                        assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            let expected_to_be_same = b.to_bits_le();
+
+            for x in v.iter().zip(expected_to_be_same.iter()) {
+                match x {
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint32_xor() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+            let c: u32 = rng.gen();
+
+            let mut expected = a ^ b ^ c;
+
+            let a_bit = UInt32::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt32::constant(b);
+            let c_bit = UInt32::alloc(cs.ns(|| "c_bit"), || Ok(c)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "first xor"), &b_bit).unwrap();
+            let r = r.xor(cs.ns(|| "second xor"), &c_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            for b in r.bits.iter() {
+                match b {
+                    &Boolean::Is(ref b) => {
+                        assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Not(ref b) => {
+                        assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Constant(b) => {
+                        assert!(b == (expected & 1 == 1));
+                    }
+                }
+
+                expected >>= 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint32_rotr() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        let mut num = rng.gen();
+
+        let a = UInt32::constant(num);
+
+        for i in 0..32 {
+            let b = a.rotr(i);
+
+            assert!(b.value.unwrap() == num);
+
+            let mut tmp = num;
+            for b in &b.bits {
+                match b {
+                    &Boolean::Constant(b) => {
+                        assert_eq!(b, tmp & 1 == 1);
+                    }
+                    _ => unreachable!(),
+                }
+
+                tmp >>= 1;
+            }
+
+            num = num.rotate_right(1);
+        }
+    }
+
+    #[test]
+    fn test_uint32_addmany_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+            let c: u32 = rng.gen();
+
+            let a_bit = UInt32::constant(a);
+            let b_bit = UInt32::constant(b);
+            let c_bit = UInt32::constant(c);
+
+            let expected = a.wrapping_add(b).wrapping_add(c);
+
+            let r = UInt32::addmany(cs.ns(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint32_addmany() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+            let c: u32 = rng.gen();
+            let d: u32 = rng.gen();
+
+            let expected = (a ^ b).wrapping_add(c).wrapping_add(d);
+
+            let a_bit = UInt32::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt32::constant(b);
+            let c_bit = UInt32::constant(c);
+            let d_bit = UInt32::alloc(cs.ns(|| "d_bit"), || Ok(d)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "xor"), &b_bit).unwrap();
+            let r = UInt32::addmany(cs.ns(|| "addition"), &[r, c_bit, d_bit]).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the addition constraint still works
+            if cs.get("addition/result bit_gadget 0/boolean").is_zero() {
+                cs.set("addition/result bit_gadget 0/boolean", Field::one());
+            } else {
+                cs.set("addition/result bit_gadget 0/boolean", Field::zero());
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint32_sub_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen_range(u32::max_value() / 2u32, u32::max_value());
+            let b: u32 = rng.gen_range(0u32, u32::max_value() / 2u32);
+
+            let a_bit = UInt32::constant(a);
+            let b_bit = UInt32::constant(b);
+
+            let expected = a.wrapping_sub(b);
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint32_sub() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen_range(u32::max_value() / 2u32, u32::max_value());
+            let b: u32 = rng.gen_range(0u32, u32::max_value() / 2u32);
+
+            let expected = a.wrapping_sub(b);
+
+            let a_bit = UInt32::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u32::max_value() / 4 {
+                UInt32::constant(b)
+            } else {
+                UInt32::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the subtraction constraint still works
+            if cs
+                .get("subtraction/add_not/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint32_mul_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+
+            let a_bit = UInt32::constant(a);
+            let b_bit = UInt32::constant(b);
+
+            let expected = a.wrapping_mul(b);
+
+            let r = a_bit.mul(cs.ns(|| "multiply"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint32_mul() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+
+            let expected = a.wrapping_mul(b);
+
+            let a_bit = UInt32::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > (u32::max_value() / 2) {
+                UInt32::constant(b)
+            } else {
+                UInt32::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.mul(cs.ns(|| "multiplication"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the multiplication constraint still works
+            if cs
+                .get("multiplication/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint32_div_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+
+            let a_bit = UInt32::constant(a);
+            let b_bit = UInt32::constant(b);
+
+            let expected = a.wrapping_div(b);
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint32_div() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen();
+            let b: u32 = rng.gen();
+
+            let expected = a.wrapping_div(b);
+
+            let a_bit = UInt32::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u32::max_value() / 2 {
+                UInt32::constant(b)
+            } else {
+                UInt32::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the division constraint still works
+            if cs
+                .get("division/subtract_divisor_0/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint32_pow_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen_range(0, u32::from(u8::max_value()));
+            let b: u32 = rng.gen_range(0, 4);
+
+            let a_bit = UInt32::constant(a);
+            let b_bit = UInt32::constant(b);
+
+            let expected = a.wrapping_pow(b);
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint32_pow() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..10 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u32 = rng.gen_range(0, u32::from(u8::max_value()));
+            let b: u32 = rng.gen_range(0, 4);
+
+            let expected = a.wrapping_pow(b);
+
+            let a_bit = UInt32::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > 2 {
+                UInt32::constant(b)
+            } else {
+                UInt32::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the exponentiation constraint still works
+            if cs
+                .get("exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+}

--- a/gadgets/src/integers/uint64.rs
+++ b/gadgets/src/integers/uint64.rs
@@ -1,0 +1,1362 @@
+use snarkos_errors::gadgets::SynthesisError;
+use snarkos_models::{
+    curves::{Field, FpParameters, PrimeField},
+    gadgets::{
+        r1cs::{Assignment, ConstraintSystem, LinearCombination},
+        utilities::{
+            alloc::AllocGadget,
+            boolean::{AllocatedBit, Boolean},
+            eq::{ConditionalEqGadget, EqGadget},
+            select::CondSelectGadget,
+            uint8::UInt8,
+            ToBytesGadget,
+        },
+    },
+};
+use snarkos_utilities::bytes::ToBytes;
+use std::borrow::Borrow;
+
+/// Represents an interpretation of 64 `Boolean` objects as an
+/// unsigned integer.
+#[derive(Clone, Debug)]
+pub struct UInt64 {
+    // Least significant bit_gadget first
+    pub bits: Vec<Boolean>,
+    pub negated: bool,
+    pub value: Option<u64>,
+}
+
+impl UInt64 {
+    /// Construct a constant `UInt64` from a `u64`
+    pub fn constant(value: u64) -> Self {
+        let mut bits = Vec::with_capacity(64);
+
+        let mut tmp = value;
+        for _ in 0..64 {
+            if tmp & 1 == 1 {
+                bits.push(Boolean::constant(true))
+            } else {
+                bits.push(Boolean::constant(false))
+            }
+
+            tmp >>= 1;
+        }
+
+        Self {
+            bits,
+            negated: false,
+            value: Some(value),
+        }
+    }
+
+    /// Turns this `UInt64` into its little-endian byte order representation.
+    pub fn to_bits_le(&self) -> Vec<Boolean> {
+        self.bits.clone()
+    }
+
+    /// Converts a little-endian byte order representation of bits into a
+    /// `UInt64`.
+    pub fn from_bits_le(bits: &[Boolean]) -> Self {
+        assert_eq!(bits.len(), 64);
+
+        let bits = bits.to_vec();
+
+        let mut value = Some(0u64);
+        for b in bits.iter().rev() {
+            value.as_mut().map(|v| *v <<= 1);
+
+            match b {
+                &Boolean::Constant(b) => {
+                    if b {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                }
+                &Boolean::Is(ref b) => match b.get_value() {
+                    Some(true) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(false) => {}
+                    None => value = None,
+                },
+                &Boolean::Not(ref b) => match b.get_value() {
+                    Some(false) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(true) => {}
+                    None => value = None,
+                },
+            }
+        }
+
+        Self {
+            value,
+            negated: false,
+            bits,
+        }
+    }
+
+    pub fn rotr(&self, by: usize) -> Self {
+        let by = by % 64;
+
+        let new_bits = self
+            .bits
+            .iter()
+            .skip(by)
+            .chain(self.bits.iter())
+            .take(64)
+            .cloned()
+            .collect();
+
+        Self {
+            bits: new_bits,
+            negated: false,
+            value: self.value.map(|v| v.rotate_right(by as u32) as u64),
+        }
+    }
+
+    /// XOR this `UInt64` with another `UInt64`
+    pub fn xor<F, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
+    where
+        F: Field,
+        CS: ConstraintSystem<F>,
+    {
+        let new_value = match (self.value, other.value) {
+            (Some(a), Some(b)) => Some(a ^ b),
+            _ => None,
+        };
+
+        let bits = self
+            .bits
+            .iter()
+            .zip(other.bits.iter())
+            .enumerate()
+            .map(|(i, (a, b))| Boolean::xor(cs.ns(|| format!("xor of bit_gadget {}", i)), a, b))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: new_value,
+        })
+    }
+
+    /// Returns the inverse UInt64
+    pub fn negate(&self) -> Self {
+        Self {
+            bits: self.bits.clone(),
+            negated: true,
+            value: self.value.clone(),
+        }
+    }
+
+    /// Returns true if all bits in this UInt64 are constant
+    fn is_constant(&self) -> bool {
+        let mut constant = true;
+
+        // If any bits of self are allocated bits, return false
+        for bit in &self.bits {
+            match *bit {
+                Boolean::Is(ref _bit) => constant = false,
+                Boolean::Not(ref _bit) => constant = false,
+                Boolean::Constant(_bit) => {}
+            }
+        }
+
+        constant
+    }
+
+    /// Returns true if both UInt64s have constant bits
+    fn result_is_constant(first: &Self, second: &Self) -> bool {
+        // If any bits of first are allocated bits, return false
+        if !first.is_constant() {
+            return false;
+        }
+
+        // If any bits of second are allocated bits, return false
+        second.is_constant()
+    }
+
+    /// Perform modular addition of several `UInt64` objects.
+    pub fn addmany<F, CS>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>
+    where
+        F: PrimeField,
+        CS: ConstraintSystem<F>,
+    {
+        // Make some arbitrary bounds for ourselves to avoid overflows
+        // in the scalar field
+        assert!(F::Params::MODULUS_BITS >= 128);
+        assert!(operands.len() >= 2); // Weird trivial cases that should never happen
+
+        // Compute the maximum value of the sum so we allocate enough bits for
+        // the result
+        let mut max_value = (operands.len() as u128) * u128::from(u64::max_value());
+
+        // Keep track of the resulting value
+        let mut result_value = Some(0u128);
+
+        // This is a linear combination that we will enforce to be "zero"
+        let mut lc = LinearCombination::zero();
+
+        let mut all_constants = true;
+
+        // Iterate over the operands
+        for op in operands {
+            // Accumulate the value
+            match op.value {
+                Some(val) => {
+                    // Subtract or add operand
+                    if op.negated {
+                        // Perform subtraction
+                        result_value.as_mut().map(|v| *v -= u128::from(val));
+                    } else {
+                        // Perform addition
+                        result_value.as_mut().map(|v| *v += u128::from(val));
+                    }
+                }
+                None => {
+                    // If any of our operands have unknown value, we won't
+                    // know the value of the result
+                    result_value = None;
+                }
+            }
+
+            // Iterate over each bit_gadget of the operand and add the operand to
+            // the linear combination
+            let mut coeff = F::one();
+            for bit in &op.bits {
+                match *bit {
+                    Boolean::Is(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // Subtract coeff * bit gadget
+                            lc = lc - (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * bit_gadget
+                            lc = lc + (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Not(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // subtract coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc - (coeff, CS::one()) + (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc + (coeff, CS::one()) - (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Constant(bit) => {
+                        if bit {
+                            if op.negated {
+                                lc = lc - (coeff, CS::one());
+                            } else {
+                                lc = lc + (coeff, CS::one());
+                            }
+                        }
+                    }
+                }
+
+                coeff.double_in_place();
+            }
+        }
+
+        // The value of the actual result is modulo 2^64
+        let modular_value = result_value.map(|v| v as u64);
+
+        if all_constants && modular_value.is_some() {
+            // We can just return a constant, rather than
+            // unpacking the result into allocated bits.
+
+            return Ok(Self::constant(modular_value.unwrap()));
+        }
+
+        // Storage area for the resulting bits
+        let mut result_bits = vec![];
+
+        // Allocate each bit_gadget of the result
+        let mut coeff = F::one();
+        let mut i = 0;
+        while max_value != 0 {
+            // Allocate the bit_gadget
+            let b = AllocatedBit::alloc(cs.ns(|| format!("result bit_gadget {}", i)), || {
+                result_value.map(|v| (v >> i) & 1 == 1).get()
+            })?;
+
+            // Subtract this bit_gadget from the linear combination to ensure the sums
+            // balance out
+            lc = lc - (coeff, b.get_variable());
+
+            result_bits.push(b.into());
+
+            max_value >>= 1;
+            i += 1;
+            coeff.double_in_place();
+        }
+
+        // Enforce that the linear combination equals zero
+        cs.enforce(|| "modular addition", |lc| lc, |lc| lc, |_| lc);
+
+        // Discard carry bits that we don't care about
+        result_bits.truncate(64);
+
+        Ok(Self {
+            bits: result_bits,
+            negated: false,
+            value: modular_value,
+        })
+    }
+
+    /// Perform modular subtraction of two `UInt64` objects.
+    pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // a - b
+        // a + (-b)
+
+        Self::addmany(&mut cs.ns(|| "add_not"), &[self.clone(), other.negate()])
+    }
+
+    /// Perform unsafe subtraction of two `UInt64` objects which returns 0 if overflowed
+    fn sub_unsafe<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        match (self.value, other.value) {
+            (Some(val1), Some(val2)) => {
+                // Check for overflow
+                if val1 < val2 {
+                    // Instead of erroring, return 0
+
+                    if Self::result_is_constant(&self, &other) {
+                        // Return constant 0u64
+                        Ok(Self::constant(0u64))
+                    } else {
+                        // Return allocated 0u64
+                        let result_value = Some(0u64);
+                        let modular_value = result_value.map(|v| v as u64);
+
+                        // Storage area for the resulting bits
+                        let mut result_bits = vec![];
+
+                        // This is a linear combination that we will enforce to be "zero"
+                        let mut lc = LinearCombination::zero();
+
+                        // Allocate each bit_gadget of the result
+                        let mut coeff = F::one();
+                        for i in 0..64 {
+                            // Allocate the bit_gadget
+                            let b = AllocatedBit::alloc(
+                                cs.ns(|| format!("result bit_gadget {}", i)),
+                                || result_value.map(|v| (v >> i) & 1 == 1).get(),
+                            )?;
+
+                            // Subtract this bit_gadget from the linear combination to ensure the sums
+                            // balance out
+                            lc = lc - (coeff, b.get_variable());
+
+                            result_bits.push(b.into());
+
+                            coeff.double_in_place();
+                        }
+
+                        // Enforce that the linear combination equals zero
+                        cs.enforce(|| "unsafe subtraction", |lc| lc, |lc| lc, |_| lc);
+
+                        // Discard carry bits that we don't care about
+                        result_bits.truncate(64);
+
+                        Ok(Self {
+                            bits: result_bits,
+                            negated: false,
+                            value: modular_value,
+                        })
+                    }
+                } else {
+                    // Perform subtraction
+                    self.sub(&mut cs.ns(|| ""), &other)
+                }
+            }
+            (_, _) => {
+                // If either of our operands have unknown value, we won't
+                // know the value of the result
+                return Err(SynthesisError::AssignmentMissing);
+            }
+        }
+    }
+
+    /// Bitwise multiplication of two `UInt64` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
+    pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // res = 0;
+        // shifted_self = self;
+        // for bit in other.bits {
+        //   if bit {
+        //     res += shifted_self;
+        //   }
+        //   shifted_self = shifted_self << 1;
+        // }
+        // return res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(0u64);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u64"), || Ok(0u64))?;
+        let zero_result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        let mut left_shift = self.clone();
+
+        let partial_products = other
+            .bits
+            .iter()
+            .enumerate()
+            .map(|(i, bit)| {
+                let current_left_shift = left_shift.clone();
+                left_shift = Self::addmany(
+                    &mut cs.ns(|| format!("shift_left_{}", i)),
+                    &[left_shift.clone(), left_shift.clone()],
+                )
+                .unwrap();
+
+                Self::conditionally_select(
+                    &mut cs.ns(|| format!("calculate_product_{}", i)),
+                    &bit,
+                    &current_left_shift,
+                    &zero_result,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<Self>>();
+
+        Self::addmany(
+            &mut cs.ns(|| format!("partial_products")),
+            &partial_products,
+        )
+    }
+
+    /// Perform long division of two `UInt64` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Division_algorithm
+    pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // if D = 0 then error(DivisionByZeroException) end
+        // Q := 0                  -- Initialize quotient and remainder to zero
+        // R := 0
+        // for i := n − 1 .. 0 do  -- Where n is number of bits in N
+        //   R := R << 1           -- Left-shift R by 1 bit
+        //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
+        //   if R ≥ D then
+        //     R := R − D
+        //     Q(i) := 1
+        //   end
+        // end
+
+        if other.eq(&Self::constant(0u64)) {
+            return Err(SynthesisError::DivisionByZero);
+        }
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+
+        let allocated_true =
+            Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
+        let true_bit = Boolean::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_true"),
+            &is_constant,
+            &Boolean::constant(true),
+            &allocated_true,
+        )?;
+
+        let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1u64))?;
+        let one = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_1u64"),
+            &is_constant,
+            &Self::constant(1u64),
+            &allocated_one,
+        )?;
+
+        let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0u64))?;
+        let zero = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_0u64"),
+            &is_constant,
+            &Self::constant(0u64),
+            &allocated_zero,
+        )?;
+
+        let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0u64)));
+        let mut quotient = zero.clone();
+        let mut remainder = zero.clone();
+
+        for (i, bit) in self.bits.iter().rev().enumerate() {
+            // Left shift remainder by 1
+            remainder = Self::addmany(
+                &mut cs.ns(|| format!("shift_left_{}", i)),
+                &[remainder.clone(), remainder.clone()],
+            )?;
+
+            // Set the least-significant bit of remainder to bit i of the numerator
+            let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
+            let new_remainder = Self::addmany(
+                &mut cs.ns(|| format!("set_remainder_bit_{}", i)),
+                &[remainder.clone(), one.clone()],
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
+                &bit_is_true,
+                &new_remainder,
+                &remainder,
+            )?;
+
+            // Greater than or equal to:
+            //   R >= D
+            //   (R == D) || (R > D)
+            //   (R == D) || ((R !=D) && ((R - D) != 0))
+            //
+            //  (R > D)                     checks subtraction overflow before evaluation
+            //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
+
+            let no_remainder = Boolean::constant(remainder.eq(&other));
+            let subtraction =
+                remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
+            let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0)));
+            let cond1 = Boolean::and(
+                &mut cs.ns(|| format!("cond_1_{}", i)),
+                &no_remainder.not(),
+                &sub_is_zero.not(),
+            )?;
+            let cond2 = Boolean::or(
+                &mut cs.ns(|| format!("cond_2_{}", i)),
+                &no_remainder,
+                &cond1,
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("subtract_or_same_{}", i)),
+                &cond2,
+                &subtraction,
+                &remainder,
+            )?;
+
+            let index = 63 - i as usize;
+            let bit_value = 1u64 << (index as u64);
+            let mut new_quotient = quotient.clone();
+            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
+
+            quotient = Self::conditionally_select(
+                &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
+                &cond2,
+                &new_quotient,
+                &quotient,
+            )?;
+        }
+        Self::conditionally_select(
+            &mut cs.ns(|| "self_or_quotient"),
+            &self_is_zero,
+            self,
+            &quotient,
+        )
+    }
+
+    /// Bitwise multiplication of two `UInt64` objects.
+    /// Reference: /snarkOS/models/src/curves/field.rs
+    pub fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // let mut res = Self::one();
+        //
+        // let mut found_one = false;
+        //
+        // for i in BitIterator::new(exp) {
+        //     if !found_one {
+        //         if i {
+        //             found_one = true;
+        //         } else {
+        //             continue;
+        //         }
+        //     }
+        //
+        //     res.square_in_place();
+        //
+        //     if i {
+        //         res *= self;
+        //     }
+        // }
+        // res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(1u64);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u64"), || Ok(1u64))?;
+        let mut result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        for (i, bit) in other.bits.iter().rev().enumerate() {
+            let found_one = Boolean::Constant(result.eq(&Self::constant(1u64)));
+            let cond1 = Boolean::and(cs.ns(|| format!("found_one_{}", i)), &bit.not(), &found_one)?;
+            let square = result
+                .mul(cs.ns(|| format!("square_{}", i)), &result)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("result_or_sqaure_{}", i)),
+                &cond1,
+                &result,
+                &square,
+            )?;
+
+            let mul_by_self = result
+                .mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("mul_by_self_or_result_{}", i)),
+                &bit,
+                &mul_by_self,
+                &result,
+            )?;
+        }
+
+        Ok(result)
+    }
+}
+
+impl<F: Field> ToBytesGadget<F> for UInt64 {
+    #[inline]
+    fn to_bytes<CS: ConstraintSystem<F>>(&self, _cs: CS) -> Result<Vec<UInt8>, SynthesisError> {
+        let value_chunks = match self.value.map(|val| {
+            let mut bytes = [0u8; 8];
+            val.write(bytes.as_mut()).unwrap();
+            bytes
+        }) {
+            Some(chunks) => [
+                Some(chunks[0]),
+                Some(chunks[1]),
+                Some(chunks[2]),
+                Some(chunks[3]),
+            ],
+            None => [None, None, None, None],
+        };
+        let mut bytes = Vec::new();
+        for (i, chunk8) in self.to_bits_le().chunks(8).into_iter().enumerate() {
+            let byte = UInt8 {
+                bits: chunk8.to_vec(),
+                negated: false,
+                value: value_chunks[i],
+            };
+            bytes.push(byte);
+        }
+
+        Ok(bytes)
+    }
+
+    fn to_bytes_strict<CS: ConstraintSystem<F>>(
+        &self,
+        cs: CS,
+    ) -> Result<Vec<UInt8>, SynthesisError> {
+        self.to_bytes(cs)
+    }
+}
+
+impl PartialEq for UInt64 {
+    fn eq(&self, other: &Self) -> bool {
+        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+    }
+}
+
+impl Eq for UInt64 {}
+
+impl<F: Field> EqGadget<F> for UInt64 {}
+
+impl<F: Field> ConditionalEqGadget<F> for UInt64 {
+    fn conditional_enforce_equal<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError> {
+        for (i, (a, b)) in self.bits.iter().zip(&other.bits).enumerate() {
+            a.conditional_enforce_equal(
+                &mut cs.ns(|| format!("uint64_equal_{}", i)),
+                b,
+                condition,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn cost() -> usize {
+        64 * <Boolean as ConditionalEqGadget<F>>::cost()
+    }
+}
+
+impl<F: PrimeField> CondSelectGadget<F> for UInt64 {
+    fn conditionally_select<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        cond: &Boolean,
+        first: &Self,
+        second: &Self,
+    ) -> Result<Self, SynthesisError> {
+        if let Boolean::Constant(cond) = *cond {
+            if cond {
+                Ok(first.clone())
+            } else {
+                Ok(second.clone())
+            }
+        } else {
+            let mut is_negated = false;
+
+            let result_val = cond.get_value().and_then(|c| {
+                if c {
+                    is_negated = first.negated;
+                    first.value
+                } else {
+                    is_negated = second.negated;
+                    second.value
+                }
+            });
+
+            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || {
+                result_val.get().map(|v| v)
+            })?;
+
+            result.negated = is_negated;
+
+            let expected_bits = first
+                .bits
+                .iter()
+                .zip(&second.bits)
+                .enumerate()
+                .map(|(i, (a, b))| {
+                    Boolean::conditionally_select(
+                        &mut cs.ns(|| format!("uint64_cond_select_{}", i)),
+                        cond,
+                        a,
+                        b,
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<Boolean>>();
+
+            for (i, (actual, expected)) in result
+                .to_bits_le()
+                .iter()
+                .zip(expected_bits.iter())
+                .enumerate()
+            {
+                actual.enforce_equal(
+                    &mut cs.ns(|| format!("selected_result_bit_{}", i)),
+                    expected,
+                )?;
+            }
+
+            Ok(result)
+        }
+    }
+
+    fn cost() -> usize {
+        64 * (<Boolean as ConditionalEqGadget<F>>::cost()
+            + <Boolean as CondSelectGadget<F>>::cost())
+    }
+}
+
+impl<F: Field> AllocGadget<u64, F> for UInt64 {
+    fn alloc<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u64>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(64);
+
+                for _ in 0..64 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 64],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+
+    fn alloc_input<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u64>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(64);
+
+                for _ in 0..64 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 64],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc_input(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use snarkos_models::{
+        curves::Field,
+        gadgets::{
+            r1cs::{Fr, TestConstraintSystem},
+            utilities::boolean::Boolean,
+        },
+    };
+
+    use rand::{Rng, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+    use std::convert::TryInto;
+
+    fn check_all_constant_bits(mut expected: u64, actual: UInt64) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(_) => panic!(),
+                &Boolean::Not(_) => panic!(),
+                &Boolean::Constant(b) => {
+                    assert!(b == (expected & 1 == 1));
+                }
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    fn check_all_allocated_bits(mut expected: u64, actual: UInt64) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(ref b) => {
+                    assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Not(ref b) => {
+                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Constant(_) => unreachable!(),
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    #[test]
+    fn test_uint64_from_bits() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let v = (0..64)
+                .map(|_| Boolean::constant(rng.gen()))
+                .collect::<Vec<_>>();
+
+            let b = UInt64::from_bits_le(&v);
+
+            for (i, bit_gadget) in b.bits.iter().enumerate() {
+                match bit_gadget {
+                    &Boolean::Constant(bit_gadget) => {
+                        assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            let expected_to_be_same = b.to_bits_le();
+
+            for x in v.iter().zip(expected_to_be_same.iter()) {
+                match x {
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint64_xor() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+            let c: u64 = rng.gen();
+
+            let mut expected = a ^ b ^ c;
+
+            let a_bit = UInt64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt64::constant(b);
+            let c_bit = UInt64::alloc(cs.ns(|| "c_bit"), || Ok(c)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "first xor"), &b_bit).unwrap();
+            let r = r.xor(cs.ns(|| "second xor"), &c_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            for b in r.bits.iter() {
+                match b {
+                    &Boolean::Is(ref b) => {
+                        assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Not(ref b) => {
+                        assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Constant(b) => {
+                        assert!(b == (expected & 1 == 1));
+                    }
+                }
+
+                expected >>= 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint64_rotr() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        let mut num = rng.gen();
+
+        let a = UInt64::constant(num);
+
+        for i in 0..64 {
+            let b = a.rotr(i);
+
+            assert!(b.value.unwrap() == num);
+
+            let mut tmp = num;
+            for b in &b.bits {
+                match b {
+                    &Boolean::Constant(b) => {
+                        assert_eq!(b, tmp & 1 == 1);
+                    }
+                    _ => unreachable!(),
+                }
+
+                tmp >>= 1;
+            }
+
+            num = num.rotate_right(1);
+        }
+    }
+
+    #[test]
+    fn test_uint64_addmany_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+            let c: u64 = rng.gen();
+
+            let a_bit = UInt64::constant(a);
+            let b_bit = UInt64::constant(b);
+            let c_bit = UInt64::constant(c);
+
+            let expected = a.wrapping_add(b).wrapping_add(c);
+
+            let r = UInt64::addmany(cs.ns(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint64_addmany() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+            let c: u64 = rng.gen();
+            let d: u64 = rng.gen();
+
+            let expected = (a ^ b).wrapping_add(c).wrapping_add(d);
+
+            let a_bit = UInt64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt64::constant(b);
+            let c_bit = UInt64::constant(c);
+            let d_bit = UInt64::alloc(cs.ns(|| "d_bit"), || Ok(d)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "xor"), &b_bit).unwrap();
+            let r = UInt64::addmany(cs.ns(|| "addition"), &[r, c_bit, d_bit]).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the addition constraint still works
+            if cs.get("addition/result bit_gadget 0/boolean").is_zero() {
+                cs.set("addition/result bit_gadget 0/boolean", Field::one());
+            } else {
+                cs.set("addition/result bit_gadget 0/boolean", Field::zero());
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint64_sub_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen_range(u64::max_value() / 2u64, u64::max_value());
+            let b: u64 = rng.gen_range(0u64, u64::max_value() / 2u64);
+
+            let a_bit = UInt64::constant(a);
+            let b_bit = UInt64::constant(b);
+
+            let expected = a.wrapping_sub(b);
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint64_sub() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen_range(u64::max_value() / 2u64, u64::max_value());
+            let b: u64 = rng.gen_range(0u64, u64::max_value() / 2u64);
+
+            let expected = a.wrapping_sub(b);
+
+            let a_bit = UInt64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u64::max_value() / 4 {
+                UInt64::constant(b)
+            } else {
+                UInt64::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the subtraction constraint still works
+            if cs
+                .get("subtraction/add_not/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint64_mul_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+
+            let a_bit = UInt64::constant(a);
+            let b_bit = UInt64::constant(b);
+
+            let expected = a.wrapping_mul(b);
+
+            let r = a_bit.mul(cs.ns(|| "multiply"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint64_mul() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+
+            let expected = a.wrapping_mul(b);
+
+            let a_bit = UInt64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > (u64::max_value() / 2) {
+                UInt64::constant(b)
+            } else {
+                UInt64::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.mul(cs.ns(|| "multiplication"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the multiplication constraint still works
+            if cs
+                .get("multiplication/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint64_div_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+
+            let a_bit = UInt64::constant(a);
+            let b_bit = UInt64::constant(b);
+
+            let expected = a.wrapping_div(b);
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint64_div() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen();
+            let b: u64 = rng.gen();
+
+            let expected = a.wrapping_div(b);
+
+            let a_bit = UInt64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u64::max_value() / 2 {
+                UInt64::constant(b)
+            } else {
+                UInt64::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the division constraint still works
+            if cs
+                .get("division/subtract_divisor_0/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint64_pow_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen_range(0, u64::from(u16::max_value()));
+            let b: u64 = rng.gen_range(0, 4);
+
+            let a_bit = UInt64::constant(a);
+            let b_bit = UInt64::constant(b);
+
+            let expected = a.wrapping_pow(b.try_into().unwrap());
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint64_pow() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..4 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u64 = rng.gen_range(0, u64::from(u16::max_value()));
+            let b: u64 = rng.gen_range(0, 4);
+
+            let expected = a.wrapping_pow(b.try_into().unwrap());
+
+            let a_bit = UInt64::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt64::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap();
+
+            println!("num constraints before {}", cs.num_constraints());
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+            println!("num constraints after {}\n", cs.num_constraints());
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the exponentiation constraint still works
+            if cs
+                .get("exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+}

--- a/gadgets/src/integers/uint8.rs
+++ b/gadgets/src/integers/uint8.rs
@@ -1,0 +1,1407 @@
+use snarkos_errors::gadgets::SynthesisError;
+use snarkos_models::{
+    curves::{to_field_vec::ToConstraintField, Field, FpParameters, PrimeField},
+    gadgets::{
+        curves::fp::FpGadget,
+        r1cs::{Assignment, ConstraintSystem, LinearCombination},
+        utilities::{
+            alloc::AllocGadget,
+            boolean::{AllocatedBit, Boolean},
+            eq::{ConditionalEqGadget, EqGadget},
+            select::CondSelectGadget,
+            ToBitsGadget,
+        },
+    },
+};
+
+use std::borrow::Borrow;
+
+/// Represents an interpretation of 8 `Boolean` objects as an
+/// unsigned integer.
+#[derive(Clone, Debug)]
+pub struct UInt8 {
+    // Least significant bit_gadget first
+    pub bits: Vec<Boolean>,
+    pub negated: bool,
+    pub value: Option<u8>,
+}
+
+impl UInt8 {
+    /// Construct a constant vector of `UInt8` from a vector of `u8`
+    pub fn constant_vec(values: &[u8]) -> Vec<Self> {
+        let mut result = Vec::new();
+        for value in values {
+            result.push(UInt8::constant(*value));
+        }
+        result
+    }
+
+    /// Construct a constant `UInt8` from a `u8`
+    pub fn constant(value: u8) -> Self {
+        let mut bits = Vec::with_capacity(8);
+
+        let mut tmp = value;
+        for _ in 0..8 {
+            // If last bit is one, push one.
+            if tmp & 1 == 1 {
+                bits.push(Boolean::constant(true))
+            } else {
+                bits.push(Boolean::constant(false))
+            }
+
+            tmp >>= 1;
+        }
+
+        Self {
+            bits,
+            negated: false,
+            value: Some(value),
+        }
+    }
+
+    pub fn alloc_vec<F, CS, T>(mut cs: CS, values: &[T]) -> Result<Vec<Self>, SynthesisError>
+    where
+        F: Field,
+        CS: ConstraintSystem<F>,
+        T: Into<Option<u8>> + Copy,
+    {
+        let mut output_vec = Vec::with_capacity(values.len());
+        for (i, value) in values.into_iter().enumerate() {
+            let byte: Option<u8> = Into::into(*value);
+            let alloc_byte = Self::alloc(&mut cs.ns(|| format!("byte_{}", i)), || byte.get())?;
+            output_vec.push(alloc_byte);
+        }
+        Ok(output_vec)
+    }
+
+    /// Allocates a vector of `u8`'s by first converting (chunks of) them to
+    /// `F` elements, (thus reducing the number of input allocations),
+    /// and then converts this list of `F` gadgets back into
+    /// bytes.
+    pub fn alloc_input_vec<F, CS>(mut cs: CS, values: &[u8]) -> Result<Vec<Self>, SynthesisError>
+    where
+        F: PrimeField,
+        CS: ConstraintSystem<F>,
+    {
+        let values_len = values.len();
+        let field_elements: Vec<F> = ToConstraintField::<F>::to_field_elements(values).unwrap();
+
+        let max_size = 8 * (F::Params::CAPACITY / 8) as usize;
+        let mut allocated_bits = Vec::new();
+        for (i, field_element) in field_elements.into_iter().enumerate() {
+            let fe = FpGadget::alloc_input(&mut cs.ns(|| format!("Field element {}", i)), || {
+                Ok(field_element)
+            })?;
+            let mut fe_bits = fe.to_bits(cs.ns(|| format!("Convert fe to bits {}", i)))?;
+            // FpGadget::to_bits outputs a big-endian binary representation of
+            // fe_gadget's value, so we have to reverse it to get the little-endian
+            // form.
+            fe_bits.reverse();
+
+            // Remove the most significant bit, because we know it should be zero
+            // because `values.to_field_elements()` only
+            // packs field elements up to the penultimate bit.
+            // That is, the most significant bit (`F::NUM_BITS`-th bit) is
+            // unset, so we can just pop it off.
+            allocated_bits.extend_from_slice(&fe_bits[0..max_size]);
+        }
+
+        // Chunk up slices of 8 bit into bytes.
+        Ok(allocated_bits[0..8 * values_len]
+            .chunks(8)
+            .map(Self::from_bits_le)
+            .collect())
+    }
+
+    /// Turns this `UInt8` into its little-endian byte order representation.
+    /// LSB-first means that we can easily get the corresponding field element
+    /// via double and add.
+    pub fn into_bits_le(&self) -> Vec<Boolean> {
+        self.bits.iter().cloned().collect()
+    }
+
+    /// Converts a little-endian byte order representation of bits into a
+    /// `UInt8`.
+    pub fn from_bits_le(bits: &[Boolean]) -> Self {
+        assert_eq!(bits.len(), 8);
+
+        let bits = bits.to_vec();
+
+        let mut value = Some(0u8);
+        for b in bits.iter().rev() {
+            value.as_mut().map(|v| *v <<= 1);
+
+            match *b {
+                Boolean::Constant(b) => {
+                    if b {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                }
+                Boolean::Is(ref b) => match b.get_value() {
+                    Some(true) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(false) => {}
+                    None => value = None,
+                },
+                Boolean::Not(ref b) => match b.get_value() {
+                    Some(false) => {
+                        value.as_mut().map(|v| *v |= 1);
+                    }
+                    Some(true) => {}
+                    None => value = None,
+                },
+            }
+        }
+
+        Self {
+            value,
+            negated: false,
+            bits,
+        }
+    }
+
+    pub fn rotr(&self, by: usize) -> Self {
+        let by = by % 8;
+
+        let new_bits = self
+            .bits
+            .iter()
+            .skip(by)
+            .chain(self.bits.iter())
+            .take(8)
+            .cloned()
+            .collect();
+
+        Self {
+            bits: new_bits,
+            negated: false,
+            value: self.value.map(|v| v.rotate_right(by as u32) as u8),
+        }
+    }
+
+    /// XOR this `UInt8` with another `UInt8`
+    pub fn xor<F, CS>(&self, mut cs: CS, other: &Self) -> Result<Self, SynthesisError>
+    where
+        F: Field,
+        CS: ConstraintSystem<F>,
+    {
+        let new_value = match (self.value, other.value) {
+            (Some(a), Some(b)) => Some(a ^ b),
+            _ => None,
+        };
+
+        let bits = self
+            .bits
+            .iter()
+            .zip(other.bits.iter())
+            .enumerate()
+            .map(|(i, (a, b))| Boolean::xor(cs.ns(|| format!("xor of bit_gadget {}", i)), a, b))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: new_value,
+        })
+    }
+
+    /// Returns the inverse `UInt8`
+    pub fn negate(&self) -> Self {
+        Self {
+            bits: self.bits.clone(),
+            negated: true,
+            value: self.value.clone(),
+        }
+    }
+
+    /// Returns true if all bits in this `UInt8` are constant
+    fn is_constant(&self) -> bool {
+        let mut constant = true;
+
+        // If any bits of self are allocated bits, return false
+        for bit in &self.bits {
+            match *bit {
+                Boolean::Is(ref _bit) => constant = false,
+                Boolean::Not(ref _bit) => constant = false,
+                Boolean::Constant(_bit) => {}
+            }
+        }
+
+        constant
+    }
+
+    /// Returns true if both `UInt8` objects have constant bits
+    fn result_is_constant(first: &Self, second: &Self) -> bool {
+        // If any bits of first are allocated bits, return false
+        if !first.is_constant() {
+            return false;
+        }
+
+        // If any bits of second are allocated bits, return false
+        second.is_constant()
+    }
+
+    /// Perform modular addition of several `UInt8` objects.
+    pub fn addmany<F, CS>(mut cs: CS, operands: &[Self]) -> Result<Self, SynthesisError>
+    where
+        F: PrimeField,
+        CS: ConstraintSystem<F>,
+    {
+        // Make some arbitrary bounds for ourselves to avoid overflows
+        // in the scalar field
+        assert!(F::Params::MODULUS_BITS >= 64);
+        assert!(operands.len() >= 2); // Weird trivial cases that should never happen
+
+        // Compute the maximum value of the sum so we allocate enough bits for
+        // the result
+        let mut max_value = (operands.len() as u64) * u64::from(u8::max_value());
+
+        // Keep track of the resulting value
+        let mut result_value = Some(0u64);
+
+        // This is a linear combination that we will enforce to be "zero"
+        let mut lc = LinearCombination::zero();
+
+        let mut all_constants = true;
+
+        // Iterate over the operands
+        for op in operands {
+            // Accumulate the value
+            match op.value {
+                Some(val) => {
+                    // Subtract or add operand
+                    if op.negated {
+                        // Perform subtraction
+                        result_value.as_mut().map(|v| *v -= u64::from(val));
+                    } else {
+                        // Perform addition
+                        result_value.as_mut().map(|v| *v += u64::from(val));
+                    }
+                }
+                None => {
+                    // If any of our operands have unknown value, we won't
+                    // know the value of the result
+                    result_value = None;
+                }
+            }
+
+            // Iterate over each bit_gadget of the operand and add the operand to
+            // the linear combination
+            let mut coeff = F::one();
+            for bit in &op.bits {
+                match *bit {
+                    Boolean::Is(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // Subtract coeff * bit gadget
+                            lc = lc - (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * bit_gadget
+                            lc = lc + (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Not(ref bit) => {
+                        all_constants = false;
+
+                        if op.negated {
+                            // subtract coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc - (coeff, CS::one()) + (coeff, bit.get_variable());
+                        } else {
+                            // Add coeff * (1 - bit_gadget) = coeff * ONE - coeff * bit_gadget
+                            lc = lc + (coeff, CS::one()) - (coeff, bit.get_variable());
+                        }
+                    }
+                    Boolean::Constant(bit) => {
+                        if bit {
+                            if op.negated {
+                                lc = lc - (coeff, CS::one());
+                            } else {
+                                lc = lc + (coeff, CS::one());
+                            }
+                        }
+                    }
+                }
+
+                coeff.double_in_place();
+            }
+        }
+
+        // The value of the actual result is modulo 2^32
+        let modular_value = result_value.map(|v| v as u8);
+
+        if all_constants && modular_value.is_some() {
+            // We can just return a constant, rather than
+            // unpacking the result into allocated bits.
+
+            return Ok(Self::constant(modular_value.unwrap()));
+        }
+
+        // Storage area for the resulting bits
+        let mut result_bits = vec![];
+
+        // Allocate each bit_gadget of the result
+        let mut coeff = F::one();
+        let mut i = 0;
+        while max_value != 0 {
+            // Allocate the bit_gadget
+            let b = AllocatedBit::alloc(cs.ns(|| format!("result bit_gadget {}", i)), || {
+                result_value.map(|v| (v >> i) & 1 == 1).get()
+            })?;
+
+            // Subtract this bit_gadget from the linear combination to ensure the sums
+            // balance out
+            lc = lc - (coeff, b.get_variable());
+
+            result_bits.push(b.into());
+
+            max_value >>= 1;
+            i += 1;
+            coeff.double_in_place();
+        }
+
+        // Enforce that the linear combination equals zero
+        cs.enforce(|| "modular addition", |lc| lc, |lc| lc, |_| lc);
+
+        // Discard carry bits that we don't care about
+        result_bits.truncate(8);
+
+        Ok(Self {
+            bits: result_bits,
+            negated: false,
+            value: modular_value,
+        })
+    }
+
+    /// Perform modular subtraction of two `UInt8` objects.
+    pub fn sub<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // a - b
+        // a + (-b)
+
+        Self::addmany(&mut cs.ns(|| "add_not"), &[self.clone(), other.negate()])
+    }
+
+    /// Perform unsafe subtraction of two `UInt8` objects which returns 0 if overflowed
+    fn sub_unsafe<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        match (self.value, other.value) {
+            (Some(val1), Some(val2)) => {
+                // Check for overflow
+                if val1 < val2 {
+                    // Instead of erroring, return 0
+
+                    if Self::result_is_constant(&self, &other) {
+                        // Return constant 0u32
+                        Ok(Self::constant(0u8))
+                    } else {
+                        // Return allocated 0u32
+                        let result_value = Some(0u64);
+                        let modular_value = result_value.map(|v| v as u8);
+
+                        // Storage area for the resulting bits
+                        let mut result_bits = vec![];
+
+                        // This is a linear combination that we will enforce to be "zero"
+                        let mut lc = LinearCombination::zero();
+
+                        // Allocate each bit_gadget of the result
+                        let mut coeff = F::one();
+                        for i in 0..8 {
+                            // Allocate the bit_gadget
+                            let b = AllocatedBit::alloc(
+                                cs.ns(|| format!("result bit_gadget {}", i)),
+                                || result_value.map(|v| (v >> i) & 1 == 1).get(),
+                            )?;
+
+                            // Subtract this bit_gadget from the linear combination to ensure the sums
+                            // balance out
+                            lc = lc - (coeff, b.get_variable());
+
+                            result_bits.push(b.into());
+
+                            coeff.double_in_place();
+                        }
+
+                        // Enforce that the linear combination equals zero
+                        cs.enforce(|| "unsafe subtraction", |lc| lc, |lc| lc, |_| lc);
+
+                        // Discard carry bits that we don't care about
+                        result_bits.truncate(8);
+
+                        Ok(Self {
+                            bits: result_bits,
+                            negated: false,
+                            value: modular_value,
+                        })
+                    }
+                } else {
+                    // Perform subtraction
+                    self.sub(&mut cs.ns(|| ""), &other)
+                }
+            }
+            (_, _) => {
+                // If either of our operands have unknown value, we won't
+                // know the value of the result
+                return Err(SynthesisError::AssignmentMissing);
+            }
+        }
+    }
+
+    /// Bitwise multiplication of two `UInt8` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Binary_multiplier
+    pub fn mul<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // res = 0;
+        // shifted_self = self;
+        // for bit in other.bits {
+        //   if bit {
+        //     res += shifted_self;
+        //   }
+        //   shifted_self = shifted_self << 1;
+        // }
+        // return res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(0u8);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u32"), || Ok(0u8))?;
+        let zero_result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        let mut left_shift = self.clone();
+
+        let partial_products = other
+            .bits
+            .iter()
+            .enumerate()
+            .map(|(i, bit)| {
+                let current_left_shift = left_shift.clone();
+                left_shift = Self::addmany(
+                    &mut cs.ns(|| format!("shift_left_{}", i)),
+                    &[left_shift.clone(), left_shift.clone()],
+                )
+                .unwrap();
+
+                Self::conditionally_select(
+                    &mut cs.ns(|| format!("calculate_product_{}", i)),
+                    &bit,
+                    &current_left_shift,
+                    &zero_result,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<Self>>();
+
+        Self::addmany(
+            &mut cs.ns(|| format!("partial_products")),
+            &partial_products,
+        )
+    }
+
+    /// Perform long division of two `UInt8` objects.
+    /// Reference: https://en.wikipedia.org/wiki/Division_algorithm
+    pub fn div<F: PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // pseudocode:
+        //
+        // if D = 0 then error(DivisionByZeroException) end
+        // Q := 0                  -- Initialize quotient and remainder to zero
+        // R := 0
+        // for i := n − 1 .. 0 do  -- Where n is number of bits in N
+        //   R := R << 1           -- Left-shift R by 1 bit
+        //   R(0) := N(i)          -- Set the least-significant bit of R equal to bit i of the numerator
+        //   if R ≥ D then
+        //     R := R − D
+        //     Q(i) := 1
+        //   end
+        // end
+
+        if other.eq(&Self::constant(0u8)) {
+            return Err(SynthesisError::DivisionByZero);
+        }
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+
+        let allocated_true =
+            Boolean::from(AllocatedBit::alloc(&mut cs.ns(|| "true"), || Ok(true)).unwrap());
+        let true_bit = Boolean::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_true"),
+            &is_constant,
+            &Boolean::constant(true),
+            &allocated_true,
+        )?;
+
+        let allocated_one = Self::alloc(&mut cs.ns(|| "one"), || Ok(1u8))?;
+        let one = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_1u32"),
+            &is_constant,
+            &Self::constant(1u8),
+            &allocated_one,
+        )?;
+
+        let allocated_zero = Self::alloc(&mut cs.ns(|| "zero"), || Ok(0u8))?;
+        let zero = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated_0u32"),
+            &is_constant,
+            &Self::constant(0u8),
+            &allocated_zero,
+        )?;
+
+        let self_is_zero = Boolean::Constant(self.eq(&Self::constant(0u8)));
+        let mut quotient = zero.clone();
+        let mut remainder = zero.clone();
+
+        for (i, bit) in self.bits.iter().rev().enumerate() {
+            // Left shift remainder by 1
+            remainder = Self::addmany(
+                &mut cs.ns(|| format!("shift_left_{}", i)),
+                &[remainder.clone(), remainder.clone()],
+            )?;
+
+            // Set the least-significant bit of remainder to bit i of the numerator
+            let bit_is_true = Boolean::constant(bit.eq(&Boolean::constant(true)));
+            let new_remainder = Self::addmany(
+                &mut cs.ns(|| format!("set_remainder_bit_{}", i)),
+                &[remainder.clone(), one.clone()],
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("increment_or_remainder_{}", i)),
+                &bit_is_true,
+                &new_remainder,
+                &remainder,
+            )?;
+
+            // Greater than or equal to:
+            //   R >= D
+            //   (R == D) || (R > D)
+            //   (R == D) || ((R !=D) && ((R - D) != 0))
+            //
+            //  (R > D)                     checks subtraction overflow before evaluation
+            //  (R != D) && ((R - D) != 0)  instead evaluate subtraction and check for overflow after
+
+            let no_remainder = Boolean::constant(remainder.eq(&other));
+            let subtraction =
+                remainder.sub_unsafe(&mut cs.ns(|| format!("subtract_divisor_{}", i)), &other)?;
+            let sub_is_zero = Boolean::constant(subtraction.eq(&Self::constant(0)));
+            let cond1 = Boolean::and(
+                &mut cs.ns(|| format!("cond_1_{}", i)),
+                &no_remainder.not(),
+                &sub_is_zero.not(),
+            )?;
+            let cond2 = Boolean::or(
+                &mut cs.ns(|| format!("cond_2_{}", i)),
+                &no_remainder,
+                &cond1,
+            )?;
+
+            remainder = Self::conditionally_select(
+                &mut cs.ns(|| format!("subtract_or_same_{}", i)),
+                &cond2,
+                &subtraction,
+                &remainder,
+            )?;
+
+            let index = 7 - i as usize;
+            let bit_value = 1u8 << (index as u8);
+            let mut new_quotient = quotient.clone();
+            new_quotient.bits[index] = true_bit.clone();
+            new_quotient.value = Some(new_quotient.value.unwrap() + bit_value);
+
+            quotient = Self::conditionally_select(
+                &mut cs.ns(|| format!("set_bit_or_same_{}", i)),
+                &cond2,
+                &new_quotient,
+                &quotient,
+            )?;
+        }
+        Self::conditionally_select(
+            &mut cs.ns(|| "self_or_quotient"),
+            &self_is_zero,
+            self,
+            &quotient,
+        )
+    }
+
+    /// Bitwise multiplication of two `UInt8` objects.
+    /// Reference: /snarkOS/models/src/curves/field.rs
+    pub fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+    ) -> Result<Self, SynthesisError> {
+        // let mut res = Self::one();
+        //
+        // let mut found_one = false;
+        //
+        // for i in BitIterator::new(exp) {
+        //     if !found_one {
+        //         if i {
+        //             found_one = true;
+        //         } else {
+        //             continue;
+        //         }
+        //     }
+        //
+        //     res.square_in_place();
+        //
+        //     if i {
+        //         res *= self;
+        //     }
+        // }
+        // res
+
+        let is_constant = Boolean::constant(Self::result_is_constant(&self, &other));
+        let constant_result = Self::constant(1u8);
+        let allocated_result = Self::alloc(&mut cs.ns(|| "allocated_1u32"), || Ok(1u8))?;
+        let mut result = Self::conditionally_select(
+            &mut cs.ns(|| "constant_or_allocated"),
+            &is_constant,
+            &constant_result,
+            &allocated_result,
+        )?;
+
+        for (i, bit) in other.bits.iter().rev().enumerate() {
+            let found_one = Boolean::Constant(result.eq(&Self::constant(1u8)));
+            let cond1 = Boolean::and(cs.ns(|| format!("found_one_{}", i)), &bit.not(), &found_one)?;
+            let square = result
+                .mul(cs.ns(|| format!("square_{}", i)), &result)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("result_or_sqaure_{}", i)),
+                &cond1,
+                &result,
+                &square,
+            )?;
+
+            let mul_by_self = result
+                .mul(cs.ns(|| format!("multiply_by_self_{}", i)), &self)
+                .unwrap();
+
+            result = Self::conditionally_select(
+                &mut cs.ns(|| format!("mul_by_self_or_result_{}", i)),
+                &bit,
+                &mul_by_self,
+                &result,
+            )?;
+        }
+
+        Ok(result)
+    }
+}
+
+impl PartialEq for UInt8 {
+    fn eq(&self, other: &Self) -> bool {
+        !self.value.is_none() && !other.value.is_none() && self.value == other.value
+    }
+}
+
+impl Eq for UInt8 {}
+
+impl<F: Field> EqGadget<F> for UInt8 {}
+
+impl<F: Field> ConditionalEqGadget<F> for UInt8 {
+    fn conditional_enforce_equal<CS: ConstraintSystem<F>>(
+        &self,
+        mut cs: CS,
+        other: &Self,
+        condition: &Boolean,
+    ) -> Result<(), SynthesisError> {
+        for (i, (a, b)) in self.bits.iter().zip(&other.bits).enumerate() {
+            a.conditional_enforce_equal(
+                &mut cs.ns(|| format!("UInt8 equality check for {}-th bit", i)),
+                b,
+                condition,
+            )?;
+        }
+        Ok(())
+    }
+
+    fn cost() -> usize {
+        8 * <Boolean as ConditionalEqGadget<F>>::cost()
+    }
+}
+
+impl<F: PrimeField> CondSelectGadget<F> for UInt8 {
+    fn conditionally_select<CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        cond: &Boolean,
+        first: &Self,
+        second: &Self,
+    ) -> Result<Self, SynthesisError> {
+        if let Boolean::Constant(cond) = *cond {
+            if cond {
+                Ok(first.clone())
+            } else {
+                Ok(second.clone())
+            }
+        } else {
+            let mut is_negated = false;
+
+            let result_val = cond.get_value().and_then(|c| {
+                if c {
+                    is_negated = first.negated;
+                    first.value
+                } else {
+                    is_negated = second.negated;
+                    second.value
+                }
+            });
+
+            let mut result = Self::alloc(cs.ns(|| "cond_select_result"), || {
+                result_val.get().map(|v| v)
+            })?;
+
+            result.negated = is_negated;
+
+            let expected_bits = first
+                .bits
+                .iter()
+                .zip(&second.bits)
+                .enumerate()
+                .map(|(i, (a, b))| {
+                    Boolean::conditionally_select(
+                        &mut cs.ns(|| format!("uint8_cond_select_{}", i)),
+                        cond,
+                        a,
+                        b,
+                    )
+                    .unwrap()
+                })
+                .collect::<Vec<Boolean>>();
+
+            for (i, (actual, expected)) in result
+                .into_bits_le()
+                .iter()
+                .zip(expected_bits.iter())
+                .enumerate()
+            {
+                actual.enforce_equal(
+                    &mut cs.ns(|| format!("selected_result_bit_{}", i)),
+                    expected,
+                )?;
+            }
+
+            Ok(result)
+        }
+    }
+
+    fn cost() -> usize {
+        8 * (<Boolean as ConditionalEqGadget<F>>::cost() + <Boolean as CondSelectGadget<F>>::cost())
+    }
+}
+
+impl<F: Field> AllocGadget<u8, F> for UInt8 {
+    fn alloc<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u8>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(8);
+
+                for _ in 0..8 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 8],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+
+    fn alloc_input<Fn, T, CS: ConstraintSystem<F>>(
+        mut cs: CS,
+        value_gen: Fn,
+    ) -> Result<Self, SynthesisError>
+    where
+        Fn: FnOnce() -> Result<T, SynthesisError>,
+        T: Borrow<u8>,
+    {
+        let value = value_gen().map(|val| *val.borrow());
+        let values = match value {
+            Ok(mut val) => {
+                let mut v = Vec::with_capacity(8);
+                for _ in 0..8 {
+                    v.push(Some(val & 1 == 1));
+                    val >>= 1;
+                }
+
+                v
+            }
+            _ => vec![None; 8],
+        };
+
+        let bits = values
+            .into_iter()
+            .enumerate()
+            .map(|(i, v)| {
+                Ok(Boolean::from(AllocatedBit::alloc_input(
+                    &mut cs.ns(|| format!("allocated bit_gadget {}", i)),
+                    || v.ok_or(SynthesisError::AssignmentMissing),
+                )?))
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        Ok(Self {
+            bits,
+            negated: false,
+            value: value.ok(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use snarkos_models::gadgets::r1cs::{Fr, TestConstraintSystem};
+
+    use rand::{Rng, SeedableRng};
+    use rand_xorshift::XorShiftRng;
+
+    fn check_all_constant_bits(mut expected: u8, actual: UInt8) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(_) => panic!(),
+                &Boolean::Not(_) => panic!(),
+                &Boolean::Constant(b) => {
+                    assert!(b == (expected & 1 == 1));
+                }
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    fn check_all_allocated_bits(mut expected: u8, actual: UInt8) {
+        for b in actual.bits.iter() {
+            match b {
+                &Boolean::Is(ref b) => {
+                    assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Not(ref b) => {
+                    assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                }
+                &Boolean::Constant(_) => unreachable!(),
+            }
+
+            expected >>= 1;
+        }
+    }
+
+    #[test]
+    fn test_uint8_from_bits_to_bits() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let byte_val = 0b01110001;
+        let byte = UInt8::alloc(cs.ns(|| "alloc value"), || Ok(byte_val)).unwrap();
+        let bits = byte.into_bits_le();
+        for (i, bit) in bits.iter().enumerate() {
+            assert_eq!(bit.get_value().unwrap(), (byte_val >> i) & 1 == 1)
+        }
+    }
+
+    #[test]
+    fn test_uint8_alloc_input_vec() {
+        let mut cs = TestConstraintSystem::<Fr>::new();
+        let byte_vals = (64u8..128u8).into_iter().collect::<Vec<_>>();
+        let bytes = UInt8::alloc_input_vec(cs.ns(|| "alloc value"), &byte_vals).unwrap();
+        for (native_byte, gadget_byte) in byte_vals.into_iter().zip(bytes) {
+            let bits = gadget_byte.into_bits_le();
+            for (i, bit) in bits.iter().enumerate() {
+                assert_eq!(bit.get_value().unwrap(), (native_byte >> i) & 1 == 1)
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint8_from_bits() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let v = (0..8)
+                .map(|_| Boolean::constant(rng.gen()))
+                .collect::<Vec<_>>();
+
+            let b = UInt8::from_bits_le(&v);
+
+            for (i, bit_gadget) in b.bits.iter().enumerate() {
+                match bit_gadget {
+                    &Boolean::Constant(bit_gadget) => {
+                        assert!(bit_gadget == ((b.value.unwrap() >> i) & 1 == 1));
+                    }
+                    _ => unreachable!(),
+                }
+            }
+
+            let expected_to_be_same = b.into_bits_le();
+
+            for x in v.iter().zip(expected_to_be_same.iter()) {
+                match x {
+                    (&Boolean::Constant(true), &Boolean::Constant(true)) => {}
+                    (&Boolean::Constant(false), &Boolean::Constant(false)) => {}
+                    _ => unreachable!(),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint8_xor() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen();
+            let c: u8 = rng.gen();
+
+            let mut expected = a ^ b ^ c;
+
+            let a_bit = UInt8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt8::constant(b);
+            let c_bit = UInt8::alloc(cs.ns(|| "c_bit"), || Ok(c)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "first xor"), &b_bit).unwrap();
+            let r = r.xor(cs.ns(|| "second xor"), &c_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            for b in r.bits.iter() {
+                match b {
+                    &Boolean::Is(ref b) => {
+                        assert!(b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Not(ref b) => {
+                        assert!(!b.get_value().unwrap() == (expected & 1 == 1));
+                    }
+                    &Boolean::Constant(b) => {
+                        assert!(b == (expected & 1 == 1));
+                    }
+                }
+
+                expected >>= 1;
+            }
+        }
+    }
+
+    #[test]
+    fn test_uint8_rotr() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        let mut num = rng.gen();
+
+        let a = UInt8::constant(num);
+
+        for i in 0..8 {
+            let b = a.rotr(i);
+
+            assert!(b.value.unwrap() == num);
+
+            let mut tmp = num;
+            for b in &b.bits {
+                match b {
+                    &Boolean::Constant(b) => {
+                        assert_eq!(b, tmp & 1 == 1);
+                    }
+                    _ => unreachable!(),
+                }
+
+                tmp >>= 1;
+            }
+
+            num = num.rotate_right(1);
+        }
+    }
+
+    #[test]
+    fn test_uint8_addmany_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen();
+            let c: u8 = rng.gen();
+
+            let a_bit = UInt8::constant(a);
+            let b_bit = UInt8::constant(b);
+            let c_bit = UInt8::constant(c);
+
+            let expected = a.wrapping_add(b).wrapping_add(c);
+
+            let r = UInt8::addmany(cs.ns(|| "addition"), &[a_bit, b_bit, c_bit]).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint8_addmany() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen();
+            let c: u8 = rng.gen();
+            let d: u8 = rng.gen();
+
+            let expected = (a ^ b).wrapping_add(c).wrapping_add(d);
+
+            let a_bit = UInt8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = UInt8::constant(b);
+            let c_bit = UInt8::constant(c);
+            let d_bit = UInt8::alloc(cs.ns(|| "d_bit"), || Ok(d)).unwrap();
+
+            let r = a_bit.xor(cs.ns(|| "xor"), &b_bit).unwrap();
+            let r = UInt8::addmany(cs.ns(|| "addition"), &[r, c_bit, d_bit]).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the addition constraint still works
+            if cs.get("addition/result bit_gadget 0/boolean").is_zero() {
+                cs.set("addition/result bit_gadget 0/boolean", Field::one());
+            } else {
+                cs.set("addition/result bit_gadget 0/boolean", Field::zero());
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint8_sub_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen_range(u8::max_value() / 2u8, u8::max_value());
+            let b: u8 = rng.gen_range(0u8, u8::max_value() / 2u8);
+
+            let a_bit = UInt8::constant(a);
+            let b_bit = UInt8::constant(b);
+
+            let expected = a.wrapping_sub(b);
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint8_sub() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen_range(u8::max_value() / 2u8, u8::max_value());
+            let b: u8 = rng.gen_range(0u8, u8::max_value() / 2u8);
+
+            let expected = a.wrapping_sub(b);
+
+            let a_bit = UInt8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u8::max_value() / 4 {
+                UInt8::constant(b)
+            } else {
+                UInt8::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.sub(cs.ns(|| "subtraction"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the subtraction constraint still works
+            if cs
+                .get("subtraction/add_not/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "subtraction/add_not/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint8_mul_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen_range(0, u8::max_value());
+            let b: u8 = rng.gen_range(0, u8::max_value());
+
+            let a_bit = UInt8::constant(a);
+            let b_bit = UInt8::constant(b);
+
+            let expected = a.wrapping_mul(b);
+
+            let r = a_bit.mul(cs.ns(|| "multiply"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint8_mul() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen_range(0, u8::max_value());
+            let b: u8 = rng.gen_range(0, u8::max_value());
+
+            let expected = a.wrapping_mul(b);
+
+            let a_bit = UInt8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u8::max_value() / 2 {
+                UInt8::constant(b)
+            } else {
+                UInt8::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.mul(cs.ns(|| "multiplication"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the multiplication constraint still works
+            if cs
+                .get("multiplication/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "multiplication/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint8_div_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen_range(1, u8::max_value());
+
+            let a_bit = UInt8::constant(a);
+            let b_bit = UInt8::constant(b);
+
+            let expected = a.wrapping_div(b);
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint8_div() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen_range(1, u8::max_value());
+
+            let expected = a.wrapping_div(b);
+
+            let a_bit = UInt8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u8::max_value() / 2 {
+                UInt8::constant(b)
+            } else {
+                UInt8::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.div(cs.ns(|| "division"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the division constraint still works
+            if cs
+                .get("division/subtract_divisor_0/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "division/subtract_divisor_0/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+
+    #[test]
+    fn test_uint8_pow_constants() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..1000 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen();
+
+            let a_bit = UInt8::constant(a);
+            let b_bit = UInt8::constant(b);
+
+            let expected = a.wrapping_pow(b.into());
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(r.value == Some(expected));
+
+            check_all_constant_bits(expected, r);
+        }
+    }
+
+    #[test]
+    fn test_uint8_pow() {
+        let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+        for _ in 0..100 {
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let a: u8 = rng.gen();
+            let b: u8 = rng.gen();
+
+            let expected = a.wrapping_pow(b.into());
+
+            let a_bit = UInt8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();
+            let b_bit = if b > u8::max_value() / 2 {
+                UInt8::constant(b)
+            } else {
+                UInt8::alloc(cs.ns(|| "b_bit"), || Ok(b)).unwrap()
+            };
+
+            let r = a_bit.pow(cs.ns(|| "exponentiation"), &b_bit).unwrap();
+
+            assert!(cs.is_satisfied());
+
+            assert!(r.value == Some(expected));
+
+            check_all_allocated_bits(expected, r);
+
+            // Flip a bit_gadget and see if the exponentiation constraint still works
+            if cs
+                .get("exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean")
+                .is_zero()
+            {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::one(),
+                );
+            } else {
+                cs.set(
+                    "exponentiation/multiply_by_self_0/partial_products/result bit_gadget 0/boolean",
+                    Field::zero(),
+                );
+            }
+
+            assert!(!cs.is_satisfied());
+        }
+    }
+}

--- a/gadgets/src/lib.rs
+++ b/gadgets/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod integers;


### PR DESCRIPTION
### Changes
- [x]  moves `uint8`, `uint16`, `uint32`, `uint64`, `uint128` gadgets into leo