### PR TITLE
make assignee rule more strict during pest parsing

### DIFF
--- a/ast/src/common/assignee.rs
+++ b/ast/src/common/assignee.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{access::AssigneeAccess, ast::Rule, common::KeywordOrIdentifier, SpanDef};
+use crate::{access::AssigneeAccess, ast::Rule, common::SelfKeywordOrIdentifier, SpanDef};
 
 use pest::Span;
 use pest_ast::FromPest;
@@ -24,7 +24,7 @@ use std::fmt;
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
 #[pest_ast(rule(Rule::assignee))]
 pub struct Assignee<'ast> {
-    pub name: KeywordOrIdentifier<'ast>,
+    pub name: SelfKeywordOrIdentifier<'ast>,
     pub accesses: Vec<AssigneeAccess<'ast>>,
     #[pest_ast(outer())]
     #[serde(with = "SpanDef")]

--- a/ast/src/common/mod.rs
+++ b/ast/src/common/mod.rs
@@ -44,6 +44,9 @@ pub use range_or_expression::*;
 pub mod self_keyword;
 pub use self_keyword::*;
 
+pub mod self_keyword_or_identifier;
+pub use self_keyword_or_identifier::*;
+
 pub mod spread;
 pub use spread::*;
 

--- a/ast/src/common/self_keyword_or_identifier.rs
+++ b/ast/src/common/self_keyword_or_identifier.rs
@@ -14,26 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{ast::Rule, common::SelfKeywordOrIdentifier, functions::InputKeyword, types::SelfType};
+use crate::{
+    ast::Rule,
+    common::{Identifier, SelfKeyword},
+};
 
 use pest_ast::FromPest;
 use serde::Serialize;
 use std::fmt;
 
 #[derive(Clone, Debug, FromPest, PartialEq, Serialize)]
-#[pest_ast(rule(Rule::keyword_or_identifier))]
-pub enum KeywordOrIdentifier<'ast> {
-    SelfType(SelfType<'ast>),
-    Input(InputKeyword<'ast>),
-    SelfKeywordOrIdentifier(SelfKeywordOrIdentifier<'ast>),
+#[pest_ast(rule(Rule::self_keyword_or_identifier))]
+pub enum SelfKeywordOrIdentifier<'ast> {
+    SelfKeyword(SelfKeyword<'ast>),
+    Identifier(Identifier<'ast>),
 }
 
-impl<'ast> fmt::Display for KeywordOrIdentifier<'ast> {
+impl<'ast> fmt::Display for SelfKeywordOrIdentifier<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            KeywordOrIdentifier::SelfType(self_type) => write!(f, "{}", self_type),
-            KeywordOrIdentifier::Input(input_keyword) => write!(f, "{}", input_keyword),
-            KeywordOrIdentifier::SelfKeywordOrIdentifier(name) => write!(f, "{}", name),
+            SelfKeywordOrIdentifier::SelfKeyword(self_keyword) => write!(f, "{}", self_keyword),
+            SelfKeywordOrIdentifier::Identifier(identifier) => write!(f, "{}", identifier),
         }
     }
 }

--- a/ast/src/leo.pest
+++ b/ast/src/leo.pest
@@ -1,7 +1,7 @@
 /// Common
 
 // Declared in common/assignee.rs
-assignee = { keyword_or_identifier ~ access_assignee* }
+assignee = { self_keyword_or_identifier ~ access_assignee* }
 
 // Declared in files/file.rs
 file = { SOI ~ NEWLINE* ~ definition* ~ NEWLINE* ~ EOI }
@@ -46,6 +46,19 @@ protected_name = {
 
 // Declared in common/self_keyword.rs
 self_keyword = { "self" }
+
+// Declared in common/self_keyword_or_identifier.rs
+self_keyword_or_identifier = {
+    self_keyword
+    | identifier
+}
+
+// Declared in common/keyword_or_identifier.rs
+keyword_or_identifier = {
+    input_keyword
+    | type_self
+    | self_keyword_or_identifier
+}
 
 // Declared in common/line_end.rs
 LINE_END = { ";" ~ NEWLINE* }
@@ -364,14 +377,6 @@ expression_unary = { operation_unary ~ expression_term }
 
 // Declared in expressions/postfix_expression.rs
 expression_postfix = ${ keyword_or_identifier ~ access+ }
-
-// Declared in expressions/postfix_expression.rs
-keyword_or_identifier = {
-    input_keyword
-    | self_keyword
-    | type_self
-    | identifier
-}
 
 /// Statements
 

--- a/typed/src/common/assignee.rs
+++ b/typed/src/common/assignee.rs
@@ -17,7 +17,7 @@
 use crate::{Expression, Identifier, RangeOrExpression};
 use leo_ast::{
     access::AssigneeAccess as AstAssigneeAccess,
-    common::{Assignee as AstAssignee, Identifier as AstIdentifier, KeywordOrIdentifier},
+    common::{Assignee as AstAssignee, Identifier as AstIdentifier, SelfKeywordOrIdentifier},
 };
 
 use serde::{Deserialize, Serialize};
@@ -38,8 +38,8 @@ impl<'ast> From<AstIdentifier<'ast>> for Assignee {
     }
 }
 
-impl<'ast> From<KeywordOrIdentifier<'ast>> for Assignee {
-    fn from(name: KeywordOrIdentifier<'ast>) -> Self {
+impl<'ast> From<SelfKeywordOrIdentifier<'ast>> for Assignee {
+    fn from(name: SelfKeywordOrIdentifier<'ast>) -> Self {
         Assignee::Identifier(Identifier::from(name))
     }
 }

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -17,17 +17,14 @@
 use crate::Span;
 use leo_ast::{
     annotations::AnnotationArgument,
-    common::Identifier as AstIdentifier,
+    common::{Identifier as AstIdentifier, KeywordOrIdentifier, SelfKeyword, SelfKeywordOrIdentifier},
+    expressions::CircuitName,
+    functions::InputKeyword,
     imports::PackageName as AstPackageName,
+    types::SelfType,
 };
 use leo_input::common::Identifier as InputAstIdentifier;
 
-use leo_ast::{
-    common::{KeywordOrIdentifier, SelfKeyword},
-    expressions::CircuitName,
-    functions::InputKeyword,
-    types::SelfType,
-};
 use serde::{
     de::{self, Visitor},
     Deserialize,
@@ -93,10 +90,18 @@ impl<'ast> From<AnnotationArgument<'ast>> for Identifier {
 impl<'ast> From<KeywordOrIdentifier<'ast>> for Identifier {
     fn from(name: KeywordOrIdentifier<'ast>) -> Self {
         match name {
-            KeywordOrIdentifier::SelfKeyword(keyword) => Identifier::from(keyword),
+            KeywordOrIdentifier::SelfKeywordOrIdentifier(keyword) => Identifier::from(keyword),
             KeywordOrIdentifier::SelfType(self_type) => Identifier::from(self_type),
             KeywordOrIdentifier::Input(keyword) => Identifier::from(keyword),
-            KeywordOrIdentifier::Identifier(identifier) => Identifier::from(identifier),
+        }
+    }
+}
+
+impl<'ast> From<SelfKeywordOrIdentifier<'ast>> for Identifier {
+    fn from(name: SelfKeywordOrIdentifier<'ast>) -> Self {
+        match name {
+            SelfKeywordOrIdentifier::Identifier(identifier) => Identifier::from(identifier),
+            SelfKeywordOrIdentifier::SelfKeyword(keyword) => Identifier::from(keyword),
         }
     }
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #358 
Changes assignee rule in `leo.pest`.
Does not affect current Leo syntax.
