### PR TITLE
fn call array params

### DIFF
--- a/compiler/tests/function/array_params_direct_call.leo
+++ b/compiler/tests/function/array_params_direct_call.leo
@@ -1,0 +1,9 @@
+function do_nothing(arr: [u32; 2]) {}
+
+function main() {
+    let arr: [u32; 2] = [0; 2];
+
+    do_nothing(arr);
+    do_nothing([...arr]);
+    do_nothing(arr[1u32..]);
+}

--- a/compiler/tests/function/mod.rs
+++ b/compiler/tests/function/mod.rs
@@ -203,3 +203,11 @@ fn test_return_tuple_conditional() {
 
     assert_satisfied(program);
 }
+
+#[test]
+fn test_array_params_direct_call() {
+    let program_string = include_str!("array_params_direct_call.leo");
+    let program = parse_program(program_string).unwrap();
+
+    assert_satisfied(program);
+}


### PR DESCRIPTION
Adding a test for bug #522, which was resolved by the asg.

Closes #522 