### PR TITLE
Fix build-time OOMs by performing out-of-scope cleanups for CircuitSynthesizer objects

### DIFF
--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -122,11 +122,12 @@ impl Command for Build {
             // Generate the program on the constraint system and verify correctness
             {
                 let mut cs = CircuitSynthesizer::<Bls12_377> {
-                    at: vec![],
-                    bt: vec![],
-                    ct: vec![],
-                    public_variables: vec![],
-                    private_variables: vec![],
+                    at: Default::default(),
+                    bt: Default::default(),
+                    ct: Default::default(),
+                    public_variables: Default::default(),
+                    private_variables: Default::default(),
+                    namespaces: Default::default(),
                 };
                 let temporary_program = program.clone();
                 let output = temporary_program.compile_constraints(&mut cs)?;

--- a/synthesizer/src/circuit_synthesizer.rs
+++ b/synthesizer/src/circuit_synthesizer.rs
@@ -17,18 +17,31 @@
 use snarkvm_errors::gadgets::SynthesisError;
 use snarkvm_models::{
     curves::{Field, PairingEngine},
-    gadgets::r1cs::{ConstraintSystem, Index, LinearCombination, Variable},
+    gadgets::{
+        r1cs::{ConstraintSystem, Index, LinearCombination, Variable},
+        utilities::OptionalVec,
+    },
 };
+
+#[derive(Default)]
+pub struct Namespace {
+    constraint_indices: Vec<usize>,
+    public_var_indices: Vec<usize>,
+    private_var_indices: Vec<usize>,
+}
 
 pub struct CircuitSynthesizer<E: PairingEngine> {
     // Constraints
-    pub at: Vec<Vec<(E::Fr, Index)>>,
-    pub bt: Vec<Vec<(E::Fr, Index)>>,
-    pub ct: Vec<Vec<(E::Fr, Index)>>,
+    pub at: OptionalVec<Vec<(E::Fr, Index)>>,
+    pub bt: OptionalVec<Vec<(E::Fr, Index)>>,
+    pub ct: OptionalVec<Vec<(E::Fr, Index)>>,
 
     // Assignments of variables
-    pub public_variables: Vec<E::Fr>,
-    pub private_variables: Vec<E::Fr>,
+    pub public_variables: OptionalVec<E::Fr>,
+    pub private_variables: OptionalVec<E::Fr>,
+
+    // Technical namespaces used to remove of out-of-scope objects.
+    pub namespaces: Vec<Namespace>,
 }
 
 impl<E: PairingEngine> ConstraintSystem<E::Fr> for CircuitSynthesizer<E> {
@@ -41,8 +54,10 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for CircuitSynthesizer<E> {
         A: FnOnce() -> AR,
         AR: AsRef<str>,
     {
-        let index = self.private_variables.len();
-        self.private_variables.push(f()?);
+        let index = self.private_variables.insert(f()?);
+        if let Some(ref mut ns) = self.namespaces.last_mut() {
+            ns.private_var_indices.push(index);
+        }
         Ok(Variable::new_unchecked(Index::Private(index)))
     }
 
@@ -53,8 +68,10 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for CircuitSynthesizer<E> {
         A: FnOnce() -> AR,
         AR: AsRef<str>,
     {
-        let index = self.public_variables.len();
-        self.public_variables.push(f()?);
+        let index = self.public_variables.insert(f()?);
+        if let Some(ref mut ns) = self.namespaces.last_mut() {
+            ns.public_var_indices.push(index);
+        }
         Ok(Variable::new_unchecked(Index::Public(index)))
     }
 
@@ -67,17 +84,17 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for CircuitSynthesizer<E> {
         LB: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
         LC: FnOnce(LinearCombination<E::Fr>) -> LinearCombination<E::Fr>,
     {
-        let num_constraints = self.num_constraints();
+        let index = self.at.insert(Vec::new());
+        self.bt.insert(Vec::new());
+        self.ct.insert(Vec::new());
 
-        self.at.push(Vec::new());
-        self.bt.push(Vec::new());
-        self.ct.push(Vec::new());
+        push_constraints(a(LinearCombination::zero()), &mut self.at, index);
+        push_constraints(b(LinearCombination::zero()), &mut self.bt, index);
+        push_constraints(c(LinearCombination::zero()), &mut self.ct, index);
 
-        push_constraints(a(LinearCombination::zero()), &mut self.at, num_constraints);
-
-        push_constraints(b(LinearCombination::zero()), &mut self.bt, num_constraints);
-
-        push_constraints(c(LinearCombination::zero()), &mut self.ct, num_constraints);
+        if let Some(ref mut ns) = self.namespaces.last_mut() {
+            ns.constraint_indices.push(index);
+        }
     }
 
     fn push_namespace<NR, N>(&mut self, _: N)
@@ -85,11 +102,25 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for CircuitSynthesizer<E> {
         NR: AsRef<str>,
         N: FnOnce() -> NR,
     {
-        // Do nothing; we don't care about namespaces in this context.
+        self.namespaces.push(Namespace::default());
     }
 
     fn pop_namespace(&mut self) {
-        // Do nothing; we don't care about namespaces in this context.
+        if let Some(ns) = self.namespaces.pop() {
+            for idx in ns.constraint_indices {
+                self.at.remove(idx);
+                self.bt.remove(idx);
+                self.ct.remove(idx);
+            }
+
+            for idx in ns.private_var_indices {
+                self.private_variables.remove(idx);
+            }
+
+            for idx in ns.public_var_indices {
+                self.public_variables.remove(idx);
+            }
+        }
     }
 
     fn get_root(&mut self) -> &mut Self::Root {
@@ -109,7 +140,11 @@ impl<E: PairingEngine> ConstraintSystem<E::Fr> for CircuitSynthesizer<E> {
     }
 }
 
-fn push_constraints<F: Field>(l: LinearCombination<F>, constraints: &mut [Vec<(F, Index)>], this_constraint: usize) {
+fn push_constraints<F: Field>(
+    l: LinearCombination<F>,
+    constraints: &mut OptionalVec<Vec<(F, Index)>>,
+    this_constraint: usize,
+) {
     for (var, coeff) in l.as_ref() {
         match var.get_unchecked() {
             Index::Public(i) => constraints[this_constraint].push((*coeff, Index::Public(i))),


### PR DESCRIPTION
Profiling with `valgrind --tool=massif` reveals that `circuit_synthesizer::push_constraints` is responsible for rapid build-time memory use growth leading to out-of-memory issues even when objects are not retained. In order to fix this, the `CircuitSynthesizer` (specifically, its `ConstraintSystem` implementation) needs to keep track of when variables are being allocated and discard them when they go out of scope.

Below is a comparison of build-time memory use before:
![massif_before](https://user-images.githubusercontent.com/3750347/109668160-2c51a080-7b71-11eb-9121-66efaf0ac11d.png)

and after these changes:
![massif_after](https://user-images.githubusercontent.com/3750347/109668188-34114500-7b71-11eb-83c4-b63d23ba3a45.png)

The test case used for profiling purposes is the one from https://github.com/AleoHQ/leo/issues/711.

Fixes https://github.com/AleoHQ/leo/issues/711.