### PR TITLE
A few post-merge cleanups

### DIFF
--- a/ast/src/ast.rs
+++ b/ast/src/ast.rs
@@ -159,12 +159,11 @@ impl<'ast> FromPest<'ast> for Expression<'ast> {
     type Rule = Rule;
 
     fn from_pest(pest: &mut Pairs<'ast, Rule>) -> Result<Self, ConversionError<Void>> {
-        let mut clone = pest.clone();
-        let pair = clone.next().ok_or(::from_pest::ConversionError::NoMatch)?;
+        let pair = pest.peek().ok_or(::from_pest::ConversionError::NoMatch)?;
         match pair.as_rule() {
             Rule::expression => {
-                // Transfer iterated state to pest.
-                *pest = clone;
+                // advance the iterator
+                pest.next();
                 Ok(PRECEDENCE_CLIMBER.climb(pair.into_inner(), parse_term, binary_expression))
             }
             _ => Err(ConversionError::NoMatch),

--- a/ast/tests/serialization/json.rs
+++ b/ast/tests/serialization/json.rs
@@ -14,13 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::LeoAst;
-
-use std::path::PathBuf;
-
 #[test]
 #[cfg(not(feature = "ci_skip"))]
 fn test_serialize() {
+    use leo_ast::LeoAst;
+    use std::path::PathBuf;
+
     let mut program_filepath = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     program_filepath.push("tests/serialization/main.leo");
 

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -36,14 +36,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         index: RangeOrExpression,
         span: &Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
-        let array = match self.enforce_operand(
-            cs,
-            file_scope.clone(),
-            function_scope.clone(),
-            expected_type,
-            array,
-            span,
-        )? {
+        let array = match self.enforce_operand(cs, file_scope, function_scope, expected_type, array, span)? {
             ConstrainedValue::Array(array) => array,
             value => return Err(ExpressionError::undefined_array(value.to_string(), span.to_owned())),
         };

--- a/compiler/src/expression/circuit/access.rs
+++ b/compiler/src/expression/circuit/access.rs
@@ -39,12 +39,12 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         file_scope: &str,
         function_scope: &str,
         expected_type: Option<Type>,
-        circuit_identifier: Box<Expression>,
+        circuit_identifier: Expression,
         circuit_member: Identifier,
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // access a circuit member using the `self` keyword
-        if let Expression::Identifier(ref identifier) = *circuit_identifier {
+        if let Expression::Identifier(ref identifier) = circuit_identifier {
             if identifier.is_self() {
                 let self_file_scope = new_scope(&file_scope, &identifier.name);
                 let self_function_scope = new_scope(&self_file_scope, &identifier.name);
@@ -56,17 +56,11 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             }
         }
 
-        let (circuit_name, members) = match self.enforce_operand(
-            cs,
-            file_scope,
-            function_scope,
-            expected_type,
-            *circuit_identifier,
-            &span,
-        )? {
-            ConstrainedValue::CircuitExpression(name, members) => (name, members),
-            value => return Err(ExpressionError::undefined_circuit(value.to_string(), span)),
-        };
+        let (circuit_name, members) =
+            match self.enforce_operand(cs, file_scope, function_scope, expected_type, circuit_identifier, &span)? {
+                ConstrainedValue::CircuitExpression(name, members) => (name, members),
+                value => return Err(ExpressionError::undefined_circuit(value.to_string(), span)),
+            };
 
         let matched_member = members.clone().into_iter().find(|member| member.0 == circuit_member);
 

--- a/compiler/src/expression/circuit/static_access.rs
+++ b/compiler/src/expression/circuit/static_access.rs
@@ -32,12 +32,12 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         file_scope: &str,
         function_scope: &str,
         expected_type: Option<Type>,
-        circuit_identifier: Box<Expression>,
+        circuit_identifier: Expression,
         circuit_member: Identifier,
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
         // Get defined circuit
-        let circuit = match *circuit_identifier {
+        let circuit = match circuit_identifier {
             Expression::Identifier(identifier) => {
                 // Use the "Self" keyword to access a static circuit function
                 if identifier.is_self() {

--- a/compiler/src/expression/expression.rs
+++ b/compiler/src/expression/expression.rs
@@ -261,7 +261,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 self.enforce_tuple(cs, file_scope, function_scope, expected_type, tuple, span)
             }
             Expression::TupleAccess(tuple, index, span) => {
-                self.enforce_tuple_access(cs, file_scope, function_scope, expected_type, tuple, index, &span)
+                self.enforce_tuple_access(cs, file_scope, function_scope, expected_type, *tuple, index, &span)
             }
 
             // Circuits
@@ -273,7 +273,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 file_scope,
                 function_scope,
                 expected_type,
-                circuit_variable,
+                *circuit_variable,
                 circuit_member,
                 span,
             ),
@@ -283,7 +283,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     file_scope,
                     function_scope,
                     expected_type,
-                    circuit_identifier,
+                    *circuit_identifier,
                     circuit_member,
                     span,
                 ),
@@ -294,7 +294,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 file_scope,
                 function_scope,
                 expected_type,
-                function,
+                *function,
                 arguments,
                 span,
             ),

--- a/compiler/src/expression/function/function.rs
+++ b/compiler/src/expression/function/function.rs
@@ -42,7 +42,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
                 // Save a reference to the circuit we are mutating.
                 let circuit_id_string = circuit_identifier.to_string();
-                let declared_circuit_reference = new_scope(function_scope.clone(), &circuit_id_string);
+                let declared_circuit_reference = new_scope(function_scope, &circuit_id_string);
 
                 (
                     declared_circuit_reference,

--- a/compiler/src/expression/function/function.rs
+++ b/compiler/src/expression/function/function.rs
@@ -32,11 +32,11 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         file_scope: &str,
         function_scope: &str,
         expected_type: Option<Type>,
-        function: Box<Expression>,
+        function: Expression,
         arguments: Vec<Expression>,
         span: Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
-        let (declared_circuit_reference, function_value) = match *function {
+        let (declared_circuit_reference, function_value) = match function {
             Expression::CircuitMemberAccess(circuit_identifier, circuit_member, span) => {
                 // Call a circuit function that can mutate self.
 
@@ -51,7 +51,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                         file_scope,
                         function_scope,
                         expected_type,
-                        circuit_identifier,
+                        *circuit_identifier,
                         circuit_member,
                         span,
                     )?,

--- a/compiler/src/expression/tuple/access.rs
+++ b/compiler/src/expression/tuple/access.rs
@@ -32,11 +32,11 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         file_scope: &str,
         function_scope: &str,
         expected_type: Option<Type>,
-        tuple: Box<Expression>,
+        tuple: Expression,
         index: usize,
         span: &Span,
     ) -> Result<ConstrainedValue<F, G>, ExpressionError> {
-        let tuple = match self.enforce_operand(cs, file_scope, function_scope, expected_type, *tuple, &span)? {
+        let tuple = match self.enforce_operand(cs, file_scope, function_scope, expected_type, tuple, &span)? {
             ConstrainedValue::Tuple(tuple) => tuple,
             value => return Err(ExpressionError::undefined_array(value.to_string(), span.to_owned())),
         };

--- a/typed/benches/typed_ast.rs
+++ b/typed/benches/typed_ast.rs
@@ -18,10 +18,7 @@ use leo_ast::LeoAst;
 use leo_typed::LeoTypedAst;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use std::{
-    path::{Path, PathBuf},
-    time::Duration,
-};
+use std::{path::Path, time::Duration};
 
 fn leo_typed_ast<'ast>(ast: &LeoAst<'ast>) -> LeoTypedAst {
     LeoTypedAst::new("leo_typed_tree", &ast)

--- a/typed/tests/serialization/json.rs
+++ b/typed/tests/serialization/json.rs
@@ -15,7 +15,9 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use leo_ast::LeoAst;
-use leo_typed::{LeoTypedAst, Program};
+use leo_typed::LeoTypedAst;
+#[cfg(not(feature = "ci_skip"))]
+use leo_typed::Program;
 
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
After the recent host of PRs there were a few small bits lost in conflicts; this PR includes them, making `cargo clippy --workspace --tests --examples --benches` clean.