### PR TITLE
Change the AST benchmark to a more stable one, remove an unnecessary clone

### DIFF
--- a/ast/benches/ast.rs
+++ b/ast/benches/ast.rs
@@ -14,24 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{errors::ParserError, files::File, LeoAst};
+use leo_ast::LeoAst;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::path::{Path, PathBuf};
 
-fn leo_ast<'ast>(filepath: &'ast PathBuf, program_string: &'ast str) {
-    let result = LeoAst::<'ast>::new(filepath, program_string).unwrap();
-    black_box(result);
+fn leo_ast<'ast>(filepath: &'ast PathBuf, program_string: &'ast str) -> LeoAst<'ast> {
+    LeoAst::<'ast>::new(filepath, program_string).unwrap()
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     let filepath = Path::new("./main.leo").to_path_buf();
-    // let program_string = &LeoAst::load_file(&filepath).unwrap();
     let program_string = include_str!("./main.leo");
 
-    c.bench_function("LeoAst::new", |b| {
-        b.iter(|| leo_ast(black_box(&filepath), black_box(program_string)))
-    });
+    c.bench_function("LeoAst::new", |b| b.iter(|| leo_ast(&filepath, program_string)));
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/ast/benches/main.leo
+++ b/ast/benches/main.leo
@@ -1,3 +1,26 @@
-function main() {
-    return 1 + 1
+circuit PedersenHash {
+    parameters: [group; 256],
+
+    // Instantiates a Pedersen hash circuit
+    static function new(parameters: [group; 256]) -> Self {
+        return Self { parameters: parameters }
+    }
+
+    function hash(bits: [bool; 256]) -> group {
+        let mut digest: group = 0;
+        for i in 0..256 {
+            if bits[i] {
+                digest += self.parameters[i];
+            }
+        }
+        return digest
+    }
+}
+
+// The 'pedersen-hash' main function.
+function main() -> group {
+    const parameters = [1group; 256];
+    const pedersen = PedersenHash::new(parameters);
+    let hash_input: [bool; 256] = [true; 256];
+    return pedersen.hash(hash_input)
 }

--- a/ast/src/ast.rs
+++ b/ast/src/ast.rs
@@ -163,12 +163,11 @@ impl<'ast> FromPest<'ast> for Expression<'ast> {
     type Rule = Rule;
 
     fn from_pest(pest: &mut Pairs<'ast, Rule>) -> Result<Self, ConversionError<Void>> {
-        let mut clone = pest.clone();
-        let pair = clone.next().ok_or(::from_pest::ConversionError::NoMatch)?;
+        let pair = pest.peek().ok_or(::from_pest::ConversionError::NoMatch)?;
         match pair.as_rule() {
             Rule::expression => {
-                // Transfer iterated state to pest.
-                *pest = clone;
+                // advance the iterator
+                pest.next();
                 Ok(*PRECEDENCE_CLIMBER.climb(pair.into_inner(), parse_term, binary_expression))
             }
             _ => Err(ConversionError::NoMatch),


### PR DESCRIPTION
This PR changes the existing, trivial benchmark to a more advanced one, so that its results are more stable and at the same time more sensitive to future changes. I investigated the option of introducing more specialized AST benchmarks like in https://github.com/AleoHQ/leo/pull/388, but since there isn't much happening there other than the pest work, it would ultimately just be benchmarking `pest`.

In addition, the PR removes an unnecessary clone of the `Pairs` iterator by utilizing its [`peek`](https://docs.rs/pest/2.1.3/pest/iterators/struct.Pairs.html#method.peek) capabilities instead.