### PR TITLE
Fix early halting of leo commands due to updater checks

### DIFF
--- a/leo/errors/updater.rs
+++ b/leo/errors/updater.rs
@@ -14,11 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod cli;
-pub use self::cli::*;
+#[derive(Debug, Error)]
+pub enum UpdaterError {
+    #[error("{}: {}", _0, _1)]
+    Crate(&'static str, String),
 
-pub mod commands;
-pub use self::commands::*;
+    #[error("The current version {} is more recent than the release version {}", _0, _1)]
+    OldReleaseVersion(String, String),
+}
 
-pub mod updater;
-pub use self::updater::*;
+impl From<self_update::errors::Error> for UpdaterError {
+    fn from(error: self_update::errors::Error) -> Self {
+        tracing::error!("{}\n", error);
+        UpdaterError::Crate("self_update", error.to_string())
+    }
+}

--- a/leo/updater.rs
+++ b/leo/updater.rs
@@ -72,10 +72,7 @@ impl Updater {
         if bump_is_greater(&current_version, &latest_release.version)? {
             Ok(latest_release.version)
         } else {
-            Err(UpdaterError::OldReleaseVersion(
-                current_version.to_string(),
-                latest_release.version.to_string(),
-            ))
+            Err(UpdaterError::OldReleaseVersion(current_version, latest_release.version))
         }
     }
 


### PR DESCRIPTION
## Motivation

Fixes #472

This PR fixes the error where the updater exits Leo CLI commands from executing when the updater fails to fetch the latest release version. 
 