### PR TITLE
[easy] Simplifies a number of pattern-matches

### DIFF
--- a/asg/src/reducer/visitor_director.rs
+++ b/asg/src/reducer/visitor_director.rs
@@ -71,10 +71,7 @@ impl<'a, R: ExpressionVisitor<'a>> VisitorDirector<'a, R> {
     }
 
     fn visit_opt_expression(&mut self, input: &Cell<Option<&'a Expression<'a>>>) -> ConcreteVisitResult {
-        let interior = match input.get() {
-            Some(expr) => Some(Cell::new(expr)),
-            None => None,
-        };
+        let interior = input.get().map(Cell::new);
         if let Some(interior) = interior.as_ref() {
             let result = self.visit_expression(interior);
             input.replace(Some(interior.get()));
@@ -246,10 +243,7 @@ impl<'a, R: StatementVisitor<'a>> VisitorDirector<'a, R> {
     }
 
     fn visit_opt_statement(&mut self, input: &Cell<Option<&'a Statement<'a>>>) -> ConcreteVisitResult {
-        let interior = match input.get() {
-            Some(expr) => Some(Cell::new(expr)),
-            None => None,
-        };
+        let interior = input.get().map(Cell::new);
         if let Some(interior) = interior.as_ref() {
             let result = self.visit_statement(interior);
             input.replace(Some(interior.get()));

--- a/compiler/src/expression/function/core_circuit.rs
+++ b/compiler/src/expression/function/core_circuit.rs
@@ -34,11 +34,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         arguments: &[Cell<&'a Expression<'a>>],
         span: &Span,
     ) -> Result<ConstrainedValue<'a, F, G>, ExpressionError> {
-        let target_value = if let Some(target) = target {
-            Some(self.enforce_expression(cs, target)?)
-        } else {
-            None
-        };
+        let target_value = target.map(|target| self.enforce_expression(cs, target)).transpose()?;
 
         // Get the value of each core function argument
         let arguments = arguments

--- a/compiler/src/function/function.rs
+++ b/compiler/src/function/function.rs
@@ -34,11 +34,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         target: Option<&'a Expression<'a>>,
         arguments: &[Cell<&'a Expression<'a>>],
     ) -> Result<ConstrainedValue<'a, F, G>, FunctionError> {
-        let target_value = if let Some(target) = target {
-            Some(self.enforce_expression(cs, target)?)
-        } else {
-            None
-        };
+        let target_value = target.map(|target| self.enforce_expression(cs, target)).transpose()?;
 
         let self_var = if let Some(target) = &target_value {
             let self_var = function

--- a/leo/commands/package/add.rs
+++ b/leo/commands/package/add.rs
@@ -96,10 +96,7 @@ impl Command for Add {
             return Err(anyhow!("Package manifest not found, try running `leo init`"));
         };
 
-        let (author, package_name) = match self.try_read_arguments() {
-            Ok((author, package)) => (author, package),
-            Err(err) => return Err(err),
-        };
+        let (author, package_name) = self.try_read_arguments()?;
 
         // Attempt to fetch the package.
         let reader = {

--- a/leo/commands/package/clone.rs
+++ b/leo/commands/package/clone.rs
@@ -105,10 +105,7 @@ impl Command for Clone {
     }
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
-        let (author, package_name) = match self.try_read_arguments() {
-            Ok((author, package)) => (author, package),
-            Err(err) => return Err(err),
-        };
+        let (author, package_name) = self.try_read_arguments()?;
 
         // Attempt to fetch the package.
         let reader = {

--- a/leo/commands/package/publish.rs
+++ b/leo/commands/package/publish.rs
@@ -93,10 +93,10 @@ impl Command for Publish {
         // Client for make POST request
         let client = Client::new();
 
-        let token = match context.api.auth_token() {
-            Some(token) => token,
-            None => return Err(anyhow!("Login before publishing package: try leo login --help")),
-        };
+        let token = context
+            .api
+            .auth_token()
+            .ok_or_else(|| anyhow!("Login before publishing package: try leo login --help"))?;
 
         // Headers for request to publish package
         let mut headers = HeaderMap::new();

--- a/leo/context.rs
+++ b/leo/context.rs
@@ -49,10 +49,7 @@ impl Context {
 
 /// Create a new context for the current directory.
 pub fn create_context(path: PathBuf) -> Result<Context> {
-    let token = match config::read_token() {
-        Ok(token) => Some(token),
-        Err(_) => None,
-    };
+    let token = config::read_token().ok();
 
     let api = Api::new(PACKAGE_MANAGER_URL.to_string(), token);
 
@@ -61,10 +58,7 @@ pub fn create_context(path: PathBuf) -> Result<Context> {
 
 /// Returns project context.
 pub fn get_context() -> Result<Context> {
-    let token = match config::read_token() {
-        Ok(token) => Some(token),
-        Err(_) => None,
-    };
+    let token = config::read_token().ok();
 
     let api = Api::new(PACKAGE_MANAGER_URL.to_string(), token);
 

--- a/leo/synthesizer/serialized_circuit.rs
+++ b/leo/synthesizer/serialized_circuit.rs
@@ -174,11 +174,11 @@ impl TryFrom<SerializedCircuit> for CircuitSynthesizer<Bls12_377> {
         }
 
         Ok(CircuitSynthesizer::<Bls12_377> {
-            input_assignment,
-            aux_assignment,
             at,
             bt,
             ct,
+            input_assignment,
+            aux_assignment,
         })
     }
 }


### PR DESCRIPTION
Into the direct `Result` / `Option` combinator they correspond to, for concision / clarity.

Reviewed from automated suggestions generated from [comby-rust](https://github.com/huitseeker/comby-rust).


