### PR TITLE
Undeprecate parse_program_from_string

### DIFF
--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -229,9 +229,6 @@ impl<F: Field + PrimeField, G: GroupType<F>> Compiler<F, G> {
     /// Equivalent to parse_and_check_program but uses the given program_string instead of a main
     /// file path.
     ///
-    /// Used for testing only.
-    ///
-    #[deprecated(note = "Please use the 'parse_program' method instead.")]
     pub fn parse_program_from_string(&mut self, program_string: &str) -> Result<(), CompilerError> {
         // Use the given bytes to construct the abstract syntax tree.
         let ast = Grammar::new(&self.main_file_path, &program_string).map_err(|mut e| {

--- a/compiler/tests/compiler/main.leo
+++ b/compiler/tests/compiler/main.leo
@@ -1,0 +1,3 @@
+function main() {
+    let a: u32 = 1 + 2;
+}

--- a/compiler/tests/compiler/mod.rs
+++ b/compiler/tests/compiler/mod.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2019-2020 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{assert_satisfied, get_output, parse_program, EdwardsTestCompiler};
+
+use std::{env::current_dir, path::PathBuf};
+
+static MAIN_FILE_NAME: &str = "tests/compiler/main.leo";
+
+// Compiler tests rely on knowledge of local directories. They should be run locally only.
+
+#[test]
+#[ignore]
+fn test_parse_program_from_string() {
+    // Parse program from string with compiler.
+    let program_string = include_str!("main.leo");
+    let mut compiler_no_path = EdwardsTestCompiler::new("".to_string(), PathBuf::new(), PathBuf::new());
+
+    compiler_no_path.parse_program_from_string(program_string).unwrap();
+
+    // Parse program from file path with compiler.
+    let mut local = current_dir().unwrap();
+    local.push(MAIN_FILE_NAME);
+
+    let compiler_with_path =
+        EdwardsTestCompiler::parse_program_without_input("".to_string(), local, PathBuf::new()).unwrap();
+
+    // Compare output bytes.
+    let expected_output = get_output(compiler_no_path);
+    let actual_output = get_output(compiler_with_path);
+
+    assert_eq!(expected_output, actual_output);
+}

--- a/compiler/tests/mod.rs
+++ b/compiler/tests/mod.rs
@@ -21,6 +21,7 @@ pub mod address;
 pub mod array;
 pub mod boolean;
 pub mod circuits;
+pub mod compiler;
 pub mod console;
 pub mod core;
 pub mod definition;


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #454 

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Add test ensuring parse_program and parse_program_from_string functionality matches.
