### PR TITLE
Fix array spread type bug

### DIFF
--- a/compiler/tests/array/spread.leo
+++ b/compiler/tests/array/spread.leo
@@ -1,6 +1,7 @@
 // A spread operator `...` copies the elements of one array into another
 function main(a: [u8; 3]) {
     let b = [1u8, 1u8];
+    let c = [1u8, ...b];
 
-    console.assert(a == [1u8, ...b]);
+    console.assert(a == c);
 }

--- a/type-inference/src/objects/frame.rs
+++ b/type-inference/src/objects/frame.rs
@@ -837,7 +837,7 @@ impl Frame {
 
                 // Check that the type is an array.
                 match array_type {
-                    Type::Array(element_type) => Ok(Type::Array(element_type)),
+                    Type::Array(element_type) => Ok(*element_type),
                     type_ => Err(FrameError::invalid_spread(type_, span)),
                 }
             }


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes a bug where the type inference pass did not correctly calculate the type of an array spread expression.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Test that a variable can be initialized with an array spread expression and that the expression returns the correct type.

Simply running the following code in a test would achieve this.
```rust
function main() {
    let a: [u32; 2] = [1, 2];
    let b: [u32; 3] = [...a, 3]; // This line should not fail.

    console.assert(b == [1, 2, 3]);
}
```