### PR TITLE
[CI] Adds Pedersen Hash constraints check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,6 +158,19 @@ jobs:
             export LEO=/home/circleci/project/project/bin/leo
             ./project/.circleci/leo-add-remove.sh
 
+  leo-check-constraints:
+    docker:
+      - image: cimg/rust:1.50.0
+    resource_class: xlarge
+    steps:
+      - attach_workspace:
+          at: /home/circleci/project/
+      - run:
+          name: leo check constraints for Pedersen Hash
+          command: |
+            export LEO=/home/circleci/project/project/bin/leo
+            ./project/.circleci/leo-check-constraints.sh
+
   leo-login-logout:
     docker:
       - image: cimg/rust:1.50.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,9 @@ workflows:
       - leo-add-remove:
           requires:
             - leo-executable
+      - leo-check-constraints:
+          requires:
+            - leo-executable
       - leo-login-logout:
           requires:
             - leo-executable

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -2,16 +2,16 @@
 
 cd ./project/examples/pedersen-hash
 
-export PEDERSEH_HASH_CONSTRAINTS=1538
+export PEDERSEN_HASH_CONSTRAINTS=1539
 
 # 1. build 
 # 2. find lines with constraint number
-# 3. find lines with $PEDERSEH_HASH_CONSTRAINTS
+# 3. find lines with $PEDERSEN_HASH_CONSTRAINTS
 # 4. count lines
 # 4.Er if result is 0 -> constraint number changed
 # 4.Ok if result is 1 -> all good
 
-[[ $($LEO build | grep "Number of constraints" | grep $PEDERSEH_HASH_CONSTRAINTS | wc -l) -eq 1 ]] || { 
+[[ $($LEO build | grep "Number of constraints" | grep $PEDERSEN_HASH_CONSTRAINTS | wc -l) -eq 1 ]] || { 
     echo >&2 "Number of constraints for Pedersen Hash is not $PEDERSEN_HASH_CONSTRAINTS"; 
     exit 1; 
 } 

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -1,6 +1,6 @@
 # leo new hello-world
 
-cd examples/pedersen-hash
+cd ./project/examples/pedersen-hash
 
 PEDERSEH_HASH_CONSTRAINTS=1539
 

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -6,12 +6,11 @@ export PEDERSEN_HASH_CONSTRAINTS=1539
 
 # 1. build 
 # 2. find lines with constraint number
-# 3. find lines with $PEDERSEN_HASH_CONSTRAINTS
-# 4. count lines
-# 4.Er if result is 0 -> constraint number changed
+# 3. search this line for CONSTRAINTS number
+# 4.Er if result is 0 -> constraint number changed exit 1
 # 4.Ok if result is 1 -> all good
 
-[[ $($LEO build | grep "Number of constraints" | grep $PEDERSEN_HASH_CONSTRAINTS | wc -l) -eq 1 ]] || { 
+[[ $(cargo run -q -- build | grep constraints) == *"$PEDERSEN_HASH_CONSTRAINTS"* ]] || { 
     echo >&2 "Number of constraints for Pedersen Hash is not $PEDERSEN_HASH_CONSTRAINTS"; 
     exit 1; 
-} 
+}

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -2,7 +2,7 @@
 
 cd ./project/examples/pedersen-hash
 
-PEDERSEH_HASH_CONSTRAINTS=1539
+export PEDERSEH_HASH_CONSTRAINTS=1539
 
 # 1. build 
 # 2. find lines with constraint number
@@ -11,7 +11,7 @@ PEDERSEH_HASH_CONSTRAINTS=1539
 # 4.Er if result is 0 -> constraint number changed
 # 4.Ok if result is 1 -> all good
 
-[[ $($LEO build | grep "Number of constraints" | grep $PEDERSEH_HASH_CONSTRAINTS | wc -l) -eq 0 ]] || { 
+[[ $($LEO build | grep "Number of constraints" | grep $PEDERSEH_HASH_CONSTRAINTS | wc -l) -eq 1 ]] || { 
     echo >&2 "Number of constraints for Pedersen Hash is not $PEDERSEN_HASH_CONSTRAINTS"; 
     exit 1; 
 } 

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -1,0 +1,17 @@
+# leo new hello-world
+
+cd examples/pedersen-hash
+
+PEDERSEH_HASH_CONSTRAINTS=1539
+
+# 1. build 
+# 2. find lines with constraint number
+# 3. find lines with $PEDERSEH_HASH_CONSTRAINTS
+# 4. count lines
+# 4.Er if result is 0 -> constraint number changed
+# 4.Ok if result is 1 -> all good
+
+[[ $($LEO build | grep "Number of constraints" | grep $PEDERSEH_HASH_CONSTRAINTS | wc -l) -eq 0 ]] || { 
+    echo >&2 "Number of constraints for Pedersen Hash is not $PEDERSEN_HASH_CONSTRAINTS"; 
+    exit 1; 
+} 

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -1,16 +1,16 @@
 # leo new hello-world
 
-cd ./project/examples/pedersen-hash
+cd ./examples/pedersen-hash
 
-export PEDERSEN_HASH_CONSTRAINTS=1539
+export PEDERSEN_HASH_CONSTRAINTS=1539;
 
-# 1. build 
-# 2. find lines with constraint number
-# 3. search this line for CONSTRAINTS number
-# 4.Er if result is 0 -> constraint number changed exit 1
-# 4.Ok if result is 1 -> all good
+# line that we're searching for is:
+# `Build Number of constraints - 1539`
+export ACTUAL_CONSTRAINTS=$($LEO build | grep constraints | awk '{print $NF}')
 
-[[ $(cargo run -q -- build | grep constraints) == *"$PEDERSEN_HASH_CONSTRAINTS"* ]] || { 
+# if else expression with only else block
+[[ PEDERSEN_HASH_CONSTRAINTS -eq ACTUAL_CONSTRAINTS ]] || { 
     echo >&2 "Number of constraints for Pedersen Hash is not $PEDERSEN_HASH_CONSTRAINTS"; 
+    echo >&2 "Real number of constraints is $ACTUAL_CONSTRAINTS";
     exit 1; 
 }

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -1,6 +1,6 @@
 # leo new hello-world
 
-cd ./examples/pedersen-hash
+cd ./project/examples/pedersen-hash
 
 export PEDERSEN_HASH_CONSTRAINTS=1539;
 

--- a/.circleci/leo-check-constraints.sh
+++ b/.circleci/leo-check-constraints.sh
@@ -2,7 +2,7 @@
 
 cd ./project/examples/pedersen-hash
 
-export PEDERSEH_HASH_CONSTRAINTS=1539
+export PEDERSEH_HASH_CONSTRAINTS=1538
 
 # 1. build 
 # 2. find lines with constraint number


### PR DESCRIPTION
Adds constraint number checking CI run.
Closes #805.

## Motivation

Described in #805.

## Note

We may consider using different approach and just add test within Leo instead of doing it on CI side. But on the other hand by using only CI tools we test application as a blackbox avoiding possible side effects.