### PR TITLE
fix leo new and leo init to generate state files

### DIFF
--- a/leo/commands/init.rs
+++ b/leo/commands/init.rs
@@ -76,8 +76,15 @@ impl CLI for InitCommand {
             // Verify the input file does not exist
             let input_file = InputFile::new(&package_name);
             if !input_file.exists_at(&path) {
-                // Create the input file in the input directory
+                // Create the input file in the inputs directory
                 input_file.write_to(&path)?;
+            }
+
+            // Verify the state file does not exist
+            let state_file = StateFile::new(&package_name);
+            if !state_file.exists_at(&path) {
+                // Create the state file in the inputs directory
+                state_file.write_to(&path)?;
             }
 
             // Verify the main file does not exist

--- a/leo/commands/new.rs
+++ b/leo/commands/new.rs
@@ -90,8 +90,11 @@ impl CLI for NewCommand {
             // Create the input directory
             InputsDirectory::create(&path)?;
 
-            // Create the input file in the input directory
+            // Create the input file in the inputs directory
             InputFile::new(&package_name).write_to(&path)?;
+
+            // Create the state file in the inputs directory
+            StateFile::new(&package_name).write_to(&path)?;
 
             // Create the main file in the source directory
             MainFile::new(&package_name).write_to(&path)?;

--- a/package/src/inputs/input.rs
+++ b/package/src/inputs/input.rs
@@ -50,6 +50,9 @@ impl InputFile {
 [main]
 a: u32 = 1;
 b: u32 = 2;
+
+[registers]
+r0: u32 = 0;
 "#,
             self.package_name
         )


### PR DESCRIPTION
## Motivation

Fixes #130 

`leo new` and `leo init` now correctly generate state files. All leo commands can be run afterward successfully.