### PR TITLE
[cli] adds empty line for help command 

### DIFF
--- a/leo/main.rs
+++ b/leo/main.rs
@@ -84,6 +84,7 @@ fn main() -> Result<(), CLIError> {
             Updater::print_cli();
 
             help.print_help()?;
+            println!();
             Ok(())
         }
     }


### PR DESCRIPTION
Closes #362 

Details:
- clap 2.X has an issue with adding empty line in the end
- proper fixing of this problem should be by updating to V3

Resources:
- 2018 issue with code example: https://github.com/clap-rs/clap/issues/1127#issuecomment-359790460
- https://gitmemory.com/issue/clap-rs/clap/1536/534784807 

