### PR TITLE
Feature/mutable self circuit values

### DIFF
--- a/ast/src/common/assignee.rs
+++ b/ast/src/common/assignee.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{access::AssigneeAccess, ast::Rule, common::Identifier, SpanDef};
+use crate::{access::AssigneeAccess, ast::Rule, common::KeywordOrIdentifier, SpanDef};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -24,7 +24,7 @@ use std::fmt;
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::assignee))]
 pub struct Assignee<'ast> {
-    pub identifier: Identifier<'ast>,
+    pub name: KeywordOrIdentifier<'ast>,
     pub accesses: Vec<AssigneeAccess<'ast>>,
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]
@@ -33,7 +33,7 @@ pub struct Assignee<'ast> {
 
 impl<'ast> fmt::Display for Assignee<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.identifier)?;
+        write!(f, "{}", self.name)?;
         for (i, access) in self.accesses.iter().enumerate() {
             write!(f, "{}", access)?;
             if i < self.accesses.len() - 1 {

--- a/ast/src/common/keyword_or_identifier.rs
+++ b/ast/src/common/keyword_or_identifier.rs
@@ -15,27 +15,29 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{
-    ast::{span_into_string, Rule},
-    SpanDef,
+    ast::Rule,
+    common::{Identifier, SelfKeyword},
+    functions::InputKeyword,
 };
 
-use pest::Span;
 use pest_ast::FromPest;
 use serde::Serialize;
 use std::fmt;
 
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
-#[pest_ast(rule(Rule::self_keyword))]
-pub struct SelfKeyword<'ast> {
-    #[pest_ast(outer(with(span_into_string)))]
-    pub keyword: String,
-    #[pest_ast(outer())]
-    #[serde(with = "SpanDef")]
-    pub span: Span<'ast>,
+#[pest_ast(rule(Rule::keyword_or_identifier))]
+pub enum KeywordOrIdentifier<'ast> {
+    SelfKeyword(SelfKeyword<'ast>),
+    Input(InputKeyword<'ast>),
+    Identifier(Identifier<'ast>),
 }
 
-impl<'ast> fmt::Display for SelfKeyword<'ast> {
+impl<'ast> fmt::Display for KeywordOrIdentifier<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.keyword)
+        match self {
+            KeywordOrIdentifier::SelfKeyword(self_keyword) => write!(f, "{}", self_keyword),
+            KeywordOrIdentifier::Input(input_keyword) => write!(f, "{}", input_keyword),
+            KeywordOrIdentifier::Identifier(identifier) => write!(f, "{}", identifier),
+        }
     }
 }

--- a/ast/src/common/mod.rs
+++ b/ast/src/common/mod.rs
@@ -26,6 +26,9 @@ pub use eoi::*;
 pub mod identifier;
 pub use identifier::*;
 
+pub mod keyword_or_identifier;
+pub use keyword_or_identifier::*;
+
 pub mod line_end;
 pub use line_end::*;
 

--- a/ast/src/expressions/postfix_expression.rs
+++ b/ast/src/expressions/postfix_expression.rs
@@ -14,13 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{
-    access::Access,
-    ast::Rule,
-    common::{Identifier, SelfKeyword},
-    functions::InputKeyword,
-    SpanDef,
-};
+use crate::{access::Access, ast::Rule, common::KeywordOrIdentifier, SpanDef};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -34,12 +28,4 @@ pub struct PostfixExpression<'ast> {
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]
     pub span: Span<'ast>,
-}
-
-#[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
-#[pest_ast(rule(Rule::keyword_or_identifier))]
-pub enum KeywordOrIdentifier<'ast> {
-    SelfKeyword(SelfKeyword<'ast>),
-    Input(InputKeyword<'ast>),
-    Identifier(Identifier<'ast>),
 }

--- a/ast/src/functions/input/input_keyword.rs
+++ b/ast/src/functions/input/input_keyword.rs
@@ -22,6 +22,7 @@ use crate::{
 use pest::Span;
 use pest_ast::FromPest;
 use serde::Serialize;
+use std::fmt;
 
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::input_keyword))]
@@ -31,4 +32,10 @@ pub struct InputKeyword<'ast> {
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]
     pub span: Span<'ast>,
+}
+
+impl<'ast> fmt::Display for InputKeyword<'ast> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.keyword)
+    }
 }

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -1,7 +1,7 @@
 /// Common
 
 // Declared in common/assignee.rs
-assignee = { identifier ~ access_assignee* }
+assignee = { keyword_or_identifier ~ access_assignee* }
 
 // Declared in files/file.rs
 file = { SOI ~ NEWLINE* ~ definition* ~ NEWLINE* ~ EOI }

--- a/compiler/src/function/function.rs
+++ b/compiler/src/function/function.rs
@@ -47,6 +47,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         caller_scope: String,
         function: Function,
         input: Vec<Expression>,
+        declared_circuit_reference: String,
     ) -> Result<ConstrainedValue<F, G>, FunctionError> {
         let function_name = new_scope(scope.clone(), function.get_name());
 
@@ -103,6 +104,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 None,
                 statement.clone(),
                 function.returns.clone(),
+                declared_circuit_reference.clone(),
             )?;
 
             results.append(&mut result);

--- a/compiler/src/function/main_function.rs
+++ b/compiler/src/function/main_function.rs
@@ -77,7 +77,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         }
 
         let span = function.span.clone();
-        let result_value = self.enforce_function(cs, scope, function_name, function, input_variables)?;
+        let result_value = self.enforce_function(cs, scope, function_name, function, input_variables, "".to_owned())?;
         let output_bytes = OutputBytes::new_from_constrained_value(registers, result_value, span)?;
 
         Ok(output_bytes)

--- a/compiler/src/statement/assign/assign.rs
+++ b/compiler/src/statement/assign/assign.rs
@@ -79,8 +79,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 span,
             ),
             Assignee::Tuple(_tuple, index) => self.assign_tuple(cs, indicator, variable_name, index, new_value, span),
-            Assignee::CircuitField(_assignee, object_name) => {
-                self.mutute_circuit_variable(cs, indicator, variable_name, object_name, new_value, span)
+            Assignee::CircuitField(_assignee, circuit_variable) => {
+                self.mutute_circuit_variable(cs, indicator, variable_name, circuit_variable, new_value, span)
             }
         }
     }

--- a/compiler/src/statement/branch/branch.rs
+++ b/compiler/src/statement/branch/branch.rs
@@ -44,6 +44,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 indicator.clone(),
                 statement.clone(),
                 return_type.clone(),
+                "".to_owned(),
             )?;
 
             results.append(&mut value);

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -38,6 +38,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         indicator: Option<Boolean>,
         statement: Statement,
         return_type: Option<Type>,
+        declared_circuit_reference: String,
     ) -> Result<Vec<(Option<Boolean>, ConstrainedValue<F, G>)>, StatementError> {
         let mut results = vec![];
 
@@ -62,7 +63,16 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 )?;
             }
             Statement::Assign(variable, expression, span) => {
-                self.enforce_assign_statement(cs, file_scope, function_scope, indicator, variable, expression, span)?;
+                self.enforce_assign_statement(
+                    cs,
+                    file_scope,
+                    function_scope,
+                    declared_circuit_reference,
+                    indicator,
+                    variable,
+                    expression,
+                    span,
+                )?;
             }
             Statement::Conditional(statement, span) => {
                 let mut result = self.enforce_conditional_statement(

--- a/compiler/tests/circuits/mod.rs
+++ b/compiler/tests/circuits/mod.rs
@@ -134,6 +134,71 @@ fn test_member_static_function_undefined() {
     expect_fail(program)
 }
 
+// Mutability
+#[test]
+fn test_mutate_function_fail() {
+    let bytes = include_bytes!("mut_function_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_mutate_self_variable() {
+    let bytes = include_bytes!("mut_self_variable.leo");
+    let program = parse_program(bytes).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
+fn test_mutate_self_variable_fail() {
+    let bytes = include_bytes!("mut_self_variable_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_mutate_self_function_fail() {
+    let bytes = include_bytes!("mut_self_function_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_mutate_self_static_function_fail() {
+    let bytes = include_bytes!("mut_self_static_function_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_mutate_static_function_fail() {
+    let bytes = include_bytes!("mut_static_function_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_mutate_variable() {
+    let bytes = include_bytes!("mut_variable.leo");
+    let program = parse_program(bytes).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
+fn test_mutate_variable_fail() {
+    let bytes = include_bytes!("mut_variable_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
 // Self
 #[test]
 fn test_self_member_pass() {

--- a/compiler/tests/circuits/mut_function_fail.leo
+++ b/compiler/tests/circuits/mut_function_fail.leo
@@ -1,0 +1,9 @@
+circuit Foo {
+    function bar() {}
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    f.bar = 1u8;
+}

--- a/compiler/tests/circuits/mut_self_function_fail.leo
+++ b/compiler/tests/circuits/mut_self_function_fail.leo
@@ -1,0 +1,15 @@
+circuit Foo {
+    a: u8,
+
+    function bar() {}
+
+    function set_a(new: u8) {
+        self.bar = new;
+    }
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    f.set_a(1u8);
+}

--- a/compiler/tests/circuits/mut_self_static_function_fail.leo
+++ b/compiler/tests/circuits/mut_self_static_function_fail.leo
@@ -1,0 +1,15 @@
+circuit Foo {
+    a: u8,
+
+    static function bar() {}
+
+    function set_a(new: u8) {
+        self.bar = new;
+    }
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    f.set_a(1u8);
+}

--- a/compiler/tests/circuits/mut_self_variable.leo
+++ b/compiler/tests/circuits/mut_self_variable.leo
@@ -1,0 +1,21 @@
+circuit Foo {
+    mut a: u8,
+
+    function set_a(new: u8) {
+        self.a = new;
+    }
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    console.assert(f.a == 0u8);
+
+    f.set_a(1u8);
+
+    console.assert(f.a == 1u8);
+
+    f.set_a(2u8);
+
+    console.assert(f.a == 2u8);
+}

--- a/compiler/tests/circuits/mut_self_variable.leo
+++ b/compiler/tests/circuits/mut_self_variable.leo
@@ -3,6 +3,7 @@ circuit Foo {
 
     function set_a(new: u8) {
         self.a = new;
+        console.assert(self.a == new);
     }
 }
 

--- a/compiler/tests/circuits/mut_self_variable_fail.leo
+++ b/compiler/tests/circuits/mut_self_variable_fail.leo
@@ -1,0 +1,13 @@
+circuit Foo {
+    a: u8,
+
+    function set_a(new: u8) {
+        self.a = new;
+    }
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    f.set_a(1u8);
+}

--- a/compiler/tests/circuits/mut_static_function_fail.leo
+++ b/compiler/tests/circuits/mut_static_function_fail.leo
@@ -1,0 +1,9 @@
+circuit Foo {
+    static function bar() {}
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    f.bar = 1u8;
+}

--- a/compiler/tests/circuits/mut_variable.leo
+++ b/compiler/tests/circuits/mut_variable.leo
@@ -1,0 +1,17 @@
+circuit Foo {
+    mut a: u8,
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    console.assert(f.a == 0u8);
+
+    f.a = 1u8;
+
+    console.assert(f.a == 1u8);
+
+    f.a = 2u8;
+
+    console.assert(f.a == 2u8);
+}

--- a/compiler/tests/circuits/mut_variable_fail.leo
+++ b/compiler/tests/circuits/mut_variable_fail.leo
@@ -1,0 +1,9 @@
+circuit Foo {
+    a: u8,
+}
+
+function main() {
+    let mut f  = Foo { a: 0u8 };
+
+    f.a = 1u8;
+}

--- a/typed/src/common/assignee.rs
+++ b/typed/src/common/assignee.rs
@@ -17,7 +17,7 @@
 use crate::{Expression, Identifier, RangeOrExpression};
 use leo_ast::{
     access::AssigneeAccess as AstAssigneeAccess,
-    common::{Assignee as AstAssignee, Identifier as AstIdentifier},
+    common::{Assignee as AstAssignee, Identifier as AstIdentifier, KeywordOrIdentifier},
 };
 
 use serde::{Deserialize, Serialize};
@@ -38,9 +38,15 @@ impl<'ast> From<AstIdentifier<'ast>> for Assignee {
     }
 }
 
+impl<'ast> From<KeywordOrIdentifier<'ast>> for Assignee {
+    fn from(name: KeywordOrIdentifier<'ast>) -> Self {
+        Assignee::Identifier(Identifier::from(name))
+    }
+}
+
 impl<'ast> From<AstAssignee<'ast>> for Assignee {
     fn from(assignee: AstAssignee<'ast>) -> Self {
-        let variable = Assignee::from(assignee.identifier);
+        let variable = Assignee::from(assignee.name);
 
         // We start with the id, and we fold the array of accesses by wrapping the current value
         assignee

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -23,8 +23,8 @@ use leo_ast::{
 use leo_input::common::Identifier as InputAstIdentifier;
 
 use leo_ast::{
-    common::SelfKeyword,
-    expressions::{CircuitName, KeywordOrIdentifier},
+    common::{KeywordOrIdentifier, SelfKeyword},
+    expressions::CircuitName,
     functions::InputKeyword,
     types::SelfType,
 };

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -362,7 +362,7 @@ impl<'ast> From<AstExpression<'ast>> for Expression {
 // Assignee -> Expression for operator assign statements
 impl<'ast> From<Assignee<'ast>> for Expression {
     fn from(assignee: Assignee<'ast>) -> Self {
-        let variable = Expression::Identifier(Identifier::from(assignee.identifier));
+        let variable = Expression::Identifier(Identifier::from(assignee.name));
 
         // we start with the id, and we fold the array of accesses by wrapping the current value
         assignee


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This pr allows circuit variables to be mutated using the self keyword:
```rust
circuit Foo {
    mut a: u8,

    function set_a(new: u8) {
        self.a = new; // Changes the value of `f.a = new`

        console.assert(self.a == new);
    }
}

function main() {
    let mut f  = Foo { a: 0u8 };

    f.set_a(1u8); // Changes the value of `f.a = 1`

    console.assert(f.a == 1u8);
```

Both user testing and slack discussion indicate that Leo should support this functionality.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Test mutating circuit variable using the self keyword changes the variable inside the circuit function.
Test mutating circuit variable using the self keyword changes the variable outside the circuit function.
Test mutating an immutable circuit variable errors.
Test mutating a circuit function errors.
Test mutating a static circuit function errors.
