### PR TITLE
Prefer BTreeMap over HashMap in ast

### DIFF
--- a/ast/src/annotation.rs
+++ b/ast/src/annotation.rs
@@ -20,14 +20,14 @@ use leo_grammar::{
     definitions::{AnnotatedDefinition, Definition},
 };
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub fn load_annotation(
     annotated_definition: AnnotatedDefinition,
     _imports: &mut Vec<ImportStatement>,
-    _circuits: &mut HashMap<Identifier, Circuit>,
-    _functions: &mut HashMap<Identifier, Function>,
-    tests: &mut HashMap<Identifier, TestFunction>,
+    _circuits: &mut BTreeMap<Identifier, Circuit>,
+    _functions: &mut BTreeMap<Identifier, Function>,
+    tests: &mut BTreeMap<Identifier, TestFunction>,
     _expected: &mut Vec<FunctionInput>,
 ) {
     let ast_annotation = annotated_definition.annotation;
@@ -45,7 +45,7 @@ pub fn load_annotation(
     }
 }
 
-pub fn load_annotated_test(test: TestFunction, annotation: Annotation, tests: &mut HashMap<Identifier, TestFunction>) {
+pub fn load_annotated_test(test: TestFunction, annotation: Annotation, tests: &mut BTreeMap<Identifier, TestFunction>) {
     let name = annotation.name;
     let ast_arguments = annotation.arguments;
 
@@ -57,7 +57,7 @@ pub fn load_annotated_test(test: TestFunction, annotation: Annotation, tests: &m
 pub fn load_annotated_test_context(
     mut test: TestFunction,
     ast_arguments: AnnotationArguments,
-    tests: &mut HashMap<Identifier, TestFunction>,
+    tests: &mut BTreeMap<Identifier, TestFunction>,
 ) {
     let arguments = ast_arguments.arguments;
 

--- a/ast/src/common/identifier.rs
+++ b/ast/src/common/identifier.rs
@@ -33,6 +33,7 @@ use serde::{
     Serializer,
 };
 use std::{
+    cmp::Ordering,
     collections::BTreeMap,
     fmt,
     hash::{Hash, Hasher},
@@ -182,6 +183,18 @@ impl PartialEq for Identifier {
 }
 
 impl Eq for Identifier {}
+
+impl Ord for Identifier {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.name.cmp(&other.name)
+    }
+}
+
+impl PartialOrd for Identifier {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 impl Hash for Identifier {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/ast/src/common/identifier.rs
+++ b/ast/src/common/identifier.rs
@@ -185,8 +185,19 @@ impl PartialEq for Identifier {
 impl Eq for Identifier {}
 
 impl Ord for Identifier {
+    ///
+    /// Order identifiers by name first, then span.
+    ///
     fn cmp(&self, other: &Self) -> Ordering {
-        self.name.cmp(&other.name)
+        // Order by name string.
+        match self.name.cmp(&other.name) {
+            Ordering::Equal => {
+                // Order by span if names are equal.
+                self.span.cmp(&other.span)
+            }
+            Ordering::Greater => Ordering::Greater,
+            Ordering::Less => Ordering::Less,
+        }
     }
 }
 

--- a/ast/src/common/span.rs
+++ b/ast/src/common/span.rs
@@ -16,7 +16,10 @@
 
 use pest::Span as GrammarSpan;
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+use std::{
+    cmp::Ordering,
+    hash::{Hash, Hasher},
+};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Span {
@@ -37,6 +40,18 @@ impl PartialEq for Span {
 }
 
 impl Eq for Span {}
+
+impl Ord for Span {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.line.cmp(&other.line)
+    }
+}
+
+impl PartialOrd for Span {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 impl Hash for Span {
     fn hash<H: Hasher>(&self, state: &mut H) {

--- a/ast/src/input/macros.rs
+++ b/ast/src/input/macros.rs
@@ -22,7 +22,7 @@ macro_rules! input_section_impl {
         #[derive(Clone, PartialEq, Eq, Default)]
         pub struct $name {
             is_present: bool,
-            values: HashMap<Parameter, Option<InputValue>>,
+            values: BTreeMap<Parameter, Option<InputValue>>,
         }
 
         impl $name {
@@ -63,8 +63,8 @@ macro_rules! input_section_impl {
                 Ok(())
             }
 
-            /// Returns this section's hashmap of values
-            pub fn values(&self) -> HashMap<Parameter, Option<InputValue>> {
+            /// Returns this section's [BTreeMap] of values
+            pub fn values(&self) -> BTreeMap<Parameter, Option<InputValue>> {
                 self.values.clone()
             }
         }

--- a/ast/src/input/parameters/parameter.rs
+++ b/ast/src/input/parameters/parameter.rs
@@ -17,6 +17,8 @@
 use crate::{Identifier, Span, Type};
 use leo_input::parameters::Parameter as GrammarParameter;
 
+use std::cmp::Ordering;
+
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct Parameter {
     pub variable: Identifier,
@@ -31,5 +33,17 @@ impl<'ast> From<GrammarParameter<'ast>> for Parameter {
             type_: Type::from(parameter.type_),
             span: Span::from(parameter.span),
         }
+    }
+}
+
+impl Ord for Parameter {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.variable.cmp(&other.variable)
+    }
+}
+
+impl PartialOrd for Parameter {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }

--- a/ast/src/input/program_input/main_input.rs
+++ b/ast/src/input/program_input/main_input.rs
@@ -16,11 +16,11 @@
 
 use crate::InputValue;
 use leo_input::{definitions::Definition, InputParserError};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Clone, PartialEq, Eq, Default)]
 pub struct MainInput {
-    input: HashMap<String, Option<InputValue>>,
+    input: BTreeMap<String, Option<InputValue>>,
 }
 
 #[allow(clippy::len_without_is_empty)]

--- a/ast/src/input/program_input/registers.rs
+++ b/ast/src/input/program_input/registers.rs
@@ -17,6 +17,6 @@
 use crate::{InputValue, Parameter};
 use leo_input::{definitions::Definition, InputParserError};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 input_section_impl!(Registers);

--- a/ast/src/input/program_state/private_state/record.rs
+++ b/ast/src/input/program_state/private_state/record.rs
@@ -17,6 +17,6 @@
 use crate::{InputValue, Parameter};
 use leo_input::{definitions::Definition, InputParserError};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 input_section_impl!(Record);

--- a/ast/src/input/program_state/private_state/state_leaf.rs
+++ b/ast/src/input/program_state/private_state/state_leaf.rs
@@ -17,6 +17,6 @@
 use crate::{InputValue, Parameter};
 use leo_input::{definitions::Definition, InputParserError};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 input_section_impl!(StateLeaf);

--- a/ast/src/input/program_state/public_state/state.rs
+++ b/ast/src/input/program_state/public_state/state.rs
@@ -17,6 +17,6 @@
 use crate::{InputValue, Parameter};
 use leo_input::{definitions::Definition, InputParserError};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 input_section_impl!(State);

--- a/ast/src/program.rs
+++ b/ast/src/program.rs
@@ -21,7 +21,7 @@ use crate::{load_annotation, Circuit, Function, FunctionInput, Identifier, Impor
 use leo_grammar::{definitions::Definition, files::File};
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Stores the Leo program abstract syntax tree.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -29,9 +29,9 @@ pub struct Program {
     pub name: String,
     pub expected_input: Vec<FunctionInput>,
     pub imports: Vec<ImportStatement>,
-    pub circuits: HashMap<Identifier, Circuit>,
-    pub functions: HashMap<Identifier, Function>,
-    pub tests: HashMap<Identifier, TestFunction>,
+    pub circuits: BTreeMap<Identifier, Circuit>,
+    pub functions: BTreeMap<Identifier, Function>,
+    pub tests: BTreeMap<Identifier, TestFunction>,
 }
 
 const MAIN_FUNCTION_NAME: &str = "main";
@@ -40,9 +40,9 @@ impl<'ast> Program {
     //! Logic to convert from an abstract syntax tree (ast) representation to a Leo program.
     pub fn from(program_name: &str, program_ast: &File<'ast>) -> Self {
         let mut imports = vec![];
-        let mut circuits = HashMap::new();
-        let mut functions = HashMap::new();
-        let mut tests = HashMap::new();
+        let mut circuits = BTreeMap::new();
+        let mut functions = BTreeMap::new();
+        let mut tests = BTreeMap::new();
         let mut expected_input = vec![];
 
         program_ast
@@ -94,9 +94,9 @@ impl Program {
             name,
             expected_input: vec![],
             imports: vec![],
-            circuits: HashMap::new(),
-            functions: HashMap::new(),
-            tests: HashMap::new(),
+            circuits: BTreeMap::new(),
+            functions: BTreeMap::new(),
+            tests: BTreeMap::new(),
         }
     }
 

--- a/compiler/src/function/input/input_section.rs
+++ b/compiler/src/function/input/input_section.rs
@@ -21,14 +21,14 @@ use snarkos_models::{
     curves::{Field, PrimeField},
     gadgets::r1cs::ConstraintSystem,
 };
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
     pub fn allocate_input_section<CS: ConstraintSystem<F>>(
         &mut self,
         cs: &mut CS,
         identifier: Identifier,
-        section: HashMap<Parameter, Option<InputValue>>,
+        section: BTreeMap<Parameter, Option<InputValue>>,
     ) -> Result<ConstrainedValue<F, G>, FunctionError> {
         let mut members = Vec::with_capacity(section.len());
 

--- a/compiler/src/program/program.rs
+++ b/compiler/src/program/program.rs
@@ -20,16 +20,16 @@ use crate::{value::ConstrainedValue, GroupType};
 
 use snarkos_models::curves::{Field, PrimeField};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub struct ConstrainedProgram<F: Field + PrimeField, G: GroupType<F>> {
-    pub identifiers: HashMap<String, ConstrainedValue<F, G>>,
+    pub identifiers: BTreeMap<String, ConstrainedValue<F, G>>,
 }
 
 impl<F: Field + PrimeField, G: GroupType<F>> Default for ConstrainedProgram<F, G> {
     fn default() -> Self {
         Self {
-            identifiers: HashMap::new(),
+            identifiers: BTreeMap::new(),
         }
     }
 }

--- a/imports/src/parser/import_parser.rs
+++ b/imports/src/parser/import_parser.rs
@@ -18,7 +18,7 @@ use crate::errors::ImportParserError;
 use leo_ast::{Package, Program};
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     env::current_dir,
 };
 
@@ -28,7 +28,7 @@ use std::{
 /// directory, foreign in the imports directory, or part of the core package list.
 #[derive(Clone, Default)]
 pub struct ImportParser {
-    imports: HashMap<String, Program>,
+    imports: BTreeMap<String, Program>,
     core_packages: HashSet<Package>,
 }
 

--- a/state/src/utilities/input_value.rs
+++ b/state/src/utilities/input_value.rs
@@ -17,13 +17,13 @@
 use crate::InputValueError;
 use leo_ast::{InputValue, Parameter};
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Returns the input parameter with the given name.
 /// If a parameter with the given name does not exist, then an error is returned.
 pub fn find_input(
     name: String,
-    parameters: &HashMap<Parameter, Option<InputValue>>,
+    parameters: &BTreeMap<Parameter, Option<InputValue>>,
 ) -> Result<InputValue, InputValueError> {
     let matched_parameter = parameters
         .iter()

--- a/symbol-table/src/symbol_table.rs
+++ b/symbol-table/src/symbol_table.rs
@@ -19,7 +19,7 @@ use leo_ast::{Circuit, Function, Identifier, ImportStatement, ImportSymbol, Inpu
 use leo_core::CorePackageList;
 use leo_imports::ImportParser;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 pub const INPUT_VARIABLE_NAME: &str = "input";
 pub const RECORD_VARIABLE_NAME: &str = "record";
@@ -35,13 +35,13 @@ pub const STATE_LEAF_VARIABLE_NAME: &str = "state_leaf";
 #[derive(Clone, Default)]
 pub struct SymbolTable {
     /// Maps name -> parameter type.
-    names: HashMap<String, UserDefinedType>,
+    names: BTreeMap<String, UserDefinedType>,
 
     /// Maps circuit name -> circuit type.
-    circuits: HashMap<String, CircuitType>,
+    circuits: BTreeMap<String, CircuitType>,
 
     /// Maps function name -> function type.
-    functions: HashMap<String, FunctionType>,
+    functions: BTreeMap<String, FunctionType>,
 
     /// The parent of this symbol table.
     parent: Option<Box<SymbolTable>>,
@@ -84,6 +84,7 @@ impl SymbolTable {
     /// variable type is returned.
     ///
     pub fn insert_name(&mut self, name: String, variable_type: UserDefinedType) -> Option<UserDefinedType> {
+        println!("name {}", name);
         self.names.insert(name, variable_type)
     }
 
@@ -214,7 +215,7 @@ impl SymbolTable {
     /// If a circuit name has no duplicates, then it is inserted into the symbol table.
     /// Types defined later in the program cannot have the same name.
     ///
-    pub fn check_circuit_names(&mut self, circuits: &HashMap<Identifier, Circuit>) -> Result<(), SymbolTableError> {
+    pub fn check_circuit_names(&mut self, circuits: &BTreeMap<Identifier, Circuit>) -> Result<(), SymbolTableError> {
         // Iterate over circuit names and definitions.
         for (identifier, circuit) in circuits.iter() {
             // Attempt to insert the circuit name into the symbol table.
@@ -230,7 +231,7 @@ impl SymbolTable {
     /// If a function name has no duplicates, then it is inserted into the symbol table.
     /// Types defined later in the program cannot have the same name.
     ///
-    pub fn check_function_names(&mut self, functions: &HashMap<Identifier, Function>) -> Result<(), SymbolTableError> {
+    pub fn check_function_names(&mut self, functions: &BTreeMap<Identifier, Function>) -> Result<(), SymbolTableError> {
         // Iterate over function names and definitions.
         for (identifier, function) in functions.iter() {
             // Attempt to insert the function name into the symbol table.
@@ -416,7 +417,7 @@ impl SymbolTable {
     /// symbol table. Variables defined later in the program can lookup the definition
     /// and refer to its expected types
     ///
-    pub fn check_types_circuits(&mut self, circuits: &HashMap<Identifier, Circuit>) -> Result<(), SymbolTableError> {
+    pub fn check_types_circuits(&mut self, circuits: &BTreeMap<Identifier, Circuit>) -> Result<(), SymbolTableError> {
         // Iterate over circuit names and definitions.
         for circuit in circuits.values() {
             // Get the identifier of the circuit.
@@ -439,7 +440,10 @@ impl SymbolTable {
     /// symbol table. Variables defined later in the program can lookup the definition
     /// and refer to its expected types
     ///
-    pub fn check_types_functions(&mut self, functions: &HashMap<Identifier, Function>) -> Result<(), SymbolTableError> {
+    pub fn check_types_functions(
+        &mut self,
+        functions: &BTreeMap<Identifier, Function>,
+    ) -> Result<(), SymbolTableError> {
         // Iterate over function names and definitions.
         for function in functions.values() {
             // Get the identifier of the function.

--- a/symbol-table/src/types/circuits/circuit.rs
+++ b/symbol-table/src/types/circuits/circuit.rs
@@ -26,7 +26,7 @@ use leo_ast::{Circuit, CircuitMember, Identifier, InputValue, Parameter, Span};
 
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
+    collections::BTreeMap,
     hash::{Hash, Hasher},
 };
 
@@ -152,7 +152,7 @@ impl CircuitType {
     pub fn from_input_section(
         table: &SymbolTable,
         name: String,
-        section: HashMap<Parameter, Option<InputValue>>,
+        section: BTreeMap<Parameter, Option<InputValue>>,
     ) -> Result<Self, TypeError> {
         // Create a new `CircuitVariableType` for each section pair.
         let mut variables = Vec::new();

--- a/type-inference/src/objects/variable_table.rs
+++ b/type-inference/src/objects/variable_table.rs
@@ -16,11 +16,11 @@
 
 use crate::VariableTableError;
 use leo_symbol_table::{FunctionInputType, Type};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 /// Mapping of variable names to types
 #[derive(Clone)]
-pub struct VariableTable(pub HashMap<String, Type>);
+pub struct VariableTable(pub BTreeMap<String, Type>);
 
 impl VariableTable {
     ///
@@ -67,6 +67,6 @@ impl VariableTable {
 
 impl Default for VariableTable {
     fn default() -> Self {
-        Self(HashMap::new())
+        Self(BTreeMap::new())
     }
 }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

HashMap is slower and does not map pairs in a predictable ordered fashion. This can have unintended consequences. For example, running the compiler multiple times on the same Leo program might produce different ASTs. While the differing ASTs should not produce different circuits, the undefined behavior caused by HashMap hurts determinism. 
