### PR TITLE
Refactor/keywords

### DIFF
--- a/ast/src/common/self_keyword.rs
+++ b/ast/src/common/self_keyword.rs
@@ -14,44 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod assignee;
-pub use assignee::*;
+use crate::{
+    ast::{span_into_string, Rule},
+    SpanDef,
+};
 
-pub mod declare;
-pub use declare::*;
+use pest::Span;
+use pest_ast::FromPest;
+use serde::Serialize;
 
-pub mod eoi;
-pub use eoi::*;
-
-pub mod identifier;
-pub use identifier::*;
-
-pub mod line_end;
-pub use line_end::*;
-
-pub mod mutable;
-pub use mutable::*;
-
-pub mod range;
-pub use range::*;
-
-pub mod range_or_expression;
-pub use range_or_expression::*;
-
-pub mod self_keyword;
-pub use self_keyword::*;
-
-pub mod spread;
-pub use spread::*;
-
-pub mod spread_or_expression;
-pub use spread_or_expression::*;
-
-pub mod static_;
-pub use static_::*;
-
-pub mod variables;
-pub use variables::*;
-
-pub mod variable_name;
-pub use variable_name::*;
+#[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
+#[pest_ast(rule(Rule::self_keyword))]
+pub struct SelfKeyword<'ast> {
+    #[pest_ast(outer(with(span_into_string)))]
+    pub keyword: String,
+    #[pest_ast(outer())]
+    #[serde(with = "SpanDef")]
+    pub span: Span<'ast>,
+}

--- a/ast/src/expressions/circuit_inline_expression.rs
+++ b/ast/src/expressions/circuit_inline_expression.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ast::Rule, circuits::CircuitVariable, common::Identifier, SpanDef};
+use crate::{ast::Rule, circuits::CircuitVariable, common::Identifier, types::SelfType, SpanDef};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -23,9 +23,16 @@ use serde::Serialize;
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::expression_circuit_inline))]
 pub struct CircuitInlineExpression<'ast> {
-    pub identifier: Identifier<'ast>,
+    pub name: CircuitName<'ast>,
     pub members: Vec<CircuitVariable<'ast>>,
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]
     pub span: Span<'ast>,
+}
+
+#[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
+#[pest_ast(rule(Rule::circuit_name))]
+pub enum CircuitName<'ast> {
+    SelfType(SelfType<'ast>),
+    Identifier(Identifier<'ast>),
 }

--- a/ast/src/expressions/postfix_expression.rs
+++ b/ast/src/expressions/postfix_expression.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{access::Access, ast::Rule, common::Identifier, SpanDef};
+use crate::{access::Access, ast::Rule, common::Identifier, functions::InputKeyword, SpanDef};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -23,9 +23,16 @@ use serde::Serialize;
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::expression_postfix))]
 pub struct PostfixExpression<'ast> {
-    pub identifier: Identifier<'ast>,
+    pub name: KeywordOrIdentifier<'ast>,
     pub accesses: Vec<Access<'ast>>,
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]
     pub span: Span<'ast>,
+}
+
+#[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
+#[pest_ast(rule(Rule::keyword_or_identifier))]
+pub enum KeywordOrIdentifier<'ast> {
+    Input(InputKeyword<'ast>),
+    Identifier(Identifier<'ast>),
 }

--- a/ast/src/expressions/postfix_expression.rs
+++ b/ast/src/expressions/postfix_expression.rs
@@ -14,7 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{access::Access, ast::Rule, common::Identifier, functions::InputKeyword, SpanDef};
+use crate::{
+    access::Access,
+    ast::Rule,
+    common::{Identifier, SelfKeyword},
+    functions::InputKeyword,
+    SpanDef,
+};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -33,6 +39,7 @@ pub struct PostfixExpression<'ast> {
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::keyword_or_identifier))]
 pub enum KeywordOrIdentifier<'ast> {
+    SelfKeyword(SelfKeyword<'ast>),
     Input(InputKeyword<'ast>),
     Identifier(Identifier<'ast>),
 }

--- a/ast/src/functions/input/function_input.rs
+++ b/ast/src/functions/input/function_input.rs
@@ -30,7 +30,7 @@ use serde::Serialize;
 pub struct FunctionInput<'ast> {
     pub mutable: Option<Mutable>,
     pub identifier: Identifier<'ast>,
-    pub _type: Type<'ast>,
+    pub type_: Type<'ast>,
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]
     pub span: Span<'ast>,

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -39,6 +39,7 @@ protected_name = {
     | "string"
     | "test"
     | type_data
+    | type_self
     | value_boolean
 }
 
@@ -351,7 +352,15 @@ expression_array_inline = { "[" ~ NEWLINE* ~ inline_array_inner ~ NEWLINE* ~ "]"
 inline_array_inner = _{(spread_or_expression ~ ("," ~ NEWLINE* ~ spread_or_expression)*)?}
 
 // Declared in expressions/circuit_inline_expression.rs
-expression_circuit_inline = { identifier ~ "{" ~ NEWLINE* ~ circuit_variable_list ~ NEWLINE* ~ "}" }
+expression_circuit_inline = { circuit_name ~ "{" ~ NEWLINE* ~ circuit_variable_list ~ NEWLINE* ~ "}" }
+
+// Declared in expressions/circuit_inline_expression.rs
+circuit_name = {
+    type_self
+    | identifier
+}
+
+// Declared in expressions/circuit_inline_expression.rs
 circuit_variable_list = _{ (circuit_variable ~ ("," ~ NEWLINE* ~ circuit_variable)*)? ~ ","? }
 
 // Declared in expressions/unary_expression.rs
@@ -360,7 +369,7 @@ expression_unary = { operation_unary ~ expression_term }
 // Declared in expressions/postfix_expression.rs
 expression_postfix = ${ keyword_or_identifier ~ access+ }
 
-// Declared in expressions
+// Declared in expressions/postfix_expression.rs
 keyword_or_identifier = {
     input_keyword
     | identifier

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -30,6 +30,7 @@ protected_name = {
     | "function"
     | "if"
     | "import"
+    | input_keyword
     | "in"
     | "let"
     | "mut"
@@ -37,8 +38,8 @@ protected_name = {
     | "static"
     | "string"
     | "test"
-    | value_boolean
     | type_data
+    | value_boolean
 }
 
 // Declared in common/line_end.rs
@@ -357,7 +358,13 @@ circuit_variable_list = _{ (circuit_variable ~ ("," ~ NEWLINE* ~ circuit_variabl
 expression_unary = { operation_unary ~ expression_term }
 
 // Declared in expressions/postfix_expression.rs
-expression_postfix = ${ identifier ~ access+ }
+expression_postfix = ${ keyword_or_identifier ~ access+ }
+
+// Declared in expressions
+keyword_or_identifier = {
+    input_keyword
+    | identifier
+}
 
 /// Statements
 
@@ -409,8 +416,8 @@ input_keyword = { "input" }
 
 // Declared in functions/input/input.rs
 input = {
-    function_input
-    | input_keyword
+    input_keyword
+    | function_input
 }
 input_tuple = _{ "(" ~ NEWLINE* ~ (input ~ ("," ~ NEWLINE* ~ input)* ~ ","?)? ~ NEWLINE* ~ ")"}
 

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -35,6 +35,7 @@ protected_name = {
     | "let"
     | "mut"
     | "return"
+    | self_keyword
     | "static"
     | "string"
     | "test"
@@ -42,6 +43,9 @@ protected_name = {
     | type_self
     | value_boolean
 }
+
+// Declared in common/self_keyword.rs
+self_keyword = { "self" }
 
 // Declared in common/line_end.rs
 LINE_END = { ";" ~ NEWLINE* }
@@ -372,6 +376,7 @@ expression_postfix = ${ keyword_or_identifier ~ access+ }
 // Declared in expressions/postfix_expression.rs
 keyword_or_identifier = {
     input_keyword
+    | self_keyword
     | identifier
 }
 

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -21,17 +21,13 @@ definition_annotated = { annotation ~ NEWLINE* ~ definition}
 // Declared in common/identifier.rs
 identifier = @{ ((!protected_name ~ ASCII_ALPHA) | (protected_name ~ (ASCII_ALPHANUMERIC | "_"))) ~ (ASCII_ALPHANUMERIC | "_")* }
 protected_name = {
-    "address"
-    | "as"
+    "as"
     | "circuit"
     | "const"
     | "console"
     | "else"
-    | "false"
-    | "field"
     | "for"
     | "function"
-    | "group"
     | "if"
     | "import"
     | "in"
@@ -41,7 +37,8 @@ protected_name = {
     | "static"
     | "string"
     | "test"
-    | "true"
+    | value_boolean
+    | type_data
 }
 
 // Declared in common/line_end.rs

--- a/ast/src/types/array_element.rs
+++ b/ast/src/types/array_element.rs
@@ -25,5 +25,5 @@ pub enum ArrayElement<'ast> {
     Basic(DataType),
     Tuple(TupleType<'ast>),
     Circuit(CircuitType<'ast>),
-    SelfType(SelfType),
+    SelfType(SelfType<'ast>),
 }

--- a/ast/src/types/self_type.rs
+++ b/ast/src/types/self_type.rs
@@ -14,11 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::ast::Rule;
+use crate::{
+    ast::{span_into_string, Rule},
+    SpanDef,
+};
 
+use pest::Span;
 use pest_ast::FromPest;
 use serde::Serialize;
 
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::type_self))]
-pub struct SelfType {}
+pub struct SelfType<'ast> {
+    #[pest_ast(outer(with(span_into_string)))]
+    pub keyword: String,
+    #[pest_ast(outer())]
+    #[serde(with = "SpanDef")]
+    pub span: Span<'ast>,
+}

--- a/ast/src/types/type_.rs
+++ b/ast/src/types/type_.rs
@@ -27,7 +27,7 @@ pub enum Type<'ast> {
     Array(ArrayType<'ast>),
     Tuple(TupleType<'ast>),
     Circuit(CircuitType<'ast>),
-    SelfType(SelfType),
+    SelfType(SelfType<'ast>),
 }
 
 impl<'ast> fmt::Display for Type<'ast> {
@@ -37,7 +37,7 @@ impl<'ast> fmt::Display for Type<'ast> {
             Type::Array(ref _type) => write!(f, "array"),
             Type::Tuple(ref _type) => write!(f, "tuple"),
             Type::Circuit(ref _type) => write!(f, "struct"),
-            Type::SelfType(ref _type) => write!(f, "Self"),
+            Type::SelfType(ref type_) => write!(f, "{}", type_.keyword),
         }
     }
 }

--- a/compiler/tests/array/mod.rs
+++ b/compiler/tests/array/mod.rs
@@ -18,7 +18,6 @@ use crate::{
     assert_satisfied,
     expect_compiler_error,
     get_output,
-    integers::{expect_computation_error, expect_parsing_error},
     parse_program,
     parse_program_with_input,
     EdwardsTestCompiler,

--- a/compiler/tests/circuits/pedersen_mock.leo
+++ b/compiler/tests/circuits/pedersen_mock.leo
@@ -19,9 +19,9 @@ circuit PedersenHash {
 function main() {
     let parameters = [0u32; 512];
     let pedersen = PedersenHash::new(parameters);
-    let input: [bool; 512] = [true; 512];
+    let hash_input: [bool; 512] = [true; 512];
 
-    let res = pedersen.hash(input);
+    let res = pedersen.hash(hash_input);
 
     console.assert(res == 0u32);
 }

--- a/compiler/tests/syntax/identifiers/address_fail.leo
+++ b/compiler/tests/syntax/identifiers/address_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let address = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/console_fail.leo
+++ b/compiler/tests/syntax/identifiers/console_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let console = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/field_fail.leo
+++ b/compiler/tests/syntax/identifiers/field_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let field = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/group_fail.leo
+++ b/compiler/tests/syntax/identifiers/group_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let group = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/i8_fail.leo
+++ b/compiler/tests/syntax/identifiers/i8_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let i8 = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/input_fail.leo
+++ b/compiler/tests/syntax/identifiers/input_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let input = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/mod.rs
+++ b/compiler/tests/syntax/identifiers/mod.rs
@@ -65,6 +65,22 @@ fn test_input_name_fail() {
 }
 
 #[test]
+fn test_self_type_name_fail() {
+    let bytes = include_bytes!("self_type_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_self_keyword_name_fail() {
+    let bytes = include_bytes!("self_keyword_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
 fn test_true_name_fail() {
     let bytes = include_bytes!("true_fail.leo");
     let syntax_error = parse_program(bytes).is_err();

--- a/compiler/tests/syntax/identifiers/mod.rs
+++ b/compiler/tests/syntax/identifiers/mod.rs
@@ -57,6 +57,14 @@ fn test_i8_name_fail() {
 }
 
 #[test]
+fn test_input_name_fail() {
+    let bytes = include_bytes!("input_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
 fn test_true_name_fail() {
     let bytes = include_bytes!("true_fail.leo");
     let syntax_error = parse_program(bytes).is_err();

--- a/compiler/tests/syntax/identifiers/mod.rs
+++ b/compiler/tests/syntax/identifiers/mod.rs
@@ -1,0 +1,73 @@
+// Copyright (C) 2019-2020 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::parse_program;
+
+#[test]
+fn test_address_name_fail() {
+    let bytes = include_bytes!("address_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_console_name_fail() {
+    let bytes = include_bytes!("console_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_field_name_fail() {
+    let bytes = include_bytes!("field_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_group_name_fail() {
+    let bytes = include_bytes!("group_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_i8_name_fail() {
+    let bytes = include_bytes!("i8_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_true_name_fail() {
+    let bytes = include_bytes!("true_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}
+
+#[test]
+fn test_u8_name_fail() {
+    let bytes = include_bytes!("u8_fail.leo");
+    let syntax_error = parse_program(bytes).is_err();
+
+    assert!(syntax_error);
+}

--- a/compiler/tests/syntax/identifiers/self_keyword_fail.leo
+++ b/compiler/tests/syntax/identifiers/self_keyword_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let Self = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/self_type_fail.leo
+++ b/compiler/tests/syntax/identifiers/self_type_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let Self = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/true_fail.leo
+++ b/compiler/tests/syntax/identifiers/true_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let address = 0u32;
+}

--- a/compiler/tests/syntax/identifiers/u8_fail.leo
+++ b/compiler/tests/syntax/identifiers/u8_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    let u8 = 0u32;
+}

--- a/compiler/tests/syntax/mod.rs
+++ b/compiler/tests/syntax/mod.rs
@@ -19,6 +19,8 @@ use leo_ast::ParserError;
 use leo_compiler::errors::{CompilerError, ExpressionError, FunctionError, StatementError};
 use leo_input::InputParserError;
 
+pub mod identifiers;
+
 #[test]
 #[ignore]
 fn test_semicolon() {

--- a/examples/pedersen-hash/src/main.leo
+++ b/examples/pedersen-hash/src/main.leo
@@ -21,6 +21,6 @@ circuit PedersenHash {
 function main() -> group {
     const parameters = [1group; 256];
     const pedersen = PedersenHash::new(parameters);
-    let input: [bool; 256] = [true; 256];
-    return pedersen.hash(input)
+    let hash_input: [bool; 256] = [true; 256];
+    return pedersen.hash(hash_input)
 }

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -22,7 +22,11 @@ use leo_ast::{
 };
 use leo_input::common::Identifier as InputAstIdentifier;
 
-use leo_ast::{expressions::KeywordOrIdentifier, functions::InputKeyword};
+use leo_ast::{
+    expressions::{CircuitName, KeywordOrIdentifier},
+    functions::InputKeyword,
+    types::SelfType,
+};
 use serde::{
     de::{self, Visitor},
     Deserialize,
@@ -99,6 +103,24 @@ impl<'ast> From<InputKeyword<'ast>> for Identifier {
         Self {
             name: input.keyword,
             span: Span::from(input.span),
+        }
+    }
+}
+
+impl<'ast> From<CircuitName<'ast>> for Identifier {
+    fn from(name: CircuitName<'ast>) -> Self {
+        match name {
+            CircuitName::SelfType(self_type) => Identifier::from(self_type),
+            CircuitName::Identifier(identifier) => Identifier::from(identifier),
+        }
+    }
+}
+
+impl<'ast> From<SelfType<'ast>> for Identifier {
+    fn from(self_type: SelfType<'ast>) -> Self {
+        Self {
+            name: self_type.keyword,
+            span: Span::from(self_type.span),
         }
     }
 }

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -23,6 +23,7 @@ use leo_ast::{
 use leo_input::common::Identifier as InputAstIdentifier;
 
 use leo_ast::{
+    common::SelfKeyword,
     expressions::{CircuitName, KeywordOrIdentifier},
     functions::InputKeyword,
     types::SelfType,
@@ -92,8 +93,18 @@ impl<'ast> From<AnnotationArgument<'ast>> for Identifier {
 impl<'ast> From<KeywordOrIdentifier<'ast>> for Identifier {
     fn from(name: KeywordOrIdentifier<'ast>) -> Self {
         match name {
+            KeywordOrIdentifier::SelfKeyword(keyword) => Identifier::from(keyword),
             KeywordOrIdentifier::Input(keyword) => Identifier::from(keyword),
             KeywordOrIdentifier::Identifier(identifier) => Identifier::from(identifier),
+        }
+    }
+}
+
+impl<'ast> From<SelfKeyword<'ast>> for Identifier {
+    fn from(self_: SelfKeyword<'ast>) -> Self {
+        Self {
+            name: self_.keyword,
+            span: Span::from(self_.span),
         }
     }
 }

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -22,6 +22,7 @@ use leo_ast::{
 };
 use leo_input::common::Identifier as InputAstIdentifier;
 
+use leo_ast::{expressions::KeywordOrIdentifier, functions::InputKeyword};
 use serde::{
     de::{self, Visitor},
     Deserialize,
@@ -80,6 +81,24 @@ impl<'ast> From<AnnotationArgument<'ast>> for Identifier {
         Self {
             name: argument.value,
             span: Span::from(argument.span),
+        }
+    }
+}
+
+impl<'ast> From<KeywordOrIdentifier<'ast>> for Identifier {
+    fn from(name: KeywordOrIdentifier<'ast>) -> Self {
+        match name {
+            KeywordOrIdentifier::Input(keyword) => Identifier::from(keyword),
+            KeywordOrIdentifier::Identifier(identifier) => Identifier::from(identifier),
+        }
+    }
+}
+
+impl<'ast> From<InputKeyword<'ast>> for Identifier {
+    fn from(input: InputKeyword<'ast>) -> Self {
+        Self {
+            name: input.keyword,
+            span: Span::from(input.span),
         }
     }
 }

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -288,7 +288,7 @@ impl<'ast> From<CircuitInlineExpression<'ast>> for Expression {
 
 impl<'ast> From<PostfixExpression<'ast>> for Expression {
     fn from(expression: PostfixExpression<'ast>) -> Self {
-        let variable = Expression::Identifier(Identifier::from(expression.identifier));
+        let variable = Expression::Identifier(Identifier::from(expression.name));
 
         // ast::PostFixExpression contains an array of "accesses": `a(34)[42]` is represented as `[a, [Call(34), Select(42)]]`, but Access call expressions
         // are recursive, so it is `Select(Call(a, 34), 42)`. We apply this transformation here

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -275,7 +275,7 @@ impl<'ast> fmt::Display for Expression {
 
 impl<'ast> From<CircuitInlineExpression<'ast>> for Expression {
     fn from(expression: CircuitInlineExpression<'ast>) -> Self {
-        let circuit_name = Identifier::from(expression.identifier);
+        let circuit_name = Identifier::from(expression.name);
         let members = expression
             .members
             .into_iter()

--- a/typed/src/functions/input/function_input.rs
+++ b/typed/src/functions/input/function_input.rs
@@ -33,7 +33,7 @@ impl<'ast> From<AstFunctionInput<'ast>> for FunctionInput {
         FunctionInput {
             identifier: Identifier::from(parameter.identifier),
             mutable: parameter.mutable.is_some(),
-            type_: Type::from(parameter._type),
+            type_: Type::from(parameter.type_),
             span: Span::from(parameter.span),
         }
     }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Resolves several bugs caught by @acoglio and discussions on slack.

Fixes #161 #324 #339 

Prevents users from naming their variables, functions, circuits, tests as:
- `u8`, `u16`, `u32`, `u64`, `u128`
- `i8`, `i16`, `i32`, `i164`, `i128`
- `bool`
- `group`
- `field`
- `address`
- `Self`
- `self`
- `input`

Most of these cases were caught in post-parsing. They are now caught sooner by the pest file.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

A new test module has been added with several identifier definition tests to verify the above names are protected.
The module is located in `compiler/tests/syntax/identifiers`
