### PR TITLE
Runtime array indexing

### DIFF
--- a/asg/src/error/mod.rs
+++ b/asg/src/error/mod.rs
@@ -180,6 +180,14 @@ impl AsgConvertError {
         Self::new_from_span(format!("tuple index out of bounds: '{}'", index), span)
     }
 
+    pub fn array_index_out_of_bounds(index: usize, span: &Span) -> Self {
+        Self::new_from_span(format!("array index out of bounds: '{}'", index), span)
+    }
+
+    pub fn unknown_array_size(span: &Span) -> Self {
+        Self::new_from_span("array size cannot be inferred, add explicit types".to_string(), span)
+    }
+
     pub fn unexpected_call_argument_count(expected: usize, got: usize, span: &Span) -> Self {
         Self::new_from_span(
             format!("function call expected {} arguments, got {}", expected, got),

--- a/asg/src/expression/array_access.rs
+++ b/asg/src/expression/array_access.rs
@@ -89,8 +89,8 @@ impl<'a> FromAst<'a, leo_ast::ArrayAccessExpression> for ArrayAccessExpression<'
             &*value.array,
             Some(PartialType::Array(expected_type.map(Box::new), None)),
         )?;
-        match array.get_type() {
-            Some(Type::Array(..)) => (),
+        let array_len = match array.get_type() {
+            Some(Type::Array(_, len)) => len,
             type_ => {
                 return Err(AsgConvertError::unexpected_type(
                     "array",
@@ -98,7 +98,7 @@ impl<'a> FromAst<'a, leo_ast::ArrayAccessExpression> for ArrayAccessExpression<'
                     &value.span,
                 ));
             }
-        }
+        };
 
         let index = <&Expression<'a>>::from_ast(
             scope,
@@ -106,10 +106,17 @@ impl<'a> FromAst<'a, leo_ast::ArrayAccessExpression> for ArrayAccessExpression<'
             Some(PartialType::Integer(None, Some(IntegerType::U32))),
         )?;
 
-        if !index.is_consty() {
-            return Err(AsgConvertError::unexpected_nonconst(
-                &index.span().cloned().unwrap_or_default(),
-            ));
+        if let Some(index) = index
+            .const_value()
+            .map(|x| x.int().map(|x| x.to_usize()).flatten())
+            .flatten()
+        {
+            if index > array_len {
+                return Err(AsgConvertError::array_index_out_of_bounds(
+                    index,
+                    &array.span().cloned().unwrap_or_default(),
+                ));
+            }
         }
 
         Ok(ArrayAccessExpression {

--- a/asg/src/expression/array_access.rs
+++ b/asg/src/expression/array_access.rs
@@ -111,7 +111,7 @@ impl<'a> FromAst<'a, leo_ast::ArrayAccessExpression> for ArrayAccessExpression<'
             .map(|x| x.int().map(|x| x.to_usize()).flatten())
             .flatten()
         {
-            if index > array_len {
+            if index >= array_len {
                 return Err(AsgConvertError::array_index_out_of_bounds(
                     index,
                     &array.span().cloned().unwrap_or_default(),

--- a/asg/src/expression/array_range_access.rs
+++ b/asg/src/expression/array_range_access.rs
@@ -26,6 +26,9 @@ pub struct ArrayRangeAccessExpression<'a> {
     pub array: Cell<&'a Expression<'a>>,
     pub left: Cell<Option<&'a Expression<'a>>>,
     pub right: Cell<Option<&'a Expression<'a>>>,
+    // this is either const(right) - const(left) OR the length inferred by type checking
+    // special attention must be made to update this if semantic-altering changes are made to left or right.
+    pub length: usize,
 }
 
 impl<'a> Node for ArrayRangeAccessExpression<'a> {
@@ -55,25 +58,12 @@ impl<'a> ExpressionNode<'a> for ArrayRangeAccessExpression<'a> {
     }
 
     fn get_type(&self) -> Option<Type<'a>> {
-        let (element, array_len) = match self.array.get().get_type() {
-            Some(Type::Array(element, len)) => (element, len),
+        let element = match self.array.get().get_type() {
+            Some(Type::Array(element, _)) => element,
             _ => return None,
         };
-        let const_left = match self.left.get().map(|x| x.const_value()) {
-            Some(Some(ConstValue::Int(x))) => x.to_usize()?,
-            None => 0,
-            _ => return None,
-        };
-        let const_right = match self.right.get().map(|x| x.const_value()) {
-            Some(Some(ConstValue::Int(x))) => x.to_usize()?,
-            None => array_len,
-            _ => return None,
-        };
-        if const_left > const_right || const_right > array_len {
-            return None;
-        }
 
-        Some(Type::Array(element, const_right - const_left))
+        Some(Type::Array(element, self.length))
     }
 
     fn is_mut_ref(&self) -> bool {
@@ -113,9 +103,9 @@ impl<'a> FromAst<'a, leo_ast::ArrayRangeAccessExpression> for ArrayRangeAccessEx
         value: &leo_ast::ArrayRangeAccessExpression,
         expected_type: Option<PartialType<'a>>,
     ) -> Result<ArrayRangeAccessExpression<'a>, AsgConvertError> {
-        let expected_array = match expected_type {
-            Some(PartialType::Array(element, _len)) => Some(PartialType::Array(element, None)),
-            None => None,
+        let (expected_array, expected_len) = match expected_type.clone() {
+            Some(PartialType::Array(element, len)) => (Some(PartialType::Array(element, None)), len),
+            None => (None, None),
             Some(x) => {
                 return Err(AsgConvertError::unexpected_type(
                     &x.to_string(),
@@ -126,8 +116,8 @@ impl<'a> FromAst<'a, leo_ast::ArrayRangeAccessExpression> for ArrayRangeAccessEx
         };
         let array = <&Expression<'a>>::from_ast(scope, &*value.array, expected_array)?;
         let array_type = array.get_type();
-        match array_type {
-            Some(Type::Array(_, _)) => (),
+        let (parent_element, parent_size) = match array_type {
+            Some(Type::Array(inner, size)) => (inner, size),
             type_ => {
                 return Err(AsgConvertError::unexpected_type(
                     "array",
@@ -135,7 +125,8 @@ impl<'a> FromAst<'a, leo_ast::ArrayRangeAccessExpression> for ArrayRangeAccessEx
                     &value.span,
                 ));
             }
-        }
+        };
+
         let left = value
             .left
             .as_deref()
@@ -151,26 +142,72 @@ impl<'a> FromAst<'a, leo_ast::ArrayRangeAccessExpression> for ArrayRangeAccessEx
             })
             .transpose()?;
 
-        if let Some(left) = left.as_ref() {
-            if !left.is_consty() {
-                return Err(AsgConvertError::unexpected_nonconst(
-                    &left.span().cloned().unwrap_or_default(),
-                ));
+        let const_left = match left.map(|x| x.const_value()) {
+            Some(Some(ConstValue::Int(x))) => x.to_usize(),
+            None => Some(0),
+            _ => None,
+        };
+        let const_right = match right.map(|x| x.const_value()) {
+            Some(Some(ConstValue::Int(value))) => {
+                let value = value.to_usize();
+                if let Some(value) = value {
+                    if value > parent_size {
+                        return Err(AsgConvertError::array_index_out_of_bounds(
+                            value,
+                            &right.unwrap().span().cloned().unwrap_or_default(),
+                        ));
+                    } else if let Some(left) = const_left {
+                        if left > value {
+                            return Err(AsgConvertError::array_index_out_of_bounds(
+                                value,
+                                &right.unwrap().span().cloned().unwrap_or_default(),
+                            ));
+                        }
+                    }
+                }
+                value
             }
-        }
-        if let Some(right) = right.as_ref() {
-            if !right.is_consty() {
-                return Err(AsgConvertError::unexpected_nonconst(
-                    &right.span().cloned().unwrap_or_default(),
-                ));
+            None => Some(parent_size),
+            _ => None,
+        };
+
+        let mut length = if let (Some(left), Some(right)) = (const_left, const_right) {
+            Some(right - left)
+        } else {
+            None
+        };
+        if let Some(expected_len) = expected_len {
+            if let Some(length) = length {
+                if length != expected_len {
+                    let concrete_type = Type::Array(parent_element, length);
+                    return Err(AsgConvertError::unexpected_type(
+                        &expected_type.as_ref().unwrap().to_string(),
+                        Some(&concrete_type.to_string()),
+                        &value.span,
+                    ));
+                }
             }
+            if let Some(value) = const_left {
+                if value + expected_len > parent_size {
+                    return Err(AsgConvertError::array_index_out_of_bounds(
+                        value,
+                        &left.unwrap().span().cloned().unwrap_or_default(),
+                    ));
+                }
+            }
+            length = Some(expected_len);
         }
+        if length.is_none() {
+            return Err(AsgConvertError::unknown_array_size(&value.span));
+        }
+
         Ok(ArrayRangeAccessExpression {
             parent: Cell::new(None),
             span: Some(value.span.clone()),
             array: Cell::new(array),
             left: Cell::new(left),
             right: Cell::new(right),
+            length: length.unwrap(),
         })
     }
 }

--- a/asg/src/reducer/reconstructing_reducer.rs
+++ b/asg/src/reducer/reconstructing_reducer.rs
@@ -74,6 +74,7 @@ pub trait ReconstructingReducerExpression<'a> {
             left: Cell::new(left),
             right: Cell::new(right),
             span: input.span,
+            length: input.length,
         })
     }
 

--- a/compiler/src/errors/expression.rs
+++ b/compiler/src/errors/expression.rs
@@ -85,8 +85,20 @@ impl ExpressionError {
         Self::new_from_span(message, span)
     }
 
-    pub fn index_out_of_bounds(index: usize, span: &Span) -> Self {
+    pub fn tuple_index_out_of_bounds(index: usize, span: &Span) -> Self {
         let message = format!("cannot access index {} of tuple out of bounds", index);
+
+        Self::new_from_span(message, span)
+    }
+
+    pub fn array_index_out_of_bounds(index: usize, span: &Span) -> Self {
+        let message = format!("cannot access index {} of array out of bounds", index);
+
+        Self::new_from_span(message, span)
+    }
+
+    pub fn array_invalid_slice_length(span: &Span) -> Self {
+        let message = "illegal length of slice".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/errors/expression.rs
+++ b/compiler/src/errors/expression.rs
@@ -67,6 +67,18 @@ impl ExpressionError {
         Self::new_from_span(message, span)
     }
 
+    pub fn array_length_out_of_bounds(span: &Span) -> Self {
+        let message = "array length cannot be >= 2^32".to_string();
+
+        Self::new_from_span(message, span)
+    }
+
+    pub fn array_index_out_of_legal_bounds(span: &Span) -> Self {
+        let message = "array index cannot be >= 2^32".to_string();
+
+        Self::new_from_span(message, span)
+    }
+
     pub fn conditional_boolean(actual: String, span: &Span) -> Self {
         let message = format!("if, else conditional must resolve to a boolean, found `{}`", actual);
 

--- a/compiler/src/errors/statement.rs
+++ b/compiler/src/errors/statement.rs
@@ -61,6 +61,12 @@ impl StatementError {
         Self::new_from_span(message, span)
     }
 
+    pub fn array_assign_index_const(span: &Span) -> Self {
+        let message = "Cannot assign to non-const array index".to_string();
+
+        Self::new_from_span(message, span)
+    }
+
     pub fn array_assign_interior_index(span: &Span) -> Self {
         let message = "Cannot assign single index to interior of array of values".to_string();
 
@@ -214,6 +220,12 @@ impl StatementError {
 
     pub fn undefined_circuit_variable(name: String, span: &Span) -> Self {
         let message = format!("Attempted to assign to unknown circuit member variable `{}`", name);
+
+        Self::new_from_span(message, span)
+    }
+
+    pub fn loop_index_const(span: &Span) -> Self {
+        let message = "iteration range must be const".to_string();
 
         Self::new_from_span(message, span)
     }

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -16,10 +16,22 @@
 
 //! Enforces array access in a compiled Leo program.
 
-use crate::{errors::ExpressionError, program::ConstrainedProgram, value::ConstrainedValue, GroupType};
-use leo_asg::{Expression, Span};
+use crate::{
+    arithmetic::*,
+    errors::ExpressionError,
+    program::ConstrainedProgram,
+    relational::*,
+    value::{ConstrainedValue, Integer},
+    GroupType,
+};
+use leo_asg::{ConstInt, Expression, Span};
 
 use snarkvm_fields::PrimeField;
+use snarkvm_gadgets::utilities::{
+    boolean::Boolean,
+    eq::{EqGadget, EvaluateEqGadget},
+    select::CondSelectGadget,
+};
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
@@ -31,13 +43,58 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         index: &'a Expression<'a>,
         span: &Span,
     ) -> Result<ConstrainedValue<'a, F, G>, ExpressionError> {
-        let array = match self.enforce_expression(cs, array)? {
+        let mut array = match self.enforce_expression(cs, array)? {
             ConstrainedValue::Array(array) => array,
             value => return Err(ExpressionError::undefined_array(value.to_string(), span)),
         };
 
         let index_resolved = self.enforce_index(cs, index, span)?;
-        Ok(array[index_resolved].to_owned())
+        if let Some(resolved) = index_resolved.to_usize() {
+            if resolved >= array.len() {
+                return Err(ExpressionError::array_index_out_of_bounds(resolved, span));
+            }
+            Ok(array[resolved].to_owned())
+        } else {
+            if array.is_empty() {
+                return Err(ExpressionError::array_index_out_of_bounds(0, span));
+            }
+            {
+                let bounds_check = evaluate_lt::<F, G, CS>(
+                    cs,
+                    ConstrainedValue::Integer(index_resolved.clone()),
+                    ConstrainedValue::Integer(Integer::new(&ConstInt::U32(array.len() as u32))),
+                    span,
+                )?;
+                let bounds_check = match bounds_check {
+                    ConstrainedValue::Boolean(b) => b,
+                    _ => unimplemented!("illegal non-Integer returned from lt"),
+                };
+                let namespace_string = format!("evaluate array access bounds {}:{}", span.line_start, span.col_start);
+                let mut unique_namespace = cs.ns(|| namespace_string);
+                bounds_check
+                    .enforce_equal(&mut unique_namespace, &Boolean::Constant(true))
+                    .map_err(|e| ExpressionError::cannot_enforce("array bounds check".to_string(), e, span))?;
+            }
+            let mut current_value = array.pop().unwrap();
+            for (i, item) in array.into_iter().enumerate() {
+                let namespace_string = format!("evaluate array access eq {} {}:{}", i, span.line_start, span.col_start);
+                let eq_namespace = cs.ns(|| namespace_string);
+                //todo: bounds check static index
+                let const_index = ConstInt::U32(i as u32).cast_to(&index_resolved.get_type());
+                let index_comparison = index_resolved
+                    .evaluate_equal(eq_namespace, &Integer::new(&const_index))
+                    .map_err(|_| ExpressionError::cannot_evaluate("==".to_string(), span))?;
+
+                //todo: handle out of bounds
+                let unique_namespace =
+                    cs.ns(|| format!("select array access {} {}:{}", i, span.line_start, span.col_start));
+                let value =
+                    ConstrainedValue::conditionally_select(unique_namespace, &index_comparison, &item, &current_value)
+                        .map_err(|e| ExpressionError::cannot_enforce("conditional select".to_string(), e, span))?;
+                current_value = value;
+            }
+            Ok(current_value)
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -47,6 +104,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         array: &'a Expression<'a>,
         left: Option<&'a Expression<'a>>,
         right: Option<&'a Expression<'a>>,
+        length: usize,
         span: &Span,
     ) -> Result<ConstrainedValue<'a, F, G>, ExpressionError> {
         let array = match self.enforce_expression(cs, array)? {
@@ -56,12 +114,98 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
 
         let from_resolved = match left {
             Some(from_index) => self.enforce_index(cs, from_index, span)?,
-            None => 0usize, // Array slice starts at index 0
+            None => Integer::new(&ConstInt::U32(0)), // Array slice starts at index 0
         };
         let to_resolved = match right {
             Some(to_index) => self.enforce_index(cs, to_index, span)?,
-            None => array.len(), // Array slice ends at array length
+            // todo: handle out of bounds for array len
+            None => Integer::new(&ConstInt::U32(array.len() as u32)), // Array slice ends at array length
         };
-        Ok(ConstrainedValue::Array(array[from_resolved..to_resolved].to_owned()))
+        let const_dimensions = match (from_resolved.to_usize(), to_resolved.to_usize()) {
+            (Some(from), Some(to)) => Some((from, to)),
+            (Some(from), None) => Some((from, from + length)),
+            (None, Some(to)) => Some((to - length, to)),
+            (None, None) => None,
+        };
+        Ok(if let Some((left, right)) = const_dimensions {
+            if right - left != length {
+                return Err(ExpressionError::array_invalid_slice_length(span));
+            }
+            if right > array.len() {
+                return Err(ExpressionError::array_index_out_of_bounds(right, span));
+            }
+            ConstrainedValue::Array(array[left..right].to_owned())
+        } else {
+            {
+                let calc_len = enforce_sub::<F, G, _>(
+                    cs,
+                    ConstrainedValue::Integer(to_resolved.clone()),
+                    ConstrainedValue::Integer(from_resolved.clone()),
+                    span,
+                )?;
+                let calc_len = match calc_len {
+                    ConstrainedValue::Integer(i) => i,
+                    _ => unimplemented!("illegal non-Integer returned from sub"),
+                };
+                let namespace_string = format!(
+                    "evaluate array range access length check {}:{}",
+                    span.line_start, span.col_start
+                );
+                let mut unique_namespace = cs.ns(|| namespace_string);
+                calc_len
+                    .enforce_equal(&mut unique_namespace, &Integer::new(&ConstInt::U32(length as u32)))
+                    .map_err(|e| ExpressionError::cannot_enforce("array length check".to_string(), e, span))?;
+            }
+            {
+                let bounds_check = evaluate_le::<F, G, _>(
+                    cs,
+                    ConstrainedValue::Integer(to_resolved),
+                    ConstrainedValue::Integer(Integer::new(&ConstInt::U32(array.len() as u32))),
+                    span,
+                )?;
+                let bounds_check = match bounds_check {
+                    ConstrainedValue::Boolean(b) => b,
+                    _ => unimplemented!("illegal non-Integer returned from le"),
+                };
+                let namespace_string = format!(
+                    "evaluate array range access bounds {}:{}",
+                    span.line_start, span.col_start
+                );
+                let mut unique_namespace = cs.ns(|| namespace_string);
+                bounds_check
+                    .enforce_equal(&mut unique_namespace, &Boolean::Constant(true))
+                    .map_err(|e| ExpressionError::cannot_enforce("array bounds check".to_string(), e, span))?;
+            }
+            let mut windows = array.windows(length);
+            let mut result = ConstrainedValue::Array(vec![]);
+
+            for i in 0..length {
+                let window = if let Some(window) = windows.next() {
+                    window
+                } else {
+                    break;
+                };
+                let array_value = ConstrainedValue::Array(window.to_vec());
+                let mut unique_namespace =
+                    cs.ns(|| format!("array index eq-check {} {}:{}", i, span.line_start, span.col_start));
+
+                let equality = evaluate_eq::<F, G, _>(
+                    &mut unique_namespace,
+                    ConstrainedValue::Integer(from_resolved.clone()),
+                    ConstrainedValue::Integer(Integer::new(&ConstInt::U32(i as u32))),
+                    span,
+                )?;
+                let equality = match equality {
+                    ConstrainedValue::Boolean(b) => b,
+                    _ => unimplemented!("unexpected non-Boolean for evaluate_eq"),
+                };
+
+                let unique_namespace =
+                    unique_namespace.ns(|| format!("array index {} {}:{}", i, span.line_start, span.col_start));
+                result = ConstrainedValue::conditionally_select(unique_namespace, &equality, &array_value, &result)
+                    .map_err(|e| ExpressionError::cannot_enforce("conditional select".to_string(), e, span))?;
+            }
+            result
+        })
     }
 }

--- a/compiler/src/expression/array/index.rs
+++ b/compiler/src/expression/array/index.rs
@@ -16,7 +16,7 @@
 
 //! Enforces an array index expression in a compiled Leo program.
 
-use crate::{errors::ExpressionError, program::ConstrainedProgram, value::ConstrainedValue, GroupType};
+use crate::{errors::ExpressionError, program::ConstrainedProgram, value::ConstrainedValue, GroupType, Integer};
 use leo_asg::{Expression, Span};
 
 use snarkvm_fields::PrimeField;
@@ -28,9 +28,9 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         cs: &mut CS,
         index: &'a Expression<'a>,
         span: &Span,
-    ) -> Result<usize, ExpressionError> {
+    ) -> Result<Integer, ExpressionError> {
         match self.enforce_expression(cs, index)? {
-            ConstrainedValue::Integer(number) => Ok(number.to_usize(span)?),
+            ConstrainedValue::Integer(number) => Ok(number),
             value => Err(ExpressionError::invalid_index(value.to_string(), span)),
         }
     }

--- a/compiler/src/expression/binary/binary.rs
+++ b/compiler/src/expression/binary/binary.rs
@@ -32,8 +32,15 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         left: &'a Expression<'a>,
         right: &'a Expression<'a>,
     ) -> Result<ConstrainedValuePair<'a, F, G>, ExpressionError> {
-        let resolved_left = self.enforce_expression(cs, left)?;
-        let resolved_right = self.enforce_expression(cs, right)?;
+        let resolved_left = {
+            let mut left_namespace = cs.ns(|| "left".to_string());
+            self.enforce_expression(&mut left_namespace, left)?
+        };
+
+        let resolved_right = {
+            let mut right_namespace = cs.ns(|| "right".to_string());
+            self.enforce_expression(&mut right_namespace, right)?
+        };
 
         Ok((resolved_left, resolved_right))
     }

--- a/compiler/src/expression/expression.rs
+++ b/compiler/src/expression/expression.rs
@@ -133,9 +133,13 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
             Expression::ArrayAccess(ArrayAccessExpression { array, index, .. }) => {
                 self.enforce_array_access(cs, array.get(), index.get(), span)
             }
-            Expression::ArrayRangeAccess(ArrayRangeAccessExpression { array, left, right, .. }) => {
-                self.enforce_array_range_access(cs, array.get(), left.get(), right.get(), span)
-            }
+            Expression::ArrayRangeAccess(ArrayRangeAccessExpression {
+                array,
+                left,
+                right,
+                length,
+                ..
+            }) => self.enforce_array_range_access(cs, array.get(), left.get(), right.get(), *length, span),
 
             // Tuples
             Expression::TupleInit(TupleInitExpression { elements, .. }) => self.enforce_tuple(cs, &elements[..]),

--- a/compiler/src/expression/tuple/access.rs
+++ b/compiler/src/expression/tuple/access.rs
@@ -40,7 +40,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         // Check for out of bounds access.
         if index > tuple.len() - 1 {
             // probably safe to be a panic here
-            return Err(ExpressionError::index_out_of_bounds(index, span));
+            return Err(ExpressionError::tuple_index_out_of_bounds(index, span));
         }
 
         Ok(tuple[index].to_owned())

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -17,6 +17,7 @@
 //! Enforces an iteration statement in a compiled Leo program.
 
 use crate::{
+    errors::StatementError,
     program::ConstrainedProgram,
     value::ConstrainedValue,
     GroupType,
@@ -42,8 +43,14 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
 
         let span = statement.span.clone().unwrap_or_default();
 
-        let from = self.enforce_index(cs, statement.start.get(), &span)?;
-        let to = self.enforce_index(cs, statement.stop.get(), &span)?;
+        let from = self
+            .enforce_index(cs, statement.start.get(), &span)?
+            .to_usize()
+            .ok_or_else(|| StatementError::loop_index_const(&span))?;
+        let to = self
+            .enforce_index(cs, statement.stop.get(), &span)?
+            .to_usize()
+            .ok_or_else(|| StatementError::loop_index_const(&span))?;
 
         for i in from..to {
             // Store index in current function scope.

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -17,7 +17,7 @@
 //! Enforces a statement in a compiled Leo program.
 
 use crate::{errors::StatementError, program::ConstrainedProgram, value::ConstrainedValue, GroupType};
-use leo_asg::Statement;
+use leo_asg::{Node, Statement};
 
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::traits::utilities::boolean::Boolean;
@@ -42,6 +42,9 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         statement: &'a Statement<'a>,
     ) -> StatementResult<Vec<IndicatorAndConstrainedValue<'a, F, G>>> {
         let mut results = vec![];
+        let span = statement.span().cloned().unwrap_or_default();
+        let mut cs = cs.ns(|| format!("statement {}:{}", span.line_start, span.col_start));
+        let cs = &mut cs;
 
         match statement {
             Statement::Return(statement) => {

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -111,15 +111,9 @@ impl Integer {
         match_integer!(integer => integer.get_value())
     }
 
-    pub fn to_usize(&self, span: &Span) -> Result<usize, IntegerError> {
+    pub fn to_usize(&self) -> Option<usize> {
         let unsigned_integer = self;
-        let value_option: Option<String> = match_unsigned_integer!(unsigned_integer => unsigned_integer.get_value());
-
-        let value = value_option.ok_or_else(|| IntegerError::invalid_index(span))?;
-        let value_usize = value
-            .parse::<usize>()
-            .map_err(|_| IntegerError::invalid_integer(value, span))?;
-        Ok(value_usize)
+        match_unsigned_integer!(unsigned_integer => unsigned_integer.get_index())
     }
 
     pub fn get_type(&self) -> IntegerType {

--- a/compiler/tests/array/mod.rs
+++ b/compiler/tests/array/mod.rs
@@ -539,3 +539,153 @@ fn test_variable_slice_fail() {
 
     expect_asg_error(error);
 }
+
+#[test]
+fn test_array_index() {
+    let program_string = r#"
+    function main(i: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert(2 == b[i]);
+        console.assert(3 == b[2]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 1;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
+fn test_array_index_bounds_fail() {
+    let program_string = r#"
+    function main(i: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert(2 == b[i]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 4;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_array_range_index() {
+    let program_string = r#"
+    function main(i: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([1u8, 2] == b[0..i]);
+        console.assert([3u8, 4] == b[i..4]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 2;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
+fn test_array_range_index_dyn() {
+    let program_string = r#"
+    function main(i: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([1u8, 2] == b[..i]);
+        console.assert([3u8, 4] == b[i..]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 2;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
+fn test_array_range_index_full_dyn() {
+    let program_string = r#"
+    function main(i: u32, y: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([3u8, 4] == b[i..y]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 2;
+    y: u32 = 4;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    assert_satisfied(program);
+}
+
+#[test]
+fn test_array_range_index_fail_bounds() {
+    let program_string = r#"
+    function main(i: u32, y: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([1, 2] == b[3..5]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 2;
+    "#;
+    let err = parse_program_with_input(program_string, input_string).is_err();
+
+    assert!(err);
+}
+
+#[test]
+fn test_array_range_index_full_dyn_resized_fail() {
+    let program_string = r#"
+    function main(i: u32, y: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([3u8, 4] == b[i..y]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 1;
+    y: u32 = 4;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    expect_compiler_error(program);
+}
+
+#[test]
+fn test_array_range_index_full_dyn_bounds_fail() {
+    let program_string = r#"
+    function main(i: u32, y: u32) {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([3u8, 4] == b[i..y]);
+    }
+    "#;
+    let input_string = r#"
+    [main]
+    i: u32 = 3;
+    y: u32 = 5;
+    "#;
+    let program = parse_program_with_input(program_string, input_string).unwrap();
+
+    expect_compiler_error(program);
+}

--- a/compiler/tests/array/mod.rs
+++ b/compiler/tests/array/mod.rs
@@ -578,6 +578,21 @@ fn test_array_index_bounds_fail() {
 }
 
 #[test]
+fn test_const_array_index_bounds_fail() {
+    let program_string = r#"
+    function main() {
+        let b = [1u8, 2, 3, 4];
+        const i: u32 = 4;
+    
+        console.assert(2 == b[i]);
+    }
+    "#;
+    let error = parse_program(program_string).err().unwrap();
+
+    expect_asg_error(error);
+}
+
+#[test]
 fn test_array_range_index() {
     let program_string = r#"
     function main(i: u32) {
@@ -635,21 +650,31 @@ fn test_array_range_index_full_dyn() {
 }
 
 #[test]
-fn test_array_range_index_fail_bounds() {
+fn test_array_range_index_out_of_bounds_fail() {
     let program_string = r#"
-    function main(i: u32, y: u32) {
+    function main() {
         let b = [1u8, 2, 3, 4];
     
         console.assert([1, 2] == b[3..5]);
     }
     "#;
-    let input_string = r#"
-    [main]
-    i: u32 = 2;
-    "#;
-    let err = parse_program_with_input(program_string, input_string).is_err();
+    let error = parse_program(program_string).err().unwrap();
 
-    assert!(err);
+    expect_asg_error(error);
+}
+
+#[test]
+fn test_array_range_index_invalid_bounds_fail() {
+    let program_string = r#"
+    function main() {
+        let b = [1u8, 2, 3, 4];
+    
+        console.assert([1, 2] == b[2..1]);
+    }
+    "#;
+    let error = parse_program(program_string).err().unwrap();
+
+    expect_asg_error(error);
 }
 
 #[test]

--- a/compiler/tests/function/array_params_direct_call.leo
+++ b/compiler/tests/function/array_params_direct_call.leo
@@ -5,5 +5,5 @@ function main() {
 
     do_nothing(arr);
     do_nothing([...arr]);
-    do_nothing(arr[1u32..]);
+    do_nothing(arr[0u32..]);
 }

--- a/examples/silly-sudoku/.gitignore
+++ b/examples/silly-sudoku/.gitignore
@@ -1,0 +1,2 @@
+outputs/
+/.leo

--- a/examples/silly-sudoku/Leo.toml
+++ b/examples/silly-sudoku/Leo.toml
@@ -1,0 +1,8 @@
+[project]
+name = "silly-sudoku"
+version = "0.1.3"
+description = "A simple Sudoku puzzle grid"
+license = "MIT"
+
+[remote]
+author = "howard"

--- a/examples/silly-sudoku/README.md
+++ b/examples/silly-sudoku/README.md
@@ -1,0 +1,23 @@
+# silly-sudoku
+
+A simple Sudoku puzzle grid in Leo.
+
+## Walkthrough
+
+Start by defining a puzzle grid:
+```
+[[0, 4, 6],
+ [3, 0, 9],
+ [7, 5, 0]]
+```
+We treat all 0's as empty cells in the grid.
+
+Next, generate an answer and construct it as a puzzle grid solution:
+```
+[[8, 4, 6],
+ [3, 1, 9],
+ [7, 5, 2]]
+```
+
+The SillySudoku circuit will proceed to verify that the solution grid matches the starting puzzle grid,
+and check that each number between 1 - 9 is used exactly once.

--- a/examples/silly-sudoku/inputs/silly-sudoku.in
+++ b/examples/silly-sudoku/inputs/silly-sudoku.in
@@ -1,0 +1,12 @@
+// The program input for tmp-test/src/main.leo
+[main]
+puzzle: [u8; (3, 3)] = [[0, 2, 0],
+                        [0, 0, 6],
+                        [0, 8, 9]];
+
+answer: [u8; (3, 3)] = [[1, 2, 3],
+                        [4, 5, 6],
+                        [7, 8, 9]];
+
+[registers]
+r: bool = false;

--- a/examples/silly-sudoku/inputs/silly-sudoku.state
+++ b/examples/silly-sudoku/inputs/silly-sudoku.state
@@ -1,0 +1,26 @@
+// The program state for tmp-test/src/main.leo
+[[public]]
+
+[state]
+leaf_index: u32 = 0;
+root: [u8; 32] = [0; 32];
+
+[[private]]
+
+[record]
+serial_number: [u8; 64] = [0; 64];
+commitment: [u8; 32] = [0; 32];
+owner: address = aleo1daxej63vwrmn2zhl4dymygagh89k5d2vaw6rjauueme7le6k2q8sjn0ng9;
+is_dummy: bool = false;
+value: u64 = 0;
+payload: [u8; 32] = [0; 32];
+birth_program_id: [u8; 48] = [0; 48];
+death_program_id: [u8; 48] = [0; 48];
+serial_number_nonce: [u8; 32] = [0; 32];
+commitment_randomness: [u8; 32] = [0; 32];
+
+[state_leaf]
+path: [u8; 128] = [0; 128];
+memo: [u8; 32] = [0; 32];
+network_id: u8 = 0;
+leaf_randomness: [u8; 32] = [0; 32];

--- a/examples/silly-sudoku/src/lib.leo
+++ b/examples/silly-sudoku/src/lib.leo
@@ -1,0 +1,70 @@
+/**
+ * The SillySudoku circuit
+ *
+ * This circuit generates a silly Sudoku puzzle,
+ * by constructing a 3x3 puzzle grid with some preset numbers 1-9,
+ * and requiring an answer where each number is used exactly once.
+ *
+ *  -----------
+ * | 5 | 8 | 3 |
+ * |-----------|
+ * | 2 | 7 | 4 |
+ * |-----------|
+ * | 1 | 9 | 6 |
+ *  -----------
+ */
+circuit SillySudoku {
+    // The starting grid values for the Sudoku puzzle.
+    // Unset cells on the puzzle grid are set to 0.
+    puzzle_grid: [u8; (3, 3)],
+
+    /**
+     * Returns true if a given Sudoku answer is correct.
+     * 
+     * Verifies a given answer by iterating through the Sudoku puzzle,
+     * and checking that each number is set exactly once.
+     */
+    function solve(self, answer: [u8; (3, 3)]) -> bool {
+        // The result boolean is set to true, if the answer is correct.
+        let result = true;
+        // An array that tracks the numbers used on the Sudoku grid.
+        let seen = [false; 9];
+        
+        // Iterate through the Sudoku grid and check each cell.
+        for i in 0..3 {
+            for j in 0..3 {
+                
+                // Fetch the current cell value for the Sudoku grid.
+                let grid_value = self.puzzle_grid[i][j];
+
+                // Fetch the current cell value for the given answer.
+                let answer_value = answer[i][j];
+
+                // Set the index by subtracting 1 from the answer value.
+                let index = answer_value - 1;
+
+                // Check if this number has already been used on the grid.
+                let already_seen: bool = seen[index];
+
+                // If this number is already used, the answer is incorrect.
+                // Sets the result to false.
+                if already_seen {
+                    result = false;
+                }
+
+                // If the cell is not empty, and the grid value doesn't match
+                // the answer value, the answer is incorrect.
+                // Sets the result to false.
+                if (grid_value != 0 && grid_value != answer_value) {
+                    result = false;
+                }
+
+                // Sets the answer value as seen.
+                seen[index] = true;
+            }
+        }
+
+        // Returns true if all numbers 1-9 have been seen exactly once.
+        return result
+    }
+}

--- a/examples/silly-sudoku/src/main.leo
+++ b/examples/silly-sudoku/src/main.leo
@@ -1,0 +1,71 @@
+import lib.SillySudoku;
+
+// The `silly-sudoku` main function
+function main(puzzle: [u8; (3, 3)], answer: [u8; (3, 3)]) -> bool {
+    console.log("Starting Sudoku solver...");
+    console.log("{}", puzzle);
+
+    // Instantiate the Sudoku puzzle.
+    let sudoku = SillySudoku { puzzle_grid: puzzle };
+
+    console.log("Checking Sudoku answer...");
+    console.log("{}", answer);
+
+    // Evaluate the Sudoku puzzle with the given answer.
+    let result = sudoku.solve(answer);
+
+    console.log("The answer is {}.", result);
+
+    return result
+}
+
+// Tests that the `silly-sudoku` circuit outputs true on a correct answer.
+@test
+function test_solve_pass() {
+    let puzzle: [u8; (3, 3)] = [[0, 2, 0],
+                                [0, 0, 6],
+                                [0, 8, 9]];
+
+    let answer: [u8; (3, 3)] = [[1, 2, 3],
+                                [4, 5, 6],
+                                [7, 8, 9]];
+
+    // Runs the Sudoku checker.
+    let result = main(puzzle, answer);
+
+    // Expects the result to be true.
+    console.assert(true == result);
+}
+
+// Tests that the `silly-sudoku` circuit outputs false on an incorrect answer.
+@test
+function test_solve_fail() {
+    let puzzle: [u8; (3, 3)] = [[0, 2, 0],
+                                [0, 0, 6],
+                                [0, 8, 0]];
+
+    let answer: [u8; (3, 3)] = [[1, 2, 3],
+                                [4, 5, 6],
+                                [7, 8, 8]]; // We have an extra `8` in this column!
+
+    // Runs the Sudoku checker.
+    let result = main(puzzle, answer);
+
+    // Expects the result to be false.
+    console.assert(false == result);
+}
+
+// Test that the `silly-sudoku` circuit outputs the expected value on a custom test input.
+@test(test_input)
+function test_solve_with_input(
+    puzzle: [u8; (3, 3)],
+    answer: [u8; (3, 3)],
+    expected: bool
+) {
+    // Runs the Sudoku checker.
+    let result = main(puzzle, answer);
+
+    console.log("expected {}, got {}", expected, result);
+
+    console.assert(expected == result);
+}


### PR DESCRIPTION
NOTE: based on #797.
## Motivation

Allow runtime array indexing. This PR does not add loop runtime indexing or array assignment runtime indexing.

Closes #746