### PR TITLE
Adds a noconfig feature for release builds, updates CI to rust 1.51

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
-[target.'cfg(not(target_arch = "wasm32"))']
+[target.'cfg(any(not(target_arch = "wasm32"), feature = "release"))']
 rustflags = ["-C", "target-cpu=native"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ jobs:
 
   rust-stable:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - checkout
@@ -62,7 +62,7 @@ jobs:
 
   rust-nightly:
     docker:
-      - image: howardwu/snarkos-ci:2021-01-31
+      - image: howardwu/snarkos-ci:2021-03-25
     resource_class: xlarge
     steps:
       - checkout
@@ -77,8 +77,8 @@ jobs:
 
   leo-executable:
     docker:
-      - image: cimg/rust:1.50.0
-    resource_class: xlarge
+      - image: cimg/rust:1.51.0
+    resource_class: 2xlarge
     steps:
       - checkout
       - setup_environment:
@@ -95,7 +95,7 @@ jobs:
 
   leo-new:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -108,7 +108,7 @@ jobs:
 
   leo-init:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -121,7 +121,7 @@ jobs:
 
   leo-clean:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -134,7 +134,7 @@ jobs:
 
   leo-setup:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -147,7 +147,7 @@ jobs:
 
   leo-add-remove:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -160,7 +160,7 @@ jobs:
 
   leo-login-logout:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -173,7 +173,7 @@ jobs:
 
   leo-clone:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -186,7 +186,7 @@ jobs:
 
   leo-publish:
     docker:
-      - image: cimg/rust:1.50.0
+      - image: cimg/rust:1.51.0
     resource_class: xlarge
     steps:
       - attach_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
   leo-executable:
     docker:
       - image: cimg/rust:1.51.0
-    resource_class: 2xlarge
+    resource_class: xlarge
     steps:
       - checkout
       - setup_environment:
@@ -86,7 +86,7 @@ jobs:
       - run:
           name: Build and install Leo
           no_output_timeout: 30m
-          command: cargo install --path . --root .
+          command: cargo install --path . --root . --locked
       - persist_to_workspace:
           root: ~/
           paths: project/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --all --release && strip target/release/leo
+          cargo build --all --release --features noconfig && strip target/release/leo
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --all --release && strip target/release/leo
+          cargo build --all --release --features noconfig && strip target/release/leo
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 
@@ -118,7 +118,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --all --release
+          cargo build --all --release --features noconfig
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,8 +155,10 @@ version = "0.5"
 version = "0.11.2"
 
 [features]
-default = [ ]
+default = []
 ci_skip = [ "leo-compiler/ci_skip" ]
+# This feature flag is used to disable `target-cpu=native` in `.cargo/config`.
+noconfig = []
 
 [profile.release]
 opt-level = 3


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

- Adds a `noconfig` feature for release builds
- Updates CI to Rust v1.51
