### PR TITLE
Bug 625/fix negative fields not allowed

### DIFF
--- a/compiler/src/value/field/field_type.rs
+++ b/compiler/src/value/field/field_type.rs
@@ -67,7 +67,7 @@ impl<F: Field + PrimeField> FieldType<F> {
                 .chars()
                 .next()
                 .map(|c| &string[c.len_utf8()..])
-                .ok_or(FieldError::invalid_field(string.clone(), span.to_owned()))?;
+                .ok_or_else(|| FieldError::invalid_field(string.clone(), span.to_owned()))?;
             value = -F::from_str(&new_string).map_err(|_| FieldError::invalid_field(string, span.to_owned()))?;
         } else {
             value = F::from_str(&string).map_err(|_| FieldError::invalid_field(string, span.to_owned()))?;

--- a/compiler/src/value/field/field_type.rs
+++ b/compiler/src/value/field/field_type.rs
@@ -40,7 +40,6 @@ use snarkvm_models::{
 use std::{borrow::Borrow, cmp::Ordering};
 
 #[derive(Clone, Debug)]
-// Isn't this redudant?
 // PrimeField already implements Field.
 pub enum FieldType<F: Field + PrimeField> {
     Constant(F),

--- a/compiler/src/value/field/field_type.rs
+++ b/compiler/src/value/field/field_type.rs
@@ -40,7 +40,6 @@ use snarkvm_models::{
 use std::{borrow::Borrow, cmp::Ordering};
 
 #[derive(Clone, Debug)]
-// PrimeField already implements Field.
 pub enum FieldType<F: Field + PrimeField> {
     Constant(F),
     Allocated(FpGadget<F>),

--- a/compiler/tests/field/mod.rs
+++ b/compiler/tests/field/mod.rs
@@ -67,6 +67,14 @@ fn test_negate() {
 }
 
 #[test]
+fn test_negative_declaration() {
+    let program_string = include_str!("negative_declaration.leo");
+    let mut program = parse_program(program_string).unwrap();
+
+    assert_satisfied(program)
+}
+
+#[test]
 fn test_add() {
     use std::ops::Add;
 

--- a/compiler/tests/field/negative_declaration.leo
+++ b/compiler/tests/field/negative_declaration.leo
@@ -1,0 +1,3 @@
+function main() {
+    let negOneField: field = -1field;
+}

--- a/compiler/tests/input_files/program_input/input/main_field.in
+++ b/compiler/tests/input_files/program_input/input/main_field.in
@@ -1,0 +1,2 @@
+[main]
+a: field = 1;

--- a/compiler/tests/input_files/program_input/main_field.leo
+++ b/compiler/tests/input_files/program_input/main_field.leo
@@ -1,0 +1,4 @@
+function main(a: field) {
+    // Change to assert when == is implemented for field.
+    console.log("a: {}", a);
+}

--- a/compiler/tests/input_files/program_input/mod.rs
+++ b/compiler/tests/input_files/program_input/mod.rs
@@ -93,3 +93,13 @@ fn test_input_array_dimensions_mismatch() {
 
     expect_fail(program);
 }
+
+#[test]
+fn test_field_input() {
+    let program_string = include_str!("main_field.leo");
+    let input_string = include_str!("input/main_field.in");
+
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    assert_satisfied(program);
+}


### PR DESCRIPTION
Resolves #625. Logic used to do so is in check if first character of string to convert is a negative sign. If so remove first character convert from string to field, and then negate it on the leo side. If first character wasn't a negative sign, do the same as before.