### PR TITLE
Fix/static call nested

### DIFF
--- a/ast/src/expressions/postfix_expression.rs
+++ b/ast/src/expressions/postfix_expression.rs
@@ -22,6 +22,7 @@ use crate::{
     SpanDef,
 };
 
+use crate::types::SelfType;
 use pest::Span;
 use pest_ast::FromPest;
 use serde::Serialize;
@@ -40,6 +41,7 @@ pub struct PostfixExpression<'ast> {
 #[pest_ast(rule(Rule::keyword_or_identifier))]
 pub enum KeywordOrIdentifier<'ast> {
     SelfKeyword(SelfKeyword<'ast>),
+    SelfType(SelfType<'ast>),
     Input(InputKeyword<'ast>),
     Identifier(Identifier<'ast>),
 }

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -369,6 +369,7 @@ expression_postfix = ${ keyword_or_identifier ~ access+ }
 keyword_or_identifier = {
     input_keyword
     | self_keyword
+    | type_self
     | identifier
 }
 

--- a/compiler/src/errors/expression.rs
+++ b/compiler/src/errors/expression.rs
@@ -140,6 +140,12 @@ impl ExpressionError {
         Self::new_from_span(message, span)
     }
 
+    pub fn self_keyword(span: Span) -> Self {
+        let message = format!("cannot call keyword `Self` outside of a circuit function");
+
+        Self::new_from_span(message, span)
+    }
+
     pub fn undefined_array(actual: String, span: Span) -> Self {
         let message = format!("array `{}` must be declared before it is used in an expression", actual);
 

--- a/compiler/src/expression/circuit/static_access.rs
+++ b/compiler/src/expression/circuit/static_access.rs
@@ -38,25 +38,26 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // Get defined circuit
         let circuit = match *circuit_identifier.clone() {
             Expression::Identifier(identifier) => {
+                // Use the "Self" keyword to access a static circuit function
                 if identifier.is_self() {
-                    let circuit = self.get(&file_scope).unwrap();
+                    let circuit = self
+                        .get(&file_scope)
+                        .ok_or(ExpressionError::self_keyword(identifier.span.clone()))?;
 
-                    circuit.to_owned().extract_circuit(span.clone())?
+                    circuit.to_owned()
                 } else {
                     self.evaluate_identifier(file_scope.clone(), function_scope.clone(), expected_type, identifier)?
-                        .extract_circuit(span.clone())?
                 }
             }
-            expression => self
-                .enforce_expression(
-                    cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
-                    expected_type,
-                    expression,
-                )?
-                .extract_circuit(span.clone())?,
-        };
+            expression => self.enforce_expression(
+                cs,
+                file_scope.clone(),
+                function_scope.clone(),
+                expected_type,
+                expression,
+            )?,
+        }
+        .extract_circuit(span.clone())?;
 
         // Find static circuit function
         let matched_function = circuit.members.into_iter().find(|member| match member {

--- a/compiler/tests/circuits/member_static_function_nested.leo
+++ b/compiler/tests/circuits/member_static_function_nested.leo
@@ -1,0 +1,15 @@
+circuit Foo {
+    static function qux() {}
+
+    static function bar() {
+        Self::qux();
+    }
+
+    static function baz() {
+        Self::bar();
+    }
+}
+
+function main() {
+    Foo::baz();
+}

--- a/compiler/tests/circuits/mod.rs
+++ b/compiler/tests/circuits/mod.rs
@@ -119,6 +119,14 @@ fn test_member_static_function() {
 }
 
 #[test]
+fn test_member_static_function_nested() {
+    let bytes = include_bytes!("member_static_function_nested.leo");
+    let program = parse_program(bytes).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
 fn test_member_static_function_invalid() {
     let bytes = include_bytes!("member_static_function_invalid.leo");
     let program = parse_program(bytes).unwrap();

--- a/compiler/tests/circuits/mod.rs
+++ b/compiler/tests/circuits/mod.rs
@@ -143,6 +143,15 @@ fn test_member_static_function_undefined() {
 }
 
 // Self
+
+#[test]
+fn test_self_fail() {
+    let bytes = include_bytes!("self_fail.leo");
+    let program = parse_program(bytes).unwrap();
+
+    expect_compiler_error(program);
+}
+
 #[test]
 fn test_self_member_pass() {
     let bytes = include_bytes!("self_member.leo");

--- a/compiler/tests/circuits/self_fail.leo
+++ b/compiler/tests/circuits/self_fail.leo
@@ -1,0 +1,3 @@
+function main() {
+    Self::main();
+}

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -94,6 +94,7 @@ impl<'ast> From<KeywordOrIdentifier<'ast>> for Identifier {
     fn from(name: KeywordOrIdentifier<'ast>) -> Self {
         match name {
             KeywordOrIdentifier::SelfKeyword(keyword) => Identifier::from(keyword),
+            KeywordOrIdentifier::SelfType(self_type) => Identifier::from(self_type),
             KeywordOrIdentifier::Input(keyword) => Identifier::from(keyword),
             KeywordOrIdentifier::Identifier(identifier) => Identifier::from(identifier),
         }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes a bug where static functions could not be called from inside a static function.
**Example:**
```
circuit Foo {
    static function bar() {}

    static function baz() {
        Self::bar(); // Call static function `bar` from inside `baz`
    }
}

function main() {
    Foo::baz();
}
```

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Test accessing static function from within static function is successful.
Test using Self keyword to access anything outside of a circuit function fails.
