### PR TITLE
Align with snarkVM's Integer changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2571,9 +2571,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472ed062cdd1f54076312dd34e5fb56bd585c80c12209045f4b5bbbd368e9000"
+checksum = "bdf8ca73d429824090b96f751846e37e539f24c527f1f1ce0254984ade6d17b2"
 dependencies = [
  "blake2",
  "derivative",
@@ -2594,9 +2594,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfdfa3aa137f64a7f49df03393e5d0269f133ca8c8c79e569cb3bb13181aeb2"
+checksum = "64610b135b8b1152439d5dfa4f745515933366082f08651961344aa0bb5abfca"
 dependencies = [
  "derivative",
  "rand",
@@ -2610,9 +2610,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2ba967601ff2534adbc6a71a691be4285e61c83d23d54a59824f8fa80f6038"
+checksum = "46c9829b6e2023b4c7c4d6c55e88fe755dd997171a6c9c063b75c28161d04326"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2623,9 +2623,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4cb55898089843ba44b9f96448dcb2badcc1ce12daa8d7365d4e41513e37bc"
+checksum = "491ae936e24e17c358d112ff8638b260500b5a982ecefc804861e28b5279f552"
 dependencies = [
  "anyhow",
  "base58",
@@ -2649,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca9ea954196e76fe8968fb99eced7ccf08f901ab22747c4c489bda6674a7cb39"
+checksum = "8c49c69d02df11be58e07f626c9d6f5804c6dd4ccf42e425f2be8d79fe6e5bb7"
 dependencies = [
  "bincode",
  "derivative",
@@ -2664,9 +2664,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdda42a0a6484d9f008801a8a4d494a69a4db3f7b317057a8cc3c6e4b3ef6884"
+checksum = "bd6f9ac2a166d926e1755a06fdae21ce40ce6164c75c89120401b8d78f3b7ba4"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2681,9 +2681,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-objects"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e20d13db49cedc147df06c4a6f2dd727ea25640bdf50b876f40005331767a68f"
+checksum = "9bd9779ec6ab9211f34a6ba25566feb575a396f4c41cc0e002ec2d48d7560a2a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2702,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d35fa1819d803e45b4e99fe822e6981f177716f5384eef27245b5f6ed59a8305"
+checksum = "98378f612206fc7dd44a26f4e345bd1f3ba51bd325acad1e5cc3785d14750ec5"
 dependencies = [
  "curl",
  "hex",
@@ -2715,15 +2715,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7834d57af37a31f2f280f08b61d07a04a9a4b7720819b06ca325da32a5a925f5"
+checksum = "b2460ac01c25f79f5ea306e4de82a1d4105e811f868206b4fd31c0c9b62a3d7b"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0838118f276e7bb673cbf3741f4966c56861aaff399a46d343fc98c12851d9eb"
+checksum = "a3a0d54b15802976aff7522765dd29d5733f338612449629cc57c5a4a4d51f05"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -2736,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-storage"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42d92a817502878f315cc264704fa2a3d563755f16186316d8177ea685769af"
+checksum = "1d76881939f008d7bba4c8cc4118d29567b5c71908ad66bef9880f8aa7c52881"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2757,9 +2757,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5598f7f71c8aaf4fc267b5b420b2440a4d86c9243cecd57ff0af5c366217e5cc"
+checksum = "c763843fa67a3aa4ce68173c8cd96b4f04aaa135a5792bc051c36eec0fe1cd73"
 dependencies = [
  "bincode",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,23 +69,23 @@ path = "./synthesizer"
 version = "1.2.3"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 #default-features = false
 
 [dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.anyhow]
 version = "1.0"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -50,27 +50,27 @@ path = "../asg-passes"
 version = "1.2.3"
 
 [dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.bincode]
 version = "1.3"
@@ -111,7 +111,7 @@ version = "0.3"
 default-features = false
 
 [dev-dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dev-dependencies.tempfile]

--- a/compiler/src/errors/value/integer.rs
+++ b/compiler/src/errors/value/integer.rs
@@ -16,7 +16,7 @@
 
 use leo_ast::{FormattedError, LeoError, Span};
 
-use snarkvm_gadgets::errors::SignedIntegerError;
+use snarkvm_gadgets::errors::{SignedIntegerError, UnsignedIntegerError};
 use snarkvm_r1cs::SynthesisError;
 
 #[derive(Debug, Error)]
@@ -34,6 +34,15 @@ impl IntegerError {
 
     pub fn signed(error: SignedIntegerError, span: &Span) -> Self {
         let message = format!("integer operation failed due to the signed integer error `{:?}`", error);
+
+        Self::new_from_span(message, span)
+    }
+
+    pub fn unsigned(error: UnsignedIntegerError, span: &Span) -> Self {
+        let message = format!(
+            "integer operation failed due to the unsigned integer error `{:?}`",
+            error
+        );
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -23,6 +23,7 @@ use crate::{
     GroupType,
     IndicatorAndConstrainedValue,
     Integer,
+    IntegerTrait,
     StatementResult,
 };
 use leo_asg::IterationStatement;

--- a/compiler/src/value/address/address.rs
+++ b/compiler/src/value/address/address.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{errors::AddressError, ConstrainedValue, GroupType};
+use crate::{errors::AddressError, ConstrainedValue, GroupType, IntegerTrait};
 use leo_ast::{InputValue, Span};
 
 use snarkvm_dpc::{account::AccountAddress, base_dpc::instantiated::Components};
@@ -24,7 +24,7 @@ use snarkvm_gadgets::traits::utilities::{
     boolean::Boolean,
     eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
     select::CondSelectGadget,
-    uint::{UInt, UInt8},
+    uint::UInt8,
 };
 use snarkvm_r1cs::{Assignment, ConstraintSystem, SynthesisError};
 use snarkvm_utilities::ToBytes;

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -31,7 +31,7 @@ use snarkvm_gadgets::traits::utilities::{
     uint::{Sub as UIntSub, *},
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
-use std::fmt;
+use std::{convert::TryInto, fmt};
 
 /// An integer type enum wrapping the integer value.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd)]
@@ -113,7 +113,7 @@ impl Integer {
 
     pub fn to_usize(&self) -> Option<usize> {
         let unsigned_integer = self;
-        match_unsigned_integer!(unsigned_integer => unsigned_integer.get_index())
+        match_unsigned_integer!(unsigned_integer => unsigned_integer.value.map(|num| num.try_into().ok()).flatten())
     }
 
     pub fn get_type(&self) -> IntegerType {

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -28,7 +28,7 @@ use snarkvm_gadgets::traits::utilities::{
     eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
     int::{Int128, Int16, Int32, Int64, Int8},
     select::CondSelectGadget,
-    uint::*,
+    uint::{Sub as UIntSub, *},
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use std::fmt;
@@ -83,7 +83,7 @@ impl Integer {
 
     pub fn get_bits(&self) -> Vec<Boolean> {
         let integer = self;
-        match_integer!(integer => integer.get_bits())
+        match_integer!(integer => integer.to_bits_le())
     }
 
     // pub fn get_bits_typed(&self) -> (Vec<Boolean>, IntegerType) {

--- a/compiler/src/value/integer/macros.rs
+++ b/compiler/src/value/integer/macros.rs
@@ -14,41 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use snarkvm_gadgets::traits::utilities::{
-    boolean::Boolean,
-    int::{Int128, Int16, Int32, Int64, Int8},
-    uint::{UInt128, UInt16, UInt32, UInt64, UInt8},
-};
-use std::{convert::TryInto, fmt::Debug};
-
-pub trait IntegerTrait: Sized + Clone + Debug {
-    fn get_value(&self) -> Option<String>;
-
-    fn get_index(&self) -> Option<usize>;
-
-    fn get_bits(&self) -> Vec<Boolean>;
-}
-
-macro_rules! integer_trait_impl {
-    ($($gadget: ident)*) => ($(
-        impl IntegerTrait for $gadget {
-            fn get_value(&self) -> Option<String> {
-                self.value.map(|num| num.to_string())
-            }
-
-            fn get_index(&self) -> Option<usize> {
-                self.value.map(|num| num.try_into().ok()).flatten()
-            }
-
-            fn get_bits(&self) -> Vec<Boolean> {
-                self.bits.clone()
-            }
-        }
-
-    )*)
-}
-
-integer_trait_impl!(UInt8 UInt16 UInt32 UInt64 UInt128 Int8 Int16 Int32 Int64 Int128);
+pub use snarkvm_gadgets::traits::utilities::integer::Integer as IntegerTrait;
 
 /// Useful macros to avoid duplicating `match` constructions.
 #[macro_export]
@@ -125,19 +91,19 @@ macro_rules! match_integers_span {
     (($a: ident, $b: ident), $span: ident => $expression:expr) => {
         match ($a, $b) {
             (Integer::U8($a), Integer::U8($b)) => {
-                Some(Integer::U8($expression.map_err(|e| IntegerError::synthesis(e, $span))?))
+                Some(Integer::U8($expression.map_err(|e| IntegerError::unsigned(e, $span))?))
             }
-            (Integer::U16($a), Integer::U16($b)) => Some(Integer::U16(
-                $expression.map_err(|e| IntegerError::synthesis(e, $span))?,
-            )),
-            (Integer::U32($a), Integer::U32($b)) => Some(Integer::U32(
-                $expression.map_err(|e| IntegerError::synthesis(e, $span))?,
-            )),
-            (Integer::U64($a), Integer::U64($b)) => Some(Integer::U64(
-                $expression.map_err(|e| IntegerError::synthesis(e, $span))?,
-            )),
+            (Integer::U16($a), Integer::U16($b)) => {
+                Some(Integer::U16($expression.map_err(|e| IntegerError::unsigned(e, $span))?))
+            }
+            (Integer::U32($a), Integer::U32($b)) => {
+                Some(Integer::U32($expression.map_err(|e| IntegerError::unsigned(e, $span))?))
+            }
+            (Integer::U64($a), Integer::U64($b)) => {
+                Some(Integer::U64($expression.map_err(|e| IntegerError::unsigned(e, $span))?))
+            }
             (Integer::U128($a), Integer::U128($b)) => Some(Integer::U128(
-                $expression.map_err(|e| IntegerError::synthesis(e, $span))?,
+                $expression.map_err(|e| IntegerError::unsigned(e, $span))?,
             )),
 
             (Integer::I8($a), Integer::I8($b)) => {

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -26,19 +26,19 @@ path = "../ast"
 version = "1.2.3"
 
 [dependencies.snarkvm-algorithms]
-version = "0.2.1"
+version = "0.2.2"
 #default-features = false
 
 [dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.2.1"
+version = "0.2.2"
 
 [dependencies.indexmap]
 version = "1.6.2"
@@ -54,7 +54,7 @@ version = "0.3"
 version = "1.0"
 
 [dev-dependencies.snarkvm-storage]
-version = "0.2.1"
+version = "0.2.2"
 
 [dev-dependencies.rand_core]
 version = "0.6.2"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -18,19 +18,19 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-curves]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.2.1"
+version = "0.2.2"
 default-features = false
 
 [dependencies.num-bigint]


### PR DESCRIPTION
This PR fixes Leo's build with current snarkVM `master` branch. Once https://github.com/AleoHQ/snarkVM/pull/121 is merged and a new snarkVM is released, it only requires its crates' versions to be bumped in addition to these changes.