### PR TITLE
require spacing after keywords and add optional comma after circuit fields

### DIFF
--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -183,13 +183,13 @@ circuit = { "circuit " ~ identifier ~ "{" ~ NEWLINE* ~ circuit_member* ~ NEWLINE
 circuit_field = { identifier ~ ":" ~ expression }
 
 // Declared in circuits/circuit_field_definition.rs
-circuit_field_definition = { identifier ~ ":" ~ type_ ~ NEWLINE* }
+circuit_field_definition = { identifier ~ ":" ~ type_ ~ ","?}
 
 // Declared in circuits/circuit_function.rs
 circuit_function = { static_? ~ function_definition }
 
 // Declared in circuits/circuit_member.rs
-circuit_member = { circuit_function | circuit_field_definition }
+circuit_member = { circuit_function | circuit_field_definition ~ NEWLINE*}
 
 /// Conditionals
 

--- a/compiler/tests/circuits/member_field.leo
+++ b/compiler/tests/circuits/member_field.leo
@@ -1,5 +1,5 @@
 circuit Circ {
-  x: u32
+  x: u32,
 }
 
 function main() -> u32 {

--- a/compiler/tests/circuits/member_field_and_function.leo
+++ b/compiler/tests/circuits/member_field_and_function.leo
@@ -1,5 +1,5 @@
 circuit Foo {
-    foo: u32
+    foo: u32,
 
     static function bar() -> u32 {
         return 0


### PR DESCRIPTION
Fixes issue where pest parser does not check for space after keywords.
```
letmut a:u32 = 1+1; // old
let mut a: u32 = 1+1; //new
```
Adds optional comma after circuit fields
```
circuit Foo {
    a: field  //old   
}

circuit Foo {
    a: field,   //new
}
```