### PR TITLE
[CLI] Adds --skip-key-check option to setup, run and prove commands

### DIFF
--- a/.github/workflows/leo-add-remove.yml
+++ b/.github/workflows/leo-add-remove.yml
@@ -42,6 +42,9 @@ jobs:
           cd .. && leo new my-app && cd my-app
           leo login -u "$USER" -p "$PASS"
           leo add argus4130/xnor
+          leo setup
+          leo setup
+          leo setup --skip-key-check
           leo remove xnor
           leo clean
 

--- a/.github/workflows/leo-setup.yml
+++ b/.github/workflows/leo-setup.yml
@@ -1,4 +1,4 @@
-name: leo-add-remove
+name: leo-setup
 on:
   pull_request:
   push:
@@ -34,14 +34,14 @@ jobs:
           command: install
           args: --path .
 
-      - name: 'leo login & add'
+      - name: 'leo setup for examples'
         env:
           USER: ${{ secrets.ALEO_PM_USERNAME }}
           PASS: ${{ secrets.ALEO_PM_PASSWORD }}
         run: |
-          cd .. && leo new my-app && cd my-app
-          leo login -u "$USER" -p "$PASS"
-          leo add argus4130/xnor
-          leo remove xnor
+          cd examples/pedersen-hash
+          leo setup
+          leo setup
+          leo setup --skip-key-check
           leo clean
 

--- a/leo/commands/prove.rs
+++ b/leo/commands/prove.rs
@@ -29,24 +29,24 @@ use std::{convert::TryFrom, env::current_dir, time::Instant};
 pub struct ProveCommand;
 
 impl CLI for ProveCommand {
-    type Options = ();
+    type Options = bool;
     type Output = (Proof<Bls12_377>, PreparedVerifyingKey<Bls12_377>);
 
     const ABOUT: AboutType = "Run the program and produce a proof";
     const ARGUMENTS: &'static [ArgumentType] = &[];
-    const FLAGS: &'static [FlagType] = &[];
+    const FLAGS: &'static [FlagType] = &[("--skip-key-check")];
     const NAME: NameType = "prove";
     const OPTIONS: &'static [OptionType] = &[];
     const SUBCOMMANDS: &'static [SubCommandType] = &[];
 
     #[cfg_attr(tarpaulin, skip)]
-    fn parse(_arguments: &ArgMatches) -> Result<Self::Options, CLIError> {
-        Ok(())
+    fn parse(arguments: &ArgMatches) -> Result<Self::Options, CLIError> {
+        Ok(!arguments.is_present("skip-key-check"))
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    fn output(options: Self::Options) -> Result<Self::Output, CLIError> {
-        let (program, parameters, prepared_verifying_key) = SetupCommand::output(options)?;
+    fn output(do_setup_check: Self::Options) -> Result<Self::Output, CLIError> {
+        let (program, parameters, prepared_verifying_key) = SetupCommand::output(do_setup_check)?;
 
         // Begin "Proving" context for console logging
         let span = tracing::span!(tracing::Level::INFO, "Proving");

--- a/leo/commands/run.rs
+++ b/leo/commands/run.rs
@@ -28,24 +28,24 @@ use std::time::Instant;
 pub struct RunCommand;
 
 impl CLI for RunCommand {
-    type Options = ();
+    type Options = bool;
     type Output = ();
 
     const ABOUT: AboutType = "Run a program with input variables";
     const ARGUMENTS: &'static [ArgumentType] = &[];
-    const FLAGS: &'static [FlagType] = &[];
+    const FLAGS: &'static [FlagType] = &[("--skip-key-check")];
     const NAME: NameType = "run";
     const OPTIONS: &'static [OptionType] = &[];
     const SUBCOMMANDS: &'static [SubCommandType] = &[];
 
     #[cfg_attr(tarpaulin, skip)]
-    fn parse(_arguments: &ArgMatches) -> Result<Self::Options, CLIError> {
-        Ok(())
+    fn parse(arguments: &ArgMatches) -> Result<Self::Options, CLIError> {
+        Ok(!arguments.is_present("skip-key-check"))
     }
 
     #[cfg_attr(tarpaulin, skip)]
-    fn output(options: Self::Options) -> Result<(), CLIError> {
-        let (proof, prepared_verifying_key) = ProveCommand::output(options)?;
+    fn output(do_setup_check: Self::Options) -> Result<(), CLIError> {
+        let (proof, prepared_verifying_key) = ProveCommand::output(do_setup_check)?;
 
         // Begin "Verifying" context for console logging
         let span = tracing::span!(tracing::Level::INFO, "Verifying");


### PR DESCRIPTION
## Motivation

Follow up on #521. As @damons suggested, I am attaching this PR for demonstration and proposal purposes.

This is a suggestion to add `--skip-key-check` flag to commands: setup, run and prove. Skipping this check would allow Leo developers to speed up these commands by skipping affine curve checks inside `snarkvm_algorithms`. Flag will only work when CLI command is run on already generated prove key (i.e. 2nd and 3rd and Nth time).

All commands output execution time and it is possible to see the results in CI workflow (leo-add-remove) for this PR. 

## Test Plan

Includes changes to CI workflow, adds `leo setup` and `leo setup --skip-key-check`.
