### PR TITLE
[CLI] Ignore non-input/state files in inputs folder when running tests

### DIFF
--- a/package/src/inputs/pairs.rs
+++ b/package/src/inputs/pairs.rs
@@ -27,6 +27,7 @@ pub struct InputPairs {
     pub pairs: HashMap<String, InputPair>,
 }
 
+#[derive(Debug)]
 pub struct InputPair {
     pub input_file: String,
     pub state_file: String,
@@ -47,9 +48,12 @@ impl TryFrom<&Path> for InputPairs {
         let mut pairs = HashMap::<String, InputPair>::new();
 
         for file in files {
-            let file_extension = file
-                .extension()
-                .ok_or_else(|| InputsDirectoryError::GettingFileExtension(file.as_os_str().to_owned()))?;
+            // if file name starts with . (dot) None is returned - we're
+            // skipping these files intentionally but not exiting
+            let file_extension = match file.extension() {
+                Some(extension) => extension,
+                None => continue,
+            };
 
             let file_name = file
                 .file_stem()
@@ -84,10 +88,8 @@ impl TryFrom<&Path> for InputPairs {
                     pairs.insert(file_name.to_owned(), pair);
                 }
             } else {
-                return Err(InputsDirectoryError::InvalidFileExtension(
-                    file_name.to_owned(),
-                    file_extension.to_owned(),
-                ));
+                // kept for verbosity, can be removed
+                continue;
             }
         }
 


### PR DESCRIPTION
Closes #660 

## Motivation

Any non-state or non-input file in program inputs folder causes test command to fail with error. This case is described in #660. Another case is also covered - files starting with dot (i.e. `.smth`) caused different error - now skipped.

Proposed behavior is skipping other files (with no warning/error) instead of erroring out. 

## Test Plan

Tested locally, changes are small enough to see through
