### PR TITLE
Remove compiler return check

### DIFF
--- a/compiler/src/function/result/result.rs
+++ b/compiler/src/function/result/result.rs
@@ -48,16 +48,6 @@ impl<F: Field + PrimeField, G: GroupType<F>> ConstrainedProgram<F, G> {
         // Initialize empty return value.
         let mut return_value = ConstrainedValue::Tuple(vec![]);
 
-        // Error if the function or one of its branches does not return.
-        if !expected_return.is_unit()
-            && results
-                .iter()
-                .find(|(indicator, _res)| get_indicator_value(indicator))
-                .is_none()
-        {
-            return Err(StatementError::no_returns(&expected_return, span.to_owned()));
-        }
-
         // Find the return value
         let mut ignored = vec![];
         let mut found_return = false;

--- a/compiler/tests/function/conditional_return.leo
+++ b/compiler/tests/function/conditional_return.leo
@@ -1,0 +1,7 @@
+function main(x: u8) -> u8 {
+    if x == 2u8 {
+        return 3u8
+    } else {
+        return 4u8
+    } 
+}

--- a/compiler/tests/function/input/conditional_return.in
+++ b/compiler/tests/function/input/conditional_return.in
@@ -1,0 +1,5 @@
+[main]
+x: u8 = 1u8;
+
+[registers]
+x: u8 = 0;

--- a/compiler/tests/function/mod.rs
+++ b/compiler/tests/function/mod.rs
@@ -17,6 +17,19 @@
 use crate::{assert_satisfied, expect_asg_error, get_output, parse_program, parse_program_with_input};
 
 #[test]
+fn test_conditional_return() {
+    let input_string = include_str!("input/conditional_return.in");
+    let program_string = include_str!("conditional_return.leo");
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    let expected_string = include_str!("output/conditional_return.out");
+    let actual_bytes = get_output(program);
+    let actual_string = std::str::from_utf8(actual_bytes.bytes().as_slice()).unwrap();
+
+    assert_eq!(expected_string, actual_string);
+}
+
+#[test]
 fn test_empty() {
     let program_string = include_str!("empty.leo");
     let program = parse_program(program_string).unwrap();

--- a/compiler/tests/function/output/conditional_return.out
+++ b/compiler/tests/function/output/conditional_return.out
@@ -1,0 +1,2 @@
+[registers]
+x: u8 = 4;


### PR DESCRIPTION
Fixes #535 .

Return path checking is provided by ASG, compiler return path checking is overzealous in a valid const branch evaluation due to use of `get_indicator_value` always being `false` if non-const.