### PR TITLE
Remove compile flag target-cpu=native to fix "illegal instructions" error

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,2 @@
-[build]
-rustflags = ["-C", "target-cpu=native"]
-
 [net]
 git-fetch-with-cli = true


### PR DESCRIPTION
## Motivation
The Windows leo binary, which builds manually, and Linux leo binaries, which builds by GitHub actions, are for 64-bit processor architecture and they are not working for all 64-bit processors. In some cases, it throws Illegal instructions error.
![image](https://user-images.githubusercontent.com/585251/107335046-23b10180-6ac0-11eb-9afe-f8fe995ec1b6.png)
In the image, you can see that leo 1.0.3 was run and the update was initiated by itself. After update to 1.0.4, it throws an error.

According to documentation https://rust-lang.github.io/packed_simd/perf-guide/target-feature/rustflags.html#target-cpu

> Using native as the CPU model will cause Rust to generate and optimize code for the CPU running the compiler. It is useful when building programs which you plan to only use locally. This should never be used when the generated programs are meant to be run on other computers, such as when packaging for distribution or cross-compiling.

## Test Plan
Build with target-cpu=native and run.
Build without target-cpu=native and run.

