### PR TITLE
Updates CI to remove need for SSH keys as secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Load snarkOS
-        run: |
-          mkdir ~/.ssh
-          echo "${{ secrets.SNARKOS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          eval $(ssh-agent -s)
-          ssh-add -k ~/.ssh/id_rsa
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -52,14 +44,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Load snarkOS
-        run: |
-          mkdir ~/.ssh
-          echo "${{ secrets.SNARKOS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          eval $(ssh-agent -s)
-          ssh-add -k ~/.ssh/id_rsa
 
       - name: Install Rust (${{ matrix.rust }})
         uses: actions-rs/toolchain@v1
@@ -130,14 +114,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-
-      - name: Load snarkOS
-        run: |
-          mkdir ~/.ssh
-          echo "${{ secrets.SNARKOS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          eval $(ssh-agent -s)
-          ssh-add -k ~/.ssh/id_rsa
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -15,14 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Load snarkOS
-        run: |
-          mkdir ~/.ssh
-          echo "${{ secrets.SNARKOS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          eval $(ssh-agent -s)
-          ssh-add -k ~/.ssh/id_rsa
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -53,14 +45,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-
-      - name: Load snarkOS
-        run: |
-          mkdir ~/.ssh
-          echo "${{ secrets.SNARKOS_DEPLOY_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          eval $(ssh-agent -s)
-          ssh-add -k ~/.ssh/id_rsa
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Removes a legacy piece of CI where we load SSH keys for snarkOS. As these are now public, we no longer need them.
