### PR TITLE
Fix default license to MIT

### DIFF
--- a/package/src/root/manifest.rs
+++ b/package/src/root/manifest.rs
@@ -99,7 +99,7 @@ name = "{name}"
 version = "0.1.0"
 description = "The {name} package"
 remote = "[AUTHOR]/{name}"
-license = "LICENSE-MIT"
+license = "MIT"
 "#,
             name = self.package.name
         )


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR fixes the default license in the `leo.toml` file from "LICENSE-MIT" to "MIT".