### PR TITLE
Add README.md generation to `leo new`

### DIFF
--- a/leo/commands/new.rs
+++ b/leo/commands/new.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 use leo_package::{
     inputs::*,
-    root::{Gitignore, Manifest},
+    root::{Gitignore, Manifest, README},
     source::{LibFile, MainFile, SourceDirectory},
 };
 
@@ -94,6 +94,9 @@ impl CLI for NewCommand {
 
         // Create the .gitignore file
         Gitignore::new().write_to(&path)?;
+
+        // Create the README.md file
+        README::new(&package_name).write_to(&path)?;
 
         // Create the source directory
         SourceDirectory::create(&path)?;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR updates the `leo new` command to generate a default `README.md` file in the same fashion as `leo init`.