### PR TITLE
allow newlines and trailing commas in function declarations

### DIFF
--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -191,7 +191,7 @@ type_circuit = { identifier }
 // Declared in types/array_type.rs
 type_array = { type_data ~ ("[" ~ number_positive ~ "]")+ }
 
-type_tuple = { "(" ~ type_ ~ ("," ~ type_)+ ~ ")" }
+type_tuple = { "(" ~ NEWLINE* ~ type_ ~ ("," ~ NEWLINE* ~ type_)+ ~ ","? ~ NEWLINE* ~ ")" }
 
 /// Values
 
@@ -381,7 +381,7 @@ input = {
     function_input
     | input_keyword
 }
-input_tuple = _{ "(" ~(input ~ ("," ~ NEWLINE* ~ input)*)? ~ ")"}
+input_tuple = _{ "(" ~ NEWLINE* ~ (input ~ ("," ~ NEWLINE* ~ input)* ~ ","?)? ~ NEWLINE* ~ ")"}
 
 
 /// Imports

--- a/compiler/tests/function/input/newlines.in
+++ b/compiler/tests/function/input/newlines.in
@@ -1,0 +1,7 @@
+[main]
+a: u32 = 0;
+b: u32 = 0;
+
+[registers]
+a: u32 = 0;
+b: u32 = 0;

--- a/compiler/tests/function/mod.rs
+++ b/compiler/tests/function/mod.rs
@@ -42,6 +42,20 @@ fn test_iteration_repeated() {
 }
 
 #[test]
+fn test_newlines() {
+    let input_bytes = include_bytes!("input/newlines.in");
+    let program_bytes = include_bytes!("newlines.leo");
+    let program = parse_program_with_input(program_bytes, input_bytes).unwrap();
+
+    let expected_bytes = include_bytes!("output_/newlines.out");
+    let expected = std::str::from_utf8(expected_bytes).unwrap();
+    let actual_bytes = get_output(program);
+    let actual = std::str::from_utf8(actual_bytes.bytes().as_slice()).unwrap();
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn test_multiple_returns() {
     let bytes = include_bytes!("multiple.leo");
     let program = parse_program(bytes).unwrap();

--- a/compiler/tests/function/newlines.leo
+++ b/compiler/tests/function/newlines.leo
@@ -1,0 +1,9 @@
+function main(
+    a: u32,
+    b: u32,
+) -> (
+    u32,
+    u32,
+) {
+    return (a, b)
+}

--- a/compiler/tests/function/output_/newlines.out
+++ b/compiler/tests/function/output_/newlines.out
@@ -1,0 +1,3 @@
+[registers]
+a: u32 = 0u32;
+b: u32 = 0u32;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Allows for newlines and commas in function definitions.
Need for dp1 examples

## Test Plan

Test with multiple function arguments + multiple returns + trailing commas has been added
