### PR TITLE
Simplify Pest rule for package names

### DIFF
--- a/grammar/src/leo.pest
+++ b/grammar/src/leo.pest
@@ -443,8 +443,8 @@ input_tuple = _{ "(" ~ NEWLINE* ~ (input ~ ("," ~ NEWLINE* ~ input)* ~ ","?)? ~ 
 // Declared in imports/import.rs
 import = { "import " ~ package ~ LINE_END}
 
-
-package_name = @{ ((ASCII_ALPHA_LOWER | ASCII_DIGIT) ~ ( "-" ~ (ASCII_ALPHA_LOWER | ASCII_DIGIT))*)+ }
+// Declared in imports/package_name.rs
+package_name = @{ (ASCII_ALPHA_LOWER | ASCII_DIGIT)+ ~ ( "-" ~ (ASCII_ALPHA_LOWER | ASCII_DIGIT)+)* }
 
 // Declared in imports/package.rs
 package = { package_name ~ "." ~ package_access }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Closes #462 

Improves the `package_name` grammar rule in pest.
This PR does not change the current Leo ast.