### PR TITLE
Restrict zipped package files in `leo publish`

### DIFF
--- a/package/src/source/directory.rs
+++ b/package/src/source/directory.rs
@@ -20,7 +20,7 @@ use std::{fs, path::PathBuf};
 
 pub static SOURCE_DIRECTORY_NAME: &str = "src/";
 
-static SOURCE_FILE_EXTENSION: &str = "leo";
+pub static SOURCE_FILE_EXTENSION: &str = ".leo";
 
 pub struct SourceDirectory;
 
@@ -61,7 +61,7 @@ impl SourceDirectory {
             let file_extension = file_path
                 .extension()
                 .ok_or_else(|| SourceDirectoryError::GettingFileExtension(file_path.as_os_str().to_owned()))?;
-            if file_extension != SOURCE_FILE_EXTENSION {
+            if file_extension != SOURCE_FILE_EXTENSION.trim_start_matches(".") {
                 return Err(SourceDirectoryError::InvalidFileExtension(
                     file_path.as_os_str().to_owned(),
                     file_extension.to_owned(),


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Previously, `leo publish` allowed users to upload arbitrary files and file formats. This PR updates how `leo publish` selects files in the package to zip.

Currently `publish` only zips the `README.md` + `Leo.toml` files in the package root directory and all `.leo` files in the `src/` directory (including nested directories holding `.leo` files).


`leo publish` currently does not verify the contents of the package files.