### PR TITLE
fix accessing self variable inside nested scope bug

### DIFF
--- a/compiler/src/statement/block/block.rs
+++ b/compiler/src/statement/block/block.rs
@@ -36,6 +36,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         indicator: &Boolean,
         block: Block,
         return_type: Option<Type>,
+        declared_circuit_reference: &str,
         mut_self: bool,
     ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
         let mut results = Vec::with_capacity(block.statements.len());
@@ -48,7 +49,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 indicator,
                 statement,
                 return_type.clone(),
-                "",
+                declared_circuit_reference,
                 mut_self,
             )?;
 

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -52,6 +52,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         indicator: &Boolean,
         statement: ConditionalStatement,
         return_type: Option<Type>,
+        declared_circuit_reference: &str,
         mut_self: bool,
         span: &Span,
     ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
@@ -96,6 +97,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
             &branch_1_indicator,
             statement.block,
             return_type.clone(),
+            declared_circuit_reference,
             mut_self,
         )?;
 
@@ -125,6 +127,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     &branch_2_indicator,
                     *nested,
                     return_type,
+                    declared_circuit_reference,
                     mut_self,
                     span,
                 )?,
@@ -135,6 +138,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     &branch_2_indicator,
                     block,
                     return_type,
+                    declared_circuit_reference,
                     mut_self,
                 )?,
             },

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -48,6 +48,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         stop: Expression,
         block: Block,
         return_type: Option<Type>,
+        declared_circuit_reference: &str,
         mut_self: bool,
         span: &Span,
     ) -> StatementResult<Vec<IndicatorAndConstrainedValue<F, G>>> {
@@ -75,6 +76,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                 indicator,
                 block.clone(),
                 return_type.clone(),
+                declared_circuit_reference,
                 mut_self,
             )?;
 

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -90,6 +90,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     indicator,
                     statement,
                     return_type,
+                    declared_circuit_reference,
                     mut_self,
                     &span,
                 )?;
@@ -107,6 +108,7 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
                     start_stop.1,
                     block,
                     return_type,
+                    declared_circuit_reference,
                     mut_self,
                     &span,
                 )?;

--- a/compiler/tests/circuits/mod.rs
+++ b/compiler/tests/circuits/mod.rs
@@ -151,6 +151,14 @@ fn test_mutate_self_variable() {
 }
 
 #[test]
+fn test_mutate_self_variable_conditional() {
+    let program_string = include_str!("mut_self_variable_conditional.leo");
+    let program = parse_program(program_string).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
 fn test_mutate_self_variable_fail() {
     let program_string = include_str!("mut_self_variable_fail.leo");
     let program = parse_program(program_string).unwrap();

--- a/compiler/tests/circuits/mut_self_variable_conditional.leo
+++ b/compiler/tests/circuits/mut_self_variable_conditional.leo
@@ -1,0 +1,15 @@
+function main() {
+    let mut f = Foo { a: 0u32 };
+
+    f.bar();
+}
+
+circuit Foo {
+    a: u32
+
+    function bar(mut self) {
+        if true {
+            self.a = 5u32; // Mutating a variable inside a conditional statement should work.
+        }
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes a strange bug where accessing the `self` keyword in a new scope in a circuit function would fail.

Both conditional branches and for loops could previously not access or modify self.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

```rust
function main() {
    let mut f = Foo { a: 0u32 };

    f.bar();
}

circuit Foo {
    a: u32

    function bar(mut self) {
        if true {
            self.a = 5u32; // Mutating a variable inside a conditional statement should work.
        }
    }
}
```
