### PR TITLE
Restrict pest grammar rule for array initializers

### DIFF
--- a/ast/src/expressions/array_initializer_expression.rs
+++ b/ast/src/expressions/array_initializer_expression.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ast::Rule, common::SpreadOrExpression, values::PositiveNumber, SpanDef};
+use crate::{ast::Rule, expressions::Expression, values::PositiveNumber, SpanDef};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -23,7 +23,7 @@ use serde::Serialize;
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::expression_array_initializer))]
 pub struct ArrayInitializerExpression<'ast> {
-    pub expression: Box<SpreadOrExpression<'ast>>,
+    pub expression: Box<Expression<'ast>>,
     pub count: PositiveNumber<'ast>,
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -324,7 +324,7 @@ expression = { expression_term ~ (operation_binary ~ expression_term)* }
 expression_tuple = { "(" ~ (expression ~ ("," ~ expression)*)? ~ ")" }
 
 // Declared in expressions/array_initializer_expression.rs
-expression_array_initializer = { "[" ~ spread_or_expression ~ ";" ~ number_positive ~ "]" }
+expression_array_initializer = { "[" ~ expression ~ ";" ~ number_positive ~ "]" }
 
 // Declared in expressions/array_inline_expression.rs
 expression_array_inline = { "[" ~ NEWLINE* ~ inline_array_inner ~ NEWLINE* ~ "]"}

--- a/typed/src/common/spread_or_expression.rs
+++ b/typed/src/common/spread_or_expression.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::Expression;
-use leo_ast::common::SpreadOrExpression as AstSpreadOrExpression;
+use leo_ast::{common::SpreadOrExpression as AstSpreadOrExpression, expressions::Expression as AstExpression};
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -35,6 +35,12 @@ impl<'ast> From<AstSpreadOrExpression<'ast>> for SpreadOrExpression {
                 SpreadOrExpression::Expression(Expression::from(expression))
             }
         }
+    }
+}
+
+impl<'ast> From<AstExpression<'ast>> for SpreadOrExpression {
+    fn from(expression: AstExpression<'ast>) -> Self {
+        SpreadOrExpression::Expression(Expression::from(expression))
     }
 }
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #199 

Removes unused `spread_or_expression` rule from array initializers.
