### PR TITLE
Fix signed integer division

### DIFF
--- a/compiler/tests/integers/int_macro.rs
+++ b/compiler/tests/integers/int_macro.rs
@@ -118,7 +118,7 @@ macro_rules! test_int {
                     // make sure that we can calculate the inverse of each number
                     // Leo signed integer division is non-wrapping. Thus attempting to calculate a
                     // division result that wraps should be ignored here.
-                    if a.checked_neg().is_none() || b.checked_neg().is_none() {
+                    if a.checked_neg().is_none() {
                         continue;
                     }
 

--- a/gadgets/tests/signed_integer/i8.rs
+++ b/gadgets/tests/signed_integer/i8.rs
@@ -282,12 +282,16 @@ fn test_int8_div_constants() {
     for _ in 0..1000 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i8 = rng.gen_range(-127i8, i8::MAX);
-        let b: i8 = rng.gen_range(-127i8, i8::MAX);
+        let a: i8 = rng.gen();
+        let b: i8 = rng.gen();
+
+        if a.checked_neg().is_none() {
+            return;
+        }
 
         let expected = match a.checked_div(b) {
             Some(valid) => valid,
-            None => continue,
+            None => return,
         };
 
         let a_bit = Int8::constant(a);
@@ -308,12 +312,16 @@ fn test_int8_div() {
     for _ in 0..100 {
         let mut cs = TestConstraintSystem::<Fr>::new();
 
-        let a: i8 = rng.gen_range(-127i8, i8::MAX);
-        let b: i8 = rng.gen_range(-127i8, i8::MAX);
+        let a: i8 = rng.gen();
+        let b: i8 = rng.gen();
+
+        if a.checked_neg().is_none() {
+            continue;
+        }
 
         let expected = match a.checked_div(b) {
             Some(valid) => valid,
-            None => continue,
+            None => return,
         };
 
         let a_bit = Int8::alloc(cs.ns(|| "a_bit"), || Ok(a)).unwrap();


### PR DESCRIPTION
## Motivation

Fixes #138 
The current signed integer division fails when dividing the minimum value.
Example failure: `let result: i8 = 1 / -128;`

The reason for the failure is that the division algorithm evaluates the two's complement of the denominator during calculation.
`-128` has no inverse.

However, since our division algorithm rounds to 0 we know the result when the denominator is the minimum the result will be 0 or 1.
* `let result: i8 = -128 / -128; // = 1`
* `let result: i8 =  x / -128; // = 0`

We add two additional checks to the division algorithm to implement the above cases.
The gadget tests and compiler tests have been updated for all signed integers.