### PR TITLE
introduce a helper ConstraintSet object

### DIFF
--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -122,9 +122,7 @@ impl Command for Build {
             // Generate the program on the constraint system and verify correctness
             {
                 let mut cs = CircuitSynthesizer::<Bls12_377> {
-                    at: Default::default(),
-                    bt: Default::default(),
-                    ct: Default::default(),
+                    constraints: Default::default(),
                     public_variables: Default::default(),
                     private_variables: Default::default(),
                     namespaces: Default::default(),


### PR DESCRIPTION
Since the `at`, `bt` and `ct` constraints are all aligned, i.e. created and used simultaneously, it makes sense to keep them together within another object, so that they are always handled at the same time and there's no confusion about things like determining the number of constraints or the index of a new one (i.e. currently just `at` is checked, which is valid, but not obvious).