### PR TITLE
[CI] adds leo add and leo remove CI workflow

### DIFF
--- a/.github/workflows/leo-add-remove.yml
+++ b/.github/workflows/leo-add-remove.yml
@@ -1,0 +1,47 @@
+name: leo-clean
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - 'docs/**'
+      - 'documentation/**'
+env:
+  RUST_BACKTRACE: 1
+
+jobs:
+  add:
+    name: Add Package ('leo add')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+
+      - name: Install Leo
+        uses: actions-rs/cargo@v1
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+        with:
+          command: install
+          args: --path .
+
+      - name: 'leo login & add'
+        env:
+          USER: ${{ secrets.ALEO_PM_USERNAME }}
+          PASS: ${{ secrets.ALEO_PM_PASSWORD }}
+        run: |
+          cd .. && leo new my-app && cd my-app
+          leo login -u "$USER" -p "$PASS"
+          leo add argus4130/xnor
+          leo remove xnor
+          leo clean
+

--- a/.github/workflows/leo-add-remove.yml
+++ b/.github/workflows/leo-add-remove.yml
@@ -1,4 +1,4 @@
-name: leo-clean
+name: leo-add-remove
 on:
   pull_request:
   push:


### PR DESCRIPTION
Copies #569
Reason: PRs from forks cannot use secrets.

---

Follow up on #551 and #560 

## What is done

Added CI workflow for `leo login`, `leo add` and `leo remove` commands

> Requires `ALEO_PM_USERNAME` and `ALEO_PM_PASSWORD` to be set in secrets

## Motivation

More tests on CLI, improving developer experience
