### PR TITLE
restrict comments and logs to ascii

### DIFF
--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -128,7 +128,7 @@ operation_pow_assign = { "**=" }
 /// Types
 
 // Declared in types/type_.rs
-type_ = { type_self | type_tuple |  type_array | type_data | type_circuit }
+type_ = { type_self | type_tuple | type_array | type_data | type_circuit }
 
 // Declared in types/integer_type.rs
 type_integer = {
@@ -425,7 +425,7 @@ import_symbol = { identifier ~ ("as " ~ identifier)? }
 
 /// Utilities
 
-COMMENT = _{ ("/*" ~ (!"*/" ~ ANY)* ~ "*/") | ("//" ~ (!NEWLINE ~ ANY)*) }
+COMMENT = _{ ("/*" ~ (!"*/" ~ ASCII)* ~ "*/") | ("//" ~ (!NEWLINE ~ ASCII)*) }
 WHITESPACE = _{ " " | "\t" ~ (NEWLINE)* } // pest implicit whitespace keyword
 
 /// Console Functions
@@ -459,7 +459,7 @@ console_log = !{"log(" ~ formatted_string? ~ ")"}
 // Declared in console/formatted_string.rs
 formatted_string = {
     "\""
-    ~ (!"\"" ~ (formatted_container | ANY))*
+    ~ (!"\"" ~ (formatted_container | ASCII))*
     ~ "\""
     ~ ("," ~ formatted_parameter)*
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #202 

Replaces pest's `ANY` keyword with `ASCII` to restrict Leo to ASCII characters only.
Previously `ANY` was only used in comments and formatted strings so there are no major changes to Leo code rules.
