### PR TITLE
Clippy compliance, part 1/2

### DIFF
--- a/ast/src/access/mod.rs
+++ b/ast/src/access/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod access;
 pub use access::*;
 

--- a/ast/src/annotations/mod.rs
+++ b/ast/src/annotations/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod annotations;
 pub use annotations::*;
 

--- a/ast/src/errors/parser.rs
+++ b/ast/src/errors/parser.rs
@@ -39,20 +39,17 @@ pub enum ParserError {
 
 impl ParserError {
     pub fn set_path(&mut self, path: PathBuf) {
-        match self {
-            ParserError::SyntaxError(error) => {
-                let new_error: Error<Rule> = match error {
-                    SyntaxError::Error(error) => {
-                        let new_error = error.clone();
-                        new_error.with_path(path.to_str().unwrap())
-                    }
-                };
+        if let ParserError::SyntaxError(error) = self {
+            let new_error: Error<Rule> = match error {
+                SyntaxError::Error(error) => {
+                    let new_error = error.clone();
+                    new_error.with_path(path.to_str().unwrap())
+                }
+            };
 
-                tracing::error!("{}", new_error);
+            tracing::error!("{}", new_error);
 
-                *error = SyntaxError::Error(new_error);
-            }
-            _ => {}
+            *error = SyntaxError::Error(new_error);
         }
     }
 }

--- a/ast/src/functions/input/mod.rs
+++ b/ast/src/functions/input/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod function_input;
 pub use function_input::*;
 

--- a/ast/src/statements/conditional_statement.rs
+++ b/ast/src/statements/conditional_statement.rs
@@ -39,11 +39,11 @@ pub struct ConditionalStatement<'ast> {
 
 impl<'ast> fmt::Display for ConditionalStatement<'ast> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "if ({}) {{\n", self.condition)?;
-        write!(f, "\t{:#?}\n", self.statements)?;
+        writeln!(f, "if ({}) {{", self.condition)?;
+        writeln!(f, "\t{:#?}", self.statements)?;
         self.next
             .as_ref()
             .map(|n_or_e| write!(f, "}} {}", n_or_e))
-            .unwrap_or(write!(f, "}}"))
+            .unwrap_or_else(|| write!(f, "}}"))
     }
 }

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -135,6 +135,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> Compiler<F, G> {
     }
 
     /// Parses the Leo program file, constructs a syntax tree, and generates a program.
+    #[allow(deprecated)]
     pub(crate) fn parse_program(&mut self) -> Result<(), CompilerError> {
         // Use the parser to construct the abstract syntax tree.
         let program_string = LeoAst::load_file(&self.main_file_path)?;

--- a/compiler/src/console/assert.rs
+++ b/compiler/src/console/assert.rs
@@ -53,7 +53,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // Unwrap assertion value and handle errors
         let result_option = match assert_expression {
             ConstrainedValue::Boolean(boolean) => boolean.get_value(),
-            _ => return Err(ConsoleError::assertion_must_be_boolean(expression_string, span.clone())),
+            _ => return Err(ConsoleError::assertion_must_be_boolean(expression_string, span)),
         };
         let result_bool = result_option.ok_or(ConsoleError::assertion_depends_on_input(span.clone()))?;
 

--- a/compiler/src/console/assert.rs
+++ b/compiler/src/console/assert.rs
@@ -55,7 +55,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             ConstrainedValue::Boolean(boolean) => boolean.get_value(),
             _ => return Err(ConsoleError::assertion_must_be_boolean(expression_string, span)),
         };
-        let result_bool = result_option.ok_or(ConsoleError::assertion_depends_on_input(span.clone()))?;
+        let result_bool = result_option.ok_or_else(|| ConsoleError::assertion_depends_on_input(span.clone()))?;
 
         if !result_bool {
             return Err(ConsoleError::assertion_failed(expression_string, span));

--- a/compiler/src/console/format.rs
+++ b/compiler/src/console/format.rs
@@ -43,10 +43,10 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
         // Trim starting double quote `"`
         let mut string = formatted.string.as_str();
-        string = string.trim_start_matches("\"");
+        string = string.trim_start_matches('\"');
 
         // Trim everything after the ending double quote `"`
-        let parts: Vec<&str> = string.split("\"").collect();
+        let parts: Vec<&str> = string.split('\"').collect();
         string = parts[0];
 
         // Insert the parameter for each container `{}`

--- a/compiler/src/console/format.rs
+++ b/compiler/src/console/format.rs
@@ -37,7 +37,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             return Err(ConsoleError::length(
                 formatted.containers.len(),
                 formatted.parameters.len(),
-                formatted.span.clone(),
+                formatted.span,
             ));
         }
 

--- a/compiler/src/definition/definition.rs
+++ b/compiler/src/definition/definition.rs
@@ -32,7 +32,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         mutable: bool,
         identifier: Identifier,
         mut value: ConstrainedValue<F, G>,
-    ) -> () {
+    ) {
         // Store with given mutability
         if mutable {
             value = ConstrainedValue::Mutable(Box::new(value));

--- a/compiler/src/errors/console.rs
+++ b/compiler/src/errors/console.rs
@@ -50,7 +50,7 @@ impl ConsoleError {
     }
 
     pub fn assertion_depends_on_input(span: Span) -> Self {
-        let message = format!("console.assert() failed to evaluate. This error is caused by empty input file values");
+        let message = "console.assert() failed to evaluate. This error is caused by empty input file values".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/console.rs
+++ b/compiler/src/errors/console.rs
@@ -50,7 +50,8 @@ impl ConsoleError {
     }
 
     pub fn assertion_depends_on_input(span: Span) -> Self {
-        let message = "console.assert() failed to evaluate. This error is caused by empty input file values".to_string();
+        let message =
+            "console.assert() failed to evaluate. This error is caused by empty input file values".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/expression.rs
+++ b/compiler/src/errors/expression.rs
@@ -146,7 +146,7 @@ impl ExpressionError {
     }
 
     pub fn self_keyword(span: Span) -> Self {
-        let message = format!("cannot call keyword `Self` outside of a circuit function");
+        let message = "cannot call keyword `Self` outside of a circuit function".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/import.rs
+++ b/compiler/src/errors/import.rs
@@ -48,7 +48,7 @@ impl ImportError {
     }
 
     pub fn convert_os_string(span: Span) -> Self {
-        let message = format!("failed to convert file string name, maybe an illegal character?");
+        let message = "failed to convert file string name, maybe an illegal character?".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/output_bytes.rs
+++ b/compiler/src/errors/output_bytes.rs
@@ -36,7 +36,7 @@ impl OutputBytesError {
     }
 
     pub fn not_enough_registers(span: Span) -> Self {
-        let message = format!("number of input registers must be greater than or equal to output registers");
+        let message = "number of input registers must be greater than or equal to output registers".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/statement.rs
+++ b/compiler/src/errors/statement.rs
@@ -67,13 +67,13 @@ impl StatementError {
     }
 
     pub fn array_assign_index(span: Span) -> Self {
-        let message = format!("Cannot assign single index to array of values");
+        let message = "Cannot assign single index to array of values".to_string();
 
         Self::new_from_span(message, span)
     }
 
     pub fn array_assign_range(span: Span) -> Self {
-        let message = format!("Cannot assign range of array values to single value");
+        let message = "Cannot assign range of array values to single value".to_string();
 
         Self::new_from_span(message, span)
     }
@@ -145,7 +145,7 @@ impl StatementError {
     }
 
     pub fn tuple_assign_index(span: Span) -> Self {
-        let message = format!("Cannot assign single index to tuple of values");
+        let message = "Cannot assign single index to tuple of values".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/value/address.rs
+++ b/compiler/src/errors/value/address.rs
@@ -64,7 +64,7 @@ impl AddressError {
     }
 
     pub fn missing_address(span: Span) -> Self {
-        let message = format!("expected address input not found");
+        let message = "expected address input not found".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/value/group.rs
+++ b/compiler/src/errors/value/group.rs
@@ -88,13 +88,13 @@ impl GroupError {
     }
 
     pub fn x_recover(span: Span) -> Self {
-        let message = format!("could not recover group element from x coordinate");
+        let message = "could not recover group element from x coordinate".to_string();
 
         Self::new_from_span(message, span)
     }
 
     pub fn y_recover(span: Span) -> Self {
-        let message = format!("could not recover group element from y coordinate");
+        let message = "could not recover group element from y coordinate".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/value/integer.rs
+++ b/compiler/src/errors/value/integer.rs
@@ -85,8 +85,7 @@ impl IntegerError {
     pub fn invalid_index(span: Span) -> Self {
         let message =
             "index must be a constant value unsigned integer. allocated indices produce a circuit of unknown size"
-            .to_string()
-        ;
+                .to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/value/integer.rs
+++ b/compiler/src/errors/value/integer.rs
@@ -68,7 +68,7 @@ impl IntegerError {
     }
 
     pub fn negate_operation(span: Span) -> Self {
-        let message = format!("integer negation can only be enforced on signed integers");
+        let message = "integer negation can only be enforced on signed integers".to_string();
 
         Self::new_from_span(message, span)
     }
@@ -83,9 +83,10 @@ impl IntegerError {
     }
 
     pub fn invalid_index(span: Span) -> Self {
-        let message = format!(
+        let message =
             "index must be a constant value unsigned integer. allocated indices produce a circuit of unknown size"
-        );
+            .to_string()
+        ;
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/value/value.rs
+++ b/compiler/src/errors/value/value.rs
@@ -63,7 +63,7 @@ impl ValueError {
     }
 
     pub fn implicit_group(span: Span) -> Self {
-        let message = format!("group coordinates should be in (x, y)group format");
+        let message = "group coordinates should be in (x, y)group format".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/expression/arithmetic/div.rs
+++ b/compiler/src/expression/arithmetic/div.rs
@@ -46,10 +46,10 @@ pub fn enforce_div<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
             enforce_div(cs, val_1, val_2, span)
         }
         (val_1, val_2) => {
-            return Err(ExpressionError::incompatible_types(
+            Err(ExpressionError::incompatible_types(
                 format!("{} / {}", val_1, val_2,),
                 span,
-            ));
+            ))
         }
     }
 }

--- a/compiler/src/expression/arithmetic/div.rs
+++ b/compiler/src/expression/arithmetic/div.rs
@@ -45,11 +45,9 @@ pub fn enforce_div<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
             let val_2 = ConstrainedValue::from_other(string, &val_1, span.clone())?;
             enforce_div(cs, val_1, val_2, span)
         }
-        (val_1, val_2) => {
-            Err(ExpressionError::incompatible_types(
-                format!("{} / {}", val_1, val_2,),
-                span,
-            ))
-        }
+        (val_1, val_2) => Err(ExpressionError::incompatible_types(
+            format!("{} / {}", val_1, val_2,),
+            span,
+        )),
     }
 }

--- a/compiler/src/expression/arithmetic/mul.rs
+++ b/compiler/src/expression/arithmetic/mul.rs
@@ -45,11 +45,9 @@ pub fn enforce_mul<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
             let val_2 = ConstrainedValue::from_other(string, &val_1, span.clone())?;
             enforce_mul(cs, val_1, val_2, span)
         }
-        (val_1, val_2) => {
-            Err(ExpressionError::incompatible_types(
-                format!("{} * {}", val_1, val_2),
-                span,
-            ))
-        }
+        (val_1, val_2) => Err(ExpressionError::incompatible_types(
+            format!("{} * {}", val_1, val_2),
+            span,
+        )),
     }
 }

--- a/compiler/src/expression/arithmetic/mul.rs
+++ b/compiler/src/expression/arithmetic/mul.rs
@@ -46,10 +46,10 @@ pub fn enforce_mul<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
             enforce_mul(cs, val_1, val_2, span)
         }
         (val_1, val_2) => {
-            return Err(ExpressionError::incompatible_types(
+            Err(ExpressionError::incompatible_types(
                 format!("{} * {}", val_1, val_2),
                 span,
-            ));
+            ))
         }
     }
 }

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -57,9 +57,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     None => 0usize, // Array slice starts at index 0
                 };
                 let to_resolved = match to {
-                    Some(to_index) => {
-                        self.enforce_index(cs, file_scope, function_scope, to_index, span)?
-                    }
+                    Some(to_index) => self.enforce_index(cs, file_scope, function_scope, to_index, span)?,
                     None => array.len(), // Array slice ends at array length
                 };
                 Ok(ConstrainedValue::Array(array[from_resolved..to_resolved].to_owned()))

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -57,7 +57,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 };
                 let to_resolved = match to {
                     Some(to_index) => {
-                        self.enforce_index(cs, file_scope.clone(), function_scope.clone(), to_index, span.clone())?
+                        self.enforce_index(cs, file_scope, function_scope, to_index, span)?
                     }
                     None => array.len(), // Array slice ends at array length
                 };

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -25,6 +25,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_array_access<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/array/array.rs
+++ b/compiler/src/expression/array/array.rs
@@ -47,12 +47,12 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             match type_ {
                 Type::Array(ref type_, ref dimensions) => {
                     let number = match dimensions.first() {
-                        Some(number) => number.clone(),
+                        Some(number) => *number,
                         None => return Err(ExpressionError::unexpected_array(type_.to_string(), span)),
                     };
 
                     expected_dimensions.push(number);
-                    expected_type = Some(type_.outer_dimension(dimensions).clone());
+                    expected_type = Some(type_.outer_dimension(dimensions));
                 }
                 ref type_ => {
                     return Err(ExpressionError::unexpected_array(type_.to_string(), span));

--- a/compiler/src/expression/array/array.rs
+++ b/compiler/src/expression/array/array.rs
@@ -89,14 +89,12 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         }
 
         // Check expected_dimensions if given
-        if !expected_dimensions.is_empty() {
-            if expected_dimensions[expected_dimensions.len() - 1] != result.len() {
-                return Err(ExpressionError::invalid_length(
-                    expected_dimensions[expected_dimensions.len() - 1],
-                    result.len(),
-                    span,
-                ));
-            }
+        if !expected_dimensions.is_empty() && expected_dimensions[expected_dimensions.len() - 1] != result.len() {
+            return Err(ExpressionError::invalid_length(
+                expected_dimensions[expected_dimensions.len() - 1],
+                result.len(),
+                span,
+            ));
         }
 
         Ok(ConstrainedValue::Array(result))

--- a/compiler/src/expression/array/array.rs
+++ b/compiler/src/expression/array/array.rs
@@ -37,7 +37,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         file_scope: String,
         function_scope: String,
         mut expected_type: Option<Type>,
-        array: Vec<Box<SpreadOrExpression>>,
+        array: Vec<SpreadOrExpression>,
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // Check explicit array type dimension if given
@@ -62,7 +62,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
         let mut result = vec![];
         for element in array.into_iter() {
-            match *element {
+            match element {
                 SpreadOrExpression::Spread(spread) => match spread {
                     Expression::Identifier(identifier) => {
                         let array_name = new_scope(function_scope.clone(), identifier.to_string());

--- a/compiler/src/expression/array/index.rs
+++ b/compiler/src/expression/array/index.rs
@@ -36,13 +36,13 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         let expected_type = Some(Type::IntegerType(IntegerType::U32));
         match self.enforce_operand(
             cs,
-            file_scope.clone(),
-            function_scope.clone(),
+            file_scope,
+            function_scope,
             expected_type,
             index,
             span.clone(),
         )? {
-            ConstrainedValue::Integer(number) => Ok(number.to_usize(span.clone())?),
+            ConstrainedValue::Integer(number) => Ok(number.to_usize(span)?),
             value => Err(ExpressionError::invalid_index(value.to_string(), span)),
         }
     }

--- a/compiler/src/expression/array/index.rs
+++ b/compiler/src/expression/array/index.rs
@@ -34,14 +34,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         span: Span,
     ) -> Result<usize, ExpressionError> {
         let expected_type = Some(Type::IntegerType(IntegerType::U32));
-        match self.enforce_operand(
-            cs,
-            file_scope,
-            function_scope,
-            expected_type,
-            index,
-            span.clone(),
-        )? {
+        match self.enforce_operand(cs, file_scope, function_scope, expected_type, index, span.clone())? {
             ConstrainedValue::Integer(number) => Ok(number.to_usize(span)?),
             value => Err(ExpressionError::invalid_index(value.to_string(), span)),
         }

--- a/compiler/src/expression/binary/binary.rs
+++ b/compiler/src/expression/binary/binary.rs
@@ -24,6 +24,8 @@ use snarkos_models::{
     gadgets::r1cs::ConstraintSystem,
 };
 
+type ConstrainedValuePair<T, U> = (ConstrainedValue<T, U>, ConstrainedValue<T, U>);
+
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     #[allow(clippy::too_many_arguments)]
     pub fn enforce_binary_expression<CS: ConstraintSystem<F>>(
@@ -35,7 +37,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         left: Expression,
         right: Expression,
         span: Span,
-    ) -> Result<(ConstrainedValue<F, G>, ConstrainedValue<F, G>), ExpressionError> {
+    ) -> Result<ConstrainedValuePair<F, G>, ExpressionError> {
         let mut resolved_left = self.enforce_operand(
             cs,
             file_scope.clone(),

--- a/compiler/src/expression/binary/binary.rs
+++ b/compiler/src/expression/binary/binary.rs
@@ -45,8 +45,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         )?;
         let mut resolved_right = self.enforce_operand(
             cs,
-            file_scope.clone(),
-            function_scope.clone(),
+            file_scope,
+            function_scope,
             expected_type.clone(),
             right,
             span.clone(),

--- a/compiler/src/expression/binary/binary.rs
+++ b/compiler/src/expression/binary/binary.rs
@@ -25,6 +25,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_binary_expression<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/circuit/access.rs
+++ b/compiler/src/expression/circuit/access.rs
@@ -29,7 +29,7 @@ use snarkos_models::{
     gadgets::r1cs::ConstraintSystem,
 };
 
-static SELF_KEYWORD: &'static str = "self";
+static SELF_KEYWORD: &str = "self";
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     pub fn enforce_circuit_access<CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/circuit/access.rs
+++ b/compiler/src/expression/circuit/access.rs
@@ -32,6 +32,7 @@ use snarkos_models::{
 static SELF_KEYWORD: &str = "self";
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_circuit_access<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/circuit/access.rs
+++ b/compiler/src/expression/circuit/access.rs
@@ -45,11 +45,11 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // access a circuit member using the `self` keyword
         if let Expression::Identifier(ref identifier) = *circuit_identifier {
             if identifier.is_self() {
-                let self_file_scope = new_scope(file_scope.clone(), identifier.name.to_string());
+                let self_file_scope = new_scope(file_scope, identifier.name.to_string());
                 let self_function_scope = new_scope(self_file_scope.clone(), identifier.name.to_string());
 
                 let member_value =
-                    self.evaluate_identifier(self_file_scope, self_function_scope, None, circuit_member.clone())?;
+                    self.evaluate_identifier(self_file_scope, self_function_scope, None, circuit_member)?;
 
                 return Ok(member_value);
             }
@@ -58,9 +58,9 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         let (circuit_name, members) = match self.enforce_operand(
             cs,
             file_scope.clone(),
-            function_scope.clone(),
+            function_scope,
             expected_type,
-            *circuit_identifier.clone(),
+            *circuit_identifier,
             span.clone(),
         )? {
             ConstrainedValue::CircuitExpression(name, members) => (name, members),

--- a/compiler/src/expression/circuit/circuit.rs
+++ b/compiler/src/expression/circuit/circuit.rs
@@ -40,7 +40,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // Circuit definitions are located at the minimum file scope
-        let scopes: Vec<&str> = file_scope.split("_").collect();
+        let scopes: Vec<&str> = file_scope.split('_').collect();
         let mut program_identifier = new_scope(scopes[0].to_string(), identifier.to_string());
 
         if identifier.is_self() {

--- a/compiler/src/expression/circuit/circuit.rs
+++ b/compiler/src/expression/circuit/circuit.rs
@@ -55,7 +55,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         let circuit_identifier = circuit.circuit_name.clone();
         let mut resolved_members = vec![];
 
-        for member in circuit.members.clone().into_iter() {
+        for member in circuit.members.into_iter() {
             match member {
                 CircuitMember::CircuitVariable(is_mutable, identifier, type_) => {
                     let matched_variable = members
@@ -98,7 +98,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         }
 
         Ok(ConstrainedValue::CircuitExpression(
-            circuit_identifier.clone(),
+            circuit_identifier,
             resolved_members,
         ))
     }

--- a/compiler/src/expression/circuit/static_access.rs
+++ b/compiler/src/expression/circuit/static_access.rs
@@ -36,23 +36,23 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // Get defined circuit
-        let circuit = match *circuit_identifier.clone() {
+        let circuit = match *circuit_identifier {
             Expression::Identifier(identifier) => {
                 // Use the "Self" keyword to access a static circuit function
                 if identifier.is_self() {
                     let circuit = self
                         .get(&file_scope)
-                        .ok_or(ExpressionError::self_keyword(identifier.span.clone()))?;
+                        .ok_or(ExpressionError::self_keyword(identifier.span))?;
 
                     circuit.to_owned()
                 } else {
-                    self.evaluate_identifier(file_scope.clone(), function_scope.clone(), expected_type, identifier)?
+                    self.evaluate_identifier(file_scope, function_scope, expected_type, identifier)?
                 }
             }
             expression => self.enforce_expression(
                 cs,
-                file_scope.clone(),
-                function_scope.clone(),
+                file_scope,
+                function_scope,
                 expected_type,
                 expression,
             )?,

--- a/compiler/src/expression/circuit/static_access.rs
+++ b/compiler/src/expression/circuit/static_access.rs
@@ -50,13 +50,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     self.evaluate_identifier(file_scope, function_scope, expected_type, identifier)?
                 }
             }
-            expression => self.enforce_expression(
-                cs,
-                file_scope,
-                function_scope,
-                expected_type,
-                expression,
-            )?,
+            expression => self.enforce_expression(cs, file_scope, function_scope, expected_type, expression)?,
         }
         .extract_circuit(span.clone())?;
 

--- a/compiler/src/expression/circuit/static_access.rs
+++ b/compiler/src/expression/circuit/static_access.rs
@@ -25,6 +25,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_circuit_static_access<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/circuit/static_access.rs
+++ b/compiler/src/expression/circuit/static_access.rs
@@ -43,7 +43,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 if identifier.is_self() {
                     let circuit = self
                         .get(&file_scope)
-                        .ok_or(ExpressionError::self_keyword(identifier.span))?;
+                        .ok_or_else(|| ExpressionError::self_keyword(identifier.span))?;
 
                     circuit.to_owned()
                 } else {

--- a/compiler/src/expression/conditional/conditional.rs
+++ b/compiler/src/expression/conditional/conditional.rs
@@ -58,14 +58,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             span.clone(),
         )?;
 
-        let second_value = self.enforce_operand(
-            cs,
-            file_scope,
-            function_scope,
-            expected_type,
-            second,
-            span.clone(),
-        )?;
+        let second_value = self.enforce_operand(cs, file_scope, function_scope, expected_type, second, span.clone())?;
 
         let unique_namespace = cs.ns(|| {
             format!(

--- a/compiler/src/expression/conditional/conditional.rs
+++ b/compiler/src/expression/conditional/conditional.rs
@@ -26,6 +26,7 @@ use snarkos_models::{
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     /// Enforce ternary conditional expression
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_conditional_expression<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/conditional/conditional.rs
+++ b/compiler/src/expression/conditional/conditional.rs
@@ -74,6 +74,6 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         });
 
         ConstrainedValue::conditionally_select(unique_namespace, &conditional_value, &first_value, &second_value)
-            .map_err(|e| ExpressionError::cannot_enforce(format!("conditional select"), e, span))
+            .map_err(|e| ExpressionError::cannot_enforce("conditional select".to_string(), e, span))
     }
 }

--- a/compiler/src/expression/conditional/conditional.rs
+++ b/compiler/src/expression/conditional/conditional.rs
@@ -59,8 +59,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
         let second_value = self.enforce_operand(
             cs,
-            file_scope.clone(),
-            function_scope.clone(),
+            file_scope,
+            function_scope,
             expected_type,
             second,
             span.clone(),

--- a/compiler/src/expression/expression.rs
+++ b/compiler/src/expression/expression.rs
@@ -70,8 +70,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Add(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -83,8 +83,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Sub(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -96,8 +96,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Mul(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -109,8 +109,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Div(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -122,8 +122,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Pow(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -141,8 +141,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Or(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -154,8 +154,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::And(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     expected_type,
                     *left,
                     *right,
@@ -167,8 +167,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Eq(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     None,
                     *left,
                     *right,
@@ -180,8 +180,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Ge(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     None,
                     *left,
                     *right,
@@ -193,8 +193,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Gt(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     None,
                     *left,
                     *right,
@@ -206,8 +206,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Le(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     None,
                     *left,
                     *right,
@@ -219,8 +219,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             Expression::Lt(left, right, span) => {
                 let (resolved_left, resolved_right) = self.enforce_binary_expression(
                     cs,
-                    file_scope.clone(),
-                    function_scope.clone(),
+                    file_scope,
+                    function_scope,
                     None,
                     *left,
                     *right,

--- a/compiler/src/expression/expression.rs
+++ b/compiler/src/expression/expression.rs
@@ -165,67 +165,32 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 Ok(enforce_and(cs, resolved_left, resolved_right, span)?)
             }
             Expression::Eq(left, right, span) => {
-                let (resolved_left, resolved_right) = self.enforce_binary_expression(
-                    cs,
-                    file_scope,
-                    function_scope,
-                    None,
-                    *left,
-                    *right,
-                    span.clone(),
-                )?;
+                let (resolved_left, resolved_right) =
+                    self.enforce_binary_expression(cs, file_scope, function_scope, None, *left, *right, span.clone())?;
 
                 Ok(evaluate_eq(cs, resolved_left, resolved_right, span)?)
             }
             Expression::Ge(left, right, span) => {
-                let (resolved_left, resolved_right) = self.enforce_binary_expression(
-                    cs,
-                    file_scope,
-                    function_scope,
-                    None,
-                    *left,
-                    *right,
-                    span.clone(),
-                )?;
+                let (resolved_left, resolved_right) =
+                    self.enforce_binary_expression(cs, file_scope, function_scope, None, *left, *right, span.clone())?;
 
                 Ok(evaluate_ge(cs, resolved_left, resolved_right, span)?)
             }
             Expression::Gt(left, right, span) => {
-                let (resolved_left, resolved_right) = self.enforce_binary_expression(
-                    cs,
-                    file_scope,
-                    function_scope,
-                    None,
-                    *left,
-                    *right,
-                    span.clone(),
-                )?;
+                let (resolved_left, resolved_right) =
+                    self.enforce_binary_expression(cs, file_scope, function_scope, None, *left, *right, span.clone())?;
 
                 Ok(evaluate_gt(cs, resolved_left, resolved_right, span)?)
             }
             Expression::Le(left, right, span) => {
-                let (resolved_left, resolved_right) = self.enforce_binary_expression(
-                    cs,
-                    file_scope,
-                    function_scope,
-                    None,
-                    *left,
-                    *right,
-                    span.clone(),
-                )?;
+                let (resolved_left, resolved_right) =
+                    self.enforce_binary_expression(cs, file_scope, function_scope, None, *left, *right, span.clone())?;
 
                 Ok(evaluate_le(cs, resolved_left, resolved_right, span)?)
             }
             Expression::Lt(left, right, span) => {
-                let (resolved_left, resolved_right) = self.enforce_binary_expression(
-                    cs,
-                    file_scope,
-                    function_scope,
-                    None,
-                    *left,
-                    *right,
-                    span.clone(),
-                )?;
+                let (resolved_left, resolved_right) =
+                    self.enforce_binary_expression(cs, file_scope, function_scope, None, *left, *right, span.clone())?;
 
                 Ok(evaluate_lt(cs, resolved_left, resolved_right, span)?)
             }

--- a/compiler/src/expression/function/core_circuit.rs
+++ b/compiler/src/expression/function/core_circuit.rs
@@ -72,6 +72,6 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             }
         }
 
-        return Ok(return_value);
+        Ok(return_value)
     }
 }

--- a/compiler/src/expression/function/core_circuit.rs
+++ b/compiler/src/expression/function/core_circuit.rs
@@ -50,10 +50,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         let res = call_core_circuit(cs, core_circuit, argument_values, span.clone())?;
 
         // Convert the core function returns into constrained values
-        let returns = res
-            .into_iter()
-            .map(ConstrainedValue::from)
-            .collect::<Vec<_>>();
+        let returns = res.into_iter().map(ConstrainedValue::from).collect::<Vec<_>>();
 
         let return_value = if returns.len() == 1 {
             // The function has a single return

--- a/compiler/src/expression/function/core_circuit.rs
+++ b/compiler/src/expression/function/core_circuit.rs
@@ -52,7 +52,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // Convert the core function returns into constrained values
         let returns = res
             .into_iter()
-            .map(|value| ConstrainedValue::from(value))
+            .map(ConstrainedValue::from)
             .collect::<Vec<_>>();
 
         let return_value = if returns.len() == 1 {

--- a/compiler/src/expression/function/core_circuit.rs
+++ b/compiler/src/expression/function/core_circuit.rs
@@ -25,6 +25,7 @@ use snarkos_models::{
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     /// Call a default core circuit function with arguments
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_core_circuit_call_expression<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/function/function.rs
+++ b/compiler/src/expression/function/function.rs
@@ -35,7 +35,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         arguments: Vec<Expression>,
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
-        let (declared_circuit_reference, function_value) = match *function.clone() {
+        let (declared_circuit_reference, function_value) = match *function {
             Expression::CircuitMemberAccess(circuit_identifier, circuit_member, span) => {
                 // Call a circuit function that can mutate self.
 
@@ -62,7 +62,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             ),
         };
 
-        let (outer_scope, function_call) = function_value.extract_function(file_scope.clone(), span.clone())?;
+        let (outer_scope, function_call) = function_value.extract_function(file_scope, span.clone())?;
 
         let name_unique = format!(
             "function call {} {}:{}",

--- a/compiler/src/expression/function/function.rs
+++ b/compiler/src/expression/function/function.rs
@@ -25,6 +25,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_function_call_expression<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/identifier/identifier.rs
+++ b/compiler/src/expression/identifier/identifier.rs
@@ -37,7 +37,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         unresolved_identifier: Identifier,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // Evaluate the identifier name in the current function scope
-        let variable_name = new_scope(function_scope.clone(), unresolved_identifier.to_string());
+        let variable_name = new_scope(function_scope, unresolved_identifier.to_string());
         let identifier_name = new_scope(file_scope, unresolved_identifier.to_string());
 
         let mut result_value = if let Some(value) = self.get(&variable_name) {
@@ -58,7 +58,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             return Err(ExpressionError::undefined_identifier(unresolved_identifier));
         };
 
-        result_value.resolve_type(expected_type, unresolved_identifier.span.clone())?;
+        result_value.resolve_type(expected_type, unresolved_identifier.span)?;
 
         Ok(result_value)
     }

--- a/compiler/src/expression/logical/and.rs
+++ b/compiler/src/expression/logical/and.rs
@@ -35,7 +35,7 @@ pub fn enforce_and<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
     if let (ConstrainedValue::Boolean(left_bool), ConstrainedValue::Boolean(right_bool)) = (left, right) {
         let name_unique = format!("{} {}:{}", name, span.line, span.start);
         let result = Boolean::and(cs.ns(|| name_unique), &left_bool, &right_bool)
-            .map_err(|e| BooleanError::cannot_enforce(format!("&&"), e, span))?;
+            .map_err(|e| BooleanError::cannot_enforce("&&".to_string(), e, span))?;
 
         return Ok(ConstrainedValue::Boolean(result));
     }

--- a/compiler/src/expression/logical/or.rs
+++ b/compiler/src/expression/logical/or.rs
@@ -35,7 +35,7 @@ pub fn enforce_or<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<F
     if let (ConstrainedValue::Boolean(left_bool), ConstrainedValue::Boolean(right_bool)) = (left, right) {
         let name_unique = format!("{} {}:{}", name, span.line, span.start);
         let result = Boolean::or(cs.ns(|| name_unique), &left_bool, &right_bool)
-            .map_err(|e| BooleanError::cannot_enforce(format!("||"), e, span))?;
+            .map_err(|e| BooleanError::cannot_enforce("||".to_string(), e, span))?;
 
         return Ok(ConstrainedValue::Boolean(result));
     }

--- a/compiler/src/expression/relational/eq.rs
+++ b/compiler/src/expression/relational/eq.rs
@@ -102,7 +102,7 @@ pub fn evaluate_eq<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
         }
     };
 
-    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(format!("=="), span))?;
+    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate("==".to_string(), span))?;
 
     Ok(ConstrainedValue::Boolean(boolean))
 }

--- a/compiler/src/expression/relational/ge.rs
+++ b/compiler/src/expression/relational/ge.rs
@@ -52,7 +52,7 @@ pub fn evaluate_ge<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
         }
     };
 
-    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(format!(">="), span))?;
+    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(">=".to_string(), span))?;
 
     Ok(ConstrainedValue::Boolean(boolean))
 }

--- a/compiler/src/expression/relational/gt.rs
+++ b/compiler/src/expression/relational/gt.rs
@@ -52,7 +52,7 @@ pub fn evaluate_gt<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
         }
     };
 
-    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(format!(">"), span))?;
+    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(">".to_string(), span))?;
 
     Ok(ConstrainedValue::Boolean(boolean))
 }

--- a/compiler/src/expression/relational/le.rs
+++ b/compiler/src/expression/relational/le.rs
@@ -52,7 +52,7 @@ pub fn evaluate_le<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
         }
     };
 
-    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(format!("<="), span))?;
+    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate("<=".to_string(), span))?;
 
     Ok(ConstrainedValue::Boolean(boolean))
 }

--- a/compiler/src/expression/relational/lt.rs
+++ b/compiler/src/expression/relational/lt.rs
@@ -52,7 +52,7 @@ pub fn evaluate_lt<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
         }
     };
 
-    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate(format!("<"), span))?;
+    let boolean = constraint_result.map_err(|_| ExpressionError::cannot_evaluate("<".to_string(), span))?;
 
     Ok(ConstrainedValue::Boolean(boolean))
 }

--- a/compiler/src/expression/tuple/access.rs
+++ b/compiler/src/expression/tuple/access.rs
@@ -25,6 +25,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_tuple_access<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/expression/tuple/access.rs
+++ b/compiler/src/expression/tuple/access.rs
@@ -36,14 +36,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         index: usize,
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
-        let tuple = match self.enforce_operand(
-            cs,
-            file_scope,
-            function_scope,
-            expected_type,
-            *tuple,
-            span.clone(),
-        )? {
+        let tuple = match self.enforce_operand(cs, file_scope, function_scope, expected_type, *tuple, span.clone())? {
             ConstrainedValue::Tuple(tuple) => tuple,
             value => return Err(ExpressionError::undefined_array(value.to_string(), span)),
         };

--- a/compiler/src/expression/tuple/access.rs
+++ b/compiler/src/expression/tuple/access.rs
@@ -37,14 +37,14 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         let tuple = match self.enforce_operand(
             cs,
-            file_scope.clone(),
-            function_scope.clone(),
+            file_scope,
+            function_scope,
             expected_type,
             *tuple,
             span.clone(),
         )? {
             ConstrainedValue::Tuple(tuple) => tuple,
-            value => return Err(ExpressionError::undefined_array(value.to_string(), span.clone())),
+            value => return Err(ExpressionError::undefined_array(value.to_string(), span)),
         };
 
         if index > tuple.len() - 1 {

--- a/compiler/src/expression/tuple/tuple.rs
+++ b/compiler/src/expression/tuple/tuple.rs
@@ -38,19 +38,18 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // Check explicit tuple type dimension if given
         let mut expected_types = vec![];
 
-        if expected_type.is_some() {
-            match expected_type.unwrap() {
-                Type::Tuple(ref types) => {
-                    expected_types = types.clone();
-                }
-                ref type_ => {
-                    return Err(ExpressionError::unexpected_tuple(
-                        type_.to_string(),
-                        format!("{:?}", tuple),
-                        span,
-                    ));
-                }
+        match expected_type {
+            Some(Type::Tuple(ref types)) => {
+                expected_types = types.clone();
             }
+            Some(ref type_) => {
+                return Err(ExpressionError::unexpected_tuple(
+                    type_.to_string(),
+                    format!("{:?}", tuple),
+                    span,
+                ));
+            }
+            None => {}
         }
 
         let mut result = vec![];

--- a/compiler/src/function/function.rs
+++ b/compiler/src/function/function.rs
@@ -55,7 +55,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         check_arguments_length(function.input.len(), input.len(), function.span.clone())?;
 
         // Store input values as new variables in resolved program
-        for (input_model, input_expression) in function.input.clone().iter().zip(input.into_iter()) {
+        for (input_model, input_expression) in function.input.iter().zip(input.into_iter()) {
             let (name, value) = match input_model {
                 InputVariable::InputKeyword(identifier) => {
                     let input_value = self.enforce_function_input(

--- a/compiler/src/function/main_function.rs
+++ b/compiler/src/function/main_function.rs
@@ -54,7 +54,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     let name = input_model.identifier.name.clone();
                     let input_option = input
                         .get(&name)
-                        .ok_or(FunctionError::input_not_found(name.clone(), function.span.clone()))?;
+                        .ok_or_else(|| FunctionError::input_not_found(name.clone(), function.span.clone()))?;
                     let input_value = self.allocate_main_function_input(
                         cs,
                         input_model.type_,

--- a/compiler/src/function/result/result.rs
+++ b/compiler/src/function/result/result.rs
@@ -44,7 +44,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // If all indicators are none, then there are no branch conditions in the function.
         // We simply return the last result.
 
-        if let None = results.iter().find(|(indicator, _res)| indicator.is_some()) {
+        if results.iter().all(|(indicator, _res)| indicator.is_none()) {
             let result = &results[results.len() - 1].1;
 
             *return_value = result.clone();

--- a/compiler/src/function/result/result.rs
+++ b/compiler/src/function/result/result.rs
@@ -37,7 +37,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         span: Span,
     ) -> Result<(), StatementError> {
         // if there are no results, continue
-        if results.len() == 0 {
+        if results.is_empty() {
             return Ok(());
         }
 

--- a/compiler/src/import/parser/import_parser.rs
+++ b/compiler/src/import/parser/import_parser.rs
@@ -41,7 +41,7 @@ impl ImportParser {
         let _res = self.core_packages.push(package.clone());
     }
 
-    pub fn get_import(&self, file_name: &String) -> Option<&Program> {
+    pub fn get_import(&self, file_name: &str) -> Option<&Program> {
         self.imports.get(file_name)
     }
 

--- a/compiler/src/import/parser/import_parser.rs
+++ b/compiler/src/import/parser/import_parser.rs
@@ -53,7 +53,7 @@ impl ImportParser {
         let mut imports = Self::new();
 
         // Find all imports relative to current directory
-        let path = current_dir().map_err(|error| ImportError::current_directory_error(error))?;
+        let path = current_dir().map_err(ImportError::current_directory_error)?;
 
         // Parse each imported file
         program

--- a/compiler/src/import/parser/import_parser.rs
+++ b/compiler/src/import/parser/import_parser.rs
@@ -21,7 +21,7 @@ use std::{collections::HashMap, env::current_dir};
 
 /// Parses all relevant import files for a program.
 /// Stores compiled program structs.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct ImportParser {
     imports: HashMap<String, Program>,
     core_packages: Vec<Package>,
@@ -29,10 +29,7 @@ pub struct ImportParser {
 
 impl ImportParser {
     pub fn new() -> Self {
-        Self {
-            imports: HashMap::new(),
-            core_packages: vec![],
-        }
+        Self::default()
     }
 
     pub(crate) fn insert_import(&mut self, file_name: String, program: Program) {

--- a/compiler/src/import/parser/parse_package.rs
+++ b/compiler/src/import/parser/parse_package.rs
@@ -70,14 +70,12 @@ impl ImportParser {
 
         let entries = fs::read_dir(path)
             .map_err(|error| ImportError::directory_error(error, package_name.span.clone(), error_path.clone()))?
-            .into_iter()
             .collect::<Result<Vec<_>, std::io::Error>>()
             .map_err(|error| ImportError::directory_error(error, package_name.span.clone(), error_path.clone()))?;
 
         let matched_source_entry = entries.into_iter().find(|entry| {
             entry
                 .file_name()
-                .to_os_string()
                 .into_string()
                 .unwrap()
                 .trim_end_matches(SOURCE_FILE_EXTENSION)
@@ -90,7 +88,6 @@ impl ImportParser {
         } else if imports_directory.exists() {
             let entries = fs::read_dir(imports_directory)
                 .map_err(|error| ImportError::directory_error(error, package_name.span.clone(), error_path.clone()))?
-                .into_iter()
                 .collect::<Result<Vec<_>, std::io::Error>>()
                 .map_err(|error| ImportError::directory_error(error, package_name.span.clone(), error_path.clone()))?;
 

--- a/compiler/src/import/parser/parse_symbol.rs
+++ b/compiler/src/import/parser/parse_symbol.rs
@@ -30,11 +30,10 @@ fn parse_import_file(entry: &DirEntry, span: &Span) -> Result<Program, ImportErr
         .map_err(|error| ImportError::directory_error(error, span.clone(), entry.path()))?;
     let file_name = entry
         .file_name()
-        .to_os_string()
         .into_string()
         .map_err(|_| ImportError::convert_os_string(span.clone()))?;
 
-    let mut file_path = entry.path().to_path_buf();
+    let mut file_path = entry.path();
     if file_type.is_dir() {
         file_path.push(LIBRARY_FILE);
 
@@ -62,7 +61,7 @@ impl ImportParser {
             .extension()
             .map_or(false, |ext| ext.eq(&OsString::from(FILE_EXTENSION)));
 
-        let mut package_path = path.to_path_buf();
+        let mut package_path = path;
         package_path.push(LIBRARY_FILE);
 
         let is_package = is_dir && package_path.exists();
@@ -93,7 +92,7 @@ impl ImportParser {
             Ok(())
         } else {
             // importing * from a directory or non-leo file in `package/src/` is illegal
-            Err(ImportError::star(entry.path().to_path_buf(), span.clone()))
+            Err(ImportError::star(entry.path(), span.clone()))
         }
     }
 

--- a/compiler/src/import/store/import.rs
+++ b/compiler/src/import/store/import.rs
@@ -33,7 +33,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             .find(|package| import.package.eq(package));
 
         if let Some(package) = core_dependency {
-            self.store_core_package(scope.clone(), package.clone())?;
+            self.store_core_package(scope, package.clone())?;
 
             return Ok(());
         }

--- a/compiler/src/import/store/import.rs
+++ b/compiler/src/import/store/import.rs
@@ -45,7 +45,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             // Find imported program
             let program = imported_programs
                 .get_import(&package)
-                .ok_or(ImportError::unknown_package(import.package.name.clone()))?;
+                .ok_or_else(|| ImportError::unknown_package(import.package.name.clone()))?;
 
             // Parse imported program
             self.store_definitions(program.clone(), imported_programs)?;

--- a/compiler/src/import/store/symbol.rs
+++ b/compiler/src/import/store/symbol.rs
@@ -80,7 +80,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             };
 
             // take the alias if it is present
-            let id = symbol.alias.clone().unwrap_or(symbol.symbol.clone());
+            let id = symbol.alias.clone().unwrap_or_else(|| symbol.symbol.clone());
             let name = new_scope(scope, id.to_string());
 
             // store imported circuit under imported name

--- a/compiler/src/import/store/symbol.rs
+++ b/compiler/src/import/store/symbol.rs
@@ -59,7 +59,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
             let value = match matched_circuit {
                 Some((_circuit_name, circuit)) => ConstrainedValue::Import(
-                    program_name.clone(),
+                    program_name,
                     Box::new(ConstrainedValue::CircuitDefinition(circuit.clone())),
                 ),
                 None => {
@@ -71,7 +71,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
                     match matched_function {
                         Some((_function_name, function)) => ConstrainedValue::Import(
-                            program_name.clone(),
+                            program_name,
                             Box::new(ConstrainedValue::Function(None, function.clone())),
                         ),
                         None => return Err(ImportError::unknown_symbol(symbol.to_owned(), program_name)),

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -16,6 +16,8 @@
 
 //! Module containing structs and types that make up a Leo program.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate thiserror;
 

--- a/compiler/src/program/program.rs
+++ b/compiler/src/program/program.rs
@@ -27,6 +27,14 @@ pub struct ConstrainedProgram<F: Field + PrimeField, G: GroupType<F>> {
     pub identifiers: HashMap<String, ConstrainedValue<F, G>>,
 }
 
+impl<F: Field + PrimeField, G: GroupType<F>> Default for ConstrainedProgram<F, G> {
+    fn default() -> Self {
+        Self {
+            identifiers: HashMap::new(),
+        }
+    }
+}
+
 pub fn new_scope(outer: String, inner: String) -> String {
     format!("{}_{}", outer, inner)
 }
@@ -37,9 +45,7 @@ pub fn is_in_scope(current_scope: &String, desired_scope: &String) -> bool {
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     pub fn new() -> Self {
-        Self {
-            identifiers: HashMap::new(),
-        }
+        Self::default()
     }
 
     pub(crate) fn store(&mut self, name: String, value: ConstrainedValue<F, G>) {

--- a/compiler/src/program/program.rs
+++ b/compiler/src/program/program.rs
@@ -39,7 +39,7 @@ pub fn new_scope(outer: String, inner: String) -> String {
     format!("{}_{}", outer, inner)
 }
 
-pub fn is_in_scope(current_scope: &String, desired_scope: &String) -> bool {
+pub fn is_in_scope(current_scope: &str, desired_scope: &str) -> bool {
     current_scope.ends_with(desired_scope)
 }
 
@@ -52,11 +52,11 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         self.identifiers.insert(name, value);
     }
 
-    pub(crate) fn get(&self, name: &String) -> Option<&ConstrainedValue<F, G>> {
+    pub(crate) fn get(&self, name: &str) -> Option<&ConstrainedValue<F, G>> {
         self.identifiers.get(name)
     }
 
-    pub(crate) fn get_mut(&mut self, name: &String) -> Option<&mut ConstrainedValue<F, G>> {
+    pub(crate) fn get_mut(&mut self, name: &str) -> Option<&mut ConstrainedValue<F, G>> {
         self.identifiers.get_mut(name)
     }
 }

--- a/compiler/src/statement/assign/array.rs
+++ b/compiler/src/statement/assign/array.rs
@@ -28,6 +28,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn assign_array<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/statement/assign/array.rs
+++ b/compiler/src/statement/assign/array.rs
@@ -76,13 +76,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     None => 0usize,
                 };
                 let to_index_option = match to {
-                    Some(integer) => Some(self.enforce_index(
-                        cs,
-                        file_scope,
-                        function_scope,
-                        integer,
-                        span.clone(),
-                    )?),
+                    Some(integer) => Some(self.enforce_index(cs, file_scope, function_scope, integer, span.clone())?),
                     None => None,
                 };
 

--- a/compiler/src/statement/assign/array.rs
+++ b/compiler/src/statement/assign/array.rs
@@ -44,7 +44,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // Resolve index so we know if we are assigning to a single value or a range of values
         match range_or_expression {
             RangeOrExpression::Expression(index) => {
-                let index = self.enforce_index(cs, file_scope.clone(), function_scope.clone(), index, span.clone())?;
+                let index = self.enforce_index(cs, file_scope, function_scope, index, span.clone())?;
 
                 // Modify the single value of the array in place
                 match self.get_mutable_assignee(name, span.clone())? {
@@ -77,8 +77,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 let to_index_option = match to {
                     Some(integer) => Some(self.enforce_index(
                         cs,
-                        file_scope.clone(),
-                        function_scope.clone(),
+                        file_scope,
+                        function_scope,
                         integer,
                         span.clone(),
                     )?),

--- a/compiler/src/statement/assign/assign.rs
+++ b/compiler/src/statement/assign/assign.rs
@@ -35,6 +35,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_assign_statement<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/statement/assign/assign.rs
+++ b/compiler/src/statement/assign/assign.rs
@@ -77,7 +77,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 function_scope,
                 indicator,
                 variable_name,
-                range_or_expression,
+                *range_or_expression,
                 new_value,
                 span,
             ),

--- a/compiler/src/statement/assign/assign.rs
+++ b/compiler/src/statement/assign/assign.rs
@@ -57,7 +57,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         match assignee {
             Assignee::Identifier(_identifier) => {
                 let condition = indicator.unwrap_or(Boolean::Constant(true));
-                let old_value = self.get_mutable_assignee(variable_name.clone(), span.clone())?;
+                let old_value = self.get_mutable_assignee(variable_name, span.clone())?;
 
                 new_value.resolve_type(Some(old_value.to_type(span.clone())?), span.clone())?;
 

--- a/compiler/src/statement/assign/circuit_variable.rs
+++ b/compiler/src/statement/assign/circuit_variable.rs
@@ -43,7 +43,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         match self.get_mutable_assignee(circuit_name, span.clone())? {
             ConstrainedValue::CircuitExpression(_variable, members) => {
                 // Modify the circuit variable in place
-                let matched_variable = members.into_iter().find(|member| member.0 == variable_name);
+                let matched_variable = members.iter_mut().find(|member| member.0 == variable_name);
 
                 match matched_variable {
                     Some(member) => match &member.1 {

--- a/compiler/src/statement/assign/circuit_variable.rs
+++ b/compiler/src/statement/assign/circuit_variable.rs
@@ -81,7 +81,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
                             member.1 = selected_value.to_owned();
 
-                            Ok(selected_value.to_owned())
+                            Ok(selected_value)
                         }
                         _ => {
                             // Throw an error if we try to mutate an immutable circuit variable

--- a/compiler/src/statement/branch/branch.rs
+++ b/compiler/src/statement/branch/branch.rs
@@ -41,7 +41,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 cs,
                 file_scope.clone(),
                 function_scope.clone(),
-                indicator.clone(),
+                indicator,
                 statement.clone(),
                 return_type.clone(),
                 "".to_owned(),

--- a/compiler/src/statement/branch/branch.rs
+++ b/compiler/src/statement/branch/branch.rs
@@ -16,7 +16,7 @@
 
 //! Enforces a branch of a conditional or iteration statement in a compiled Leo program.
 
-use crate::{errors::StatementError, program::ConstrainedProgram, value::ConstrainedValue, GroupType};
+use crate::{program::ConstrainedProgram, GroupType, IndicatorAndConstrainedValue, StatementResult};
 use leo_typed::{Statement, Type};
 
 use snarkos_models::{
@@ -33,7 +33,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         indicator: Option<Boolean>,
         statements: Vec<Statement>,
         return_type: Option<Type>,
-    ) -> Result<Vec<(Option<Boolean>, ConstrainedValue<F, G>)>, StatementError> {
+    ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
         let mut results = vec![];
         // Evaluate statements. Only allow a single return argument to be returned.
         for statement in statements.iter() {

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -36,6 +36,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     /// Due to R1CS constraints, we must evaluate every branch to properly construct the circuit.
     /// At program execution, we will pass an `indicator` bit down to all child statements within each branch.
     /// The `indicator` bit will select that branch while keeping the constraint system satisfied.
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_conditional_statement<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -28,7 +28,7 @@ fn indicator_to_string(indicator: &Boolean) -> String {
     indicator
         .get_value()
         .map(|b| b.to_string())
-        .unwrap_or("[input]".to_string())
+        .unwrap_or_else(|| "[input]".to_string())
 }
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -17,8 +17,12 @@
 //! Methods to enforce constraints on statements in a compiled Leo program.
 
 use crate::{
-    errors::StatementError, program::ConstrainedProgram, value::ConstrainedValue, GroupType,
-    IndicatorAndConstrainedValue, StatementResult
+    errors::StatementError,
+    program::ConstrainedProgram,
+    value::ConstrainedValue,
+    GroupType,
+    IndicatorAndConstrainedValue,
+    StatementResult,
 };
 use leo_typed::{ConditionalNestedOrEndStatement, ConditionalStatement, Span, Type};
 

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -28,7 +28,7 @@ fn indicator_to_string(indicator: &Boolean) -> String {
     indicator
         .get_value()
         .map(|b| b.to_string())
-        .unwrap_or(format!("[input]"))
+        .unwrap_or("[input]".to_string())
 }
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -16,7 +16,10 @@
 
 //! Methods to enforce constraints on statements in a compiled Leo program.
 
-use crate::{errors::StatementError, program::ConstrainedProgram, value::ConstrainedValue, GroupType};
+use crate::{
+    errors::StatementError, program::ConstrainedProgram, value::ConstrainedValue, GroupType,
+    IndicatorAndConstrainedValue, StatementResult
+};
 use leo_typed::{ConditionalNestedOrEndStatement, ConditionalStatement, Span, Type};
 
 use snarkos_models::{
@@ -46,7 +49,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         statement: ConditionalStatement,
         return_type: Option<Type>,
         span: Span,
-    ) -> Result<Vec<(Option<Boolean>, ConstrainedValue<F, G>)>, StatementError> {
+    ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
         let statement_string = statement.to_string();
 
         // Inherit the indicator from a previous conditional statement or assume that we are the outer parent

--- a/compiler/src/statement/definition/definition.rs
+++ b/compiler/src/statement/definition/definition.rs
@@ -86,6 +86,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         Ok(values)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn enforce_tuple_definition<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,
@@ -135,6 +136,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_definition_statement<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/statement/definition/definition.rs
+++ b/compiler/src/statement/definition/definition.rs
@@ -56,7 +56,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     ) -> Result<Vec<ConstrainedValue<F, G>>, StatementError> {
         let types = match type_ {
             Some(Type::Tuple(types)) => types,
-            Some(type_) => return Err(StatementError::tuple_type(type_.to_string(), span.clone())),
+            Some(type_) => return Err(StatementError::tuple_type(type_.to_string(), span)),
             None => vec![],
         };
 
@@ -157,7 +157,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             let variable = variables.names[0].clone();
             let expression = self.enforce_expression(
                 cs,
-                file_scope.clone(),
+                file_scope,
                 function_scope.clone(),
                 variables.type_,
                 expressions[0].clone(),
@@ -181,14 +181,14 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
             let values = match self.enforce_expression(
                 cs,
-                file_scope.clone(),
+                file_scope,
                 function_scope.clone(),
                 variables.type_.clone(),
                 expressions[0].clone(),
             )? {
                 // ConstrainedValue::Return(values) => values,
                 ConstrainedValue::Tuple(values) => values,
-                value => return Err(StatementError::multiple_definition(value.to_string(), span.clone())),
+                value => return Err(StatementError::multiple_definition(value.to_string(), span)),
             };
 
             self.enforce_multiple_definition(cs, function_scope, is_constant, variables, values, span)

--- a/compiler/src/statement/definition/definition.rs
+++ b/compiler/src/statement/definition/definition.rs
@@ -63,8 +63,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         let implicit_types = types.is_empty();
         let mut expected_types = vec![];
 
-        for i in 0..expressions.len() {
-            let expected_type = if implicit_types { None } else { Some(types[i].clone()) };
+        for ty in types.iter().take(expressions.len()) {
+            let expected_type = if implicit_types { None } else { Some(ty.clone()) };
 
             expected_types.push(expected_type);
         }

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -35,6 +35,7 @@ use snarkos_models::{
 };
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_iteration_statement<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -17,12 +17,13 @@
 //! Enforces an iteration statement in a compiled Leo program.
 
 use crate::{
-    errors::StatementError,
     new_scope,
     program::ConstrainedProgram,
     value::ConstrainedValue,
     GroupType,
+    IndicatorAndConstrainedValue,
     Integer,
+    StatementResult,
 };
 use leo_typed::{Expression, Identifier, Span, Statement, Type};
 
@@ -48,7 +49,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         statements: Vec<Statement>,
         return_type: Option<Type>,
         span: Span,
-    ) -> Result<Vec<(Option<Boolean>, ConstrainedValue<F, G>)>, StatementError> {
+    ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
         let mut results = vec![];
 
         let from = self.enforce_index(cs, file_scope.clone(), function_scope.clone(), start, span.clone())?;

--- a/compiler/src/statement/return_/return_.rs
+++ b/compiler/src/statement/return_/return_.rs
@@ -28,9 +28,7 @@ fn check_return_type(expected: Option<Type>, actual: Type, span: Span) -> Result
     match expected {
         Some(expected) => {
             if expected.ne(&actual) {
-                if expected.is_self() && actual.is_circuit() {
-                    return Ok(());
-                } else if expected.match_array_types(&actual) {
+                if (expected.is_self() && actual.is_circuit()) || expected.match_array_types(&actual) {
                     return Ok(());
                 } else {
                     return Err(StatementError::arguments_type(&expected, &actual, span));

--- a/compiler/src/statement/return_/return_.rs
+++ b/compiler/src/statement/return_/return_.rs
@@ -56,8 +56,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
         let result = self.enforce_operand(
             cs,
-            file_scope.clone(),
-            function_scope.clone(),
+            file_scope,
+            function_scope,
             return_type.clone(),
             expression,
             span.clone(),

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -30,6 +30,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     /// Each evaluated statement may execute of one or more statements that may return early.
     /// To indicate which of these return values to take we conditionally select the value according
     /// to the `indicator` bit that evaluates to true.
+    #[allow(clippy::too_many_arguments)]
     pub fn enforce_statement<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -71,7 +71,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     declared_circuit_reference,
                     indicator,
                     variable,
-                    expression,
+                    *expression,
                     span,
                 )?;
             }
@@ -95,8 +95,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     function_scope,
                     indicator,
                     index,
-                    start,
-                    stop,
+                    *start,
+                    *stop,
                     statements,
                     return_type,
                     span,

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -24,6 +24,9 @@ use snarkos_models::{
     gadgets::{r1cs::ConstraintSystem, utilities::boolean::Boolean},
 };
 
+pub type StatementResult<T> = Result<T, StatementError>;
+pub type IndicatorAndConstrainedValue<T, U> = (Option<Boolean>, ConstrainedValue<T, U>);
+
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     /// Enforce a program statement.
     /// Returns a Vector of (indicator, value) tuples.
@@ -40,7 +43,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         statement: Statement,
         return_type: Option<Type>,
         declared_circuit_reference: String,
-    ) -> Result<Vec<(Option<Boolean>, ConstrainedValue<F, G>)>, StatementError> {
+    ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
         let mut results = vec![];
 
         match statement {

--- a/compiler/src/value/address/address.rs
+++ b/compiler/src/value/address/address.rs
@@ -153,7 +153,7 @@ impl<F: Field + PrimeField> AllocGadget<String, F> for Address {
 impl<F: Field + PrimeField> EvaluateEqGadget<F> for Address {
     fn evaluate_equal<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Boolean, SynthesisError> {
         if self.is_constant() && other.is_constant() {
-            return Ok(Boolean::Constant(self.eq(other)));
+            Ok(Boolean::Constant(self.eq(other)))
         } else {
             let mut result = Boolean::constant(true);
 

--- a/compiler/src/value/field/field_type.rs
+++ b/compiler/src/value/field/field_type.rs
@@ -79,7 +79,7 @@ impl<F: Field + PrimeField> FieldType<F> {
             (FieldType::Allocated(self_value), FieldType::Allocated(other_value)) => {
                 let result = self_value
                     .add(cs, other_value)
-                    .map_err(|e| FieldError::binary_operation(format!("+"), e, span))?;
+                    .map_err(|e| FieldError::binary_operation("+".to_string(), e, span))?;
 
                 Ok(FieldType::Allocated(result))
             }
@@ -88,7 +88,7 @@ impl<F: Field + PrimeField> FieldType<F> {
             | (FieldType::Allocated(allocated_value), FieldType::Constant(constant_value)) => Ok(FieldType::Allocated(
                 allocated_value
                     .add_constant(cs, constant_value)
-                    .map_err(|e| FieldError::binary_operation(format!("+"), e, span))?,
+                    .map_err(|e| FieldError::binary_operation("+".to_string(), e, span))?,
             )),
         }
     }
@@ -102,7 +102,7 @@ impl<F: Field + PrimeField> FieldType<F> {
             (FieldType::Allocated(self_value), FieldType::Allocated(other_value)) => {
                 let result = self_value
                     .sub(cs, other_value)
-                    .map_err(|e| FieldError::binary_operation(format!("-"), e, span))?;
+                    .map_err(|e| FieldError::binary_operation("-".to_string(), e, span))?;
 
                 Ok(FieldType::Allocated(result))
             }
@@ -111,7 +111,7 @@ impl<F: Field + PrimeField> FieldType<F> {
             | (FieldType::Allocated(allocated_value), FieldType::Constant(constant_value)) => Ok(FieldType::Allocated(
                 allocated_value
                     .sub_constant(cs, constant_value)
-                    .map_err(|e| FieldError::binary_operation(format!("+"), e, span))?,
+                    .map_err(|e| FieldError::binary_operation("+".to_string(), e, span))?,
             )),
         }
     }
@@ -125,7 +125,7 @@ impl<F: Field + PrimeField> FieldType<F> {
             (FieldType::Allocated(self_value), FieldType::Allocated(other_value)) => {
                 let result = self_value
                     .mul(cs, other_value)
-                    .map_err(|e| FieldError::binary_operation(format!("*"), e, span))?;
+                    .map_err(|e| FieldError::binary_operation("*".to_string(), e, span))?;
 
                 Ok(FieldType::Allocated(result))
             }
@@ -134,7 +134,7 @@ impl<F: Field + PrimeField> FieldType<F> {
             | (FieldType::Allocated(allocated_value), FieldType::Constant(constant_value)) => Ok(FieldType::Allocated(
                 allocated_value
                     .mul_by_constant(cs, constant_value)
-                    .map_err(|e| FieldError::binary_operation(format!("*"), e, span))?,
+                    .map_err(|e| FieldError::binary_operation("*".to_string(), e, span))?,
             )),
         }
     }
@@ -144,14 +144,14 @@ impl<F: Field + PrimeField> FieldType<F> {
             FieldType::Constant(constant) => {
                 let constant_inverse = constant
                     .inverse()
-                    .ok_or(FieldError::no_inverse(constant.to_string(), span.clone()))?;
+                    .ok_or_else(|| FieldError::no_inverse(constant.to_string(), span.clone()))?;
 
                 FieldType::Constant(constant_inverse)
             }
             FieldType::Allocated(allocated) => {
                 let allocated_inverse = allocated
                     .inverse(&mut cs)
-                    .map_err(|e| FieldError::binary_operation(format!("+"), e, span.clone()))?;
+                    .map_err(|e| FieldError::binary_operation("+".to_string(), e, span.clone()))?;
 
                 FieldType::Allocated(allocated_inverse)
             }

--- a/compiler/src/value/group/targets/edwards_bls12.rs
+++ b/compiler/src/value/group/targets/edwards_bls12.rs
@@ -201,7 +201,9 @@ impl EdwardsGroupType {
         let x = Fq::from_str(&x_string).map_err(|_| GroupError::x_invalid(x_string, x_span))?;
         match greatest {
             // Sign provided
-            Some(greatest) => EdwardsAffine::from_x_coordinate(x, greatest).ok_or_else(|| GroupError::x_recover(element_span)),
+            Some(greatest) => {
+                EdwardsAffine::from_x_coordinate(x, greatest).ok_or_else(|| GroupError::x_recover(element_span))
+            }
             // Sign inferred
             None => {
                 // Attempt to recover with a sign_low bit.
@@ -230,7 +232,9 @@ impl EdwardsGroupType {
 
         match greatest {
             // Sign provided
-            Some(greatest) => EdwardsAffine::from_y_coordinate(y, greatest).ok_or_else(|| GroupError::y_recover(element_span)),
+            Some(greatest) => {
+                EdwardsAffine::from_y_coordinate(y, greatest).ok_or_else(|| GroupError::y_recover(element_span))
+            }
             // Sign inferred
             None => {
                 // Attempt to recover with a sign_low bit.
@@ -294,12 +298,8 @@ impl EdwardsGroupType {
                 let x_value = allocated.x.get_value();
                 let y_value = allocated.y.get_value();
 
-                let x_allocated = FpGadget::alloc(cs.ns(|| "x"), || {
-                    x_value.ok_or(SynthesisError::AssignmentMissing)
-                })?;
-                let y_allocated = FpGadget::alloc(cs.ns(|| "y"), || {
-                    y_value.ok_or(SynthesisError::AssignmentMissing)
-                })?;
+                let x_allocated = FpGadget::alloc(cs.ns(|| "x"), || x_value.ok_or(SynthesisError::AssignmentMissing))?;
+                let y_allocated = FpGadget::alloc(cs.ns(|| "y"), || y_value.ok_or(SynthesisError::AssignmentMissing))?;
 
                 Ok(EdwardsBlsGadget::new(x_allocated, y_allocated))
             }

--- a/compiler/src/value/group/targets/edwards_bls12.rs
+++ b/compiler/src/value/group/targets/edwards_bls12.rs
@@ -143,13 +143,13 @@ impl EdwardsGroupType {
 
     pub fn edwards_affine_from_single(number: String, span: Span) -> Result<EdwardsAffine, GroupError> {
         if number.eq("0") {
-            return Ok(EdwardsAffine::zero());
+            Ok(EdwardsAffine::zero())
         } else {
             let one = edwards_affine_one();
             let number_value = Fp256::from_str(&number).map_err(|_| GroupError::n_group(number, span))?;
             let result: EdwardsAffine = one.mul(&number_value);
 
-            return Ok(result);
+            Ok(result)
         }
     }
 

--- a/compiler/src/value/group/targets/edwards_bls12.rs
+++ b/compiler/src/value/group/targets/edwards_bls12.rs
@@ -88,7 +88,7 @@ impl GroupType<Fq> for EdwardsGroupType {
                     cs,
                     other_value,
                 )
-                .map_err(|e| GroupError::binary_operation(format!("+"), e, span))?;
+                .map_err(|e| GroupError::binary_operation("+".to_string(), e, span))?;
 
                 Ok(EdwardsGroupType::Allocated(result))
             }
@@ -98,7 +98,7 @@ impl GroupType<Fq> for EdwardsGroupType {
                 Ok(EdwardsGroupType::Allocated(
                     allocated_value
                         .add_constant(cs, constant_value)
-                        .map_err(|e| GroupError::binary_operation(format!("+"), e, span))?,
+                        .map_err(|e| GroupError::binary_operation("+".to_string(), e, span))?,
                 ))
             }
         }
@@ -116,7 +116,7 @@ impl GroupType<Fq> for EdwardsGroupType {
                     cs,
                     other_value,
                 )
-                .map_err(|e| GroupError::binary_operation(format!("-"), e, span))?;
+                .map_err(|e| GroupError::binary_operation("-".to_string(), e, span))?;
 
                 Ok(EdwardsGroupType::Allocated(result))
             }
@@ -126,7 +126,7 @@ impl GroupType<Fq> for EdwardsGroupType {
                 Ok(EdwardsGroupType::Allocated(
                     allocated_value
                         .sub_constant(cs, constant_value)
-                        .map_err(|e| GroupError::binary_operation(format!("-"), e, span))?,
+                        .map_err(|e| GroupError::binary_operation("-".to_string(), e, span))?,
                 ))
             }
         }
@@ -294,10 +294,10 @@ impl EdwardsGroupType {
                 let x_value = allocated.x.get_value();
                 let y_value = allocated.y.get_value();
 
-                let x_allocated = FpGadget::alloc(cs.ns(|| format!("x")), || {
+                let x_allocated = FpGadget::alloc(cs.ns(|| "x"), || {
                     x_value.ok_or(SynthesisError::AssignmentMissing)
                 })?;
-                let y_allocated = FpGadget::alloc(cs.ns(|| format!("y")), || {
+                let y_allocated = FpGadget::alloc(cs.ns(|| "y"), || {
                     y_value.ok_or(SynthesisError::AssignmentMissing)
                 })?;
 

--- a/compiler/src/value/group/targets/edwards_bls12.rs
+++ b/compiler/src/value/group/targets/edwards_bls12.rs
@@ -201,7 +201,7 @@ impl EdwardsGroupType {
         let x = Fq::from_str(&x_string).map_err(|_| GroupError::x_invalid(x_string, x_span))?;
         match greatest {
             // Sign provided
-            Some(greatest) => EdwardsAffine::from_x_coordinate(x, greatest).ok_or(GroupError::x_recover(element_span)),
+            Some(greatest) => EdwardsAffine::from_x_coordinate(x, greatest).ok_or_else(|| GroupError::x_recover(element_span)),
             // Sign inferred
             None => {
                 // Attempt to recover with a sign_low bit.
@@ -230,7 +230,7 @@ impl EdwardsGroupType {
 
         match greatest {
             // Sign provided
-            Some(greatest) => EdwardsAffine::from_y_coordinate(y, greatest).ok_or(GroupError::y_recover(element_span)),
+            Some(greatest) => EdwardsAffine::from_y_coordinate(y, greatest).ok_or_else(|| GroupError::y_recover(element_span)),
             // Sign inferred
             None => {
                 // Attempt to recover with a sign_low bit.

--- a/compiler/src/value/group/targets/edwards_bls12.rs
+++ b/compiler/src/value/group/targets/edwards_bls12.rs
@@ -205,7 +205,7 @@ impl EdwardsGroupType {
             // Sign inferred
             None => {
                 // Attempt to recover with a sign_low bit.
-                if let Some(element) = EdwardsAffine::from_x_coordinate(x.clone(), false) {
+                if let Some(element) = EdwardsAffine::from_x_coordinate(x, false) {
                     return Ok(element);
                 }
 
@@ -234,7 +234,7 @@ impl EdwardsGroupType {
             // Sign inferred
             None => {
                 // Attempt to recover with a sign_low bit.
-                if let Some(element) = EdwardsAffine::from_y_coordinate(y.clone(), false) {
+                if let Some(element) = EdwardsAffine::from_y_coordinate(y, false) {
                     return Ok(element);
                 }
 

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -157,7 +157,7 @@ impl Integer {
         let unsigned_integer = self;
         let value_option: Option<String> = match_unsigned_integer!(unsigned_integer => unsigned_integer.get_value());
 
-        let value = value_option.ok_or(IntegerError::invalid_index(span.clone()))?;
+        let value = value_option.ok_or_else(|| IntegerError::invalid_index(span.clone()))?;
         let value_usize = value
             .parse::<usize>()
             .map_err(|_| IntegerError::invalid_integer(value, span))?;
@@ -395,7 +395,7 @@ impl Integer {
 
         let result = match_integers_span!((a, b), s => a.add(cs.ns(|| unique_namespace), &b));
 
-        result.ok_or(IntegerError::binary_operation(format!("+"), span))
+        result.ok_or_else(|| IntegerError::binary_operation("+".to_string(), span))
     }
 
     pub fn sub<F: Field + PrimeField, CS: ConstraintSystem<F>>(
@@ -412,7 +412,7 @@ impl Integer {
 
         let result = match_integers_span!((a, b), s => a.sub(cs.ns(|| unique_namespace), &b));
 
-        result.ok_or(IntegerError::binary_operation(format!("-"), span))
+        result.ok_or_else(|| IntegerError::binary_operation("-".to_string(), span))
     }
 
     pub fn mul<F: Field + PrimeField, CS: ConstraintSystem<F>>(
@@ -429,7 +429,7 @@ impl Integer {
 
         let result = match_integers_span!((a, b), s => a.mul(cs.ns(|| unique_namespace), &b));
 
-        result.ok_or(IntegerError::binary_operation(format!("*"), span))
+        result.ok_or_else(|| IntegerError::binary_operation("*".to_string(), span))
     }
 
     pub fn div<F: Field + PrimeField, CS: ConstraintSystem<F>>(
@@ -446,7 +446,7 @@ impl Integer {
 
         let result = match_integers_span!((a, b), s => a.div(cs.ns(|| unique_namespace), &b));
 
-        result.ok_or(IntegerError::binary_operation(format!("÷"), span))
+        result.ok_or_else(|| IntegerError::binary_operation("÷".to_string(), span))
     }
 
     pub fn pow<F: Field + PrimeField, CS: ConstraintSystem<F>>(
@@ -463,7 +463,7 @@ impl Integer {
 
         let result = match_integers_span!((a, b), s => a.pow(cs.ns(|| unique_namespace), &b));
 
-        result.ok_or(IntegerError::binary_operation(format!("**"), span))
+        result.ok_or_else(|| IntegerError::binary_operation("**".to_string(), span))
     }
 }
 

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -378,7 +378,7 @@ impl Integer {
 
         let result = match_signed_integer!(a, s => a.neg(cs.ns(|| unique_namespace)));
 
-        result.ok_or(IntegerError::negate_operation(span))
+        result.ok_or_else(|| IntegerError::negate_operation(span))
     }
 
     pub fn add<F: Field + PrimeField, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -402,13 +402,13 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConditionalEqGadget<F> for Constrai
                 num_1.conditional_enforce_equal(cs, num_2, condition)
             }
             (ConstrainedValue::Array(arr_1), ConstrainedValue::Array(arr_2)) => {
-                for (i, (left, right)) in arr_1.into_iter().zip(arr_2.into_iter()).enumerate() {
+                for (i, (left, right)) in arr_1.iter().zip(arr_2.iter()).enumerate() {
                     left.conditional_enforce_equal(cs.ns(|| format!("array[{}]", i)), right, condition)?;
                 }
                 Ok(())
             }
             (ConstrainedValue::Tuple(tuple_1), ConstrainedValue::Tuple(tuple_2)) => {
-                for (i, (left, right)) in tuple_1.into_iter().zip(tuple_2.into_iter()).enumerate() {
+                for (i, (left, right)) in tuple_1.iter().zip(tuple_2.iter()).enumerate() {
                     left.conditional_enforce_equal(cs.ns(|| format!("tuple index {}", i)), right, condition)?;
                 }
                 Ok(())
@@ -448,7 +448,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> CondSelectGadget<F> for Constrained
             (ConstrainedValue::Array(arr_1), ConstrainedValue::Array(arr_2)) => {
                 let mut array = vec![];
 
-                for (i, (first, second)) in arr_1.into_iter().zip(arr_2.into_iter()).enumerate() {
+                for (i, (first, second)) in arr_1.iter().zip(arr_2.iter()).enumerate() {
                     array.push(Self::conditionally_select(
                         cs.ns(|| format!("array[{}]", i)),
                         cond,
@@ -462,7 +462,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> CondSelectGadget<F> for Constrained
             (ConstrainedValue::Tuple(tuple_1), ConstrainedValue::Array(tuple_2)) => {
                 let mut array = vec![];
 
-                for (i, (first, second)) in tuple_1.into_iter().zip(tuple_2.into_iter()).enumerate() {
+                for (i, (first, second)) in tuple_1.iter().zip(tuple_2.iter()).enumerate() {
                     array.push(Self::conditionally_select(
                         cs.ns(|| format!("tuple index {}", i)),
                         cond,
@@ -484,7 +484,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> CondSelectGadget<F> for Constrained
             ) => {
                 let mut members = vec![];
 
-                for (i, (first, second)) in members_1.into_iter().zip(members_2.into_iter()).enumerate() {
+                for (i, (first, second)) in members_1.iter().zip(members_2.iter()).enumerate() {
                     members.push(ConstrainedCircuitMember::conditionally_select(
                         cs.ns(|| format!("circuit member[{}]", i)),
                         cond,

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -239,7 +239,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
             }
             ConstrainedValue::Boolean(boolean) => {
                 let option = boolean.get_value();
-                let name = option.map(|b| b.to_string()).unwrap_or("[allocated]".to_string());
+                let name = option.map(|b| b.to_string()).unwrap_or_else(|| "[allocated]".to_string());
 
                 *boolean = allocate_bool(&mut cs, name, option, span)?;
             }
@@ -256,7 +256,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
             ConstrainedValue::Integer(integer) => {
                 let integer_type = integer.get_type();
                 let option = integer.get_value();
-                let name = option.clone().unwrap_or("[allocated]".to_string());
+                let name = option.clone().unwrap_or_else(|| "[allocated]".to_string());
 
                 *integer = Integer::allocate_type(&mut cs, integer_type, name, option, span)?;
             }
@@ -328,7 +328,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> fmt::Display for ConstrainedValue<F
                 value
                     .get_value()
                     .map(|v| v.to_string())
-                    .unwrap_or("[allocated]".to_string())
+                    .unwrap_or_else(|| "[allocated]".to_string())
             ),
             ConstrainedValue::Field(ref value) => write!(f, "{:?}", value),
             ConstrainedValue::Group(ref value) => write!(f, "{:?}", value),

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -110,7 +110,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
 
             // Data type wrappers
             ConstrainedValue::Array(array) => {
-                let array_type = array[0].to_type(span.clone())?;
+                let array_type = array[0].to_type(span)?;
                 let mut dimensions = vec![array.len()];
 
                 // Nested array type
@@ -205,12 +205,12 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
                 // If this is a circuit function, evaluate inside the circuit scope
                 if let Some(identifier) = circuit_identifier {
                     // avoid creating recursive scope
-                    if !is_in_scope(&scope, &identifier.name.to_string()) {
-                        outer_scope = new_scope(scope, identifier.name.to_string());
+                    if !is_in_scope(&scope, &identifier.name) {
+                        outer_scope = new_scope(scope, identifier.name);
                     }
                 }
 
-                Ok((outer_scope, function.clone()))
+                Ok((outer_scope, function))
             }
             ConstrainedValue::Import(import_scope, function) => function.extract_function(import_scope, span),
             value => Err(ExpressionError::undefined_function(value.to_string(), span)),

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -239,7 +239,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
             }
             ConstrainedValue::Boolean(boolean) => {
                 let option = boolean.get_value();
-                let name = option.map(|b| b.to_string()).unwrap_or(format!("[allocated]"));
+                let name = option.map(|b| b.to_string()).unwrap_or("[allocated]".to_string());
 
                 *boolean = allocate_bool(&mut cs, name, option, span)?;
             }
@@ -256,7 +256,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
             ConstrainedValue::Integer(integer) => {
                 let integer_type = integer.get_type();
                 let option = integer.get_value();
-                let name = option.clone().unwrap_or(format!("[allocated]"));
+                let name = option.clone().unwrap_or("[allocated]".to_string());
 
                 *integer = Integer::allocate_type(&mut cs, integer_type, name, option, span)?;
             }
@@ -328,7 +328,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> fmt::Display for ConstrainedValue<F
                 value
                     .get_value()
                     .map(|v| v.to_string())
-                    .unwrap_or(format!("[allocated]"))
+                    .unwrap_or("[allocated]".to_string())
             ),
             ConstrainedValue::Field(ref value) => write!(f, "{:?}", value),
             ConstrainedValue::Group(ref value) => write!(f, "{:?}", value),

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -239,7 +239,9 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
             }
             ConstrainedValue::Boolean(boolean) => {
                 let option = boolean.get_value();
-                let name = option.map(|b| b.to_string()).unwrap_or_else(|| "[allocated]".to_string());
+                let name = option
+                    .map(|b| b.to_string())
+                    .unwrap_or_else(|| "[allocated]".to_string());
 
                 *boolean = allocate_bool(&mut cs, name, option, span)?;
             }
@@ -545,18 +547,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> From<Value> for ConstrainedValue<F,
             Value::I64(i64) => ConstrainedValue::Integer(Integer::I64(i64)),
             Value::I128(i128) => ConstrainedValue::Integer(Integer::I128(i128)),
 
-            Value::Array(array) => ConstrainedValue::Array(
-                array
-                    .into_iter()
-                    .map(ConstrainedValue::from)
-                    .collect(),
-            ),
-            Value::Tuple(tuple) => ConstrainedValue::Tuple(
-                tuple
-                    .into_iter()
-                    .map(ConstrainedValue::from)
-                    .collect(),
-            ),
+            Value::Array(array) => ConstrainedValue::Array(array.into_iter().map(ConstrainedValue::from).collect()),
+            Value::Tuple(tuple) => ConstrainedValue::Tuple(tuple.into_iter().map(ConstrainedValue::from).collect()),
         }
     }
 }

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -548,13 +548,13 @@ impl<F: Field + PrimeField, G: GroupType<F>> From<Value> for ConstrainedValue<F,
             Value::Array(array) => ConstrainedValue::Array(
                 array
                     .into_iter()
-                    .map(|element| ConstrainedValue::from(element))
+                    .map(ConstrainedValue::from)
                     .collect(),
             ),
             Value::Tuple(tuple) => ConstrainedValue::Tuple(
                 tuple
                     .into_iter()
-                    .map(|element| ConstrainedValue::from(element))
+                    .map(ConstrainedValue::from)
                     .collect(),
             ),
         }

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -213,7 +213,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
                 Ok((outer_scope, function.clone()))
             }
             ConstrainedValue::Import(import_scope, function) => function.extract_function(import_scope, span),
-            value => return Err(ExpressionError::undefined_function(value.to_string(), span)),
+            value => Err(ExpressionError::undefined_function(value.to_string(), span)),
         }
     }
 
@@ -221,7 +221,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
         match self {
             ConstrainedValue::CircuitDefinition(circuit) => Ok(circuit),
             ConstrainedValue::Import(_import_scope, circuit) => circuit.extract_circuit(span),
-            value => return Err(ExpressionError::undefined_circuit(value.to_string(), span)),
+            value => Err(ExpressionError::undefined_circuit(value.to_string(), span)),
         }
     }
 
@@ -413,7 +413,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConditionalEqGadget<F> for Constrai
                 }
                 Ok(())
             }
-            (_, _) => return Err(SynthesisError::Unsatisfiable),
+            (_, _) => Err(SynthesisError::Unsatisfiable),
         }
     }
 

--- a/core/src/errors/core_package.rs
+++ b/core/src/errors/core_package.rs
@@ -35,7 +35,7 @@ impl CorePackageError {
     }
 
     pub fn core_package_star(span: Span) -> Self {
-        let message = format!("Cannot import star from leo-core");
+        let message = "Cannot import star from leo-core".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/core/src/errors/core_package_list.rs
+++ b/core/src/errors/core_package_list.rs
@@ -48,7 +48,7 @@ impl CorePackageListError {
     }
 
     pub fn core_package_star(span: Span) -> Self {
-        let message = format!("Cannot import star from leo-core");
+        let message = "Cannot import star from leo-core".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/core/src/packages/unstable/blake2s.rs
+++ b/core/src/packages/unstable/blake2s.rs
@@ -141,7 +141,7 @@ impl CoreCircuit for Blake2sCircuit {
             .to_bytes(cs)
             .map_err(|e| CoreCircuitError::cannot_enforce("Vec<UInt8> ToBytes".to_owned(), e, span.clone()))?;
 
-        let return_value = bytes.into_iter().map(|byte| Value::U8(byte)).collect();
+        let return_value = bytes.into_iter().map(Value::U8).collect();
 
         // Return one array digest value
         Ok(vec![Value::Array(return_value)])

--- a/core/src/packages/unstable/blake2s.rs
+++ b/core/src/packages/unstable/blake2s.rs
@@ -104,7 +104,7 @@ impl CoreCircuit for Blake2sCircuit {
                         ),
                         span.clone(),
                     )],
-                    span: span.clone(),
+                    span,
                 },
             )],
         }

--- a/core/src/types/core_package.rs
+++ b/core/src/types/core_package.rs
@@ -87,9 +87,7 @@ impl CorePackage {
                 }
             } else {
                 // match core circuit
-                match circuit_name {
-                    name => return Err(CorePackageError::undefined_core_circuit(name.to_string(), span)),
-                }
+                return Err(CorePackageError::undefined_core_circuit(circuit_name.to_string(), span));
             };
 
             circuit_structs.push(name, circuit)

--- a/core/src/types/core_package.rs
+++ b/core/src/types/core_package.rs
@@ -71,7 +71,7 @@ impl CorePackage {
             let span = circuit.span.clone();
 
             // take the alias if it is present
-            let id = circuit.alias.clone().unwrap_or(circuit.symbol.clone());
+            let id = circuit.alias.clone().unwrap_or_else(|| circuit.symbol.clone());
             let name = id.name.clone();
 
             let circuit = if self.unstable {

--- a/core/src/types/value.rs
+++ b/core/src/types/value.rs
@@ -71,7 +71,7 @@ impl fmt::Display for Value {
             }
         };
 
-        let string = string_option.unwrap_or("[input]".to_owned());
+        let string = string_option.unwrap_or_else(|| "[input]".to_owned());
 
         write!(f, "{}", string)
     }

--- a/gadgets/src/arithmetic/add.rs
+++ b/gadgets/src/arithmetic/add.rs
@@ -30,7 +30,6 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn add<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }
 

--- a/gadgets/src/arithmetic/div.rs
+++ b/gadgets/src/arithmetic/div.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn div<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/gadgets/src/arithmetic/mul.rs
+++ b/gadgets/src/arithmetic/mul.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn mul<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/gadgets/src/arithmetic/neg.rs
+++ b/gadgets/src/arithmetic/neg.rs
@@ -29,7 +29,6 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn neg<CS: ConstraintSystem<F>>(&self, cs: CS) -> Result<Self, Self::ErrorType>;
 }
 

--- a/gadgets/src/arithmetic/neg.rs
+++ b/gadgets/src/arithmetic/neg.rs
@@ -43,7 +43,7 @@ impl<F: Field> Neg<F> for Vec<Boolean> {
         let mut one = vec![Boolean::constant(true)];
         one.append(&mut vec![Boolean::Constant(false); self.len() - 1]);
 
-        let mut bits = flipped.add_bits(cs.ns(|| format!("add one")), &one)?;
+        let mut bits = flipped.add_bits(cs.ns(|| "add one"), &one)?;
         let _carry = bits.pop(); // we already accounted for overflow above
 
         Ok(bits)

--- a/gadgets/src/arithmetic/pow.rs
+++ b/gadgets/src/arithmetic/pow.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn pow<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/gadgets/src/arithmetic/sub.rs
+++ b/gadgets/src/arithmetic/sub.rs
@@ -23,6 +23,5 @@ where
 {
     type ErrorType;
 
-    #[must_use]
     fn sub<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Self, Self::ErrorType>;
 }

--- a/gadgets/src/bits/adder.rs
+++ b/gadgets/src/bits/adder.rs
@@ -44,12 +44,12 @@ impl<'a, F: Field> FullAdder<'a, F> for Boolean {
         b: &'a Self,
         carry: &'a Self,
     ) -> Result<(Self, Self), SynthesisError> {
-        let a_x_b = Boolean::xor(cs.ns(|| format!("a XOR b")), a, b)?;
-        let sum = Boolean::xor(cs.ns(|| format!("adder sum")), &a_x_b, carry)?;
+        let a_x_b = Boolean::xor(cs.ns(|| "a XOR b"), a, b)?;
+        let sum = Boolean::xor(cs.ns(|| "adder sum"), &a_x_b, carry)?;
 
-        let c1 = Boolean::and(cs.ns(|| format!("a AND b")), a, b)?;
-        let c2 = Boolean::and(cs.ns(|| format!("carry AND (a XOR b)")), carry, &a_x_b)?;
-        let carry = Boolean::or(cs.ns(|| format!("c1 OR c2")), &c1, &c2)?;
+        let c1 = Boolean::and(cs.ns(|| "a AND b"), a, b)?;
+        let c2 = Boolean::and(cs.ns(|| "carry AND (a XOR b)"), carry, &a_x_b)?;
+        let carry = Boolean::or(cs.ns(|| "c1 OR c2"), &c1, &c2)?;
 
         Ok((sum, carry))
     }

--- a/gadgets/src/bits/rca.rs
+++ b/gadgets/src/bits/rca.rs
@@ -27,7 +27,6 @@ pub trait RippleCarryAdder<F: Field, Rhs = Self>
 where
     Self: std::marker::Sized,
 {
-    #[must_use]
     fn add_bits<CS: ConstraintSystem<F>>(&self, cs: CS, other: &Self) -> Result<Vec<Boolean>, SynthesisError>;
 }
 

--- a/gadgets/src/bits/sign_extend.rs
+++ b/gadgets/src/bits/sign_extend.rs
@@ -30,7 +30,7 @@ impl SignExtend for Boolean {
     fn sign_extend(bits: &[Boolean], length: usize) -> Vec<Boolean> {
         let msb = bits.last().expect("empty bit list");
         let bits_needed = length - bits.len();
-        let mut extension = vec![msb.clone(); bits_needed];
+        let mut extension = vec![*msb; bits_needed];
 
         let mut result = Vec::from(bits);
         result.append(&mut extension);

--- a/gadgets/src/signed_integer/arithmetic/add.rs
+++ b/gadgets/src/signed_integer/arithmetic/add.rs
@@ -87,7 +87,7 @@ macro_rules! add_int_impl {
                             all_constants = false;
 
                             // Add the coeff * bit_gadget
-                            lc = lc + (coeff, bit.get_variable());
+                            lc += (coeff, bit.get_variable());
                         }
                         Boolean::Not(ref bit) => {
                             all_constants = false;
@@ -97,7 +97,7 @@ macro_rules! add_int_impl {
                         }
                         Boolean::Constant(bit) => {
                             if bit {
-                                lc = lc + (coeff, CS::one());
+                                lc += (coeff, CS::one());
                             }
                         }
                     }

--- a/gadgets/src/signed_integer/arithmetic/div.rs
+++ b/gadgets/src/signed_integer/arithmetic/div.rs
@@ -206,13 +206,13 @@ macro_rules! div_int_impl {
                         &r
                     )?;
 
-                    index = index - 1;
+                    index -= 1;
 
                     let mut q_new = q.clone();
                     q_new.bits[index] = true_bit.clone();
                     q_new.value = Some(q_new.value.unwrap() + bit_value);
 
-                    bit_value = (bit_value >> 1);
+                    bit_value >>= 1;
 
                     q = Self::conditionally_select(
                         &mut cs.ns(|| format!("set_bit_or_same_{}", i)),

--- a/gadgets/src/signed_integer/arithmetic/mul.rs
+++ b/gadgets/src/signed_integer/arithmetic/mul.rs
@@ -146,7 +146,7 @@ macro_rules! mul_int_impl {
                             all_constants = false;
 
                             // Add the coeff * bit_gadget
-                            lc = lc + (coeff, bit.get_variable());
+                            lc += (coeff, bit.get_variable());
                         }
                         Boolean::Not(ref bit) => {
                             all_constants = false;
@@ -156,7 +156,7 @@ macro_rules! mul_int_impl {
                         }
                         Boolean::Constant(bit) => {
                             if bit {
-                                lc = lc + (coeff, CS::one());
+                                lc += (coeff, CS::one());
                             }
                         }
                     }

--- a/input/src/errors/parser.rs
+++ b/input/src/errors/parser.rs
@@ -53,20 +53,17 @@ pub enum InputParserError {
 
 impl InputParserError {
     pub fn set_path(&mut self, path: PathBuf) {
-        match self {
-            InputParserError::SyntaxError(error) => {
-                let new_error: Error<Rule> = match error {
-                    InputSyntaxError::Error(error) => {
-                        let new_error = error.clone();
-                        new_error.with_path(path.to_str().unwrap())
-                    }
-                };
+        if let InputParserError::SyntaxError(error) = self {
+            let new_error: Error<Rule> = match error {
+                InputSyntaxError::Error(error) => {
+                    let new_error = error.clone();
+                    new_error.with_path(path.to_str().unwrap())
+                }
+            };
 
-                tracing::error!("{}", new_error);
+            tracing::error!("{}", new_error);
 
-                *error = InputSyntaxError::Error(new_error);
-            }
-            _ => {}
+            *error = InputSyntaxError::Error(new_error);
         }
     }
 

--- a/leo/cli.rs
+++ b/leo/cli.rs
@@ -35,7 +35,7 @@ pub trait CLI {
             .iter()
             .map(|a| {
                 let mut args = Arg::with_name(a.0).help(a.1).required(a.3).index(a.4);
-                if a.2.len() > 0 {
+                if !a.2.is_empty() {
                     args = args.possible_values(a.2);
                 }
                 args
@@ -47,7 +47,7 @@ pub trait CLI {
             .collect::<Vec<Arg<'static, 'static>>>();
         let options = &Self::OPTIONS
             .iter()
-            .map(|a| match a.2.len() > 0 {
+            .map(|a| match !a.2.is_empty() {
                 true => Arg::from_usage(a.0)
                     .conflicts_with_all(a.1)
                     .possible_values(a.2)
@@ -64,7 +64,7 @@ pub trait CLI {
                         &s.2.iter()
                             .map(|a| {
                                 let mut args = Arg::with_name(a.0).help(a.1).required(a.3).index(a.4);
-                                if a.2.len() > 0 {
+                                if !a.2.is_empty() {
                                     args = args.possible_values(a.2);
                                 }
                                 args
@@ -78,7 +78,7 @@ pub trait CLI {
                     )
                     .args(
                         &s.4.iter()
-                            .map(|a| match a.2.len() > 0 {
+                            .map(|a| match !a.2.is_empty() {
                                 true => Arg::from_usage(a.0)
                                     .conflicts_with_all(a.1)
                                     .possible_values(a.2)

--- a/leo/commands/add.rs
+++ b/leo/commands/add.rs
@@ -167,7 +167,7 @@ impl CLI for AddCommand {
             let mut file_path = path.clone();
             file_path.push(file_name);
 
-            if file_name.ends_with("/") {
+            if file_name.ends_with('/') {
                 create_dir_all(file_path)?;
             } else {
                 if let Some(parent_directory) = path.parent() {

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -93,7 +93,7 @@ impl CLI for BuildCommand {
             // Compile the library file but do not output
             let _program = Compiler::<Fq, EdwardsGroupType>::parse_program_without_input(
                 package_name.clone(),
-                lib_file_path.clone(),
+                lib_file_path,
                 output_directory.clone(),
             )?;
             tracing::info!("Complete");
@@ -121,7 +121,7 @@ impl CLI for BuildCommand {
             // Load the program at `main_file_path`
             let program = Compiler::<Fq, EdwardsGroupType>::parse_program_with_input(
                 package_name.clone(),
-                main_file_path.clone(),
+                main_file_path,
                 output_directory,
                 &input_string,
                 input_path,

--- a/leo/commands/deploy.rs
+++ b/leo/commands/deploy.rs
@@ -65,7 +65,7 @@ impl CLI for DeployCommand {
                 Ok(())
             }
             None => {
-                let mut main_file_path = path.clone();
+                let mut main_file_path = path;
                 main_file_path.push(SOURCE_DIRECTORY_NAME);
                 main_file_path.push(MAIN_FILENAME);
 

--- a/leo/commands/lint.rs
+++ b/leo/commands/lint.rs
@@ -65,7 +65,7 @@ impl CLI for LintCommand {
                 Ok(())
             }
             None => {
-                let mut main_file_path = path.clone();
+                let mut main_file_path = path;
                 main_file_path.push(SOURCE_DIRECTORY_NAME);
                 main_file_path.push(MAIN_FILENAME);
 

--- a/leo/commands/setup.rs
+++ b/leo/commands/setup.rs
@@ -146,7 +146,7 @@ impl CLI for SetupCommand {
                 Ok((program, proving_key, prepared_verifying_key))
             }
             None => {
-                let mut main_file_path = path.clone();
+                let mut main_file_path = path;
                 main_file_path.push(SOURCE_DIRECTORY_NAME);
                 main_file_path.push(MAIN_FILENAME);
 

--- a/leo/commands/test.rs
+++ b/leo/commands/test.rs
@@ -60,7 +60,7 @@ impl CLI for TestCommand {
         let package_name = manifest.get_package_name();
 
         // Sanitize the package path to the root directory
-        let mut package_path = path.clone();
+        let mut package_path = path;
         if package_path.is_file() {
             package_path.pop();
         }
@@ -93,8 +93,8 @@ impl CLI for TestCommand {
 
         // Parse the current main program file
         let program = Compiler::<Fq, EdwardsGroupType>::parse_program_without_input(
-            package_name.clone(),
-            file_path.clone(),
+            package_name,
+            file_path,
             output_directory,
         )?;
 
@@ -102,7 +102,7 @@ impl CLI for TestCommand {
         let pairs = InputPairs::try_from(&package_path)?;
 
         // Run tests
-        let temporary_program = program.clone();
+        let temporary_program = program;
         let (passed, failed) = temporary_program.compile_test_constraints(pairs)?;
 
         // Drop "Test" context for console logging

--- a/leo/commands/test.rs
+++ b/leo/commands/test.rs
@@ -92,11 +92,8 @@ impl CLI for TestCommand {
         let start = Instant::now();
 
         // Parse the current main program file
-        let program = Compiler::<Fq, EdwardsGroupType>::parse_program_without_input(
-            package_name,
-            file_path,
-            output_directory,
-        )?;
+        let program =
+            Compiler::<Fq, EdwardsGroupType>::parse_program_without_input(package_name, file_path, output_directory)?;
 
         // Parse all inputs as input pairs
         let pairs = InputPairs::try_from(&package_path)?;

--- a/leo/commands/update.rs
+++ b/leo/commands/update.rs
@@ -52,14 +52,11 @@ impl CLI for UpdateCommand {
     ];
 
     fn parse(arguments: &clap::ArgMatches) -> Result<Self::Options, crate::errors::CLIError> {
-        match arguments.subcommand() {
-            ("automatic", Some(arguments)) => {
-                // Run the `automatic` subcommand
-                let options = UpdateAutomatic::parse(arguments)?;
-                let _output = UpdateAutomatic::output(options)?;
-                return Ok(None);
-            }
-            _ => {}
+        if let ("automatic", Some(arguments)) = arguments.subcommand() {
+            // Run the `automatic` subcommand
+            let options = UpdateAutomatic::parse(arguments)?;
+            let _output = UpdateAutomatic::output(options)?;
+            return Ok(None);
         };
 
         let show_all_versions = arguments.is_present("list");

--- a/leo/commands/watch.rs
+++ b/leo/commands/watch.rs
@@ -57,8 +57,7 @@ impl CLI for WatchCommand {
             match rx.recv() {
                 // See changes on the write event
                 Ok(DebouncedEvent::Write(_write)) => {
-                    let options = ();
-                    match BuildCommand::output(options) {
+                    match BuildCommand::output(()) {
                         Ok(_output) => {
                             tracing::info!("Built successfully");
                         }

--- a/leo/config.rs
+++ b/leo/config.rs
@@ -131,7 +131,7 @@ pub fn write_token(token: &str) -> Result<(), io::Error> {
     let config_dir = LEO_CONFIG_DIRECTORY.clone();
 
     // Create Leo config directory if it not exists
-    if !Path::new(&config_dir.to_path_buf()).exists() {
+    if !Path::new(&config_dir).exists() {
         create_dir_all(&config_dir)?;
     }
 

--- a/leo/config.rs
+++ b/leo/config.rs
@@ -91,7 +91,7 @@ impl Config {
         let toml_string = match fs::read_to_string(&config_path) {
             Ok(mut toml) => {
                 // If the config is using an incorrect format, rewrite it.
-                if let Err(_) = toml::from_str::<Config>(&toml) {
+                if toml::from_str::<Config>(&toml).is_err() {
                     let default_config_string = toml::to_string(&Config::default())?;
                     fs::write(&config_path, default_config_string.clone())?;
                     toml = default_config_string;

--- a/leo/synthesizer/serialized_circuit.rs
+++ b/leo/synthesizer/serialized_circuit.rs
@@ -57,7 +57,7 @@ impl<E: PairingEngine> From<CircuitSynthesizer<E>> for SerializedCircuit {
         let num_constraints = synthesizer.num_constraints();
 
         // Serialize assignments
-        fn get_serialized_assignments<E: PairingEngine>(assignments: &Vec<E::Fr>) -> Vec<SerializedField> {
+        fn get_serialized_assignments<E: PairingEngine>(assignments: &[E::Fr]) -> Vec<SerializedField> {
             let mut serialized = vec![];
 
             for assignment in assignments {
@@ -74,7 +74,7 @@ impl<E: PairingEngine> From<CircuitSynthesizer<E>> for SerializedCircuit {
 
         // Serialize constraints
         fn get_serialized_constraints<E: PairingEngine>(
-            constraints: &Vec<(E::Fr, Index)>,
+            constraints: &[(E::Fr, Index)],
         ) -> Vec<(SerializedField, SerializedIndex)> {
             let mut serialized = vec![];
 
@@ -128,7 +128,7 @@ impl TryFrom<SerializedCircuit> for CircuitSynthesizer<Bls12_377> {
     fn try_from(serialized: SerializedCircuit) -> Result<CircuitSynthesizer<Bls12_377>, Self::Error> {
         // Deserialize assignments
         fn get_deserialized_assignments(
-            assignments: &Vec<SerializedField>,
+            assignments: &[SerializedField],
         ) -> Result<Vec<<Bls12_377 as PairingEngine>::Fr>, FieldError> {
             let mut deserialized = vec![];
 
@@ -146,7 +146,7 @@ impl TryFrom<SerializedCircuit> for CircuitSynthesizer<Bls12_377> {
 
         // Deserialize constraints
         fn get_deserialized_constraints(
-            constraints: &Vec<(SerializedField, SerializedIndex)>,
+            constraints: &[(SerializedField, SerializedIndex)],
         ) -> Result<Vec<(<Bls12_377 as PairingEngine>::Fr, Index)>, FieldError> {
             let mut deserialized = vec![];
 

--- a/leo/synthesizer/serialized_index.rs
+++ b/leo/synthesizer/serialized_index.rs
@@ -36,8 +36,8 @@ impl From<Index> for SerializedIndex {
 impl From<&SerializedIndex> for Index {
     fn from(serialized_index: &SerializedIndex) -> Self {
         match serialized_index {
-            SerializedIndex::Input(idx) => Index::Input(idx.clone()),
-            SerializedIndex::Aux(idx) => Index::Aux(idx.clone()),
+            SerializedIndex::Input(idx) => Index::Input(*idx),
+            SerializedIndex::Aux(idx) => Index::Aux(*idx),
         }
     }
 }

--- a/package/src/inputs/pairs.rs
+++ b/package/src/inputs/pairs.rs
@@ -21,6 +21,7 @@ use crate::{
 
 use std::{collections::HashMap, convert::TryFrom, path::PathBuf};
 
+#[derive(Default)]
 pub struct InputPairs {
     /// Maps file names to input file pairs
     pub pairs: HashMap<String, InputPair>,
@@ -33,7 +34,7 @@ pub struct InputPair {
 
 impl InputPairs {
     pub fn new() -> Self {
-        Self { pairs: HashMap::new() }
+        Self::default()
     }
 }
 

--- a/package/src/inputs/pairs.rs
+++ b/package/src/inputs/pairs.rs
@@ -53,9 +53,9 @@ impl TryFrom<&PathBuf> for InputPairs {
 
             let file_name = file
                 .file_stem()
-                .ok_or(InputsDirectoryError::GettingFileName(file.as_os_str().to_owned()))?
+                .ok_or_else(|| InputsDirectoryError::GettingFileName(file.as_os_str().to_owned()))?
                 .to_str()
-                .ok_or(InputsDirectoryError::GettingFileName(file.as_os_str().to_owned()))?;
+                .ok_or_else(|| InputsDirectoryError::GettingFileName(file.as_os_str().to_owned()))?;
 
             if file_extension == INPUT_FILE_EXTENSION.trim_start_matches('.') {
                 let input_file = InputFile::new(file_name).read_from(&file)?.0;

--- a/package/src/inputs/pairs.rs
+++ b/package/src/inputs/pairs.rs
@@ -56,7 +56,7 @@ impl TryFrom<&PathBuf> for InputPairs {
                 .to_str()
                 .ok_or(InputsDirectoryError::GettingFileName(file.as_os_str().to_owned()))?;
 
-            if file_extension == INPUT_FILE_EXTENSION.trim_start_matches(".") {
+            if file_extension == INPUT_FILE_EXTENSION.trim_start_matches('.') {
                 let input_file = InputFile::new(file_name).read_from(&file)?.0;
 
                 if pairs.contains_key(file_name) {
@@ -69,7 +69,7 @@ impl TryFrom<&PathBuf> for InputPairs {
                     };
                     pairs.insert(file_name.to_owned(), pair);
                 }
-            } else if file_extension == STATE_FILE_EXTENSION.trim_start_matches(".") {
+            } else if file_extension == STATE_FILE_EXTENSION.trim_start_matches('.') {
                 let state_file = StateFile::new(file_name).read_from(&file)?.0;
 
                 if pairs.contains_key(file_name) {

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -82,7 +82,7 @@ impl Package {
             }
         }
 
-        if existing_files.len() > 0 {
+        if !existing_files.is_empty() {
             tracing::error!("File(s) {:?} already exist", existing_files);
         }
 

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -86,7 +86,7 @@ impl Package {
             tracing::error!("File(s) {:?} already exist", existing_files);
         }
 
-        return result;
+        result
     }
 
     /// Returns `true` if a package is initialized at the given path
@@ -120,7 +120,7 @@ impl Package {
             }
         }
 
-        return true;
+        true
     }
 
     /// Creates a package at the given path

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -128,9 +128,10 @@ impl Package {
         // First, verify that this directory is not already initialized as a Leo package.
         {
             if !Self::can_initialize(package_name, is_lib, path) {
-                return Err(
-                    PackageError::FailedToInitialize(package_name.to_owned(), path.as_os_str().to_owned()),
-                );
+                return Err(PackageError::FailedToInitialize(
+                    package_name.to_owned(),
+                    path.as_os_str().to_owned(),
+                ));
             }
         }
         // Next, initialize this directory as a Leo package.
@@ -174,9 +175,10 @@ impl Package {
         // Next, verify that a valid Leo package has been initialized in this directory
         {
             if !Self::is_initialized(package_name, is_lib, path) {
-                return Err(
-                    PackageError::FailedToInitialize(package_name.to_owned(), path.as_os_str().to_owned()),
-                );
+                return Err(PackageError::FailedToInitialize(
+                    package_name.to_owned(),
+                    path.as_os_str().to_owned(),
+                ));
             }
         }
 

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -129,7 +129,7 @@ impl Package {
         {
             if !Self::can_initialize(package_name, is_lib, path) {
                 return Err(
-                    PackageError::FailedToInitialize(package_name.to_owned(), path.as_os_str().to_owned()).into(),
+                    PackageError::FailedToInitialize(package_name.to_owned(), path.as_os_str().to_owned()),
                 );
             }
         }
@@ -175,7 +175,7 @@ impl Package {
         {
             if !Self::is_initialized(package_name, is_lib, path) {
                 return Err(
-                    PackageError::FailedToInitialize(package_name.to_owned(), path.as_os_str().to_owned()).into(),
+                    PackageError::FailedToInitialize(package_name.to_owned(), path.as_os_str().to_owned()),
                 );
             }
         }

--- a/package/src/root/gitignore.rs
+++ b/package/src/root/gitignore.rs
@@ -23,12 +23,12 @@ use std::{fs::File, io::Write, path::PathBuf};
 
 pub static GITIGNORE_FILENAME: &str = ".gitignore";
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Default)]
 pub struct Gitignore;
 
 impl Gitignore {
     pub fn new() -> Self {
-        Self
+        Self::default()
     }
 
     pub fn exists_at(path: &PathBuf) -> bool {

--- a/package/src/root/gitignore.rs
+++ b/package/src/root/gitignore.rs
@@ -50,9 +50,6 @@ impl Gitignore {
     }
 
     fn template(&self) -> String {
-        format!(
-            r#"outputs/
-"#,
-        )
+        "outputs/\n".to_string()
     }
 }

--- a/package/src/root/manifest.rs
+++ b/package/src/root/manifest.rs
@@ -139,7 +139,7 @@ impl TryFrom<&PathBuf> for Manifest {
             // Determine if the old remote format is being used
             if line.starts_with("remote") {
                 let remote = line
-                    .split("=") // Split the line as 'remote' = '"{author}/{package_name}"'
+                    .split('=') // Split the line as 'remote' = '"{author}/{package_name}"'
                     .collect::<Vec<&str>>()[1]; // Fetch just '"{author}/{package_name}"'
                 old_remote_format = Some(remote);
 
@@ -182,7 +182,7 @@ impl TryFrom<&PathBuf> for Manifest {
             if !new_remote_format_exists {
                 // Fetch the author from the old remote.
                 let remote_author = old_remote
-                    .split("/") // Split the old remote as '"{author}' and '{package_name}"'
+                    .split('/') // Split the old remote as '"{author}' and '{package_name}"'
                     .collect::<Vec<&str>>()[0] // Fetch just the '"{author}'
                     .replace(&['\"', ' '][..], ""); // Remove the quotes from the author string
 

--- a/package/src/root/zip.rs
+++ b/package/src/root/zip.rs
@@ -108,7 +108,7 @@ impl ZipFile {
                 f.read_to_end(&mut buffer)?;
                 zip.write_all(&*buffer)?;
                 buffer.clear();
-            } else if name.as_os_str().len() != 0 {
+            } else if !name.as_os_str().is_empty() {
                 // Only if not root Avoids path spec / warning
                 // and mapname conversion failed error on unzip
                 tracing::info!("Adding directory {:?} as {:?}", path, name);

--- a/package/src/root/zip.rs
+++ b/package/src/root/zip.rs
@@ -150,23 +150,23 @@ impl ZipFile {
 /// Check if the file path should be included in the package zip file.
 fn is_included(path: &Path) -> bool {
     // excluded directories: `input`, `output`, `imports`
-    if path.ends_with(INPUTS_DIRECTORY_NAME.trim_end_matches("/"))
-        | path.ends_with(OUTPUTS_DIRECTORY_NAME.trim_end_matches("/"))
-        | path.ends_with(IMPORTS_DIRECTORY_NAME.trim_end_matches("/"))
+    if path.ends_with(INPUTS_DIRECTORY_NAME.trim_end_matches('/'))
+        | path.ends_with(OUTPUTS_DIRECTORY_NAME.trim_end_matches('/'))
+        | path.ends_with(IMPORTS_DIRECTORY_NAME.trim_end_matches('/'))
     {
         return false;
     }
 
     // excluded extensions: `.in`, `.bytes`, `lpk`, `lvk`, `.proof`, `.sum`, `.zip`, `.bytes`
     if let Some(true) = path.extension().map(|ext| {
-        ext.eq(INPUT_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(ZIP_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(PROVING_KEY_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(VERIFICATION_KEY_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(PROOF_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(CHECKSUM_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(ZIP_FILE_EXTENSION.trim_start_matches("."))
-            | ext.eq(CIRCUIT_FILE_EXTENSION.trim_start_matches("."))
+        ext.eq(INPUT_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(ZIP_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(PROVING_KEY_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(VERIFICATION_KEY_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(PROOF_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(CHECKSUM_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(ZIP_FILE_EXTENSION.trim_start_matches('.'))
+            | ext.eq(CIRCUIT_FILE_EXTENSION.trim_start_matches('.'))
     }) {
         return false;
     }
@@ -177,12 +177,12 @@ fn is_included(path: &Path) -> bool {
     }
 
     // Only allow additional files in the `src/` directory
-    if !path.starts_with(SOURCE_DIRECTORY_NAME.trim_end_matches("/")) {
+    if !path.starts_with(SOURCE_DIRECTORY_NAME.trim_end_matches('/')) {
         return false;
     }
 
     // Allow the `.leo` files in the `src/` directory
     path.extension()
-        .map(|ext| ext.eq(SOURCE_FILE_EXTENSION.trim_start_matches(".")))
+        .map(|ext| ext.eq(SOURCE_FILE_EXTENSION.trim_start_matches('.')))
         .unwrap_or(false)
 }

--- a/package/src/root/zip.rs
+++ b/package/src/root/zip.rs
@@ -102,7 +102,7 @@ impl ZipFile {
             // Write file or directory
             if path.is_file() {
                 tracing::info!("Adding file {:?} as {:?}", path, name);
-                zip.start_file_from_path(name, options)?;
+                zip.start_file(name.to_string_lossy(), options)?;
                 let mut f = File::open(path)?;
 
                 f.read_to_end(&mut buffer)?;
@@ -112,7 +112,7 @@ impl ZipFile {
                 // Only if not root Avoids path spec / warning
                 // and mapname conversion failed error on unzip
                 tracing::info!("Adding directory {:?} as {:?}", path, name);
-                zip.add_directory_from_path(name, options)?;
+                zip.add_directory(name.to_string_lossy(), options)?;
             }
         }
 

--- a/package/src/source/directory.rs
+++ b/package/src/source/directory.rs
@@ -61,7 +61,7 @@ impl SourceDirectory {
             let file_extension = file_path
                 .extension()
                 .ok_or_else(|| SourceDirectoryError::GettingFileExtension(file_path.as_os_str().to_owned()))?;
-            if file_extension != SOURCE_FILE_EXTENSION.trim_start_matches(".") {
+            if file_extension != SOURCE_FILE_EXTENSION.trim_start_matches('.') {
                 return Err(SourceDirectoryError::InvalidFileExtension(
                     file_path.as_os_str().to_owned(),
                     file_extension.to_owned(),

--- a/state/src/lib.rs
+++ b/state/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 extern crate thiserror;
 

--- a/typed/src/circuits/circuit.rs
+++ b/typed/src/circuits/circuit.rs
@@ -41,9 +41,9 @@ impl<'ast> From<AstCircuit<'ast>> for Circuit {
 
 impl Circuit {
     fn format(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "circuit {} {{ \n", self.circuit_name)?;
+        writeln!(f, "circuit {} {{ ", self.circuit_name)?;
         for field in self.members.iter() {
-            write!(f, "    {}\n", field)?;
+            writeln!(f, "    {}", field)?;
         }
         write!(f, "}}")
     }

--- a/typed/src/circuits/circuit.rs
+++ b/typed/src/circuits/circuit.rs
@@ -32,7 +32,7 @@ impl<'ast> From<AstCircuit<'ast>> for Circuit {
         let members = circuit
             .members
             .into_iter()
-            .map(|member| CircuitMember::from(member))
+            .map(CircuitMember::from)
             .collect();
 
         Self { circuit_name, members }

--- a/typed/src/circuits/circuit.rs
+++ b/typed/src/circuits/circuit.rs
@@ -29,11 +29,7 @@ pub struct Circuit {
 impl<'ast> From<AstCircuit<'ast>> for Circuit {
     fn from(circuit: AstCircuit<'ast>) -> Self {
         let circuit_name = Identifier::from(circuit.identifier);
-        let members = circuit
-            .members
-            .into_iter()
-            .map(CircuitMember::from)
-            .collect();
+        let members = circuit.members.into_iter().map(CircuitMember::from).collect();
 
         Self { circuit_name, members }
     }

--- a/typed/src/common/assignee.rs
+++ b/typed/src/common/assignee.rs
@@ -27,7 +27,7 @@ use std::fmt;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Assignee {
     Identifier(Identifier),
-    Array(Box<Assignee>, RangeOrExpression),
+    Array(Box<Assignee>, Box<RangeOrExpression>),
     Tuple(Box<Assignee>, usize),
     CircuitField(Box<Assignee>, Identifier), // (circuit name, circuit field name)
 }
@@ -54,7 +54,7 @@ impl<'ast> From<AstAssignee<'ast>> for Assignee {
             .into_iter()
             .fold(variable, |acc, access| match access {
                 AstAssigneeAccess::Array(array) => {
-                    Assignee::Array(Box::new(acc), RangeOrExpression::from(array.expression))
+                    Assignee::Array(Box::new(acc), Box::new(RangeOrExpression::from(array.expression)))
                 }
                 AstAssigneeAccess::Tuple(tuple) => {
                     Assignee::Tuple(Box::new(acc), Expression::get_count_from_ast(tuple.number))

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -32,14 +32,14 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeMap, fmt, hash::{Hash, Hasher}};
 
 /// An identifier in the constrained program.
 ///
 /// Attention - When adding or removing fields from this struct,
 /// please remember to update it's Serialize and Deserialize implementation
 /// to reflect the new struct instantiation.
-#[derive(Clone, Hash)]
+#[derive(Clone)]
 pub struct Identifier {
     pub name: String,
     pub span: Span,
@@ -160,6 +160,12 @@ impl PartialEq for Identifier {
 }
 
 impl Eq for Identifier {}
+
+impl Hash for Identifier {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.name.hash(state);
+    }
+}
 
 impl Serialize for Identifier {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/typed/src/common/identifier.rs
+++ b/typed/src/common/identifier.rs
@@ -32,7 +32,11 @@ use serde::{
     Serialize,
     Serializer,
 };
-use std::{collections::BTreeMap, fmt, hash::{Hash, Hasher}};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    hash::{Hash, Hasher},
+};
 
 /// An identifier in the constrained program.
 ///

--- a/typed/src/common/range_or_expression.rs
+++ b/typed/src/common/range_or_expression.rs
@@ -45,8 +45,8 @@ impl fmt::Display for RangeOrExpression {
             RangeOrExpression::Range(ref from, ref to) => write!(
                 f,
                 "{}..{}",
-                from.as_ref().map(|e| format!("{}", e)).unwrap_or("".to_string()),
-                to.as_ref().map(|e| format!("{}", e)).unwrap_or("".to_string())
+                from.as_ref().map(|e| e.to_string()).unwrap_or("".to_string()),
+                to.as_ref().map(|e| e.to_string()).unwrap_or("".to_string())
             ),
             RangeOrExpression::Expression(ref e) => write!(f, "{}", e),
         }

--- a/typed/src/common/range_or_expression.rs
+++ b/typed/src/common/range_or_expression.rs
@@ -30,10 +30,9 @@ pub enum RangeOrExpression {
 impl<'ast> From<AstRangeOrExpression<'ast>> for RangeOrExpression {
     fn from(range_or_expression: AstRangeOrExpression<'ast>) -> Self {
         match range_or_expression {
-            AstRangeOrExpression::Range(range) => RangeOrExpression::Range(
-                range.from.map(Expression::from),
-                range.to.map(Expression::from),
-            ),
+            AstRangeOrExpression::Range(range) => {
+                RangeOrExpression::Range(range.from.map(Expression::from), range.to.map(Expression::from))
+            }
             AstRangeOrExpression::Expression(expression) => RangeOrExpression::Expression(Expression::from(expression)),
         }
     }

--- a/typed/src/common/range_or_expression.rs
+++ b/typed/src/common/range_or_expression.rs
@@ -31,8 +31,8 @@ impl<'ast> From<AstRangeOrExpression<'ast>> for RangeOrExpression {
     fn from(range_or_expression: AstRangeOrExpression<'ast>) -> Self {
         match range_or_expression {
             AstRangeOrExpression::Range(range) => RangeOrExpression::Range(
-                range.from.map(|expression| Expression::from(expression)),
-                range.to.map(|expression| Expression::from(expression)),
+                range.from.map(Expression::from),
+                range.to.map(Expression::from),
             ),
             AstRangeOrExpression::Expression(expression) => RangeOrExpression::Expression(Expression::from(expression)),
         }

--- a/typed/src/common/range_or_expression.rs
+++ b/typed/src/common/range_or_expression.rs
@@ -45,8 +45,8 @@ impl fmt::Display for RangeOrExpression {
             RangeOrExpression::Range(ref from, ref to) => write!(
                 f,
                 "{}..{}",
-                from.as_ref().map(|e| e.to_string()).unwrap_or("".to_string()),
-                to.as_ref().map(|e| e.to_string()).unwrap_or("".to_string())
+                from.as_ref().map(|e| e.to_string()).unwrap_or_default(),
+                to.as_ref().map(|e| e.to_string()).unwrap_or_default()
             ),
             RangeOrExpression::Expression(ref e) => write!(f, "{}", e),
         }

--- a/typed/src/common/variables.rs
+++ b/typed/src/common/variables.rs
@@ -29,11 +29,7 @@ pub struct Variables {
 
 impl<'ast> From<AstVariables<'ast>> for Variables {
     fn from(variables: AstVariables<'ast>) -> Self {
-        let names = variables
-            .names
-            .into_iter()
-            .map(VariableName::from)
-            .collect::<Vec<_>>();
+        let names = variables.names.into_iter().map(VariableName::from).collect::<Vec<_>>();
 
         let type_ = variables.type_.map(Type::from);
 

--- a/typed/src/common/variables.rs
+++ b/typed/src/common/variables.rs
@@ -32,10 +32,10 @@ impl<'ast> From<AstVariables<'ast>> for Variables {
         let names = variables
             .names
             .into_iter()
-            .map(|x| VariableName::from(x))
+            .map(VariableName::from)
             .collect::<Vec<_>>();
 
-        let type_ = variables.type_.map(|type_| Type::from(type_));
+        let type_ = variables.type_.map(Type::from);
 
         Self { names, type_ }
     }

--- a/typed/src/console/formatted_string.rs
+++ b/typed/src/console/formatted_string.rs
@@ -35,12 +35,12 @@ impl<'ast> From<AstFormattedString<'ast>> for FormattedString {
         let containers = formatted
             .containers
             .into_iter()
-            .map(|container| FormattedContainer::from(container))
+            .map(FormattedContainer::from)
             .collect();
         let parameters = formatted
             .parameters
             .into_iter()
-            .map(|parameter| FormattedParameter::from(parameter))
+            .map(FormattedParameter::from)
             .collect();
 
         Self {

--- a/typed/src/console/formatted_string.rs
+++ b/typed/src/console/formatted_string.rs
@@ -32,16 +32,8 @@ impl<'ast> From<AstFormattedString<'ast>> for FormattedString {
     fn from(formatted: AstFormattedString<'ast>) -> Self {
         let string = formatted.string;
         let span = Span::from(formatted.span);
-        let containers = formatted
-            .containers
-            .into_iter()
-            .map(FormattedContainer::from)
-            .collect();
-        let parameters = formatted
-            .parameters
-            .into_iter()
-            .map(FormattedParameter::from)
-            .collect();
+        let containers = formatted.containers.into_iter().map(FormattedContainer::from).collect();
+        let parameters = formatted.parameters.into_iter().map(FormattedParameter::from).collect();
 
         Self {
             string,

--- a/typed/src/errors/error.rs
+++ b/typed/src/errors/error.rs
@@ -18,7 +18,7 @@ use crate::Span;
 
 use std::{fmt, path::PathBuf};
 
-pub const INDENT: &'static str = "    ";
+pub const INDENT: &str = "    ";
 
 /// Formatted compiler error type
 ///     --> file.leo 2:8

--- a/typed/src/errors/error.rs
+++ b/typed/src/errors/error.rs
@@ -95,9 +95,7 @@ impl Error {
 
 fn underline(mut start: usize, mut end: usize) -> String {
     if start > end {
-        let tmp = start;
-        start = end;
-        end = tmp;
+        std::mem::swap(&mut start, &mut end)
     }
 
     let mut underline = String::new();

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -170,7 +170,7 @@ impl<'ast> Expression {
             InputArrayDimensions::Multiple(multiple) => multiple
                 .numbers
                 .into_iter()
-                .map(|number| Self::get_count_from_input_ast(number))
+                .map(Self::get_count_from_input_ast)
                 .collect(),
         }
     }
@@ -188,7 +188,7 @@ impl<'ast> Expression {
             ArrayDimensions::Multiple(multiple) => multiple
                 .numbers
                 .into_iter()
-                .map(|number| Self::get_count_from_ast(number))
+                .map(Self::get_count_from_ast)
                 .collect(),
         }
     }
@@ -301,7 +301,7 @@ impl<'ast> From<CircuitInlineExpression<'ast>> for Expression {
         let members = expression
             .members
             .into_iter()
-            .map(|member| CircuitVariableDefinition::from(member))
+            .map(CircuitVariableDefinition::from)
             .collect::<Vec<CircuitVariableDefinition>>();
 
         Expression::Circuit(circuit_name, members, Span::from(expression.span))
@@ -343,7 +343,7 @@ impl<'ast> From<PostfixExpression<'ast>> for Expression {
                             .expressions
                             .expressions
                             .into_iter()
-                            .map(|expression| Expression::from(expression))
+                            .map(Expression::from)
                             .collect(),
                         span,
                     )
@@ -506,7 +506,7 @@ impl<'ast> From<ArrayInlineExpression<'ast>> for Expression {
             array
                 .expressions
                 .into_iter()
-                .map(|s_or_e| SpreadOrExpression::from(s_or_e))
+                .map(SpreadOrExpression::from)
                 .collect(),
             Span::from(array.span),
         )
@@ -543,7 +543,7 @@ impl<'ast> From<ArrayInitializerExpression<'ast>> for Expression {
 impl<'ast> From<TupleExpression<'ast>> for Expression {
     fn from(tuple: TupleExpression<'ast>) -> Self {
         Expression::Tuple(
-            tuple.expressions.into_iter().map(|e| Expression::from(e)).collect(),
+            tuple.expressions.into_iter().map(Expression::from).collect(),
             Span::from(tuple.span),
         )
     }

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -185,11 +185,7 @@ impl<'ast> Expression {
     pub(crate) fn get_array_dimensions(dimensions: ArrayDimensions<'ast>) -> Vec<usize> {
         match dimensions {
             ArrayDimensions::Single(single) => vec![Self::get_count_from_ast(single.number)],
-            ArrayDimensions::Multiple(multiple) => multiple
-                .numbers
-                .into_iter()
-                .map(Self::get_count_from_ast)
-                .collect(),
+            ArrayDimensions::Multiple(multiple) => multiple.numbers.into_iter().map(Self::get_count_from_ast).collect(),
         }
     }
 }
@@ -503,11 +499,7 @@ impl<'ast> From<TernaryExpression<'ast>> for Expression {
 impl<'ast> From<ArrayInlineExpression<'ast>> for Expression {
     fn from(array: ArrayInlineExpression<'ast>) -> Self {
         Expression::Array(
-            array
-                .expressions
-                .into_iter()
-                .map(SpreadOrExpression::from)
-                .collect(),
+            array.expressions.into_iter().map(SpreadOrExpression::from).collect(),
             Span::from(array.span),
         )
     }
@@ -527,10 +519,8 @@ impl<'ast> From<ArrayInitializerExpression<'ast>> for Expression {
             if i == 0 {
                 elements = vec![expression.clone(); dimension];
             } else {
-                let element = SpreadOrExpression::Expression(Expression::Array(
-                    elements,
-                    Span::from(array.span.clone()),
-                ));
+                let element =
+                    SpreadOrExpression::Expression(Expression::Array(elements, Span::from(array.span.clone())));
 
                 elements = vec![element; dimension];
             }

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -92,7 +92,7 @@ pub enum Expression {
 
     // Arrays
     // (array_elements, span)
-    Array(Vec<Box<SpreadOrExpression>>, Span),
+    Array(Vec<SpreadOrExpression>, Span),
     // (array_name, range, span)
     ArrayAccess(Box<Expression>, Box<RangeOrExpression>, Span),
 
@@ -506,7 +506,7 @@ impl<'ast> From<ArrayInlineExpression<'ast>> for Expression {
             array
                 .expressions
                 .into_iter()
-                .map(|s_or_e| Box::new(SpreadOrExpression::from(s_or_e)))
+                .map(|s_or_e| SpreadOrExpression::from(s_or_e))
                 .collect(),
             Span::from(array.span),
         )
@@ -516,7 +516,7 @@ impl<'ast> From<ArrayInlineExpression<'ast>> for Expression {
 impl<'ast> From<ArrayInitializerExpression<'ast>> for Expression {
     fn from(array: ArrayInitializerExpression<'ast>) -> Self {
         let dimensions = Expression::get_array_dimensions(array.dimensions);
-        let expression = Box::new(SpreadOrExpression::from(*array.expression));
+        let expression = SpreadOrExpression::from(*array.expression);
 
         let mut elements = vec![];
 
@@ -527,10 +527,10 @@ impl<'ast> From<ArrayInitializerExpression<'ast>> for Expression {
             if i == 0 {
                 elements = vec![expression.clone(); dimension];
             } else {
-                let element = Box::new(SpreadOrExpression::Expression(Expression::Array(
+                let element = SpreadOrExpression::Expression(Expression::Array(
                     elements,
                     Span::from(array.span.clone()),
-                )));
+                ));
 
                 elements = vec![element; dimension];
             }

--- a/typed/src/functions/function.rs
+++ b/typed/src/functions/function.rs
@@ -32,17 +32,9 @@ pub struct Function {
 impl<'ast> From<AstFunction<'ast>> for Function {
     fn from(function: AstFunction<'ast>) -> Self {
         let function_name = Identifier::from(function.identifier);
-        let parameters = function
-            .parameters
-            .into_iter()
-            .map(InputVariable::from)
-            .collect();
+        let parameters = function.parameters.into_iter().map(InputVariable::from).collect();
         let returns = function.returns.map(Type::from);
-        let statements = function
-            .statements
-            .into_iter()
-            .map(Statement::from)
-            .collect();
+        let statements = function.statements.into_iter().map(Statement::from).collect();
 
         Function {
             identifier: function_name,

--- a/typed/src/functions/function.rs
+++ b/typed/src/functions/function.rs
@@ -35,13 +35,13 @@ impl<'ast> From<AstFunction<'ast>> for Function {
         let parameters = function
             .parameters
             .into_iter()
-            .map(|parameter| InputVariable::from(parameter))
+            .map(InputVariable::from)
             .collect();
-        let returns = function.returns.map(|type_| Type::from(type_));
+        let returns = function.returns.map(Type::from);
         let statements = function
             .statements
             .into_iter()
-            .map(|statement| Statement::from(statement))
+            .map(Statement::from)
             .collect();
 
         Function {

--- a/typed/src/imports/import_symbol.rs
+++ b/typed/src/imports/import_symbol.rs
@@ -31,7 +31,7 @@ impl<'ast> From<AstImportSymbol<'ast>> for ImportSymbol {
     fn from(symbol: AstImportSymbol<'ast>) -> Self {
         ImportSymbol {
             symbol: Identifier::from(symbol.value),
-            alias: symbol.alias.map(|alias| Identifier::from(alias)),
+            alias: symbol.alias.map(Identifier::from),
             span: Span::from(symbol.span),
         }
     }

--- a/typed/src/imports/package_access.rs
+++ b/typed/src/imports/package_access.rs
@@ -35,7 +35,7 @@ impl<'ast> From<AstPackageAccess<'ast>> for PackageAccess {
             AstPackageAccess::SubPackage(package) => PackageAccess::SubPackage(Box::new(Package::from(*package))),
             AstPackageAccess::Symbol(symbol) => PackageAccess::Symbol(ImportSymbol::from(symbol)),
             AstPackageAccess::Multiple(accesses) => {
-                PackageAccess::Multiple(accesses.into_iter().map(|access| PackageAccess::from(access)).collect())
+                PackageAccess::Multiple(accesses.into_iter().map(PackageAccess::from).collect())
             }
         }
     }

--- a/typed/src/input/input.rs
+++ b/typed/src/input/input.rs
@@ -37,6 +37,7 @@ impl Default for Input {
     }
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl Input {
     pub fn new() -> Self {
         Self::default()

--- a/typed/src/input/input.rs
+++ b/typed/src/input/input.rs
@@ -95,6 +95,7 @@ impl Input {
     }
 
     /// Returns the main function input value with the given `name`
+    #[allow(clippy::ptr_arg)]
     pub fn get(&self, name: &String) -> Option<Option<InputValue>> {
         self.program_input.get(name)
     }

--- a/typed/src/input/input.rs
+++ b/typed/src/input/input.rs
@@ -27,13 +27,19 @@ pub struct Input {
     program_state: ProgramState,
 }
 
-impl Input {
-    pub fn new() -> Self {
+impl Default for Input {
+    fn default() -> Self {
         Self {
             name: "default".to_owned(),
             program_input: ProgramInput::new(),
             program_state: ProgramState::new(),
         }
+    }
+}
+
+impl Input {
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Returns an empty version of this struct with `None` values.

--- a/typed/src/input/macros.rs
+++ b/typed/src/input/macros.rs
@@ -19,7 +19,7 @@ macro_rules! input_section_impl {
     ($($name: ident), *) => ($(
 
         /// An input section declared in an input file with `[$name]`
-        #[derive(Clone, PartialEq, Eq)]
+        #[derive(Clone, PartialEq, Eq, Default)]
         pub struct $name {
             is_present: bool,
             values: HashMap<Parameter, Option<InputValue>>,
@@ -27,10 +27,7 @@ macro_rules! input_section_impl {
 
         impl $name {
             pub fn new() -> Self {
-                Self {
-                    is_present: false,
-                    values: HashMap::new(),
-                }
+                Self::default()
             }
 
             /// Returns an empty version of this struct with `None` values.

--- a/typed/src/input/mod.rs
+++ b/typed/src/input/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 #[macro_use]
 pub mod macros;
 pub use macros::*;

--- a/typed/src/input/program_input/main_input.rs
+++ b/typed/src/input/program_input/main_input.rs
@@ -23,6 +23,7 @@ pub struct MainInput {
     input: HashMap<String, Option<InputValue>>,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl MainInput {
     pub fn new() -> Self {
         Self::default()

--- a/typed/src/input/program_input/main_input.rs
+++ b/typed/src/input/program_input/main_input.rs
@@ -18,14 +18,14 @@ use crate::InputValue;
 use leo_input::{definitions::Definition, InputParserError};
 use std::collections::HashMap;
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct MainInput {
     input: HashMap<String, Option<InputValue>>,
 }
 
 impl MainInput {
     pub fn new() -> Self {
-        Self { input: HashMap::new() }
+        Self::default()
     }
 
     /// Returns an empty version of this struct with `None` values.

--- a/typed/src/input/program_input/main_input.rs
+++ b/typed/src/input/program_input/main_input.rs
@@ -61,7 +61,7 @@ impl MainInput {
     }
 
     /// Returns an `Option` of the main function input at `name`
-    pub fn get(&self, name: &String) -> Option<Option<InputValue>> {
+    pub fn get(&self, name: &str) -> Option<Option<InputValue>> {
         self.input.get(name).map(|input| input.clone())
     }
 }

--- a/typed/src/input/program_input/main_input.rs
+++ b/typed/src/input/program_input/main_input.rs
@@ -63,6 +63,6 @@ impl MainInput {
 
     /// Returns an `Option` of the main function input at `name`
     pub fn get(&self, name: &str) -> Option<Option<InputValue>> {
-        self.input.get(name).map(|input| input.clone())
+        self.input.get(name).cloned()
     }
 }

--- a/typed/src/input/program_input/mod.rs
+++ b/typed/src/input/program_input/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod main_input;
 pub use main_input::*;
 

--- a/typed/src/input/program_input/program_input.rs
+++ b/typed/src/input/program_input/program_input.rs
@@ -65,6 +65,7 @@ impl ProgramInput {
     }
 
     /// Returns the main function input value with the given `name`
+    #[allow(clippy::ptr_arg)]
     pub fn get(&self, name: &String) -> Option<Option<InputValue>> {
         self.main.get(name)
     }

--- a/typed/src/input/program_input/program_input.rs
+++ b/typed/src/input/program_input/program_input.rs
@@ -20,7 +20,7 @@ use leo_input::{
     InputParserError,
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct ProgramInput {
     pub main: MainInput,
     registers: Registers,
@@ -28,10 +28,7 @@ pub struct ProgramInput {
 
 impl ProgramInput {
     pub fn new() -> Self {
-        Self {
-            main: MainInput::new(),
-            registers: Registers::new(),
-        }
+        Self::default()
     }
 
     /// Returns an empty version of this struct with `None` values.

--- a/typed/src/input/program_input/program_input.rs
+++ b/typed/src/input/program_input/program_input.rs
@@ -26,6 +26,7 @@ pub struct ProgramInput {
     registers: Registers,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl ProgramInput {
     pub fn new() -> Self {
         Self::default()

--- a/typed/src/input/program_state/mod.rs
+++ b/typed/src/input/program_state/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod private_state;
 pub use private_state::*;
 

--- a/typed/src/input/program_state/private_state/mod.rs
+++ b/typed/src/input/program_state/private_state/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod private_state;
 pub use private_state::*;
 

--- a/typed/src/input/program_state/private_state/private_state.rs
+++ b/typed/src/input/program_state/private_state/private_state.rs
@@ -20,7 +20,7 @@ use leo_input::{
     InputParserError,
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct PrivateState {
     record: Record,
     state_leaf: StateLeaf,
@@ -28,10 +28,7 @@ pub struct PrivateState {
 
 impl PrivateState {
     pub fn new() -> Self {
-        Self {
-            record: Record::new(),
-            state_leaf: StateLeaf::new(),
-        }
+        Self::default()
     }
 
     /// Returns an empty version of this struct with `None` values.

--- a/typed/src/input/program_state/private_state/private_state.rs
+++ b/typed/src/input/program_state/private_state/private_state.rs
@@ -26,6 +26,7 @@ pub struct PrivateState {
     state_leaf: StateLeaf,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl PrivateState {
     pub fn new() -> Self {
         Self::default()

--- a/typed/src/input/program_state/program_state.rs
+++ b/typed/src/input/program_state/program_state.rs
@@ -26,6 +26,7 @@ pub struct ProgramState {
     private: PrivateState,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl ProgramState {
     pub fn new() -> Self {
         Self::default()

--- a/typed/src/input/program_state/program_state.rs
+++ b/typed/src/input/program_state/program_state.rs
@@ -20,7 +20,7 @@ use leo_input::{
     InputParserError,
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct ProgramState {
     public: PublicState,
     private: PrivateState,
@@ -28,10 +28,7 @@ pub struct ProgramState {
 
 impl ProgramState {
     pub fn new() -> Self {
-        Self {
-            public: PublicState::new(),
-            private: PrivateState::new(),
-        }
+        Self::default()
     }
 
     /// Returns an empty version of this struct with `None` values.

--- a/typed/src/input/program_state/public_state/mod.rs
+++ b/typed/src/input/program_state/public_state/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod public_state;
 pub use public_state::*;
 

--- a/typed/src/input/program_state/public_state/public_state.rs
+++ b/typed/src/input/program_state/public_state/public_state.rs
@@ -25,6 +25,7 @@ pub struct PublicState {
     state: State,
 }
 
+#[allow(clippy::len_without_is_empty)]
 impl PublicState {
     pub fn new() -> Self {
         Self::default()

--- a/typed/src/input/program_state/public_state/public_state.rs
+++ b/typed/src/input/program_state/public_state/public_state.rs
@@ -20,14 +20,14 @@ use leo_input::{
     InputParserError,
 };
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Default)]
 pub struct PublicState {
     state: State,
 }
 
 impl PublicState {
     pub fn new() -> Self {
-        Self { state: State::new() }
+        Self::default()
     }
 
     /// Returns an empty version of this struct with `None` values.

--- a/typed/src/lib.rs
+++ b/typed/src/lib.rs
@@ -58,8 +58,6 @@ pub use self::types::*;
 
 use leo_ast::LeoAst;
 
-use serde_json;
-
 #[derive(Debug, Eq, PartialEq)]
 pub struct LeoTypedAst {
     typed_ast: Program,

--- a/typed/src/statements/conditional_nested_or_end_statement.rs
+++ b/typed/src/statements/conditional_nested_or_end_statement.rs
@@ -47,9 +47,9 @@ impl fmt::Display for ConditionalNestedOrEndStatement {
         match *self {
             ConditionalNestedOrEndStatement::Nested(ref nested) => write!(f, "else {}", nested),
             ConditionalNestedOrEndStatement::End(ref statements) => {
-                write!(f, "else {{\n")?;
+                writeln!(f, "else {{")?;
                 for statement in statements.iter() {
-                    write!(f, "\t\t{}\n", statement)?;
+                    writeln!(f, "\t\t{}", statement)?;
                 }
                 write!(f, "\t}}")
             }

--- a/typed/src/statements/conditional_nested_or_end_statement.rs
+++ b/typed/src/statements/conditional_nested_or_end_statement.rs
@@ -35,7 +35,7 @@ impl<'ast> From<AstConditionalNestedOrEndStatement<'ast>> for ConditionalNestedO
             AstConditionalNestedOrEndStatement::End(statements) => ConditionalNestedOrEndStatement::End(
                 statements
                     .into_iter()
-                    .map(|statement| Statement::from(statement))
+                    .map(Statement::from)
                     .collect(),
             ),
         }

--- a/typed/src/statements/conditional_nested_or_end_statement.rs
+++ b/typed/src/statements/conditional_nested_or_end_statement.rs
@@ -32,12 +32,9 @@ impl<'ast> From<AstConditionalNestedOrEndStatement<'ast>> for ConditionalNestedO
             AstConditionalNestedOrEndStatement::Nested(nested) => {
                 ConditionalNestedOrEndStatement::Nested(Box::new(ConditionalStatement::from(*nested)))
             }
-            AstConditionalNestedOrEndStatement::End(statements) => ConditionalNestedOrEndStatement::End(
-                statements
-                    .into_iter()
-                    .map(Statement::from)
-                    .collect(),
-            ),
+            AstConditionalNestedOrEndStatement::End(statements) => {
+                ConditionalNestedOrEndStatement::End(statements.into_iter().map(Statement::from).collect())
+            }
         }
     }
 }

--- a/typed/src/statements/conditional_statement.rs
+++ b/typed/src/statements/conditional_statement.rs
@@ -31,11 +31,7 @@ impl<'ast> From<AstConditionalStatement<'ast>> for ConditionalStatement {
     fn from(statement: AstConditionalStatement<'ast>) -> Self {
         ConditionalStatement {
             condition: Expression::from(statement.condition),
-            statements: statement
-                .statements
-                .into_iter()
-                .map(Statement::from)
-                .collect(),
+            statements: statement.statements.into_iter().map(Statement::from).collect(),
             next: statement
                 .next
                 .map(|n_or_e| Some(ConditionalNestedOrEndStatement::from(n_or_e)))

--- a/typed/src/statements/conditional_statement.rs
+++ b/typed/src/statements/conditional_statement.rs
@@ -34,7 +34,7 @@ impl<'ast> From<AstConditionalStatement<'ast>> for ConditionalStatement {
             statements: statement
                 .statements
                 .into_iter()
-                .map(|statement| Statement::from(statement))
+                .map(Statement::from)
                 .collect(),
             next: statement
                 .next

--- a/typed/src/statements/conditional_statement.rs
+++ b/typed/src/statements/conditional_statement.rs
@@ -46,9 +46,9 @@ impl<'ast> From<AstConditionalStatement<'ast>> for ConditionalStatement {
 
 impl fmt::Display for ConditionalStatement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "if ({}) {{\n", self.condition)?;
+        writeln!(f, "if ({}) {{", self.condition)?;
         for statement in self.statements.iter() {
-            write!(f, "\t\t{}\n", statement)?;
+            writeln!(f, "\t\t{}", statement)?;
         }
         match self.next.clone() {
             Some(n_or_e) => write!(f, "\t}} {}", n_or_e),

--- a/typed/src/statements/statement.rs
+++ b/typed/src/statements/statement.rs
@@ -36,9 +36,9 @@ use std::fmt;
 pub enum Statement {
     Return(Expression, Span),
     Definition(Declare, Variables, Vec<Expression>, Span),
-    Assign(Assignee, Expression, Span),
+    Assign(Assignee, Box<Expression>, Span),
     Conditional(ConditionalStatement, Span),
-    Iteration(Identifier, Expression, Expression, Vec<Statement>, Span),
+    Iteration(Identifier, Box<Expression>, Box<Expression>, Vec<Statement>, Span),
     Console(ConsoleFunctionCall),
     Expression(Expression, Span),
 }
@@ -78,7 +78,7 @@ impl<'ast> From<AssignStatement<'ast>> for Statement {
         match statement.assign {
             AssignOperation::Assign(ref _assign) => Statement::Assign(
                 Assignee::from(statement.assignee),
-                Expression::from(statement.expression),
+                Box::new(Expression::from(statement.expression)),
                 Span::from(statement.span),
             ),
             operation_assign => {
@@ -88,47 +88,47 @@ impl<'ast> From<AssignStatement<'ast>> for Statement {
                 match operation_assign {
                     AssignOperation::AddAssign(ref _assign) => Statement::Assign(
                         Assignee::from(statement.assignee),
-                        Expression::Add(
+                        Box::new(Expression::Add(
                             Box::new(converted),
                             Box::new(Expression::from(statement.expression)),
                             Span::from(statement.span.clone()),
-                        ),
+                        )),
                         Span::from(statement.span),
                     ),
                     AssignOperation::SubAssign(ref _assign) => Statement::Assign(
                         Assignee::from(statement.assignee),
-                        Expression::Sub(
+                        Box::new(Expression::Sub(
                             Box::new(converted),
                             Box::new(Expression::from(statement.expression)),
                             Span::from(statement.span.clone()),
-                        ),
+                        )),
                         Span::from(statement.span),
                     ),
                     AssignOperation::MulAssign(ref _assign) => Statement::Assign(
                         Assignee::from(statement.assignee),
-                        Expression::Mul(
+                        Box::new(Expression::Mul(
                             Box::new(converted),
                             Box::new(Expression::from(statement.expression)),
                             Span::from(statement.span.clone()),
-                        ),
+                        )),
                         Span::from(statement.span),
                     ),
                     AssignOperation::DivAssign(ref _assign) => Statement::Assign(
                         Assignee::from(statement.assignee),
-                        Expression::Div(
+                        Box::new(Expression::Div(
                             Box::new(converted),
                             Box::new(Expression::from(statement.expression)),
                             Span::from(statement.span.clone()),
-                        ),
+                        )),
                         Span::from(statement.span),
                     ),
                     AssignOperation::PowAssign(ref _assign) => Statement::Assign(
                         Assignee::from(statement.assignee),
-                        Expression::Pow(
+                        Box::new(Expression::Pow(
                             Box::new(converted),
                             Box::new(Expression::from(statement.expression)),
                             Span::from(statement.span.clone()),
-                        ),
+                        )),
                         Span::from(statement.span),
                     ),
                     AssignOperation::Assign(ref _assign) => unimplemented!("cannot assign twice to assign statement"),
@@ -142,8 +142,8 @@ impl<'ast> From<ForStatement<'ast>> for Statement {
     fn from(statement: ForStatement<'ast>) -> Self {
         Statement::Iteration(
             Identifier::from(statement.index),
-            Expression::from(statement.start),
-            Expression::from(statement.stop),
+            Box::new(Expression::from(statement.start)),
+            Box::new(Expression::from(statement.stop)),
             statement
                 .statements
                 .into_iter()

--- a/typed/src/statements/statement.rs
+++ b/typed/src/statements/statement.rs
@@ -144,11 +144,7 @@ impl<'ast> From<ForStatement<'ast>> for Statement {
             Identifier::from(statement.index),
             Box::new(Expression::from(statement.start)),
             Box::new(Expression::from(statement.stop)),
-            statement
-                .statements
-                .into_iter()
-                .map(Statement::from)
-                .collect(),
+            statement.statements.into_iter().map(Statement::from).collect(),
             Span::from(statement.span),
         )
     }

--- a/typed/src/statements/statement.rs
+++ b/typed/src/statements/statement.rs
@@ -204,9 +204,9 @@ impl fmt::Display for Statement {
             Statement::Assign(ref variable, ref statement, ref _span) => write!(f, "{} = {};", variable, statement),
             Statement::Conditional(ref statement, ref _span) => write!(f, "{}", statement),
             Statement::Iteration(ref var, ref start, ref stop, ref list, ref _span) => {
-                write!(f, "for {} in {}..{} {{\n", var, start, stop)?;
+                writeln!(f, "for {} in {}..{} {{", var, start, stop)?;
                 for l in list {
-                    write!(f, "\t\t{}\n", l)?;
+                    writeln!(f, "\t\t{}", l)?;
                 }
                 write!(f, "\t}}")
             }

--- a/typed/src/statements/statement.rs
+++ b/typed/src/statements/statement.rs
@@ -147,7 +147,7 @@ impl<'ast> From<ForStatement<'ast>> for Statement {
             statement
                 .statements
                 .into_iter()
-                .map(|statement| Statement::from(statement))
+                .map(Statement::from)
                 .collect(),
             Span::from(statement.span),
         )

--- a/typed/src/types/type_.rs
+++ b/typed/src/types/type_.rs
@@ -78,7 +78,7 @@ impl Type {
         type_1_expanded.eq(&type_2_expanded) && dimensions_1_expanded.eq(&dimensions_2_expanded)
     }
 
-    pub fn outer_dimension(&self, dimensions: &Vec<usize>) -> Self {
+    pub fn outer_dimension(&self, dimensions: &[usize]) -> Self {
         let type_ = self.clone();
 
         if dimensions.len() > 1 {
@@ -91,7 +91,7 @@ impl Type {
         type_
     }
 
-    pub fn inner_dimension(&self, dimensions: &Vec<usize>) -> Self {
+    pub fn inner_dimension(&self, dimensions: &[usize]) -> Self {
         let type_ = self.clone();
 
         if dimensions.len() > 1 {
@@ -105,16 +105,16 @@ impl Type {
     }
 }
 
-fn expand_array_type(type_: &Type, dimensions: &Vec<usize>) -> (Type, Vec<usize>) {
+fn expand_array_type(type_: &Type, dimensions: &[usize]) -> (Type, Vec<usize>) {
     if let Type::Array(nested_type, nested_dimensions) = type_ {
         // Expand nested array type
-        let mut expanded_dimensions = dimensions.clone();
+        let mut expanded_dimensions = dimensions.to_vec();
         expanded_dimensions.append(&mut nested_dimensions.clone());
 
         expand_array_type(nested_type, &expanded_dimensions)
     } else {
         // Array type is fully expanded
-        (type_.clone(), dimensions.clone())
+        (type_.clone(), dimensions.to_vec())
     }
 }
 

--- a/typed/src/types/type_.rs
+++ b/typed/src/types/type_.rs
@@ -111,7 +111,7 @@ fn expand_array_type(type_: &Type, dimensions: &Vec<usize>) -> (Type, Vec<usize>
         let mut expanded_dimensions = dimensions.clone();
         expanded_dimensions.append(&mut nested_dimensions.clone());
 
-        return expand_array_type(nested_type, &expanded_dimensions);
+        expand_array_type(nested_type, &expanded_dimensions)
     } else {
         // Array type is fully expanded
         (type_.clone(), dimensions.clone())

--- a/typed/src/types/type_.rs
+++ b/typed/src/types/type_.rs
@@ -143,7 +143,7 @@ impl<'ast> From<ArrayType<'ast>> for Type {
 
 impl<'ast> From<TupleType<'ast>> for Type {
     fn from(tuple_type: TupleType<'ast>) -> Self {
-        let types = tuple_type.types.into_iter().map(|type_| Type::from(type_)).collect();
+        let types = tuple_type.types.into_iter().map(Type::from).collect();
 
         Type::Tuple(types)
     }
@@ -192,7 +192,7 @@ impl<'ast> From<InputArrayType<'ast>> for Type {
 
 impl<'ast> From<InputTupleType<'ast>> for Type {
     fn from(tuple_type: InputTupleType<'ast>) -> Self {
-        let types = tuple_type.types_.into_iter().map(|type_| Type::from(type_)).collect();
+        let types = tuple_type.types_.into_iter().map(Type::from).collect();
 
         Type::Tuple(types)
     }


### PR DESCRIPTION
This is the first of two rounds (second will be just the tests) of adjustments suggested by `clippy`, paving the way towards enabling its lints in the CI or githooks. All the specific changes are confined to individual commits. Due to a high number of affected files, `cargo +nightly fmt` was only performed after all the `clippy` changes, in order to reduce conflict surface in case of a rebase.

The most noteworthy changes are:
- [derive_hash_xor_eq](https://github.com/AleoHQ/leo/commit/fae079057de3bad857ef07c836f1091abd6f8a21) ([fixes logic](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq))
- [fix_large_enum_variant](https://github.com/AleoHQ/leo/commit/ba9fc922295204bac44469a65d168fcad3932e2f) (for `EdwardsGroupType` the difference in enum variant sizes was well over 1KB)
- [fix vec_box](https://github.com/AleoHQ/leo/commit/f016b972fb7c20968842208540911271abb4b1ae) - not only reduces allocations, but also improves data locality

Some of the suggestions were silenced with `#[allow(clippy::x)]`, with `x` being:
- `module_inception` (not very important and adjusting would incur a lot of diff "traffic")
- `many_single_char_names` (fine in complex calculations, especially when following scientific names)
- `too_many_arguments` (better to treat those individually; they will be easy to find with the new attribute)
- `len_without_is_empty` (not necessarily needed)
- `ptr_arg` (in case of `HashMap`/`HashSet` keys)