### PR TITLE
Implement implicit u32 array indices

### DIFF
--- a/examples/pedersen-hash/src/main.leo
+++ b/examples/pedersen-hash/src/main.leo
@@ -2,11 +2,11 @@ circuit PedersenHash {
     parameters: [group; 256],
 
     // Instantiates a Pedersen hash circuit
-    static function new(parameters: [group; 256]) -> Self {
+    function new(parameters: [group; 256]) -> Self {
         return Self { parameters: parameters }
     }
 
-    function hash(bits: [bool; 256]) -> group {
+    function hash(self, bits: [bool; 256]) -> group {
         let mut digest: group = 0;
         for i in 0..256 {
             if bits[i] {

--- a/type-inference/src/objects/frame.rs
+++ b/type-inference/src/objects/frame.rs
@@ -426,8 +426,8 @@ impl Frame {
         let _expect_none = self.insert_variable(statement.variable.name.to_owned(), u32_type.clone(), &statement.span);
 
         // Parse `from` and `to` expressions.
-        let from_type = self.parse_expression(&statement.start)?;
-        let to_type = self.parse_expression(&statement.stop)?;
+        let from_type = self.parse_index(&statement.start)?;
+        let to_type = self.parse_index(&statement.stop)?;
 
         // Assert `from` and `to` types are a u32 or implicit.
         self.assert_equal(u32_type.clone(), from_type, &statement.span);

--- a/type-inference/src/objects/frame.rs
+++ b/type-inference/src/objects/frame.rs
@@ -799,6 +799,18 @@ impl Frame {
     }
 
     ///
+    /// Returns `Type::U32` if the given index has `Type::TypeVariable`.
+    /// Hard codes all implicitly typed indices to u32.
+    /// Ex: `arr[0]` => `arr[0u32]`
+    ///
+    fn parse_index(&mut self, index: &Expression) -> Result<Type, FrameError> {
+        Ok(match self.parse_expression(index)? {
+            Type::TypeVariable(_) => Type::IntegerType(IntegerType::U32),
+            type_ => type_,
+        })
+    }
+
+    ///
     /// Returns the type of the accessed array element.
     ///
     fn parse_array_access(&mut self, array_type: Type, index: &Expression, span: &Span) -> Result<Type, FrameError> {
@@ -809,7 +821,7 @@ impl Frame {
         };
 
         // Parse the expression type.
-        let type_ = self.parse_expression(index)?;
+        let type_ = self.parse_index(index)?;
 
         // Assert the type is an index.
         self.assert_index(&type_, span);
@@ -836,14 +848,14 @@ impl Frame {
 
         if let Some(expression) = left {
             // Parse the expression type.
-            let type_ = self.parse_expression(expression)?;
+            let type_ = self.parse_index(expression)?;
 
             self.assert_index(&type_, span);
         }
 
         if let Some(expression) = right {
             // Parse the expression type.
-            let type_ = self.parse_expression(expression)?;
+            let type_ = self.parse_index(expression)?;
 
             self.assert_index(&type_, span);
         }

--- a/type-inference/tests/arrays/index_implicit.leo
+++ b/type-inference/tests/arrays/index_implicit.leo
@@ -1,0 +1,5 @@
+function main() {
+    let a = [0u32; 4];
+
+    let b = a[0]; // This should not cause a type inference error
+}

--- a/type-inference/tests/arrays/mod.rs
+++ b/type-inference/tests/arrays/mod.rs
@@ -42,3 +42,21 @@ fn test_invalid_spread() {
 
     check.expect_error();
 }
+
+#[test]
+fn test_index_implicit() {
+    let program_string = include_str!("index_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check()
+}
+
+#[test]
+fn test_slice_implicit() {
+    let program_string = include_str!("slice_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check();
+}

--- a/type-inference/tests/arrays/slice_implicit.leo
+++ b/type-inference/tests/arrays/slice_implicit.leo
@@ -1,0 +1,5 @@
+function main() {
+    let a = [0u32; 4];
+
+    let b = a[0..2]; // This should not cause a type inference error
+}

--- a/type-inference/tests/mod.rs
+++ b/type-inference/tests/mod.rs
@@ -17,6 +17,7 @@
 pub mod arrays;
 pub mod circuits;
 pub mod functions;
+pub mod statements;
 pub mod tuples;
 pub mod variables;
 

--- a/type-inference/tests/statements/array_loop_implicit.leo
+++ b/type-inference/tests/statements/array_loop_implicit.leo
@@ -1,0 +1,7 @@
+function main() {
+    let a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    for i in 0..10 {
+        console.log("{}", a[i]);
+    }
+}

--- a/type-inference/tests/statements/loop_implicit.leo
+++ b/type-inference/tests/statements/loop_implicit.leo
@@ -1,0 +1,5 @@
+function main() {
+    for i in 0..10 {
+        console.log("{}", i);
+    }
+}

--- a/type-inference/tests/statements/mod.rs
+++ b/type-inference/tests/statements/mod.rs
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2020 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::TestTypeInference;
+
+#[test]
+fn test_loop_implicit() {
+    let program_string = include_str!("loop_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check();
+}
+
+#[test]
+fn test_array_loop_implicit() {
+    let program_string = include_str!("array_loop_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check();
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #467 

Allows use of implicitly typed indices in Leo code.
```rust
let a = [0, 1, 2];

let b = a[0]; // Previously threw a type inference error

let c = a[0..1]; // Previously threw a type inference error
```

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Tests use of implicit array indices.
Tests use of implicit array range indices.
