### PR TITLE
Clippy compliance, part 2/2

### DIFF
--- a/ast/benches/ast.rs
+++ b/ast/benches/ast.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{errors::ParserError, files::File, LeoAst};
+use leo_ast::LeoAst;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::path::{Path, PathBuf};

--- a/compiler/src/expression/circuit/circuit.rs
+++ b/compiler/src/expression/circuit/circuit.rs
@@ -53,7 +53,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         };
 
         let circuit_identifier = circuit.circuit_name.clone();
-        let mut resolved_members = vec![];
+        let mut resolved_members = Vec::with_capacity(circuit.members.len());
 
         for member in circuit.members.into_iter() {
             match member {

--- a/compiler/src/expression/function/core_circuit.rs
+++ b/compiler/src/expression/function/core_circuit.rs
@@ -37,7 +37,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // Get the value of each core function argument
-        let mut argument_values = vec![];
+        let mut argument_values = Vec::with_capacity(arguments.len());
         for argument in arguments.into_iter() {
             let argument_value =
                 self.enforce_expression(cs, file_scope.clone(), function_scope.clone(), None, argument)?;

--- a/compiler/src/expression/tuple/tuple.rs
+++ b/compiler/src/expression/tuple/tuple.rs
@@ -52,7 +52,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             None => {}
         }
 
-        let mut result = vec![];
+        let mut result = Vec::with_capacity(tuple.len());
         for (i, expression) in tuple.into_iter().enumerate() {
             let type_ = if expected_types.is_empty() {
                 None

--- a/compiler/src/function/input/input_keyword.rs
+++ b/compiler/src/function/input/input_keyword.rs
@@ -62,14 +62,14 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
         // Allocate each input variable as a circuit expression
 
-        let mut sections = vec![];
+        let mut sections = Vec::with_capacity(4);
 
         sections.push((registers_name, registers_values));
         sections.push((record_name, record_values));
         sections.push((state_name, state_values));
         sections.push((state_leaf_name, state_leaf_values));
 
-        let mut members = vec![];
+        let mut members = Vec::with_capacity(sections.len());
 
         for (name, values) in sections {
             let member_name = name.clone();

--- a/compiler/src/function/input/input_section.rs
+++ b/compiler/src/function/input/input_section.rs
@@ -30,7 +30,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         identifier: Identifier,
         section: HashMap<Parameter, Option<InputValue>>,
     ) -> Result<ConstrainedValue<F, G>, FunctionError> {
-        let mut members = vec![];
+        let mut members = Vec::with_capacity(section.len());
 
         // Allocate each section definition as a circuit member value
 

--- a/compiler/src/function/main_function.rs
+++ b/compiler/src/function/main_function.rs
@@ -42,7 +42,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         let registers = input.get_registers();
 
         // Iterate over main function input variables and allocate new values
-        let mut input_variables = vec![];
+        let mut input_variables = Vec::with_capacity(function.input.len());
         for input_model in function.input.clone().into_iter() {
             let (identifier, value) = match input_model {
                 InputVariable::InputKeyword(identifier) => {

--- a/compiler/src/output/output_bytes.rs
+++ b/compiler/src/output/output_bytes.rs
@@ -71,8 +71,7 @@ impl OutputBytes {
             string.push_str(&format);
         }
 
-        let mut bytes: Vec<u8> = vec![];
-        bytes.extend_from_slice(string.as_bytes());
+        let bytes = string.into_bytes();
 
         Ok(Self(bytes))
     }

--- a/compiler/src/statement/branch/branch.rs
+++ b/compiler/src/statement/branch/branch.rs
@@ -34,15 +34,15 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         statements: Vec<Statement>,
         return_type: Option<Type>,
     ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
-        let mut results = vec![];
+        let mut results = Vec::with_capacity(statements.len());
         // Evaluate statements. Only allow a single return argument to be returned.
-        for statement in statements.iter() {
+        for statement in statements.into_iter() {
             let mut value = self.enforce_statement(
                 cs,
                 file_scope.clone(),
                 function_scope.clone(),
                 indicator,
-                statement.clone(),
+                statement,
                 return_type.clone(),
                 "".to_owned(),
             )?;

--- a/compiler/src/statement/definition/definition.rs
+++ b/compiler/src/statement/definition/definition.rs
@@ -61,7 +61,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         };
 
         let implicit_types = types.is_empty();
-        let mut expected_types = vec![];
+        let mut expected_types = Vec::with_capacity(expressions.len());
 
         for ty in types.iter().take(expressions.len()) {
             let expected_type = if implicit_types { None } else { Some(ty.clone()) };
@@ -69,7 +69,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             expected_types.push(expected_type);
         }
 
-        let mut values = vec![];
+        let mut values = Vec::with_capacity(expressions.len());
 
         for (expression, expected_type) in expressions.into_iter().zip(expected_types.into_iter()) {
             let value = self.enforce_expression(

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -122,7 +122,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedValue<F, G> {
                 Type::Array(Box::new(array_type), dimensions)
             }
             ConstrainedValue::Tuple(tuple) => {
-                let mut types = vec![];
+                let mut types = Vec::with_capacity(tuple.len());
 
                 for value in tuple {
                     let type_ = value.to_type(span.clone())?;
@@ -448,7 +448,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> CondSelectGadget<F> for Constrained
                 ConstrainedValue::Integer(Integer::conditionally_select(cs, cond, num_1, num_2)?)
             }
             (ConstrainedValue::Array(arr_1), ConstrainedValue::Array(arr_2)) => {
-                let mut array = vec![];
+                let mut array = Vec::with_capacity(arr_1.len());
 
                 for (i, (first, second)) in arr_1.iter().zip(arr_2.iter()).enumerate() {
                     array.push(Self::conditionally_select(
@@ -462,7 +462,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> CondSelectGadget<F> for Constrained
                 ConstrainedValue::Array(array)
             }
             (ConstrainedValue::Tuple(tuple_1), ConstrainedValue::Array(tuple_2)) => {
-                let mut array = vec![];
+                let mut array = Vec::with_capacity(tuple_1.len());
 
                 for (i, (first, second)) in tuple_1.iter().zip(tuple_2.iter()).enumerate() {
                     array.push(Self::conditionally_select(
@@ -484,7 +484,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> CondSelectGadget<F> for Constrained
                 ConstrainedValue::CircuitExpression(identifier, members_1),
                 ConstrainedValue::CircuitExpression(_identifier, members_2),
             ) => {
-                let mut members = vec![];
+                let mut members = Vec::with_capacity(members_1.len());
 
                 for (i, (first, second)) in members_1.iter().zip(members_2.iter()).enumerate() {
                     members.push(ConstrainedCircuitMember::conditionally_select(

--- a/compiler/tests/address/mod.rs
+++ b/compiler/tests/address/mod.rs
@@ -17,8 +17,8 @@
 use crate::{assert_satisfied, expect_compiler_error, generate_main_input, parse_program};
 use leo_typed::InputValue;
 
-static TEST_ADDRESS_1: &'static str = "aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8sta57j8";
-static TEST_ADDRESS_2: &'static str = "aleo18qgam03qe483tdrcc3fkqwpp38ehff4a2xma6lu7hams6lfpgcpq3dq05r";
+static TEST_ADDRESS_1: &str = "aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8sta57j8";
+static TEST_ADDRESS_2: &str = "aleo18qgam03qe483tdrcc3fkqwpp38ehff4a2xma6lu7hams6lfpgcpq3dq05r";
 
 #[test]
 fn test_valid() {

--- a/compiler/tests/boolean/mod.rs
+++ b/compiler/tests/boolean/mod.rs
@@ -43,7 +43,7 @@ fn fail_boolean_statement(program: EdwardsTestCompiler) {
         CompilerError::FunctionError(FunctionError::StatementError(StatementError::ExpressionError(
             ExpressionError::BooleanError(BooleanError::Error(_)),
         ))) => {}
-        _ => panic!("Expected boolean error, got {}"),
+        e => panic!("Expected boolean error, got {}", e),
     }
 }
 

--- a/compiler/tests/mod.rs
+++ b/compiler/tests/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+// allow the use of EdwardsTestCompiler::parse_program_from_string for tests
+#![allow(deprecated)]
+
 pub mod address;
 pub mod array;
 pub mod boolean;

--- a/core/src/packages/unstable/blake2s.rs
+++ b/core/src/packages/unstable/blake2s.rs
@@ -158,7 +158,7 @@ fn check_array_bytes(value: Value, size: usize, span: Span) -> Result<Vec<UInt8>
         return Err(CoreCircuitError::array_length(size, array_value.len(), span));
     }
 
-    let mut array_bytes = vec![];
+    let mut array_bytes = Vec::with_capacity(array_value.len());
 
     for value in array_value {
         let byte = match value {

--- a/gadgets/src/bits/rca.rs
+++ b/gadgets/src/bits/rca.rs
@@ -33,7 +33,7 @@ where
 // Generic impl
 impl<F: Field> RippleCarryAdder<F> for Vec<Boolean> {
     fn add_bits<CS: ConstraintSystem<F>>(&self, mut cs: CS, other: &Self) -> Result<Vec<Boolean>, SynthesisError> {
-        let mut result = vec![];
+        let mut result = Vec::with_capacity(self.len() + 1);
         let mut carry = Boolean::constant(false);
         for (i, (a, b)) in self.iter().zip(other.iter()).enumerate() {
             let (sum, next) = Boolean::add(cs.ns(|| format!("rpc {}", i)), a, b, &carry)?;

--- a/gadgets/src/signed_integer/arithmetic/add.rs
+++ b/gadgets/src/signed_integer/arithmetic/add.rs
@@ -117,7 +117,7 @@ macro_rules! add_int_impl {
                 }
 
                 // Storage area for the resulting bits
-                let mut result_bits = vec![];
+                let mut result_bits = Vec::with_capacity(max_bits);
 
                 // Allocate each bit_gadget of the result
                 let mut coeff = F::one();

--- a/gadgets/src/signed_integer/arithmetic/mul.rs
+++ b/gadgets/src/signed_integer/arithmetic/mul.rs
@@ -84,7 +84,7 @@ macro_rules! mul_int_impl {
                     a_shifted.truncate(size);
 
                     // conditionally add
-                    let mut to_add = vec![];
+                    let mut to_add = Vec::with_capacity(a_shifted.len());
                     for (j, a_bit) in a_shifted.iter().enumerate() {
                         let selected_bit = Boolean::conditionally_select(
                             &mut cs.ns(|| format!("select product bit {} {}", i, j)),
@@ -175,7 +175,7 @@ macro_rules! mul_int_impl {
                 }
 
                 // Storage area for the resulting bits
-                let mut result_bits = vec![];
+                let mut result_bits = Vec::with_capacity(max_bits);
 
                 // Allocate each bit_gadget of the result
                 let mut coeff = F::one();

--- a/gadgets/tests/signed_integer/i128.rs
+++ b/gadgets/tests/signed_integer/i128.rs
@@ -34,10 +34,10 @@ fn check_all_constant_bits(expected: i128, actual: Int128) {
         let mask = 1 << i as i128;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 let bit = result == mask;
                 assert_eq!(b, bit);
             }
@@ -51,16 +51,16 @@ fn check_all_allocated_bits(expected: i128, actual: Int128) {
         let mask = 1 << i as i128;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 let bit = result == mask;
                 assert_eq!(b.get_value().unwrap(), bit);
             }
-            &Boolean::Not(ref b) => {
+            Boolean::Not(ref b) => {
                 let bit = result == mask;
                 assert_eq!(!b.get_value().unwrap(), bit);
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
     }
 }

--- a/gadgets/tests/signed_integer/i16.rs
+++ b/gadgets/tests/signed_integer/i16.rs
@@ -34,10 +34,10 @@ fn check_all_constant_bits(expected: i16, actual: Int16) {
         let mask = 1 << i as i16;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 let bit = result == mask;
                 assert_eq!(b, bit);
             }
@@ -51,16 +51,16 @@ fn check_all_allocated_bits(expected: i16, actual: Int16) {
         let mask = 1 << i as i16;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 let bit = result == mask;
                 assert_eq!(b.get_value().unwrap(), bit);
             }
-            &Boolean::Not(ref b) => {
+            Boolean::Not(ref b) => {
                 let bit = result == mask;
                 assert_eq!(!b.get_value().unwrap(), bit);
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
     }
 }

--- a/gadgets/tests/signed_integer/i32.rs
+++ b/gadgets/tests/signed_integer/i32.rs
@@ -34,10 +34,10 @@ fn check_all_constant_bits(expected: i32, actual: Int32) {
         let mask = 1 << i as i32;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 let bit = result == mask;
                 assert_eq!(b, bit);
             }
@@ -51,16 +51,16 @@ fn check_all_allocated_bits(expected: i32, actual: Int32) {
         let mask = 1 << i as i32;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 let bit = result == mask;
                 assert_eq!(b.get_value().unwrap(), bit);
             }
-            &Boolean::Not(ref b) => {
+            Boolean::Not(ref b) => {
                 let bit = result == mask;
                 assert_eq!(!b.get_value().unwrap(), bit);
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
     }
 }

--- a/gadgets/tests/signed_integer/i64.rs
+++ b/gadgets/tests/signed_integer/i64.rs
@@ -34,10 +34,10 @@ fn check_all_constant_bits(expected: i64, actual: Int64) {
         let mask = 1 << i as i64;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 let bit = result == mask;
                 assert_eq!(b, bit);
             }
@@ -51,16 +51,16 @@ fn check_all_allocated_bits(expected: i64, actual: Int64) {
         let mask = 1 << i as i64;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 let bit = result == mask;
                 assert_eq!(b.get_value().unwrap(), bit);
             }
-            &Boolean::Not(ref b) => {
+            Boolean::Not(ref b) => {
                 let bit = result == mask;
                 assert_eq!(!b.get_value().unwrap(), bit);
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
     }
 }

--- a/gadgets/tests/signed_integer/i8.rs
+++ b/gadgets/tests/signed_integer/i8.rs
@@ -34,10 +34,10 @@ fn check_all_constant_bits(expected: i8, actual: Int8) {
         let mask = 1 << i as i8;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(_) => panic!(),
-            &Boolean::Not(_) => panic!(),
-            &Boolean::Constant(b) => {
+        match *b {
+            Boolean::Is(_) => panic!(),
+            Boolean::Not(_) => panic!(),
+            Boolean::Constant(b) => {
                 let bit = result == mask;
                 assert_eq!(b, bit);
             }
@@ -51,16 +51,16 @@ fn check_all_allocated_bits(expected: i8, actual: Int8) {
         let mask = 1 << i as i8;
         let result = expected & mask;
 
-        match b {
-            &Boolean::Is(ref b) => {
+        match *b {
+            Boolean::Is(ref b) => {
                 let bit = result == mask;
                 assert_eq!(b.get_value().unwrap(), bit);
             }
-            &Boolean::Not(ref b) => {
+            Boolean::Not(ref b) => {
                 let bit = result == mask;
                 assert_eq!(!b.get_value().unwrap(), bit);
             }
-            &Boolean::Constant(_) => unreachable!(),
+            Boolean::Constant(_) => unreachable!(),
         }
     }
 }

--- a/leo/synthesizer/serialized_circuit.rs
+++ b/leo/synthesizer/serialized_circuit.rs
@@ -58,15 +58,7 @@ impl<E: PairingEngine> From<CircuitSynthesizer<E>> for SerializedCircuit {
 
         // Serialize assignments
         fn get_serialized_assignments<E: PairingEngine>(assignments: &[E::Fr]) -> Vec<SerializedField> {
-            let mut serialized = vec![];
-
-            for assignment in assignments {
-                let field = SerializedField::from(assignment);
-
-                serialized.push(field);
-            }
-
-            serialized
+            assignments.iter().map(SerializedField::from).collect()
         }
 
         let input_assignment = get_serialized_assignments::<E>(&synthesizer.input_assignment);
@@ -76,7 +68,7 @@ impl<E: PairingEngine> From<CircuitSynthesizer<E>> for SerializedCircuit {
         fn get_serialized_constraints<E: PairingEngine>(
             constraints: &[(E::Fr, Index)],
         ) -> Vec<(SerializedField, SerializedIndex)> {
-            let mut serialized = vec![];
+            let mut serialized = Vec::with_capacity(constraints.len());
 
             for &(ref coeff, index) in constraints {
                 let field = SerializedField::from(coeff);
@@ -88,9 +80,9 @@ impl<E: PairingEngine> From<CircuitSynthesizer<E>> for SerializedCircuit {
             serialized
         }
 
-        let mut at = vec![];
-        let mut bt = vec![];
-        let mut ct = vec![];
+        let mut at = Vec::with_capacity(num_constraints);
+        let mut bt = Vec::with_capacity(num_constraints);
+        let mut ct = Vec::with_capacity(num_constraints);
 
         for i in 0..num_constraints {
             // Serialize at[i]
@@ -130,7 +122,7 @@ impl TryFrom<SerializedCircuit> for CircuitSynthesizer<Bls12_377> {
         fn get_deserialized_assignments(
             assignments: &[SerializedField],
         ) -> Result<Vec<<Bls12_377 as PairingEngine>::Fr>, FieldError> {
-            let mut deserialized = vec![];
+            let mut deserialized = Vec::with_capacity(assignments.len());
 
             for serialized_assignment in assignments {
                 let field = <Bls12_377 as PairingEngine>::Fr::try_from(serialized_assignment)?;
@@ -148,7 +140,7 @@ impl TryFrom<SerializedCircuit> for CircuitSynthesizer<Bls12_377> {
         fn get_deserialized_constraints(
             constraints: &[(SerializedField, SerializedIndex)],
         ) -> Result<Vec<(<Bls12_377 as PairingEngine>::Fr, Index)>, FieldError> {
-            let mut deserialized = vec![];
+            let mut deserialized = Vec::with_capacity(constraints.len());
 
             for &(ref serialized_coeff, ref serialized_index) in constraints {
                 let field = <Bls12_377 as PairingEngine>::Fr::try_from(serialized_coeff)?;
@@ -160,9 +152,9 @@ impl TryFrom<SerializedCircuit> for CircuitSynthesizer<Bls12_377> {
             Ok(deserialized)
         }
 
-        let mut at = vec![];
-        let mut bt = vec![];
-        let mut ct = vec![];
+        let mut at = Vec::with_capacity(serialized.num_constraints);
+        let mut bt = Vec::with_capacity(serialized.num_constraints);
+        let mut ct = Vec::with_capacity(serialized.num_constraints);
 
         for i in 0..serialized.num_constraints {
             // Deserialize at[i]

--- a/package/tests/manifest/manifest.rs
+++ b/package/tests/manifest/manifest.rs
@@ -44,7 +44,7 @@ const NEW_PROJECT_FORMAT: &str = "[project]";
 
 /// Create a manifest file with outdated formatting.
 fn create_outdated_manifest_file(path: PathBuf) -> PathBuf {
-    let mut path = path.to_owned();
+    let mut path = path;
     if path.is_dir() {
         path.push(PathBuf::from(MANIFEST_FILENAME));
     }

--- a/package/tests/mod.rs
+++ b/package/tests/mod.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::module_inception)]
+
 pub mod initialize;
 pub mod manifest;
 
@@ -59,7 +61,7 @@ pub(crate) fn test_dir() -> PathBuf {
     let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
     TEST_ID.with(|n| *n.borrow_mut() = Some(id));
 
-    let path: PathBuf = TEST_DIR.join(&format!("t{}", id)).into();
+    let path: PathBuf = TEST_DIR.join(&format!("t{}", id));
 
     if path.exists() {
         if let Err(e) = fs::remove_dir_all(&path) {

--- a/state/src/utilities/input_value.rs
+++ b/state/src/utilities/input_value.rs
@@ -49,7 +49,7 @@ pub fn input_to_u8_vec(input: InputValue) -> Result<Vec<u8>, InputValueError> {
         value => return Err(InputValueError::ExpectedBytes(value.to_string())),
     };
 
-    let mut result_vec = vec![];
+    let mut result_vec = Vec::with_capacity(input_array.len());
 
     for input in input_array {
         let integer_string = input_to_integer_string(input)?;
@@ -67,7 +67,7 @@ pub fn input_to_nested_u8_vec(input: InputValue) -> Result<Vec<Vec<u8>>, InputVa
         value => return Err(InputValueError::ExpectedBytes(value.to_string())),
     };
 
-    let mut result_vec = vec![];
+    let mut result_vec = Vec::with_capacity(inner_arrays.len());
 
     for input_array in inner_arrays {
         let array = input_to_u8_vec(input_array)?;

--- a/state/tests/test_verify_local_data_commitment.rs
+++ b/state/tests/test_verify_local_data_commitment.rs
@@ -111,8 +111,8 @@ fn test_generate_values_from_dpc() {
     .unwrap();
 
     // Set the input records for our transaction to be the initial dummy records.
-    let old_records = vec![old_record.clone(); NUM_INPUT_RECORDS];
-    let old_account_private_keys = vec![dummy_account.private_key.clone(); NUM_INPUT_RECORDS];
+    let old_records = vec![old_record; NUM_INPUT_RECORDS];
+    let old_account_private_keys = vec![dummy_account.private_key; NUM_INPUT_RECORDS];
 
     // Construct new records.
 
@@ -128,12 +128,12 @@ fn test_generate_values_from_dpc() {
 
     // Set the new record's program to be the "always-accept" program.
 
-    let new_record_owners = vec![new_account.address.clone(); NUM_OUTPUT_RECORDS];
+    let new_record_owners = vec![new_account.address; NUM_OUTPUT_RECORDS];
     let new_is_dummy_flags = vec![false; NUM_OUTPUT_RECORDS];
     let new_values = vec![10; NUM_OUTPUT_RECORDS];
     let new_payloads = vec![RecordPayload::default(); NUM_OUTPUT_RECORDS];
     let new_birth_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
-    let new_death_program_ids = vec![noop_program_id.clone(); NUM_OUTPUT_RECORDS];
+    let new_death_program_ids = vec![noop_program_id; NUM_OUTPUT_RECORDS];
     let memo = [0u8; 32];
 
     let context = <InstantiatedDPC as DPCScheme<L>>::execute_offline(
@@ -158,13 +158,13 @@ fn test_generate_values_from_dpc() {
 
     let root = local_data.local_data_merkle_tree.root();
 
-    let serial_number = local_data.old_serial_numbers[0].clone();
+    let serial_number = local_data.old_serial_numbers[0];
     let serial_number_bytes = to_bytes![serial_number].unwrap();
 
     let memorandum = local_data.memorandum;
     let network_id = local_data.network_id;
     let input_bytes = to_bytes![serial_number, record.commitment(), memorandum, network_id].unwrap();
-    let leaf_randomness = local_data.local_data_commitment_randomizers[0].clone();
+    let leaf_randomness = local_data.local_data_commitment_randomizers[0];
 
     let old_record_leaf = <LocalDataCommitment as CommitmentScheme>::commit(
         &system_parameters.local_data_commitment,

--- a/typed/benches/typed_ast.rs
+++ b/typed/benches/typed_ast.rs
@@ -14,11 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{errors::ParserError, files::File, LeoAst};
+use leo_ast::LeoAst;
 use leo_typed::LeoTypedAst;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 fn leo_typed_ast<'ast>(ast: &LeoAst<'ast>) {
     let typed_ast = LeoTypedAst::new("leo_typed_tree", &ast);

--- a/typed/src/input/input_value.rs
+++ b/typed/src/input/input_value.rs
@@ -123,7 +123,7 @@ impl InputValue {
             Type::Array(array_type)
         };
 
-        let mut elements = vec![];
+        let mut elements = Vec::with_capacity(inline.expressions.len());
         for expression in inline.expressions.into_iter() {
             let element = InputValue::from_expression(inner_array_type.clone(), expression)?;
 
@@ -229,7 +229,7 @@ impl InputValue {
             ));
         }
 
-        let mut values = vec![];
+        let mut values = Vec::with_capacity(tuple_type.types_.len());
         for (type_, value) in tuple_type.types_.into_iter().zip(tuple.expressions.into_iter()) {
             let value = InputValue::from_expression(type_, value)?;
 

--- a/typed/src/types/type_.rs
+++ b/typed/src/types/type_.rs
@@ -82,8 +82,7 @@ impl Type {
         let type_ = self.clone();
 
         if dimensions.len() > 1 {
-            let mut next = vec![];
-            next.extend_from_slice(&dimensions[1..]);
+            let next = dimensions[1..].to_vec();
 
             return Type::Array(Box::new(type_), next);
         }
@@ -95,8 +94,7 @@ impl Type {
         let type_ = self.clone();
 
         if dimensions.len() > 1 {
-            let mut next = vec![];
-            next.extend_from_slice(&dimensions[..dimensions.len() - 1]);
+            let next = dimensions[..dimensions.len() - 1].to_vec();
 
             return Type::Array(Box::new(type_), next);
         }

--- a/typed/tests/serialization/json.rs
+++ b/typed/tests/serialization/json.rs
@@ -27,9 +27,7 @@ fn to_typed_ast(program_filepath: &PathBuf) -> LeoTypedAst {
     let ast = LeoAst::new(&program_filepath, &program_string).unwrap();
 
     // Parse the abstract syntax tree and constructs a typed syntax tree.
-    let typed_ast = LeoTypedAst::new("leo_typed_tree", &ast);
-
-    typed_ast
+    LeoTypedAst::new("leo_typed_tree", &ast)
 }
 
 #[test]


### PR DESCRIPTION
Builds on https://github.com/AleoHQ/leo/pull/384, only the last 3 commits are new. Can be merged in sequence or be the only PR merged.

There was one new lint, `match_ref_parts`, which received its own commit, but there weren't many others, so they were just put in a single commit; the last commit contains vector pre-allocations that were not suggested by `clippy`, but build on the previous changes and provide similar improvements (fewer allocations).

With this PR, `cargo clippy --workspace --examples --tests --benches` returns no warnings and `clippy` lints can be enabled in the CI or as a git hook.

As a side note, the benchmarks I'm currently working on are showing ~15% improvements with these changes.