### PR TITLE
[CLI] Optional change of STDERR for errors to STDOUT

### DIFF
--- a/leo/main.rs
+++ b/leo/main.rs
@@ -203,7 +203,7 @@ fn handle_error<T>(res: Result<T, Error>) -> T {
     match res {
         Ok(t) => t,
         Err(err) => {
-            eprintln!("Error: {}", err);
+            println!("Error: {}", err);
             exit(1);
         }
     }


### PR DESCRIPTION
## Motivation

Changes STDERR output in `leo` when process exiting with error to STDOUT. Even though STDERR is more conventional way to handle error outputs, leo fuzzer relies on STDOUT.

If there's an option to keep erroring into stderr - I'd suggest to keep it that way and close this PR.

## Test Plan

Change is so minor, so no testing required.
