### PR TITLE
[CLI, CI] Leo add does not require login

### DIFF
--- a/.github/workflows/leo-login-logout.yml
+++ b/.github/workflows/leo-login-logout.yml
@@ -1,4 +1,4 @@
-name: leo-add-remove
+name: leo-login-logout
 on:
   pull_request:
   push:
@@ -34,10 +34,15 @@ jobs:
           command: install
           args: --path .
 
-      - name: 'leo add (w/o login) & remove'
+      - name: 'leo login & logout'
+        env:
+          USER: ${{ secrets.ALEO_PM_USERNAME }}
+          PASS: ${{ secrets.ALEO_PM_PASSWORD }}
         run: |
           cd .. && leo new my-app && cd my-app
+          leo login -u "$USER" -p "$PASS"
           leo add argus4130/xnor
           leo remove xnor
           leo clean
+          leo logout
 

--- a/leo/commands/add.rs
+++ b/leo/commands/add.rs
@@ -137,9 +137,11 @@ impl CLI for AddCommand {
                     Ok(token) => {
                         tracing::info!("Logged in, using token to authorize");
                         client.post(&url).bearer_auth(token)
-                    },
-                    Err(_) => client.post(&url)
-                }.json(&json).send();
+                    }
+                    Err(_) => client.post(&url),
+                }
+                .json(&json)
+                .send();
 
                 match result {
                     Ok(response) => (response, package_name),

--- a/leo/commands/add.rs
+++ b/leo/commands/add.rs
@@ -133,7 +133,15 @@ impl CLI for AddCommand {
                     json.insert("version", version);
                 }
 
-                match client.post(&url).json(&json).send() {
+                let result = match read_token() {
+                    Ok(token) => {
+                        tracing::info!("Logged in, using token to authorize");
+                        client.post(&url).bearer_auth(token)
+                    },
+                    Err(_) => client.post(&url)
+                }.json(&json).send();
+
+                match result {
                     Ok(response) => (response, package_name),
                     //Cannot connect to the server
                     Err(_error) => {

--- a/leo/commands/add.rs
+++ b/leo/commands/add.rs
@@ -115,10 +115,6 @@ impl CLI for AddCommand {
         // Begin "Adding" context for console logging
         let span = tracing::span!(tracing::Level::INFO, "Adding");
         let _enter = span.enter();
-
-        // token can only be there if user has signed into Aleo PM
-        // so we need to verify that token exists before doing anything else
-        let token = read_token().map_err(|_| -> CLIError { NotAuthorized.into() })?;
         let path = current_dir()?;
 
         // Enforce that the current directory is a leo package
@@ -137,7 +133,7 @@ impl CLI for AddCommand {
                     json.insert("version", version);
                 }
 
-                match client.post(&url).bearer_auth(token).json(&json).send() {
+                match client.post(&url).json(&json).send() {
                     Ok(response) => (response, package_name),
                     //Cannot connect to the server
                     Err(_error) => {


### PR DESCRIPTION
## Motivation

Leo add could be done without logging into Aleo PM. So token check is removed. That simplifies process for newcomers, and helps on CI stage - no need to add credentials.

## Test Plan

This PR includes changes to CI workflows: 
- login and logout have now their own workflow
- add, remove and clean are done without login

## Related PRs

This PR finalizes work on previous tasks:
- #572 
- #560