### PR TITLE
[Bug] remove unused json deserialize logic

### DIFF
--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -29,7 +29,6 @@ use leo_package::{
 use anyhow::Result;
 use snarkvm_curves::{bls12_377::Bls12_377, edwards_bls12::Fq};
 use snarkvm_models::gadgets::r1cs::ConstraintSystem;
-use std::convert::TryFrom;
 use structopt::StructOpt;
 use tracing::span::Span;
 
@@ -149,11 +148,11 @@ impl Command for Build {
                 circuit_file.write_to(&path, json)?;
 
                 // Check that we can read the serialized circuit file
-                let serialized = circuit_file.read_from(&package_path)?;
+                // let serialized = circuit_file.read_from(&package_path)?;
 
                 // Deserialize the circuit
-                let deserialized = SerializedCircuit::from_json_string(&serialized).unwrap();
-                let _circuit_synthesizer = CircuitSynthesizer::<Bls12_377>::try_from(deserialized).unwrap();
+                // let deserialized = SerializedCircuit::from_json_string(&serialized).unwrap();
+                // let _circuit_synthesizer = CircuitSynthesizer::<Bls12_377>::try_from(deserialized).unwrap();
                 // println!("deserialized {:?}", circuit_synthesizer.num_constraints());
             }
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The `leo build` command serializes the circuit and stores it in a JSON file.
There is currently additional logic to deserialize the JSON file and the resulting circuit is unused.
