### PR TITLE
Simplify pest grammar rule for conditional statements

### DIFF
--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -359,7 +359,7 @@ statement = {
 statement_assign = { assignee ~ operation_assign ~ expression ~ LINE_END }
 
 // Declared in statements/conditional_statement.rs
-statement_conditional = {"if " ~ (expression | "(" ~ expression ~ ")") ~ "{" ~ NEWLINE* ~ statement+ ~ "}" ~ ("else " ~ conditional_nested_or_end_statement)?}
+statement_conditional = {"if " ~ expression ~ "{" ~ NEWLINE* ~ statement+ ~ "}" ~ ("else " ~ conditional_nested_or_end_statement)?}
 conditional_nested_or_end_statement = { statement_conditional | "{" ~ NEWLINE* ~ statement+ ~ "}"}
 
 // Declared in statements/definition_statement.rs


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #200 

Removes redundant parenthesis check in the conditional statement pest rule.