### PR TITLE
Fix import type checking

### DIFF
--- a/examples/pedersen-hash/src/main.leo
+++ b/examples/pedersen-hash/src/main.leo
@@ -2,11 +2,11 @@ circuit PedersenHash {
     parameters: [group; 256],
 
     // Instantiates a Pedersen hash circuit
-    static function new(parameters: [group; 256]) -> Self {
+    function new(parameters: [group; 256]) -> Self {
         return Self { parameters: parameters }
     }
 
-    function hash(bits: [bool; 256]) -> group {
+    function hash(self, bits: [bool; 256]) -> group {
         let mut digest: group = 0;
         for i in 0..256 {
             if bits[i] {

--- a/imports/src/parser/import_parser.rs
+++ b/imports/src/parser/import_parser.rs
@@ -37,7 +37,7 @@ impl ImportParser {
     /// It is okay if the imported program is already present since importing multiple symbols from
     /// the same file is allowed.
     ///
-    pub(crate) fn insert_import(&mut self, file_name: String, program: Program) {
+    pub fn insert_import(&mut self, file_name: String, program: Program) {
         // Insert the imported program.
         let _program = self.imports.insert(file_name, program);
     }
@@ -49,7 +49,7 @@ impl ImportParser {
     ///
     /// If the vector did have this file_name present, a duplicate import error is thrown.
     ///
-    pub(crate) fn insert_core_package(&mut self, package: &Package) -> Result<(), ImportParserError> {
+    pub fn insert_core_package(&mut self, package: &Package) -> Result<(), ImportParserError> {
         // Check for duplicate core package name.
         if self.core_packages.contains(package) {
             return Err(ImportParserError::duplicate_core_package(package.name.clone()));

--- a/symbol-table/src/errors/symbol_table.rs
+++ b/symbol-table/src/errors/symbol_table.rs
@@ -92,7 +92,7 @@ impl SymbolTableError {
     pub fn unknown_symbol(symbol: &ImportSymbol, program: &Program) -> Self {
         let message = format!(
             "Cannot find imported symbol `{}` in imported file `{}`",
-            symbol, program.name
+            symbol.symbol, program.name
         );
 
         Self::new_from_span(message, symbol.span.to_owned())

--- a/symbol-table/tests/mod.rs
+++ b/symbol-table/tests/mod.rs
@@ -52,12 +52,9 @@ impl TestSymbolTable {
     ///
     /// Expect no errors during parsing.
     ///
-    pub fn expect_success(self) {
+    pub fn expect_success(self, import_parser: ImportParser) {
         // Get program.
         let program = self.ast.into_repr();
-
-        // Create empty import parser.
-        let import_parser = ImportParser::default();
 
         // Create empty input.
         let input = Input::new();
@@ -82,7 +79,9 @@ impl TestSymbolTable {
         let import_parser = ImportParser::default();
 
         // Run pass one and expect an error.
-        let error = static_check.check_names(&program, &import_parser).unwrap_err();
+        let error = static_check
+            .check_names(&program, &import_parser, &Input::new())
+            .unwrap_err();
 
         match error {
             SymbolTableError::Error(_) => {} // Ok
@@ -106,7 +105,9 @@ impl TestSymbolTable {
         let import_parser = ImportParser::default();
 
         // Run the pass one and expect no errors.
-        static_check.check_names(&program, &import_parser).unwrap();
+        static_check
+            .check_names(&program, &import_parser, &Input::new())
+            .unwrap();
 
         // Run the pass two and expect and error.
         let error = static_check.check_types(&program).unwrap_err();

--- a/symbol-table/tests/symbol_table/import_alias.leo
+++ b/symbol-table/tests/symbol_table/import_alias.leo
@@ -1,8 +1,0 @@
-import bar.Bar as Baz;
-
-circuit Bar {
-    b: u32,
-}
-function main() {
-    let b = Baz { b: 0u32 };
-}

--- a/symbol-table/tests/symbol_table/import_alias.leo
+++ b/symbol-table/tests/symbol_table/import_alias.leo
@@ -1,0 +1,8 @@
+import bar.Bar as Baz;
+
+circuit Bar {
+    b: u32,
+}
+function main() {
+    let b = Baz { b: 0u32 };
+}

--- a/symbol-table/tests/symbol_table/import_circuit_alias.leo
+++ b/symbol-table/tests/symbol_table/import_circuit_alias.leo
@@ -1,0 +1,9 @@
+import bar.Bar as Baz;
+
+circuit Bar {
+    r: bool,
+}
+function main() {
+    let z = Baz { z: 0u32 };
+    let r = Bar { r: true };
+}

--- a/symbol-table/tests/symbol_table/import_function_alias.leo
+++ b/symbol-table/tests/symbol_table/import_function_alias.leo
@@ -1,0 +1,10 @@
+import foo.foo as boo;
+
+function foo() -> bool {
+    return false
+}
+
+function main() {
+    let z: u8 = boo();
+    let r: bool = foo();
+}

--- a/symbol-table/tests/symbol_table/import_star.leo
+++ b/symbol-table/tests/symbol_table/import_star.leo
@@ -1,0 +1,5 @@
+import foo.*;
+
+function main() {
+    let x: u8 = boo();
+}

--- a/symbol-table/tests/symbol_table/import_undefined.leo
+++ b/symbol-table/tests/symbol_table/import_undefined.leo
@@ -1,0 +1,5 @@
+import foo.boo;
+
+function main() {
+    let x: u8 = boo();
+}

--- a/symbol-table/tests/symbol_table/imports/bar.leo
+++ b/symbol-table/tests/symbol_table/imports/bar.leo
@@ -1,3 +1,3 @@
 circuit Bar {
-    b: u32
+    z: u32
 }

--- a/symbol-table/tests/symbol_table/imports/bar.leo
+++ b/symbol-table/tests/symbol_table/imports/bar.leo
@@ -1,0 +1,3 @@
+circuit Bar {
+    b: u32
+}

--- a/symbol-table/tests/symbol_table/imports/foo.leo
+++ b/symbol-table/tests/symbol_table/imports/foo.leo
@@ -1,0 +1,3 @@
+function foo() -> u8 {
+    return 5u8
+}

--- a/symbol-table/tests/symbol_table/mod.rs
+++ b/symbol-table/tests/symbol_table/mod.rs
@@ -16,6 +16,8 @@
 
 use crate::TestSymbolTable;
 
+use leo_imports::ImportParser;
+
 ///
 /// Defines a circuit `Foo {}`.
 /// Attempts to define a second circuit `Foo {}`.
@@ -72,4 +74,20 @@ fn test_undefined_circuit() {
     let resolver = TestSymbolTable::new(program_string);
 
     resolver.expect_pass_two_error();
+}
+
+#[test]
+fn test_import_alias() {
+    let program_string = include_str!("import_alias.leo");
+    let import_string = include_str!("imports/bar.leo");
+
+    let program_table = TestSymbolTable::new(program_string);
+    let import_table = TestSymbolTable::new(import_string);
+
+    let import_program = import_table.ast.into_repr();
+
+    let mut imports = ImportParser::default();
+    imports.insert_import("bar".to_owned(), import_program);
+
+    program_table.expect_success(imports);
 }

--- a/type-inference/src/objects/frame.rs
+++ b/type-inference/src/objects/frame.rs
@@ -426,8 +426,8 @@ impl Frame {
         let _expect_none = self.insert_variable(statement.variable.name.to_owned(), u32_type.clone(), &statement.span);
 
         // Parse `from` and `to` expressions.
-        let from_type = self.parse_expression(&statement.start)?;
-        let to_type = self.parse_expression(&statement.stop)?;
+        let from_type = self.parse_index(&statement.start)?;
+        let to_type = self.parse_index(&statement.stop)?;
 
         // Assert `from` and `to` types are a u32 or implicit.
         self.assert_equal(u32_type.clone(), from_type, &statement.span);

--- a/type-inference/src/objects/frame.rs
+++ b/type-inference/src/objects/frame.rs
@@ -799,6 +799,18 @@ impl Frame {
     }
 
     ///
+    /// Returns `Type::U32` if the given index has `Type::TypeVariable`.
+    /// Hard codes all implicitly typed indices to u32.
+    /// Ex: `arr[0]` => `arr[0u32]`
+    ///
+    fn parse_index(&mut self, index: &Expression) -> Result<Type, FrameError> {
+        Ok(match self.parse_expression(index)? {
+            Type::TypeVariable(_) => Type::IntegerType(IntegerType::U32),
+            type_ => type_,
+        })
+    }
+
+    ///
     /// Returns the type of the accessed array element.
     ///
     fn parse_array_access(&mut self, array_type: Type, index: &Expression, span: &Span) -> Result<Type, FrameError> {
@@ -809,7 +821,7 @@ impl Frame {
         };
 
         // Parse the expression type.
-        let type_ = self.parse_expression(index)?;
+        let type_ = self.parse_index(index)?;
 
         // Assert the type is an index.
         self.assert_index(&type_, span);
@@ -836,14 +848,14 @@ impl Frame {
 
         if let Some(expression) = left {
             // Parse the expression type.
-            let type_ = self.parse_expression(expression)?;
+            let type_ = self.parse_index(expression)?;
 
             self.assert_index(&type_, span);
         }
 
         if let Some(expression) = right {
             // Parse the expression type.
-            let type_ = self.parse_expression(expression)?;
+            let type_ = self.parse_index(expression)?;
 
             self.assert_index(&type_, span);
         }

--- a/type-inference/tests/arrays/index_implicit.leo
+++ b/type-inference/tests/arrays/index_implicit.leo
@@ -1,0 +1,5 @@
+function main() {
+    let a = [0u32; 4];
+
+    let b = a[0]; // This should not cause a type inference error
+}

--- a/type-inference/tests/arrays/mod.rs
+++ b/type-inference/tests/arrays/mod.rs
@@ -42,3 +42,21 @@ fn test_invalid_spread() {
 
     check.expect_error();
 }
+
+#[test]
+fn test_index_implicit() {
+    let program_string = include_str!("index_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check()
+}
+
+#[test]
+fn test_slice_implicit() {
+    let program_string = include_str!("slice_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check();
+}

--- a/type-inference/tests/arrays/slice_implicit.leo
+++ b/type-inference/tests/arrays/slice_implicit.leo
@@ -1,0 +1,5 @@
+function main() {
+    let a = [0u32; 4];
+
+    let b = a[0..2]; // This should not cause a type inference error
+}

--- a/type-inference/tests/mod.rs
+++ b/type-inference/tests/mod.rs
@@ -17,6 +17,7 @@
 pub mod arrays;
 pub mod circuits;
 pub mod functions;
+pub mod statements;
 pub mod tuples;
 pub mod variables;
 

--- a/type-inference/tests/statements/array_loop_implicit.leo
+++ b/type-inference/tests/statements/array_loop_implicit.leo
@@ -1,0 +1,7 @@
+function main() {
+    let a = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    for i in 0..10 {
+        console.log("{}", a[i]);
+    }
+}

--- a/type-inference/tests/statements/loop_implicit.leo
+++ b/type-inference/tests/statements/loop_implicit.leo
@@ -1,0 +1,5 @@
+function main() {
+    for i in 0..10 {
+        console.log("{}", i);
+    }
+}

--- a/type-inference/tests/statements/mod.rs
+++ b/type-inference/tests/statements/mod.rs
@@ -1,0 +1,35 @@
+// Copyright (C) 2019-2020 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::TestTypeInference;
+
+#[test]
+fn test_loop_implicit() {
+    let program_string = include_str!("loop_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check();
+}
+
+#[test]
+fn test_array_loop_implicit() {
+    let program_string = include_str!("array_loop_implicit.leo");
+
+    let check = TestTypeInference::new(program_string);
+
+    check.check();
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes a bug where importing a circuit under an alias would cause an undefined user type error.

**src/foo.leo**
```rust
circuit Bar {
    b: u8
}
```

**src/main.leo**
```rust
import foo.Bar as Baz;

function main() {
    let z = Baz { b: 0u8 }; // Error.
}
```

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

* Tests for undefined import names.
* Tests that import star (*) correctly fetches all names.
* Tests that importing a circuit under an alias works. Also defines a circuit under the original name to verify.
* Tests that importing a function under an alias works. Also defines a function under the original name to verify.
