### PR TITLE
Add newline after each successful test run

### DIFF
--- a/compiler/src/constraints/constraints.rs
+++ b/compiler/src/constraints/constraints.rs
@@ -127,7 +127,7 @@ pub fn generate_test_constraints<F: Field + PrimeField, G: GroupType<F>>(
 
         match (result.is_ok(), cs.is_satisfied()) {
             (true, true) => {
-                tracing::info!("{} ... ok", full_test_name);
+                tracing::info!("{} ... ok\n", full_test_name);
 
                 // write result to file
                 let output = result?;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Improve readability of test output.

**before**
```
        Test Running 3 tests
        Test silly-sudoku::test_solve_fail ... ok
        Test silly-sudoku::test_solve_pass ... ok
        Test expected true, got true
        Test silly-sudoku::test_solve_with_input ... ok
    Finished Tests passed in 128 milliseconds. 3 passed; 0 failed;
```

**after**
```
        Test Running 3 tests
        Test silly-sudoku::test_solve_pass ... ok

        Test silly-sudoku::test_solve_fail ... ok

        Test expected true, got true
        Test silly-sudoku::test_solve_with_input ... ok

    Finished Tests passed in 111 milliseconds. 3 passed; 0 failed;
```