### PR TITLE
Update leo.toml remote convention

### DIFF
--- a/leo/commands/publish.rs
+++ b/leo/commands/publish.rs
@@ -107,8 +107,8 @@ impl CLI for PublishCommand {
         zip_file.write(&path)?;
 
         let form_data = Form::new()
-            .text("name", package_name)
-            .text("remote", package_remote)
+            .text("name", package_name.clone())
+            .text("remote", format!("{}/{}", package_remote.author, package_name))
             .text("version", package_version)
             .file("file", zip_file.get_file_path(&path))?;
 

--- a/package/src/root/manifest.rs
+++ b/package/src/root/manifest.rs
@@ -106,7 +106,7 @@ description = "The {name} package"
 license = "MIT"
 
 [remote]
-author = "[AUTHOR]"
+author = "[AUTHOR]" # Add your Aleo Package Manager username, team's name, or organization's name.
 "#,
             name = self.package.name
         )
@@ -122,7 +122,7 @@ impl TryFrom<&PathBuf> for Manifest {
             path.push(PathBuf::from(MANIFEST_FILE_NAME));
         }
 
-        let mut file = File::open(path).map_err(|error| ManifestError::Opening(MANIFEST_FILE_NAME, error))?;
+        let mut file = File::open(path.clone()).map_err(|error| ManifestError::Opening(MANIFEST_FILE_NAME, error))?;
         let size = file
             .metadata()
             .map_err(|error| ManifestError::Metadata(MANIFEST_FILE_NAME, error))?
@@ -132,6 +132,65 @@ impl TryFrom<&PathBuf> for Manifest {
         file.read_to_string(&mut buffer)
             .map_err(|error| ManifestError::Reading(MANIFEST_FILE_NAME, error))?;
 
-        Ok(toml::from_str(&buffer).map_err(|error| ManifestError::Parsing(MANIFEST_FILE_NAME, error))?)
+        // Determine if the old remote format is being used, and update to new convention
+
+        let mut old_remote_format: Option<&str> = None;
+        let mut new_remote_format_exists = false;
+
+        let mut new_toml = "".to_owned();
+
+        // Read each individual line of the toml file
+        for line in buffer.lines() {
+            // Determine if the old remote format is being used
+            if line.starts_with("remote") {
+                let remote = line
+                    .split("=") // Split the line as 'remote' = '"{author}/{package_name}"'
+                    .collect::<Vec<&str>>()[1]; // Fetch just '"{author}/{package_name}"'
+                old_remote_format = Some(remote);
+                continue;
+            }
+
+            // Determine if the new remote format is being used
+            if line.starts_with("[remote]") {
+                new_remote_format_exists = true;
+            }
+            new_toml += line;
+            new_toml += "\n";
+        }
+
+        // Update the remote format
+        if let Some(old_remote) = old_remote_format {
+            // If both the old remote and new remote are missing,
+            // then skip appending the new remote, just keep the old remote.
+            if !new_remote_format_exists {
+                // Fetch the author from the old remote.
+                let remote_author = old_remote
+                    .split("/") // Split the old remote as '"{author}' and '{package_name}"'
+                    .collect::<Vec<&str>>()[0] // Fetch just the '"{author}'
+                    .replace(&['\"', ' '][..], ""); // Remove the quotes from the author string
+
+                // Construct the new remote section.
+                let new_remote = format!(
+                    r#"
+[remote]
+author = "{author}"
+"#,
+                    author = remote_author
+                );
+
+                // Append the new remote to the bottom of the manifest file.
+                new_toml += &new_remote;
+            }
+        }
+
+        // Rewrite the toml file if it has been updated
+        if buffer != new_toml {
+            let mut file = File::create(&path).map_err(|error| ManifestError::Creating(MANIFEST_FILE_NAME, error))?;
+            file.write_all(new_toml.as_bytes())
+                .map_err(|error| ManifestError::Writing(MANIFEST_FILE_NAME, error))?;
+        }
+
+        // Read the toml file
+        Ok(toml::from_str(&new_toml).map_err(|error| ManifestError::Parsing(MANIFEST_FILE_NAME, error))?)
     }
 }

--- a/package/src/root/manifest.rs
+++ b/package/src/root/manifest.rs
@@ -26,13 +26,18 @@ use std::{
 
 pub const MANIFEST_FILE_NAME: &str = "Leo.toml";
 
+#[derive(Clone, Deserialize)]
+pub struct Remote {
+    pub author: String,
+}
+
 #[derive(Deserialize)]
 pub struct Package {
     pub name: String,
     pub version: String,
     pub description: Option<String>,
     pub license: Option<String>,
-    pub remote: Option<String>,
+    pub remote: Option<Remote>,
 }
 
 #[derive(Deserialize)]
@@ -77,7 +82,7 @@ impl Manifest {
         self.package.license.clone()
     }
 
-    pub fn get_package_remote(&self) -> Option<String> {
+    pub fn get_package_remote(&self) -> Option<Remote> {
         self.package.remote.clone()
     }
 
@@ -98,8 +103,10 @@ impl Manifest {
 name = "{name}"
 version = "0.1.0"
 description = "The {name} package"
-remote = "[AUTHOR]/{name}"
 license = "MIT"
+
+[remote]
+author = "[AUTHOR]"
 "#,
             name = self.package.name
         )


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR updates the remote convention in the `leo.toml` file from 

``` remote = "{author}/{package_name}"```

to

```
[remote]
author = "{author}"
```

Additionally, the new implementation will automatically detect and replace the old remote formats.