### PR TITLE
Refactor/manifest project

### DIFF
--- a/examples/fibonacci/Leo.toml
+++ b/examples/fibonacci/Leo.toml
@@ -1,4 +1,4 @@
-[package]
+[project]
 name = "fibonacci"
 version = "0.1.0"
 description = "Returns a fibonnaci sequence"

--- a/examples/fibonacci/README.md
+++ b/examples/fibonacci/README.md
@@ -1,0 +1,1 @@
+# fibonacci

--- a/examples/hello-world/Leo.toml
+++ b/examples/hello-world/Leo.toml
@@ -1,4 +1,4 @@
-[package]
+[project]
 name = "hello-world"
 version = "0.1.0"
 description = "Returns the sum of two u32 integers"

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,1 @@
+# hello-world

--- a/examples/pedersen-hash/Leo.toml
+++ b/examples/pedersen-hash/Leo.toml
@@ -1,4 +1,4 @@
-[package]
+[project]
 name = "pedersen-hash"
 version = "0.1.0"
 description = "A 256bit hash function"

--- a/examples/pedersen-hash/README.md
+++ b/examples/pedersen-hash/README.md
@@ -1,0 +1,1 @@
+# pedersen-hash

--- a/examples/square-root/Leo.toml
+++ b/examples/square-root/Leo.toml
@@ -1,4 +1,4 @@
-[package]
+[project]
 name = "square-root"
 version = "0.1.0"
 description = "prove knowledge of the square root `a` of a number `b`"

--- a/examples/square-root/README.md
+++ b/examples/square-root/README.md
@@ -1,0 +1,1 @@
+# square-root

--- a/package/src/root/manifest.rs
+++ b/package/src/root/manifest.rs
@@ -33,14 +33,14 @@ pub struct Remote {
 
 #[derive(Deserialize)]
 pub struct Manifest {
-    pub package: Package,
+    pub project: Package,
     pub remote: Option<Remote>,
 }
 
 impl Manifest {
     pub fn new(package_name: &str) -> Self {
         Self {
-            package: Package::new(package_name),
+            project: Package::new(package_name),
             remote: None,
         }
     }
@@ -58,19 +58,19 @@ impl Manifest {
     }
 
     pub fn get_package_name(&self) -> String {
-        self.package.name.clone()
+        self.project.name.clone()
     }
 
     pub fn get_package_version(&self) -> String {
-        self.package.version.clone()
+        self.project.version.clone()
     }
 
     pub fn get_package_description(&self) -> Option<String> {
-        self.package.description.clone()
+        self.project.description.clone()
     }
 
     pub fn get_package_license(&self) -> Option<String> {
-        self.package.license.clone()
+        self.project.license.clone()
     }
 
     pub fn get_package_remote(&self) -> Option<Remote> {
@@ -90,7 +90,7 @@ impl Manifest {
 
     fn template(&self) -> String {
         format!(
-            r#"[package]
+            r#"[project]
 name = "{name}"
 version = "0.1.0"
 description = "The {name} package"
@@ -99,7 +99,7 @@ license = "MIT"
 [remote]
 author = "[AUTHOR]" # Add your Aleo Package Manager username, team's name, or organization's name.
 "#,
-            name = self.package.name
+            name = self.project.name
         )
     }
 }
@@ -145,7 +145,15 @@ impl TryFrom<&PathBuf> for Manifest {
             if line.starts_with("[remote]") {
                 new_remote_format_exists = true;
             }
-            new_toml += line;
+
+            // If the old project format is being being used, update the toml file
+            // to use the new format instead.
+            if line.starts_with("[package]") {
+                new_toml += "[project]";
+            } else {
+                new_toml += line;
+            }
+
             new_toml += "\n";
         }
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR updates the `Leo.toml` format usage of `[package]` to `[project]`. When the old `[package]` format is detected by `leo` it will automatically be updated to use `[project]`.