### PR TITLE
Arithmetic benchmarks and perf improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
 name = "leo-gadgets"
 version = "1.0.3"
 dependencies = [
+ "criterion",
  "rand",
  "rand_xorshift",
  "snarkos-errors",

--- a/compiler/src/expression/function/function.rs
+++ b/compiler/src/expression/function/function.rs
@@ -65,15 +65,17 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
         let (outer_scope, function_call) = function_value.extract_function(file_scope, &span)?;
 
-        let name_unique = format!(
-            "function call {} {}:{}",
-            function_call.get_name(),
-            span.line,
-            span.start,
-        );
+        let name_unique = || {
+            format!(
+                "function call {} {}:{}",
+                function_call.get_name(),
+                span.line,
+                span.start,
+            )
+        };
 
         self.enforce_function(
-            &mut cs.ns(|| name_unique),
+            &mut cs.ns(name_unique),
             &outer_scope,
             function_scope,
             function_call,

--- a/compiler/src/expression/logical/and.rs
+++ b/compiler/src/expression/logical/and.rs
@@ -33,9 +33,12 @@ pub fn enforce_and<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<
     let name = format!("{} && {}", left, right);
 
     if let (ConstrainedValue::Boolean(left_bool), ConstrainedValue::Boolean(right_bool)) = (left, right) {
-        let name_unique = format!("{} {}:{}", name, span.line, span.start);
-        let result = Boolean::and(cs.ns(|| name_unique), &left_bool, &right_bool)
-            .map_err(|e| BooleanError::cannot_enforce("&&".to_string(), e, span.to_owned()))?;
+        let result = Boolean::and(
+            cs.ns(|| format!("{} {}:{}", name, span.line, span.start)),
+            &left_bool,
+            &right_bool,
+        )
+        .map_err(|e| BooleanError::cannot_enforce("&&".to_string(), e, span.to_owned()))?;
 
         return Ok(ConstrainedValue::Boolean(result));
     }

--- a/compiler/src/expression/logical/or.rs
+++ b/compiler/src/expression/logical/or.rs
@@ -33,9 +33,12 @@ pub fn enforce_or<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<F
     let name = format!("{} || {}", left, right);
 
     if let (ConstrainedValue::Boolean(left_bool), ConstrainedValue::Boolean(right_bool)) = (left, right) {
-        let name_unique = format!("{} {}:{}", name, span.line, span.start);
-        let result = Boolean::or(cs.ns(|| name_unique), &left_bool, &right_bool)
-            .map_err(|e| BooleanError::cannot_enforce("||".to_string(), e, span.to_owned()))?;
+        let result = Boolean::or(
+            cs.ns(|| format!("{} {}:{}", name, span.line, span.start)),
+            &left_bool,
+            &right_bool,
+        )
+        .map_err(|e| BooleanError::cannot_enforce("||".to_string(), e, span.to_owned()))?;
 
         return Ok(ConstrainedValue::Boolean(result));
     }

--- a/compiler/src/function/result/result.rs
+++ b/compiler/src/function/result/result.rs
@@ -61,12 +61,13 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             }
 
             let condition = indicator.unwrap_or(Boolean::Constant(true));
-            let name_unique = format!("select {} {}:{}", result, span.line, span.start);
-            let selected_value =
-                ConstrainedValue::conditionally_select(cs.ns(|| name_unique), &condition, &result, return_value)
-                    .map_err(|_| {
-                        StatementError::select_fail(result.to_string(), return_value.to_string(), span.to_owned())
-                    })?;
+            let selected_value = ConstrainedValue::conditionally_select(
+                cs.ns(|| format!("select {} {}:{}", result, span.line, span.start)),
+                &condition,
+                &result,
+                return_value,
+            )
+            .map_err(|_| StatementError::select_fail(result.to_string(), return_value.to_string(), span.to_owned()))?;
 
             *return_value = selected_value;
         }

--- a/compiler/src/statement/assign/array.rs
+++ b/compiler/src/statement/assign/array.rs
@@ -52,9 +52,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     ConstrainedValue::Array(old) => {
                         new_value.resolve_type(Some(old[index].to_type(&span)?), &span)?;
 
-                        let name_unique = format!("select {} {}:{}", new_value, span.line, span.start);
                         let selected_value = ConstrainedValue::conditionally_select(
-                            cs.ns(|| name_unique),
+                            cs.ns(|| format!("select {} {}:{}", new_value, span.line, span.start)),
                             &condition,
                             &new_value,
                             &old[index],
@@ -89,12 +88,15 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     }
                     _ => return Err(StatementError::array_assign_range(span.to_owned())),
                 };
-                let name_unique = format!("select {} {}:{}", new_array, span.line, span.start);
-                let selected_array =
-                    ConstrainedValue::conditionally_select(cs.ns(|| name_unique), &condition, &new_array, old_array)
-                        .map_err(|_| {
-                            StatementError::select_fail(new_array.to_string(), old_array.to_string(), span.to_owned())
-                        })?;
+                let selected_array = ConstrainedValue::conditionally_select(
+                    cs.ns(|| format!("select {} {}:{}", new_array, span.line, span.start)),
+                    &condition,
+                    &new_array,
+                    old_array,
+                )
+                .map_err(|_| {
+                    StatementError::select_fail(new_array.to_string(), old_array.to_string(), span.to_owned())
+                })?;
 
                 *old_array = selected_array;
             }

--- a/compiler/src/statement/assign/assign.rs
+++ b/compiler/src/statement/assign/assign.rs
@@ -61,12 +61,15 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
 
                 new_value.resolve_type(Some(old_value.to_type(&span)?), &span)?;
 
-                let name_unique = format!("select {} {}:{}", new_value, span.line, span.start);
-                let selected_value =
-                    ConstrainedValue::conditionally_select(cs.ns(|| name_unique), &condition, &new_value, old_value)
-                        .map_err(|_| {
-                            StatementError::select_fail(new_value.to_string(), old_value.to_string(), span.to_owned())
-                        })?;
+                let selected_value = ConstrainedValue::conditionally_select(
+                    cs.ns(|| format!("select {} {}:{}", new_value, span.line, span.start)),
+                    &condition,
+                    &new_value,
+                    old_value,
+                )
+                .map_err(|_| {
+                    StatementError::select_fail(new_value.to_string(), old_value.to_string(), span.to_owned())
+                })?;
 
                 *old_value = selected_value;
 

--- a/compiler/src/statement/assign/circuit_variable.rs
+++ b/compiler/src/statement/assign/circuit_variable.rs
@@ -68,9 +68,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                             new_value.resolve_type(Some(value.to_type(span)?), span)?;
 
                             // Conditionally select the value if this branch is executed.
-                            let name_unique = format!("select {} {}:{}", new_value, span.line, span.start);
                             let mut selected_value = ConstrainedValue::conditionally_select(
-                                cs.ns(|| name_unique),
+                                cs.ns(|| format!("select {} {}:{}", new_value, span.line, span.start)),
                                 &condition,
                                 &new_value,
                                 &member.1,

--- a/compiler/src/statement/assign/tuple.rs
+++ b/compiler/src/statement/assign/tuple.rs
@@ -44,12 +44,15 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             ConstrainedValue::Tuple(old) => {
                 new_value.resolve_type(Some(old[index].to_type(&span)?), &span)?;
 
-                let name_unique = format!("select {} {}:{}", new_value, span.line, span.start);
-                let selected_value =
-                    ConstrainedValue::conditionally_select(cs.ns(|| name_unique), &condition, &new_value, &old[index])
-                        .map_err(|_| {
-                            StatementError::select_fail(new_value.to_string(), old[index].to_string(), span.to_owned())
-                        })?;
+                let selected_value = ConstrainedValue::conditionally_select(
+                    cs.ns(|| format!("select {} {}:{}", new_value, span.line, span.start)),
+                    &condition,
+                    &new_value,
+                    &old[index],
+                )
+                .map_err(|_| {
+                    StatementError::select_fail(new_value.to_string(), old[index].to_string(), span.to_owned())
+                })?;
 
                 old[index] = selected_value;
             }

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -67,9 +67,8 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             );
 
             // Evaluate statements and possibly return early
-            let name_unique = format!("for loop iteration {} {}:{}", i, span.line, span.start);
             let mut result = self.evaluate_branch(
-                &mut cs.ns(|| name_unique),
+                &mut cs.ns(|| format!("for loop iteration {} {}:{}", i, span.line, span.start)),
                 file_scope,
                 function_scope,
                 indicator,

--- a/compiler/src/value/address/address.rs
+++ b/compiler/src/value/address/address.rs
@@ -81,12 +81,10 @@ impl Address {
             None => None,
         };
 
-        let address_name = format!("{}: address", name);
-        let address_namespace = format!("`{}` {}:{}", address_name, span.line, span.start);
-
-        let address = Address::alloc(cs.ns(|| address_namespace), || {
-            address_value.ok_or(SynthesisError::AssignmentMissing)
-        })
+        let address = Address::alloc(
+            cs.ns(|| format!("`{}: address` {}:{}", name, span.line, span.start)),
+            || address_value.ok_or(SynthesisError::AssignmentMissing),
+        )
         .map_err(|_| AddressError::missing_address(span.to_owned()))?;
 
         Ok(ConstrainedValue::Address(address))

--- a/compiler/src/value/address/address.rs
+++ b/compiler/src/value/address/address.rs
@@ -60,13 +60,7 @@ impl Address {
     }
 
     pub(crate) fn is_constant(&self) -> bool {
-        let mut result = true;
-
-        for byte in self.bytes.iter() {
-            result = result && byte.is_constant()
-        }
-
-        result
+        self.bytes.iter().all(|byte| byte.is_constant())
     }
 
     pub(crate) fn from_input<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/boolean/input.rs
+++ b/compiler/src/value/boolean/input.rs
@@ -42,13 +42,11 @@ pub(crate) fn allocate_bool<F: Field + PrimeField, CS: ConstraintSystem<F>>(
     option: Option<bool>,
     span: &Span,
 ) -> Result<Boolean, BooleanError> {
-    let boolean_name = format!("{}: bool", name);
-    let boolean_name_unique = format!("`{}` {}:{}", boolean_name, span.line, span.start);
-
-    Boolean::alloc(cs.ns(|| boolean_name_unique), || {
-        option.ok_or(SynthesisError::AssignmentMissing)
-    })
-    .map_err(|_| BooleanError::missing_boolean(boolean_name.to_owned(), span.to_owned()))
+    Boolean::alloc(
+        cs.ns(|| format!("`{}: bool` {}:{}", name, span.line, span.start)),
+        || option.ok_or(SynthesisError::AssignmentMissing),
+    )
+    .map_err(|_| BooleanError::missing_boolean(format!("{}: bool", name), span.to_owned()))
 }
 
 pub(crate) fn bool_from_input<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/field/input.rs
+++ b/compiler/src/value/field/input.rs
@@ -31,13 +31,11 @@ pub(crate) fn allocate_field<F: Field + PrimeField, CS: ConstraintSystem<F>>(
     option: Option<String>,
     span: &Span,
 ) -> Result<FieldType<F>, FieldError> {
-    let field_name = format!("{}: field", name);
-    let field_name_unique = format!("`{}` {}:{}", field_name, span.line, span.start);
-
-    FieldType::alloc(cs.ns(|| field_name_unique), || {
-        option.ok_or(SynthesisError::AssignmentMissing)
-    })
-    .map_err(|_| FieldError::missing_field(field_name, span.to_owned()))
+    FieldType::alloc(
+        cs.ns(|| format!("`{}: field` {}:{}", name, span.line, span.start)),
+        || option.ok_or(SynthesisError::AssignmentMissing),
+    )
+    .map_err(|_| FieldError::missing_field(format!("{}: field", name), span.to_owned()))
 }
 
 pub(crate) fn field_from_input<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/group/input.rs
+++ b/compiler/src/value/group/input.rs
@@ -31,13 +31,11 @@ pub(crate) fn allocate_group<F: Field + PrimeField, G: GroupType<F>, CS: Constra
     option: Option<GroupValue>,
     span: &Span,
 ) -> Result<G, GroupError> {
-    let group_name = format!("{}: group", name);
-    let group_name_unique = format!("`{}` {}:{}", group_name, span.line, span.start);
-
-    G::alloc(cs.ns(|| group_name_unique), || {
-        option.ok_or(SynthesisError::AssignmentMissing)
-    })
-    .map_err(|_| GroupError::missing_group(group_name, span.to_owned()))
+    G::alloc(
+        cs.ns(|| format!("`{}: group` {}:{}", name, span.line, span.start)),
+        || option.ok_or(SynthesisError::AssignmentMissing),
+    )
+    .map_err(|_| GroupError::missing_group(format!("{}: group", name), span.to_owned()))
 }
 
 pub(crate) fn group_from_input<F: Field + PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -189,155 +189,142 @@ impl Integer {
     ) -> Result<Self, IntegerError> {
         Ok(match integer_type {
             IntegerType::U8 => {
-                let u8_name = format!("{}: u8", name);
-                let u8_name_unique = format!("`{}` {}:{}", u8_name, span.line, span.start);
-
                 let u8_option = option.map(|s| {
                     s.parse::<u8>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
 
-                let u8_result = UInt8::alloc(cs.ns(|| u8_name_unique), || {
+                let u8_result = UInt8::alloc(cs.ns(|| format!("`{}: u8` {}:{}", name, span.line, span.start)), || {
                     u8_option.ok_or(SynthesisError::AssignmentMissing)
                 })
-                .map_err(|_| IntegerError::missing_integer(u8_name, span.to_owned()))?;
+                .map_err(|_| IntegerError::missing_integer(format!("{}: u8", name), span.to_owned()))?;
 
                 Integer::U8(u8_result)
             }
             IntegerType::U16 => {
-                let u16_name = format!("{}: u16", name);
-                let u16_name_unique = format!("`{}` {}:{}", u16_name, span.line, span.start);
                 let u16_option = option.map(|s| {
                     s.parse::<u16>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let u16_result = UInt16::alloc(cs.ns(|| u16_name_unique), || {
-                    u16_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(u16_name, span.to_owned()))?;
+                let u16_result = UInt16::alloc(
+                    cs.ns(|| format!("`{}: u16` {}:{}", name, span.line, span.start)),
+                    || u16_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: u16", name), span.to_owned()))?;
 
                 Integer::U16(u16_result)
             }
             IntegerType::U32 => {
-                let u32_name = format!("{}: u32", name);
-                let u32_name_unique = format!("`{}` {}:{}", u32_name, span.line, span.start);
                 let u32_option = option.map(|s| {
                     s.parse::<u32>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let u32_result = UInt32::alloc(cs.ns(|| u32_name_unique), || {
-                    u32_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(u32_name, span.to_owned()))?;
+                let u32_result = UInt32::alloc(
+                    cs.ns(|| format!("`{}: u32` {}:{}", name, span.line, span.start)),
+                    || u32_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: u32", name), span.to_owned()))?;
 
                 Integer::U32(u32_result)
             }
             IntegerType::U64 => {
-                let u64_name = format!("{}: u64", name);
-                let u64_name_unique = format!("`{}` {}:{}", u64_name, span.line, span.start);
                 let u64_option = option.map(|s| {
                     s.parse::<u64>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let u64_result = UInt64::alloc(cs.ns(|| u64_name_unique), || {
-                    u64_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(u64_name, span.to_owned()))?;
+                let u64_result = UInt64::alloc(
+                    cs.ns(|| format!("`{}: u64` {}:{}", name, span.line, span.start)),
+                    || u64_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: u64", name), span.to_owned()))?;
 
                 Integer::U64(u64_result)
             }
             IntegerType::U128 => {
-                let u128_name = format!("{}: u128", name);
-                let u128_name_unique = format!("`{}` {}:{}", u128_name, span.line, span.start);
                 let u128_option = option.map(|s| {
                     s.parse::<u128>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let u128_result = UInt128::alloc(cs.ns(|| u128_name_unique), || {
-                    u128_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(u128_name, span.to_owned()))?;
+                let u128_result = UInt128::alloc(
+                    cs.ns(|| format!("`{}: u128` {}:{}", name, span.line, span.start)),
+                    || u128_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: u128", name), span.to_owned()))?;
 
                 Integer::U128(u128_result)
             }
 
             IntegerType::I8 => {
-                let i8_name = format!("{}: i8", name);
-                let i8_name_unique = format!("`{}` {}:{}", i8_name, span.line, span.start);
                 let i8_option = option.map(|s| {
                     s.parse::<i8>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let i8_result = Int8::alloc(cs.ns(|| i8_name_unique), || {
+                let i8_result = Int8::alloc(cs.ns(|| format!("`{}: i8` {}:{}", name, span.line, span.start)), || {
                     i8_option.ok_or(SynthesisError::AssignmentMissing)
                 })
-                .map_err(|_| IntegerError::missing_integer(i8_name, span.to_owned()))?;
+                .map_err(|_| IntegerError::missing_integer(format!("{}: i8", name), span.to_owned()))?;
 
                 Integer::I8(i8_result)
             }
             IntegerType::I16 => {
-                let i16_name = format!("{}: i16", name);
-                let i16_name_unique = format!("`{}` {}:{}", i16_name, span.line, span.start);
                 let i16_option = option.map(|s| {
                     s.parse::<i16>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let i16_result = Int16::alloc(cs.ns(|| i16_name_unique), || {
-                    i16_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(i16_name, span.to_owned()))?;
+                let i16_result = Int16::alloc(
+                    cs.ns(|| format!("`{}: i16` {}:{}", name, span.line, span.start)),
+                    || i16_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: i16", name), span.to_owned()))?;
 
                 Integer::I16(i16_result)
             }
             IntegerType::I32 => {
-                let i32_name = format!("{}: i32", name);
-                let i32_name_unique = format!("`{}` {}:{}", i32_name, span.line, span.start);
                 let i32_option = option.map(|s| {
                     s.parse::<i32>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let i32_result = Int32::alloc(cs.ns(|| i32_name_unique), || {
-                    i32_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(i32_name, span.to_owned()))?;
+                let i32_result = Int32::alloc(
+                    cs.ns(|| format!("`{}: i32` {}:{}", name, span.line, span.start)),
+                    || i32_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: i32", name), span.to_owned()))?;
 
                 Integer::I32(i32_result)
             }
             IntegerType::I64 => {
-                let i64_name = format!("{}: i64", name);
-                let i64_name_unique = format!("`{}` {}:{}", i64_name, span.line, span.start);
                 let i64_option = option.map(|s| {
                     s.parse::<i64>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let i64_result = Int64::alloc(cs.ns(|| i64_name_unique), || {
-                    i64_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(i64_name, span.to_owned()))?;
+                let i64_result = Int64::alloc(
+                    cs.ns(|| format!("`{}: i64` {}:{}", name, span.line, span.start)),
+                    || i64_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: i64", name), span.to_owned()))?;
 
                 Integer::I64(i64_result)
             }
             IntegerType::I128 => {
-                let i128_name = format!("{}: i128", name);
-                let i128_name_unique = format!("`{}` {}:{}", i128_name, span.line, span.start);
                 let i128_option = option.map(|s| {
                     s.parse::<i128>()
                         .map_err(|_| IntegerError::invalid_integer(s, span.to_owned()))
                         .unwrap()
                 });
-                let i128_result = Int128::alloc(cs.ns(|| i128_name_unique), || {
-                    i128_option.ok_or(SynthesisError::AssignmentMissing)
-                })
-                .map_err(|_| IntegerError::missing_integer(i128_name, span.to_owned()))?;
+                let i128_result = Int128::alloc(
+                    cs.ns(|| format!("`{}: i128` {}:{}", name, span.line, span.start)),
+                    || i128_option.ok_or(SynthesisError::AssignmentMissing),
+                )
+                .map_err(|_| IntegerError::missing_integer(format!("{}: i128", name), span.to_owned()))?;
 
                 Integer::I128(i128_result)
             }

--- a/gadgets/Cargo.toml
+++ b/gadgets/Cargo.toml
@@ -41,3 +41,11 @@ version = "1.0"
 
 [dev-dependencies.snarkos-utilities]
 version = "1.1.3"
+
+[dev-dependencies.criterion]
+version = "0.3"
+
+[[bench]]
+name = "integer_arithmetic"
+path = "benches/integer_arithmetic.rs"
+harness = false

--- a/gadgets/benches/integer_arithmetic.rs
+++ b/gadgets/benches/integer_arithmetic.rs
@@ -1,0 +1,429 @@
+// Copyright (C) 2019-2020 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use leo_gadgets::{arithmetic::*, Int128, Int16, Int32, Int64, Int8};
+
+use snarkos_models::gadgets::{
+    r1cs::{ConstraintSystem, Fr, TestConstraintSystem},
+    utilities::alloc::AllocGadget,
+};
+
+use rand::{Rng, SeedableRng};
+use rand_xorshift::XorShiftRng;
+use std::i128;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+macro_rules! create_add_bench {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if a.checked_add(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: a (add)", bench_run_id)), || Ok(a)).unwrap();
+                let b_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: b (add)", bench_run_id)), || Ok(b)).unwrap();
+
+                a_bit
+                    .add(cs.ns(|| format!("{}: a add b", bench_run_id)), &b_bit)
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_add_bench_const {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if a.checked_add(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit_const = <$bit_type>::constant(a);
+                let b_bit_const = <$bit_type>::constant(b);
+                a_bit_const
+                    .add(
+                        cs.ns(|| format!("{}: a add b: const", bench_run_id)),
+                        &b_bit_const,
+                    )
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_sub_bench {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if b.checked_neg().is_none() || a.checked_sub(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: a (sub)", bench_run_id)), || Ok(a)).unwrap();
+                let b_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: b (sub)", bench_run_id)), || Ok(b)).unwrap();
+
+                a_bit
+                    .sub(cs.ns(|| format!("{}: a sub b", bench_run_id)), &b_bit)
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_sub_bench_const {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if b.checked_neg().is_none() || a.checked_sub(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit_const = <$bit_type>::constant(a);
+                let b_bit_const = <$bit_type>::constant(b);
+                a_bit_const
+                    .sub(
+                        cs.ns(|| format!("{}: a sub b: const", bench_run_id)),
+                        &b_bit_const,
+                    )
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_mul_bench {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if a.checked_mul(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: a (mul)", bench_run_id)), || Ok(a)).unwrap();
+                let b_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: b (mul)", bench_run_id)), || Ok(b)).unwrap();
+                a_bit
+                    .mul(cs.ns(|| format!("{}: a mul b", bench_run_id)), &b_bit)
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_mul_bench_const {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if a.checked_mul(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit_const = <$bit_type>::constant(a);
+                let b_bit_const = <$bit_type>::constant(b);
+                a_bit_const
+                    .mul(
+                        cs.ns(|| format!("{}: a mul b: const", bench_run_id)),
+                        &b_bit_const,
+                    )
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_div_bench {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if a.checked_neg().is_none() || a.checked_div(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: a (div)", bench_run_id)), || Ok(a)).unwrap();
+                let b_bit = <$bit_type>::alloc(cs.ns(|| format!("{}: b (div)", bench_run_id)), || Ok(b)).unwrap();
+                a_bit
+                    .div(cs.ns(|| format!("{}: a div b", bench_run_id)), &b_bit)
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+macro_rules! create_div_bench_const {
+    ($bench_name:ident, $bench_id:expr, $foo_name:ident, $std_type:ty, $bit_type:ty) => {
+        fn $bench_name(c: &mut Criterion) {
+            fn $foo_name(cs: &mut TestConstraintSystem<Fr>, rng: &mut XorShiftRng) {
+                let a: $std_type = rng.gen();
+                let b: $std_type = rng.gen();
+
+                if a.checked_neg().is_none() || a.checked_div(b).is_none() {
+                    return;
+                }
+
+                let bench_run_id: u64 = rng.gen();
+
+                let a_bit_const = <$bit_type>::constant(a);
+                let b_bit_const = <$bit_type>::constant(b);
+                a_bit_const
+                    .div(
+                        cs.ns(|| format!("{}: a div b: const", bench_run_id)),
+                        &b_bit_const,
+                    )
+                    .unwrap();
+            }
+
+            let mut cs = TestConstraintSystem::<Fr>::new();
+
+            let mut rng = XorShiftRng::seed_from_u64(1231275789u64);
+
+            c.bench_function(&format!("integer_arithmetic::{}", $bench_id), |b| {
+                b.iter(|| $foo_name(&mut cs, &mut rng))
+            });
+        }
+    };
+}
+
+create_add_bench!(bench_i8_add, "i8_add", i8_add, i8, Int8);
+create_add_bench!(bench_i16_add, "i16_add", i16_add, i16, Int16);
+create_add_bench!(bench_i32_add, "i32_add", i32_add, i32, Int32);
+create_add_bench!(bench_i64_add, "i64_add", i64_add, i64, Int64);
+create_add_bench!(bench_i128_add, "i128_add", i128_add, i128, Int128);
+
+create_add_bench_const!(bench_i8_add_const, "i8_add_const", i8_add, i8, Int8);
+create_add_bench_const!(bench_i16_add_const, "i16_add_const", i16_add, i16, Int16);
+create_add_bench_const!(bench_i32_add_const, "i32_add_const", i32_add, i32, Int32);
+create_add_bench_const!(bench_i64_add_const, "i64_add_const", i64_add, i64, Int64);
+create_add_bench_const!(bench_i128_add_const, "i128_add_const", i128_add, i128, Int128);
+
+create_sub_bench!(bench_i8_sub, "i8_sub", i8_sub, i8, Int8);
+create_sub_bench!(bench_i16_sub, "i16_sub", i16_sub, i16, Int16);
+create_sub_bench!(bench_i32_sub, "i32_sub", i32_sub, i32, Int32);
+create_sub_bench!(bench_i64_sub, "i64_sub", i64_sub, i64, Int64);
+create_sub_bench!(bench_i128_sub, "i128_sub", i128_sub, i128, Int128);
+
+create_sub_bench_const!(bench_i8_sub_const, "i8_sub_const", i8_sub, i8, Int8);
+create_sub_bench_const!(bench_i16_sub_const, "i16_sub_const", i16_sub, i16, Int16);
+create_sub_bench_const!(bench_i32_sub_const, "i32_sub_const", i32_sub, i32, Int32);
+create_sub_bench_const!(bench_i64_sub_const, "i64_sub_const", i64_sub, i64, Int64);
+create_sub_bench_const!(bench_i128_sub_const, "i128_sub_const", i128_sub, i128, Int128);
+
+create_mul_bench!(bench_i8_mul, "i8_mul", i8_mul, i8, Int8);
+create_mul_bench!(bench_i16_mul, "i16_mul", i16_mul, i16, Int16);
+create_mul_bench!(bench_i32_mul, "i32_mul", i32_mul, i32, Int32);
+create_mul_bench!(bench_i64_mul, "i64_mul", i64_mul, i64, Int64);
+create_mul_bench!(bench_i128_mul, "i128_mul", i128_mul, i128, Int128);
+
+create_mul_bench_const!(bench_i8_mul_const, "i8_mul_const", i8_mul, i8, Int8);
+create_mul_bench_const!(bench_i16_mul_const, "i16_mul_const", i16_mul, i16, Int16);
+create_mul_bench_const!(bench_i32_mul_const, "i32_mul_const", i32_mul, i32, Int32);
+create_mul_bench_const!(bench_i64_mul_const, "i64_mul_const", i64_mul, i64, Int64);
+create_mul_bench_const!(bench_i128_mul_const, "i128_mul_const", i128_mul, i128, Int128);
+
+create_div_bench!(bench_i8_div, "i8_div", i8_div, i8, Int8);
+create_div_bench!(bench_i16_div, "i16_div", i16_div, i16, Int16);
+create_div_bench!(bench_i32_div, "i32_div", i32_div, i32, Int32);
+// create_div_bench!(bench_i64_div, "i64_div", i64_div, i64, Int64);
+// create_div_bench!(bench_i128_div, "i128_div", i128_div, i128, Int128);
+
+create_div_bench_const!(bench_i8_div_const, "i8_div_const", i8_div, i8, Int8);
+create_div_bench_const!(bench_i16_div_const, "i16_div_const", i16_div, i16, Int16);
+create_div_bench_const!(bench_i32_div_const, "i32_div_const", i32_div, i32, Int32);
+// create_div_bench_const!(bench_i64_div_const, "i64_div_const", i64_div, i64, Int64);
+// create_div_bench_const!(bench_i128_div_const, "i128_div_const", i128_div, i128, Int128);
+
+criterion_group!(
+    name = benches_add;
+    config = Criterion::default();
+    targets = bench_i8_add,
+    bench_i16_add,
+    bench_i32_add,
+    bench_i64_add,
+    bench_i128_add,
+);
+
+criterion_group!(
+    name = benches_add_const;
+    config = Criterion::default();
+    targets = bench_i8_add_const,
+    bench_i16_add_const,
+    bench_i32_add_const,
+    bench_i64_add_const,
+    bench_i128_add_const,
+);
+
+criterion_group!(
+    name = benches_sub;
+    config = Criterion::default();
+    targets = bench_i8_sub,
+    bench_i16_sub,
+    bench_i32_sub,
+    bench_i64_sub,
+    bench_i128_sub,
+);
+
+criterion_group!(
+    name = benches_sub_const;
+    config = Criterion::default();
+    targets = bench_i8_sub_const,
+    bench_i16_sub_const,
+    bench_i32_sub_const,
+    bench_i64_sub_const,
+    bench_i128_sub_const,
+);
+
+criterion_group!(
+    name = benches_mul;
+    config = Criterion::default();
+    targets = bench_i8_mul,
+    bench_i16_mul,
+    bench_i32_mul,
+    bench_i64_mul,
+    bench_i128_mul,
+);
+
+criterion_group!(
+    name = benches_mul_const;
+    config = Criterion::default();
+    targets = bench_i8_mul_const,
+    bench_i16_mul_const,
+    bench_i32_mul_const,
+    bench_i64_mul_const,
+    bench_i128_mul_const,
+);
+
+criterion_group!(
+    name = benches_div;
+    config = Criterion::default();
+    targets = bench_i8_div,
+    bench_i16_div,
+    bench_i32_div,
+    // bench_i64_div,
+    // bench_i128_div,
+);
+
+criterion_group!(
+    name = benches_div_const;
+    config = Criterion::default();
+    targets = bench_i8_div_const,
+    bench_i16_div_const,
+    bench_i32_div_const,
+    // bench_i64_div_const,
+    // bench_i128_div_const,
+);
+
+criterion_main!(
+    benches_add,
+    benches_add_const,
+    benches_sub,
+    benches_sub_const,
+    benches_mul,
+    benches_mul_const,
+    benches_div,
+    benches_div_const
+);

--- a/gadgets/src/arithmetic/neg.rs
+++ b/gadgets/src/arithmetic/neg.rs
@@ -22,6 +22,8 @@ use snarkos_models::{
     gadgets::{r1cs::ConstraintSystem, utilities::boolean::Boolean},
 };
 
+use std::iter;
+
 /// Returns a negated representation of `self` in the constraint system.
 pub trait Neg<F: Field>
 where
@@ -40,8 +42,9 @@ impl<F: Field> Neg<F> for Vec<Boolean> {
         let flipped: Self = self.iter().map(|bit| bit.not()).collect();
 
         // add one
-        let mut one = vec![Boolean::constant(true)];
-        one.append(&mut vec![Boolean::Constant(false); self.len() - 1]);
+        let mut one = Vec::with_capacity(self.len());
+        one.push(Boolean::constant(true));
+        one.extend(iter::repeat(Boolean::Constant(false)).take(self.len() - 1));
 
         let mut bits = flipped.add_bits(cs.ns(|| "add one"), &one)?;
         let _carry = bits.pop(); // we already accounted for overflow above

--- a/gadgets/src/bits/sign_extend.rs
+++ b/gadgets/src/bits/sign_extend.rs
@@ -16,6 +16,8 @@
 
 use snarkos_models::gadgets::utilities::boolean::Boolean;
 
+use std::iter;
+
 /// Sign extends an array of bits to the desired length.
 /// Expects least significant bit first
 pub trait SignExtend
@@ -30,10 +32,10 @@ impl SignExtend for Boolean {
     fn sign_extend(bits: &[Boolean], length: usize) -> Vec<Boolean> {
         let msb = bits.last().expect("empty bit list");
         let bits_needed = length - bits.len();
-        let mut extension = vec![*msb; bits_needed];
 
-        let mut result = Vec::from(bits);
-        result.append(&mut extension);
+        let mut result = Vec::with_capacity(length);
+        result.extend_from_slice(bits);
+        result.extend(iter::repeat(*msb).take(bits_needed));
 
         result
     }

--- a/gadgets/src/signed_integer/arithmetic/div.rs
+++ b/gadgets/src/signed_integer/arithmetic/div.rs
@@ -163,7 +163,7 @@ macro_rules! div_int_impl {
                 )?;
 
                 let mut q = zero.clone();
-                let mut r = zero.clone();
+                let mut r = zero;
 
                 let mut index = <$gadget as Int>::SIZE - 1 as usize;
                 let mut bit_value = (1 as <$gadget as Int>::IntegerType) << ((index - 1) as <$gadget as Int>::IntegerType);
@@ -197,20 +197,22 @@ macro_rules! div_int_impl {
                     let sub = r.sub(
                         &mut cs.ns(|| format!("subtract_divisor_{}", i)),
                         &b
-                    );
+                    )?;
 
                     r = Self::conditionally_select(
                         &mut cs.ns(|| format!("subtract_or_same_{}", i)),
                         &can_sub,
-                        &sub?,
+                        &sub,
                         &r
                     )?;
 
                     index -= 1;
 
                     let mut q_new = q.clone();
-                    q_new.bits[index] = true_bit.clone();
-                    q_new.value = Some(q_new.value.unwrap() + bit_value);
+                    q_new.bits[index] = true_bit;
+                    if let Some(ref mut value) = q_new.value {
+                        *value += bit_value;
+                    }
 
                     bit_value >>= 1;
 

--- a/gadgets/src/signed_integer/arithmetic/div.rs
+++ b/gadgets/src/signed_integer/arithmetic/div.rs
@@ -179,7 +179,7 @@ macro_rules! div_int_impl {
                     // Set the least-significant bit of remainder to bit i of the numerator
                     let r_new = r.add(
                         &mut cs.ns(|| format!("set_remainder_bit_{}", i)),
-                        &one.clone(),
+                        &one,
                     )?;
 
                     r = Self::conditionally_select(

--- a/gadgets/src/signed_integer/int_impl.rs
+++ b/gadgets/src/signed_integer/int_impl.rs
@@ -82,18 +82,8 @@ macro_rules! int_impl {
             }
 
             fn is_constant(&self) -> bool {
-                let mut constant = true;
-
                 // If any bits of self are allocated bits, return false
-                for bit in &self.bits {
-                    match *bit {
-                        Boolean::Is(ref _bit) => constant = false,
-                        Boolean::Not(ref _bit) => constant = false,
-                        Boolean::Constant(_bit) => {}
-                    }
-                }
-
-                constant
+                self.bits.iter().all(|bit| matches!(bit, Boolean::Constant(_)))
             }
         }
     };

--- a/gadgets/src/signed_integer/relational/eq.rs
+++ b/gadgets/src/signed_integer/relational/eq.rs
@@ -53,7 +53,8 @@ macro_rules! eq_gadget_impl {
 
         impl PartialEq for $gadget {
             fn eq(&self, other: &Self) -> bool {
-                !self.value.is_none() && !other.value.is_none() && self.value == other.value
+                // self.value == other.value means that other.value.is_some() too
+                self.value.is_some() && self.value == other.value
             }
         }
 

--- a/gadgets/src/signed_integer/utilities/select.rs
+++ b/gadgets/src/signed_integer/utilities/select.rs
@@ -51,23 +51,15 @@ macro_rules! select_int_impl {
 
                     let result = Self::alloc(cs.ns(|| "cond_select_result"), || result_val.get())?;
 
-                    let expected_bits = first
-                        .bits
-                        .iter()
-                        .zip(&second.bits)
-                        .enumerate()
-                        .map(|(i, (a, b))| {
-                            Boolean::conditionally_select(
-                                &mut cs.ns(|| format!("{}_cond_select_{}", <$gadget as Int>::SIZE, i)),
-                                cond,
-                                a,
-                                b,
-                            ).unwrap()
-                        })
-                        .collect::<Vec<Boolean>>();
+                    for (i, ((bit1, bit2), actual)) in first.bits.iter().zip(second.bits.iter()).zip(result.bits.iter()).enumerate() {
+                        let expected = Boolean::conditionally_select(
+                            &mut cs.ns(|| format!("{}_cond_select_{}", <$gadget as Int>::SIZE, i)),
+                            cond,
+                            bit1,
+                            bit2,
+                        ).unwrap();
 
-                    for (i, (actual, expected)) in result.bits.iter().zip(expected_bits.iter()).enumerate() {
-                        actual.enforce_equal(&mut cs.ns(|| format!("selected_result_bit_{}", i)), expected)?;
+                        actual.enforce_equal(&mut cs.ns(|| format!("selected_result_bit_{}", i)), &expected)?;
                     }
 
                     Ok(result)

--- a/gadgets/src/signed_integer/utilities/select.rs
+++ b/gadgets/src/signed_integer/utilities/select.rs
@@ -49,7 +49,7 @@ macro_rules! select_int_impl {
                         }
                     });
 
-                    let result = Self::alloc(cs.ns(|| "cond_select_result"), || result_val.get().map(|v| v))?;
+                    let result = Self::alloc(cs.ns(|| "cond_select_result"), || result_val.get())?;
 
                     let expected_bits = first
                         .bits

--- a/typed/src/expression.rs
+++ b/typed/src/expression.rs
@@ -118,39 +118,39 @@ pub enum Expression {
 }
 
 impl Expression {
-    pub fn set_span(&mut self, new_span: &Span) {
+    pub fn set_span(&mut self, new_span: Span) {
         match self {
-            Expression::Field(_, old_span) => *old_span = new_span.clone(),
+            Expression::Field(_, old_span) => *old_span = new_span,
             Expression::Group(value) => value.set_span(new_span),
 
-            Expression::Add(_, old_span) => *old_span = new_span.clone(),
-            Expression::Sub(_, old_span) => *old_span = new_span.clone(),
-            Expression::Mul(_, old_span) => *old_span = new_span.clone(),
-            Expression::Div(_, old_span) => *old_span = new_span.clone(),
-            Expression::Pow(_, old_span) => *old_span = new_span.clone(),
+            Expression::Add(_, old_span) => *old_span = new_span,
+            Expression::Sub(_, old_span) => *old_span = new_span,
+            Expression::Mul(_, old_span) => *old_span = new_span,
+            Expression::Div(_, old_span) => *old_span = new_span,
+            Expression::Pow(_, old_span) => *old_span = new_span,
 
-            Expression::Not(_, old_span) => *old_span = new_span.clone(),
-            Expression::Or(_, old_span) => *old_span = new_span.clone(),
-            Expression::And(_, old_span) => *old_span = new_span.clone(),
-            Expression::Eq(_, old_span) => *old_span = new_span.clone(),
-            Expression::Ge(_, old_span) => *old_span = new_span.clone(),
-            Expression::Gt(_, old_span) => *old_span = new_span.clone(),
-            Expression::Le(_, old_span) => *old_span = new_span.clone(),
-            Expression::Lt(_, old_span) => *old_span = new_span.clone(),
+            Expression::Not(_, old_span) => *old_span = new_span,
+            Expression::Or(_, old_span) => *old_span = new_span,
+            Expression::And(_, old_span) => *old_span = new_span,
+            Expression::Eq(_, old_span) => *old_span = new_span,
+            Expression::Ge(_, old_span) => *old_span = new_span,
+            Expression::Gt(_, old_span) => *old_span = new_span,
+            Expression::Le(_, old_span) => *old_span = new_span,
+            Expression::Lt(_, old_span) => *old_span = new_span,
 
-            Expression::IfElse(_, old_span) => *old_span = new_span.clone(),
-            Expression::Array(_, old_span) => *old_span = new_span.clone(),
-            Expression::ArrayAccess(_, old_span) => *old_span = new_span.clone(),
+            Expression::IfElse(_, old_span) => *old_span = new_span,
+            Expression::Array(_, old_span) => *old_span = new_span,
+            Expression::ArrayAccess(_, old_span) => *old_span = new_span,
 
-            Expression::Tuple(_, old_span) => *old_span = new_span.clone(),
-            Expression::TupleAccess(_, _, old_span) => *old_span = new_span.clone(),
+            Expression::Tuple(_, old_span) => *old_span = new_span,
+            Expression::TupleAccess(_, _, old_span) => *old_span = new_span,
 
-            Expression::Circuit(_, _, old_span) => *old_span = new_span.clone(),
-            Expression::CircuitMemberAccess(_, _, old_span) => *old_span = new_span.clone(),
-            Expression::CircuitStaticFunctionAccess(_, _, old_span) => *old_span = new_span.clone(),
+            Expression::Circuit(_, _, old_span) => *old_span = new_span,
+            Expression::CircuitMemberAccess(_, _, old_span) => *old_span = new_span,
+            Expression::CircuitStaticFunctionAccess(_, _, old_span) => *old_span = new_span,
 
-            Expression::FunctionCall(_, _, old_span) => *old_span = new_span.clone(),
-            Expression::CoreFunctionCall(_, _, old_span) => *old_span = new_span.clone(),
+            Expression::FunctionCall(_, _, old_span) => *old_span = new_span,
+            Expression::CoreFunctionCall(_, _, old_span) => *old_span = new_span,
             _ => {}
         }
     }

--- a/typed/src/groups/group_value.rs
+++ b/typed/src/groups/group_value.rs
@@ -36,10 +36,10 @@ pub enum GroupValue {
 }
 
 impl GroupValue {
-    pub fn set_span(&mut self, new_span: &Span) {
+    pub fn set_span(&mut self, new_span: Span) {
         match self {
-            GroupValue::Single(_, old_span) => *old_span = new_span.clone(),
-            GroupValue::Tuple(tuple) => tuple.span = new_span.clone(),
+            GroupValue::Single(_, old_span) => *old_span = new_span,
+            GroupValue::Tuple(tuple) => tuple.span = new_span,
         }
     }
 }

--- a/typed/src/statements/statement.rs
+++ b/typed/src/statements/statement.rs
@@ -58,7 +58,7 @@ impl<'ast> From<DefinitionStatement<'ast>> for Statement {
             .into_iter()
             .map(|e| {
                 let mut expression = Expression::from(e);
-                expression.set_span(&span);
+                expression.set_span(span.clone());
 
                 expression
             })
@@ -155,7 +155,7 @@ impl<'ast> From<ExpressionStatement<'ast>> for Statement {
         let span = Span::from(statement.span);
         let mut expression = Expression::from(statement.expression);
 
-        expression.set_span(&span);
+        expression.set_span(span.clone());
 
         Statement::Expression(expression, span)
     }

--- a/typed/src/types/type_.rs
+++ b/typed/src/types/type_.rs
@@ -45,17 +45,11 @@ pub enum Type {
 
 impl Type {
     pub fn is_self(&self) -> bool {
-        if let Type::SelfType = self {
-            return true;
-        }
-        false
+        matches!(self, Type::SelfType)
     }
 
     pub fn is_circuit(&self) -> bool {
-        if let Type::Circuit(_) = self {
-            return true;
-        }
-        false
+        matches!(self, Type::Circuit(_))
     }
 
     pub fn match_array_types(&self, other: &Type) -> bool {


### PR DESCRIPTION
The integer division tests (especially `test_int128_div`) are taking quite some time, so I started looking at ways of possibly improving the performance of arithmetic operations. This PR introduces a range of signed integer benchmarks modeled after their tests, and some performance-friendly changes mostly targeting avoidable allocations. There's also a handful of drive-by cleanup/refactoring commits. As usual, the commits are self-contained and their messages describe the specific changes.

One of the further possible improvements - and likely to have a big performance impact - would be to modify the `CondSelectGadget` trait so that the `first` and `second` arguments are `Cow<'a, Self>` as opposed to `&Self` in order to potentially avoid plenty of clones in case `cond` is a `Boolean::Constant`. That, however, is a large undertaking impacting SnarkOS as well, so I'll need to research it more first.