### PR TITLE
Add compiler check for signed integer array access

### DIFF
--- a/compiler/src/errors/value/integer.rs
+++ b/compiler/src/errors/value/integer.rs
@@ -83,8 +83,9 @@ impl IntegerError {
     }
 
     pub fn invalid_index(span: Span) -> Self {
-        let message =
-            format!("index must be a constant value integer. allocated indices produce a circuit of unknown size");
+        let message = format!(
+            "index must be a constant value unsigned integer. allocated indices produce a circuit of unknown size"
+        );
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -154,7 +154,10 @@ impl Integer {
     }
 
     pub fn to_usize(&self, span: Span) -> Result<usize, IntegerError> {
-        let value = self.get_value().ok_or(IntegerError::invalid_index(span.clone()))?;
+        let unsigned_integer = self;
+        let value_option: Option<String> = match_unsigned_integer!(unsigned_integer => unsigned_integer.get_value());
+
+        let value = value_option.ok_or(IntegerError::invalid_index(span.clone()))?;
         let value_usize = value
             .parse::<usize>()
             .map_err(|_| IntegerError::invalid_integer(value, span))?;

--- a/compiler/src/value/integer/macros.rs
+++ b/compiler/src/value/integer/macros.rs
@@ -66,6 +66,21 @@ macro_rules! match_integer {
 }
 
 #[macro_export]
+macro_rules! match_unsigned_integer {
+    ($integer: ident => $expression: expr) => {
+        match $integer {
+            Integer::U8($integer) => $expression,
+            Integer::U16($integer) => $expression,
+            Integer::U32($integer) => $expression,
+            Integer::U64($integer) => $expression,
+            Integer::U128($integer) => $expression,
+
+            _ => None,
+        }
+    };
+}
+
+#[macro_export]
 macro_rules! match_signed_integer {
     ($integer: ident, $span: ident => $expression: expr) => {
         match $integer {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #276 

Prevents signed integers from being used as array indices. Only unsigned integers are allowed.
