### PR TITLE
Feature/no space between literals

### DIFF
--- a/compiler/tests/field/mod.rs
+++ b/compiler/tests/field/mod.rs
@@ -75,6 +75,14 @@ fn test_field() {
 }
 
 #[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let mut program = parse_program(program_string).unwrap();
+
+    expect_compiler_error(program)
+}
+
+#[test]
 fn test_add() {
     use std::ops::Add;
 

--- a/compiler/tests/field/no_space_between_literal.leo
+++ b/compiler/tests/field/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const f = 1 field;
+}

--- a/compiler/tests/group/mod.rs
+++ b/compiler/tests/group/mod.rs
@@ -46,6 +46,14 @@ pub fn group_element_to_input_value(g: EdwardsAffine) -> GroupValue {
 }
 
 #[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let mut program = parse_program(program_string).unwrap();
+
+    expect_compiler_error(program)
+}
+
+#[test]
 fn test_one() {
     let program_string = include_str!("one.leo");
     let program = parse_program(program_string).unwrap();

--- a/compiler/tests/group/no_space_between_literal.leo
+++ b/compiler/tests/group/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const g = (0,1) group;
+}

--- a/compiler/tests/integers/i128/mod.rs
+++ b/compiler/tests/integers/i128/mod.rs
@@ -132,3 +132,11 @@ fn test_i128_assert_eq() {
 fn test_i128_ternary() {
     TestI128::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/i128/no_space_between_literal.leo
+++ b/compiler/tests/integers/i128/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 i128;
+}

--- a/compiler/tests/integers/i16/mod.rs
+++ b/compiler/tests/integers/i16/mod.rs
@@ -131,3 +131,11 @@ fn test_i16_console_assert() {
 fn test_i16_ternary() {
     TestI16::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/i16/no_space_between_literal.leo
+++ b/compiler/tests/integers/i16/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 i16;
+}

--- a/compiler/tests/integers/i32/mod.rs
+++ b/compiler/tests/integers/i32/mod.rs
@@ -131,3 +131,11 @@ fn test_i32_console_assert() {
 fn test_i32_ternary() {
     TestI32::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/i32/no_space_between_literal.leo
+++ b/compiler/tests/integers/i32/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 i32;
+}

--- a/compiler/tests/integers/i64/mod.rs
+++ b/compiler/tests/integers/i64/mod.rs
@@ -132,3 +132,11 @@ fn test_i64_console_assert() {
 fn test_i64_ternary() {
     TestI64::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/i64/no_space_between_literal.leo
+++ b/compiler/tests/integers/i64/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 i64;
+}

--- a/compiler/tests/integers/i8/mod.rs
+++ b/compiler/tests/integers/i8/mod.rs
@@ -131,3 +131,11 @@ fn test_i8_console_assert() {
 fn test_i8_ternary() {
     TestI8::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/i8/no_space_between_literal.leo
+++ b/compiler/tests/integers/i8/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 i8;
+}

--- a/compiler/tests/integers/u128/mod.rs
+++ b/compiler/tests/integers/u128/mod.rs
@@ -116,3 +116,11 @@ fn test_u128_console_assert() {
 fn test_u128_ternary() {
     TestU128::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/u128/no_space_between_literal.leo
+++ b/compiler/tests/integers/u128/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 u128;
+}

--- a/compiler/tests/integers/u16/mod.rs
+++ b/compiler/tests/integers/u16/mod.rs
@@ -116,3 +116,11 @@ fn test_u16_console_assert() {
 fn test_u16_ternary() {
     TestU16::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/u16/no_space_between_literal.leo
+++ b/compiler/tests/integers/u16/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 u16;
+}

--- a/compiler/tests/integers/u32/mod.rs
+++ b/compiler/tests/integers/u32/mod.rs
@@ -116,3 +116,11 @@ fn test_u32_console_assert() {
 fn test_u32_ternary() {
     TestU32::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/u32/no_space_between_literal.leo
+++ b/compiler/tests/integers/u32/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 u32;
+}

--- a/compiler/tests/integers/u64/mod.rs
+++ b/compiler/tests/integers/u64/mod.rs
@@ -116,3 +116,11 @@ fn test_u64_console_assert() {
 fn test_u64_ternary() {
     TestU64::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/u64/no_space_between_literal.leo
+++ b/compiler/tests/integers/u64/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 u64;
+}

--- a/compiler/tests/integers/u8/mod.rs
+++ b/compiler/tests/integers/u8/mod.rs
@@ -116,3 +116,11 @@ fn test_u8_console_assert() {
 fn test_u8_ternary() {
     TestU8::test_ternary();
 }
+
+#[test]
+fn test_no_space_between_literal() {
+    let program_string = include_str!("no_space_between_literal.leo");
+    let program = parse_program(program_string);
+
+    assert!(program.is_err());
+}

--- a/compiler/tests/integers/u8/no_space_between_literal.leo
+++ b/compiler/tests/integers/u8/no_space_between_literal.leo
@@ -1,0 +1,3 @@
+function main() {
+  const i = 1 u8;
+}

--- a/grammar/abnf-grammar.md
+++ b/grammar/abnf-grammar.md
@@ -494,7 +494,7 @@ Line terminators form whitespace, along with spaces and horizontal tabs.
 whitespace = space / horizontal-tab / newline
 ```
 
-Go to: _[horizontal-tab](#user-content-horizontal-tab), [newline](#user-content-newline), [space](#user-content-space)_;
+Go to: _[newline](#user-content-newline), [horizontal-tab](#user-content-horizontal-tab), [space](#user-content-space)_;
 
 
 There are two kinds of comments in Leo, as in other languages.
@@ -512,7 +512,7 @@ the ones used in the Java language specification.
 comment = block-comment / end-of-line-comment
 ```
 
-Go to: _[block-comment](#user-content-block-comment), [end-of-line-comment](#user-content-end-of-line-comment)_;
+Go to: _[end-of-line-comment](#user-content-end-of-line-comment), [block-comment](#user-content-block-comment)_;
 
 
 <a name="block-comment"></a>
@@ -529,7 +529,7 @@ rest-of-block-comment = "*" rest-of-block-comment-after-star
                       / not-star rest-of-block-comment
 ```
 
-Go to: _[not-star](#user-content-not-star), [rest-of-block-comment-after-star](#user-content-rest-of-block-comment-after-star), [rest-of-block-comment](#user-content-rest-of-block-comment)_;
+Go to: _[rest-of-block-comment-after-star](#user-content-rest-of-block-comment-after-star), [not-star](#user-content-not-star), [rest-of-block-comment](#user-content-rest-of-block-comment)_;
 
 
 <a name="rest-of-block-comment-after-star"></a>
@@ -539,7 +539,7 @@ rest-of-block-comment-after-star = "/"
                                  / not-star-or-slash rest-of-block-comment
 ```
 
-Go to: _[rest-of-block-comment-after-star](#user-content-rest-of-block-comment-after-star), [rest-of-block-comment](#user-content-rest-of-block-comment), [not-star-or-slash](#user-content-not-star-or-slash)_;
+Go to: _[rest-of-block-comment-after-star](#user-content-rest-of-block-comment-after-star), [not-star-or-slash](#user-content-not-star-or-slash), [rest-of-block-comment](#user-content-rest-of-block-comment)_;
 
 
 <a name="end-of-line-comment"></a>
@@ -614,7 +614,7 @@ lowercase-letter = %x61-7A   ; a-z
 letter = uppercase-letter / lowercase-letter
 ```
 
-Go to: _[lowercase-letter](#user-content-lowercase-letter), [uppercase-letter](#user-content-uppercase-letter)_;
+Go to: _[uppercase-letter](#user-content-uppercase-letter), [lowercase-letter](#user-content-lowercase-letter)_;
 
 
 An identifier is a non-empty sequence of letters, digits, and underscores,
@@ -784,12 +784,8 @@ Go to: _[integer](#user-content-integer)_;
 There are two kinds of group literals.
 One is a single integer followed by the type of group elements,
 which denotes the scalar product of the generator point by the integer.
-The other is a pair of integer coordinates,
-which are reduced modulo the prime to identify a point,
-which must be on the elliptic curve.
-It is also allowed to omit one (not both) coordinates,
-with an indication of how to infer the missing coordinate
-(i.e. sign high, sign low, or inferred).
+The other kind is not a token because it allows some whitespace inside;
+therefore, it is defined in the syntactic grammar.
 
 <a name="product-group-literal"></a>
 ```abnf
@@ -798,97 +794,6 @@ product-group-literal = integer "group"
 
 Go to: _[integer](#user-content-integer)_;
 
-
-<a name="group-coordinate"></a>
-```abnf
-group-coordinate = integer / "+" / "-" / "_"
-```
-
-Go to: _[integer](#user-content-integer)_;
-
-
-<a name="affine-group-literal"></a>
-```abnf
-affine-group-literal = "(" group-coordinate "," group-coordinate ")" "group"
-```
-
-Go to: _[group-coordinate](#user-content-group-coordinate)_;
-
-
-<a name="group-literal"></a>
-```abnf
-group-literal = product-group-literal / affine-group-literal
-```
-
-Go to: _[product-group-literal](#user-content-product-group-literal), [affine-group-literal](#user-content-affine-group-literal)_;
-
-
-Note that the rule for group literals above
-allows no whitespace between coordinates.
-If we want to allow whitespace,
-e.g. '(3, 4)group' as opposed to requiring '(3,4)group',
-then we should define affine group literals
-in the syntactic grammar instead of in the lexical grammar.
-We should have a notion of atomic literal in the lexical grammar,
-and (non-atomic) literal in the syntactic grammar.
-The lexical grammar should define a token for ')group'
-if we want no whitespace between the closing parenthesis and 'group'.
-More precisely, the rule for 'literal' below in the lexical grammar
-would be replaced with
-
-
-
-```
-atomic-literal = ... / product-group-literal
-```
-
-
-
-where the '...' stands for all the '...-literal' alternatives
-in the current rule for 'literal' below, except 'group-literal'.
-Furthermore, the rule for 'symbol' below in the lexical grammar
-would be extended to
-
-
-
-```
-symbol = ... / ")group"
-```
-
-
-
-where '...' stands for the current definiens of the rule.
-We would also have to adjust the rule for 'token' below in the lexical grammar
-to reference 'atomic-literal' instead of 'literal' in the definiens.
-We would then add to the syntactic grammar the following rules
-
-
-
-```
-affine-group-literal = "(" group-coordinate "," group-coordinate ")group"
-```
-
-
-
-```
-literal = atomic-literal / affine-group-literal
-```
-
-
-
-which would now define literals in the syntactic grammar.
-Note that now an affine group literal would have the form
-
-
-
-```
-( <ow> <coordinate> <ow> , <ow> <coordinate> <ow> )group
-```
-
-
-
-where <ow> is optional whitespace;
-however, no whitespace is allowed between the closing ')' and 'group'.
 
 Boolean literals are the usual two.
 
@@ -910,18 +815,18 @@ Go to: _[address](#user-content-address)_;
 
 The ones above are all the literals, as defined by the following rule.
 
-<a name="literal"></a>
+<a name="atomic-literal"></a>
 ```abnf
-literal = untyped-literal
-        / unsigned-literal
-        / signed-literal
-        / field-literal
-        / group-literal
-        / boolean-literal
-        / address-literal
+atomic-literal = untyped-literal
+               / unsigned-literal
+               / signed-literal
+               / field-literal
+               / product-group-literal
+               / boolean-literal
+               / address-literal
 ```
 
-Go to: _[unsigned-literal](#user-content-unsigned-literal), [untyped-literal](#user-content-untyped-literal), [field-literal](#user-content-field-literal), [group-literal](#user-content-group-literal), [address-literal](#user-content-address-literal), [boolean-literal](#user-content-boolean-literal), [signed-literal](#user-content-signed-literal)_;
+Go to: _[unsigned-literal](#user-content-unsigned-literal), [field-literal](#user-content-field-literal), [address-literal](#user-content-address-literal), [signed-literal](#user-content-signed-literal), [product-group-literal](#user-content-product-group-literal), [boolean-literal](#user-content-boolean-literal), [untyped-literal](#user-content-untyped-literal)_;
 
 
 After defining the (mostly) alphanumeric tokens above,
@@ -929,6 +834,14 @@ it remains to define tokens for non-alphanumeric symbols such as "+" and "(".
 Different programming languages used different terminologies for these,
 e.g. operators, separators, punctuators, etc.
 Here we use 'symbol', for all of them, but we can do something different.
+We also include a token consisting of
+a closing parenthesis immediately followed by 'group':
+as defined in the syntactic grammar,
+this is the final part of an affine group literal.
+Even though it includes letters,
+it seems appropriate to still consider it a symbol,
+particularly since it starts with a symbol.
+
 We could give names to all of these symbols,
 via rules such as
 
@@ -969,6 +882,7 @@ symbol = "!" / "&&" / "||"
        / "{" / "}"
        / "," / "." / ".." / "..." / ";" / ":" / "::" / "?"
        / "->" / "_"
+       / ")group"
 ```
 
 Everything defined above, other than comments and whitespace,
@@ -978,14 +892,14 @@ is a token, as defined by the following rule.
 ```abnf
 token = keyword
       / identifier
-      / literal
+      / atomic-literal
       / package-name
       / formatted-string
       / annotation-name
       / symbol
 ```
 
-Go to: _[literal](#user-content-literal), [annotation-name](#user-content-annotation-name), [formatted-string](#user-content-formatted-string), [symbol](#user-content-symbol), [identifier](#user-content-identifier), [keyword](#user-content-keyword), [package-name](#user-content-package-name)_;
+Go to: _[identifier](#user-content-identifier), [atomic-literal](#user-content-atomic-literal), [package-name](#user-content-package-name), [symbol](#user-content-symbol), [annotation-name](#user-content-annotation-name), [formatted-string](#user-content-formatted-string), [keyword](#user-content-keyword)_;
 
 
 
@@ -1021,7 +935,7 @@ signed-type = "i8" / "i16" / "i32" / "i64" / "i128"
 integer-type = unsigned-type / signed-type
 ```
 
-Go to: _[unsigned-type](#user-content-unsigned-type), [signed-type](#user-content-signed-type)_;
+Go to: _[signed-type](#user-content-signed-type), [unsigned-type](#user-content-unsigned-type)_;
 
 
 The integer types, along with the field and group types,
@@ -1063,7 +977,7 @@ address-type = "address"
 scalar-type =  boolean-type / arithmetic-type / address-type
 ```
 
-Go to: _[arithmetic-type](#user-content-arithmetic-type), [address-type](#user-content-address-type), [boolean-type](#user-content-boolean-type)_;
+Go to: _[arithmetic-type](#user-content-arithmetic-type), [boolean-type](#user-content-boolean-type), [address-type](#user-content-address-type)_;
 
 
 Circuit types are denoted by identifiers and the keyword 'Self'.
@@ -1125,7 +1039,7 @@ i.e. types whose values contain (sub)values
 aggregate-type = tuple-type / array-type / circuit-type
 ```
 
-Go to: _[array-type](#user-content-array-type), [tuple-type](#user-content-tuple-type), [circuit-type](#user-content-circuit-type)_;
+Go to: _[circuit-type](#user-content-circuit-type), [tuple-type](#user-content-tuple-type), [array-type](#user-content-array-type)_;
 
 
 Scalar and aggregate types form all the types.
@@ -1135,7 +1049,58 @@ Scalar and aggregate types form all the types.
 type = scalar-type / aggregate-type
 ```
 
-Go to: _[scalar-type](#user-content-scalar-type), [aggregate-type](#user-content-aggregate-type)_;
+Go to: _[aggregate-type](#user-content-aggregate-type), [scalar-type](#user-content-scalar-type)_;
+
+
+The lexical grammar above defines product group literals.
+The other kind of group literal is a pair of integer coordinates,
+which are reduced modulo the prime to identify a point,
+which must be on the elliptic curve.
+It is also allowed to omit one (not both) coordinates,
+with an indication of how to infer the missing coordinate
+(i.e. sign high, sign low, or inferred).
+This is an affine group literal,
+because it consists of affine point coordinates.
+
+<a name="group-coordinate"></a>
+```abnf
+group-coordinate = integer / "+" / "-" / "_"
+```
+
+Go to: _[integer](#user-content-integer)_;
+
+
+<a name="affine-group-literal"></a>
+```abnf
+affine-group-literal = "(" group-coordinate "," group-coordinate ")" "group"
+```
+
+Go to: _[group-coordinate](#user-content-group-coordinate)_;
+
+
+A literal is either an atomic one or an affine group literal.
+Here 'atomic' refers to being a token or not,
+since no whitespace is allowed within a token.
+
+<a name="literal"></a>
+```abnf
+literal = atomic-literal / affine-group-literal
+```
+
+Go to: _[atomic-literal](#user-content-atomic-literal), [affine-group-literal](#user-content-affine-group-literal)_;
+
+
+The following rule is not directly referenced in the rules for expressions
+(which reference 'literal' instead),
+but it is useful to establish terminology:
+a group literal is either a product group literal or an affine group literal.
+
+<a name="group-literal"></a>
+```abnf
+group-literal = product-group-literal / affine-group-literal
+```
+
+Go to: _[product-group-literal](#user-content-product-group-literal), [affine-group-literal](#user-content-affine-group-literal)_;
 
 
 As often done in grammatical language syntax specifications,
@@ -1166,7 +1131,7 @@ primary-expression = identifier
                    / function-call
 ```
 
-Go to: _[function-call](#user-content-function-call), [expression](#user-content-expression), [circuit-expression](#user-content-circuit-expression), [identifier](#user-content-identifier), [literal](#user-content-literal), [array-expression](#user-content-array-expression), [tuple-expression](#user-content-tuple-expression)_;
+Go to: _[function-call](#user-content-function-call), [literal](#user-content-literal), [array-expression](#user-content-array-expression), [circuit-expression](#user-content-circuit-expression), [identifier](#user-content-identifier), [expression](#user-content-expression), [tuple-expression](#user-content-tuple-expression)_;
 
 
 There are tuple expressions to construct and deconstruct tuples.
@@ -1235,7 +1200,7 @@ Go to: _[expression](#user-content-expression)_;
 array-repeat-construction = "[" expression ";" array-dimensions "]"
 ```
 
-Go to: _[expression](#user-content-expression), [array-dimensions](#user-content-array-dimensions)_;
+Go to: _[array-dimensions](#user-content-array-dimensions), [expression](#user-content-expression)_;
 
 
 <a name="array-construction"></a>
@@ -1243,7 +1208,7 @@ Go to: _[expression](#user-content-expression), [array-dimensions](#user-content
 array-construction = array-inline-construction / array-repeat-construction
 ```
 
-Go to: _[array-inline-construction](#user-content-array-inline-construction), [array-repeat-construction](#user-content-array-repeat-construction)_;
+Go to: _[array-repeat-construction](#user-content-array-repeat-construction), [array-inline-construction](#user-content-array-inline-construction)_;
 
 
 <a name="array-expression"></a>
@@ -1273,7 +1238,7 @@ circuit-construction = circuit-type "{"
                        "}"
 ```
 
-Go to: _[circuit-inline-element](#user-content-circuit-inline-element), [circuit-type](#user-content-circuit-type)_;
+Go to: _[circuit-type](#user-content-circuit-type), [circuit-inline-element](#user-content-circuit-inline-element)_;
 
 
 <a name="circuit-inline-element"></a>
@@ -1331,7 +1296,7 @@ unary-expression = postfix-expression
                  / "-" unary-expression
 ```
 
-Go to: _[postfix-expression](#user-content-postfix-expression), [unary-expression](#user-content-unary-expression)_;
+Go to: _[unary-expression](#user-content-unary-expression), [postfix-expression](#user-content-postfix-expression)_;
 
 
 Next in the operator precedence is casting.
@@ -1375,7 +1340,7 @@ additive-expression = multiplicative-expression
                     / additive-expression "-" multiplicative-expression
 ```
 
-Go to: _[additive-expression](#user-content-additive-expression), [multiplicative-expression](#user-content-multiplicative-expression)_;
+Go to: _[multiplicative-expression](#user-content-multiplicative-expression), [additive-expression](#user-content-additive-expression)_;
 
 
 Next in the precedence order are ordering relations.
@@ -1425,7 +1390,7 @@ disjunctive-expression = conjunctive-expression
                        / disjunctive-expression "||" conjunctive-expression
 ```
 
-Go to: _[disjunctive-expression](#user-content-disjunctive-expression), [conjunctive-expression](#user-content-conjunctive-expression)_;
+Go to: _[conjunctive-expression](#user-content-conjunctive-expression), [disjunctive-expression](#user-content-disjunctive-expression)_;
 
 
 Finally we have conditional expressions.
@@ -1438,7 +1403,7 @@ conditional-expression = disjunctive-expression
                          ":" conditional-expression
 ```
 
-Go to: _[conditional-expression](#user-content-conditional-expression), [expression](#user-content-expression), [disjunctive-expression](#user-content-disjunctive-expression)_;
+Go to: _[conditional-expression](#user-content-conditional-expression), [disjunctive-expression](#user-content-disjunctive-expression), [expression](#user-content-expression)_;
 
 
 These are all the expressions.
@@ -1471,7 +1436,7 @@ statement = expression-statement
           / block
 ```
 
-Go to: _[variable-definition-statement](#user-content-variable-definition-statement), [loop-statement](#user-content-loop-statement), [block](#user-content-block), [assignment-statement](#user-content-assignment-statement), [console-statement](#user-content-console-statement), [conditional-statement](#user-content-conditional-statement), [return-statement](#user-content-return-statement), [expression-statement](#user-content-expression-statement)_;
+Go to: _[variable-definition-statement](#user-content-variable-definition-statement), [conditional-statement](#user-content-conditional-statement), [console-statement](#user-content-console-statement), [return-statement](#user-content-return-statement), [expression-statement](#user-content-expression-statement), [loop-statement](#user-content-loop-statement), [assignment-statement](#user-content-assignment-statement), [block](#user-content-block)_;
 
 
 <a name="block"></a>
@@ -1514,7 +1479,7 @@ variable-definition-statement = ( "let" / "const" )
                                 [ ":" type ] "=" expression ";"
 ```
 
-Go to: _[identifier-or-identifiers](#user-content-identifier-or-identifiers), [type](#user-content-type), [expression](#user-content-expression)_;
+Go to: _[expression](#user-content-expression), [type](#user-content-type), [identifier-or-identifiers](#user-content-identifier-or-identifiers)_;
 
 
 <a name="identifier-or-identifiers"></a>
@@ -1547,7 +1512,7 @@ conditional-statement = branch
                       / branch "else" conditional-statement
 ```
 
-Go to: _[block](#user-content-block), [branch](#user-content-branch), [conditional-statement](#user-content-conditional-statement)_;
+Go to: _[conditional-statement](#user-content-conditional-statement), [branch](#user-content-branch), [block](#user-content-block)_;
 
 
 A loop statement implicitly defines a loop variable
@@ -1576,7 +1541,7 @@ assignment-operator = "=" / "+=" / "-=" / "*=" / "/=" / "**="
 assignment-statement = expression assignment-operator expression ";"
 ```
 
-Go to: _[assignment-operator](#user-content-assignment-operator), [expression](#user-content-expression)_;
+Go to: _[expression](#user-content-expression), [assignment-operator](#user-content-assignment-operator)_;
 
 
 Console statements start with the 'console' keyword,
@@ -1632,7 +1597,7 @@ Go to: _[formatted-string](#user-content-formatted-string)_;
 print-call = print-function print-arguments
 ```
 
-Go to: _[print-function](#user-content-print-function), [print-arguments](#user-content-print-arguments)_;
+Go to: _[print-arguments](#user-content-print-arguments), [print-function](#user-content-print-function)_;
 
 
 An annotation consists of an annotation name (which starts with '@')
@@ -1645,7 +1610,7 @@ annotation = annotation-name
              [ "(" identifier *( "," identifier ) ")" ]
 ```
 
-Go to: _[identifier](#user-content-identifier), [annotation-name](#user-content-annotation-name)_;
+Go to: _[annotation-name](#user-content-annotation-name), [identifier](#user-content-identifier)_;
 
 
 A function declaration defines a function.
@@ -1667,7 +1632,7 @@ function-declaration = *annotation "function" identifier
                        block
 ```
 
-Go to: _[function-parameters](#user-content-function-parameters), [type](#user-content-type), [block](#user-content-block), [identifier](#user-content-identifier)_;
+Go to: _[type](#user-content-type), [function-parameters](#user-content-function-parameters), [identifier](#user-content-identifier), [block](#user-content-block)_;
 
 
 <a name="function-parameters"></a>
@@ -1678,7 +1643,7 @@ function-parameters = self-parameter [ "," input-parameter ]
                     / input-parameter
 ```
 
-Go to: _[input-parameter](#user-content-input-parameter), [function-inputs](#user-content-function-inputs), [self-parameter](#user-content-self-parameter)_;
+Go to: _[function-inputs](#user-content-function-inputs), [input-parameter](#user-content-input-parameter), [self-parameter](#user-content-self-parameter)_;
 
 
 <a name="self-parameter"></a>
@@ -1726,7 +1691,7 @@ Go to: _[member-variable-declaration](#user-content-member-variable-declaration)
 member-variable-declaration = identifier ":" type
 ```
 
-Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;
+Go to: _[type](#user-content-type), [identifier](#user-content-identifier)_;
 
 
 <a name="member-function-declaration"></a>
@@ -1794,7 +1759,7 @@ declaration = import-declaration
             / circuit-declaration
 ```
 
-Go to: _[import-declaration](#user-content-import-declaration), [function-declaration](#user-content-function-declaration), [circuit-declaration](#user-content-circuit-declaration)_;
+Go to: _[function-declaration](#user-content-function-declaration), [circuit-declaration](#user-content-circuit-declaration), [import-declaration](#user-content-import-declaration)_;
 
 
 <a name="file"></a>

--- a/grammar/abnf-grammar.txt
+++ b/grammar/abnf-grammar.txt
@@ -540,59 +540,10 @@ field-literal = integer %s"field"
 ; There are two kinds of group literals.
 ; One is a single integer followed by the type of group elements,
 ; which denotes the scalar product of the generator point by the integer.
-; The other is a pair of integer coordinates,
-; which are reduced modulo the prime to identify a point,
-; which must be on the elliptic curve.
-; It is also allowed to omit one (not both) coordinates,
-; with an indication of how to infer the missing coordinate
-; (i.e. sign high, sign low, or inferred).
+; The other kind is not a token because it allows some whitespace inside;
+; therefore, it is defined in the syntactic grammar.
 
 product-group-literal = integer %s"group"
-
-group-coordinate = integer / "+" / "-" / "_"
-
-affine-group-literal = "(" group-coordinate "," group-coordinate ")" %s"group"
-
-group-literal = product-group-literal / affine-group-literal
-
-; Note that the rule for group literals above
-; allows no whitespace between coordinates.
-; If we want to allow whitespace,
-; e.g. '(3, 4)group' as opposed to requiring '(3,4)group',
-; then we should define affine group literals
-; in the syntactic grammar instead of in the lexical grammar.
-; We should have a notion of atomic literal in the lexical grammar,
-; and (non-atomic) literal in the syntactic grammar.
-; The lexical grammar should define a token for ')group'
-; if we want no whitespace between the closing parenthesis and 'group'.
-; More precisely, the rule for 'literal' below in the lexical grammar
-; would be replaced with
-;
-;  atomic-literal = ... / product-group-literal
-;
-; where the '...' stands for all the '...-literal' alternatives
-; in the current rule for 'literal' below, except 'group-literal'.
-; Furthermore, the rule for 'symbol' below in the lexical grammar
-; would be extended to
-;
-;  symbol = ... / %s")group"
-;
-; where '...' stands for the current definiens of the rule.
-; We would also have to adjust the rule for 'token' below in the lexical grammar
-; to reference 'atomic-literal' instead of 'literal' in the definiens.
-; We would then add to the syntactic grammar the following rules
-;
-;  affine-group-literal = "(" group-coordinate "," group-coordinate %s")group"
-;
-;  literal = atomic-literal / affine-group-literal
-;
-; which would now define literals in the syntactic grammar.
-; Note that now an affine group literal would have the form
-;
-;  ( <ow> <coordinate> <ow> , <ow> <coordinate> <ow> )group
-;
-; where <ow> is optional whitespace;
-; however, no whitespace is allowed between the closing ')' and 'group'.
 
 ; Boolean literals are the usual two.
 
@@ -605,19 +556,27 @@ address-literal = %s"address" "(" address ")"
 
 ; The ones above are all the literals, as defined by the following rule.
 
-literal = untyped-literal
-        / unsigned-literal
-        / signed-literal
-        / field-literal
-        / group-literal
-        / boolean-literal
-        / address-literal
+atomic-literal = untyped-literal
+               / unsigned-literal
+               / signed-literal
+               / field-literal
+               / product-group-literal
+               / boolean-literal
+               / address-literal
 
 ; After defining the (mostly) alphanumeric tokens above,
 ; it remains to define tokens for non-alphanumeric symbols such as "+" and "(".
 ; Different programming languages used different terminologies for these,
 ; e.g. operators, separators, punctuators, etc.
 ; Here we use 'symbol', for all of them, but we can do something different.
+; We also include a token consisting of
+; a closing parenthesis immediately followed by 'group':
+; as defined in the syntactic grammar,
+; this is the final part of an affine group literal.
+; Even though it includes letters,
+; it seems appropriate to still consider it a symbol,
+; particularly since it starts with a symbol.
+
 ; We could give names to all of these symbols,
 ; via rules such as
 ;
@@ -644,13 +603,14 @@ symbol = "!" / "&&" / "||"
        / "{" / "}"
        / "," / "." / ".." / "..." / ";" / ":" / "::" / "?"
        / "->" / "_"
+       / %s")group"
 
 ; Everything defined above, other than comments and whitespace,
 ; is a token, as defined by the following rule.
 
 token = keyword
       / identifier
-      / literal
+      / atomic-literal
       / package-name
       / formatted-string
       / annotation-name
@@ -728,6 +688,33 @@ aggregate-type = tuple-type / array-type / circuit-type
 ; Scalar and aggregate types form all the types.
 
 type = scalar-type / aggregate-type
+
+; The lexical grammar above defines product group literals.
+; The other kind of group literal is a pair of integer coordinates,
+; which are reduced modulo the prime to identify a point,
+; which must be on the elliptic curve.
+; It is also allowed to omit one (not both) coordinates,
+; with an indication of how to infer the missing coordinate
+; (i.e. sign high, sign low, or inferred).
+; This is an affine group literal,
+; because it consists of affine point coordinates.
+
+group-coordinate = integer / "+" / "-" / "_"
+
+affine-group-literal = "(" group-coordinate "," group-coordinate ")" %s"group"
+
+; A literal is either an atomic one or an affine group literal.
+; Here 'atomic' refers to being a token or not,
+; since no whitespace is allowed within a token.
+
+literal = atomic-literal / affine-group-literal
+
+; The following rule is not directly referenced in the rules for expressions
+; (which reference 'literal' instead),
+; but it is useful to establish terminology:
+; a group literal is either a product group literal or an affine group literal.
+
+group-literal = product-group-literal / affine-group-literal
 
 ; As often done in grammatical language syntax specifications,
 ; we define rules for different kinds of expressions,

--- a/parser/src/parser/context.rs
+++ b/parser/src/parser/context.rs
@@ -16,7 +16,7 @@
 
 use std::unimplemented;
 
-use crate::{tokenizer::*, SyntaxError, SyntaxResult, Token, KEYWORD_TOKENS};
+use crate::{tokenizer::*, unexpected_whitespace, SyntaxError, SyntaxResult, Token, KEYWORD_TOKENS};
 use leo_ast::*;
 use tendril::format_tendril;
 
@@ -164,10 +164,16 @@ impl ParserContext {
     /// Removes the next two tokens if they are a pair of [`GroupCoordinate`] and returns them,
     /// or [None] if the next token is not a [`GroupCoordinate`].
     ///
-    pub fn eat_group_partial(&mut self) -> Option<(GroupCoordinate, GroupCoordinate, Span)> {
+    pub fn eat_group_partial(&mut self) -> SyntaxResult<Option<(GroupCoordinate, GroupCoordinate, Span)>> {
         let mut i = self.tokens.len() - 1;
-        let start_span = self.tokens.get(i)?.span.clone();
-        let first = self.peek_group_coordinate(&mut i)?;
+        let start_span = match self.tokens.get(i) {
+            Some(span) => span.span.clone(),
+            None => return Ok(None),
+        };
+        let first = match self.peek_group_coordinate(&mut i) {
+            Some(coord) => coord,
+            None => return Ok(None),
+        };
         match self.tokens.get(i) {
             Some(SpannedToken {
                 token: Token::Comma, ..
@@ -175,19 +181,24 @@ impl ParserContext {
                 i -= 1;
             }
             _ => {
-                return None;
+                return Ok(None);
             }
         }
-        let second = self.peek_group_coordinate(&mut i)?;
+        let second = match self.peek_group_coordinate(&mut i) {
+            Some(coord) => coord,
+            None => return Ok(None),
+        };
+        let right_paren_span;
         match self.tokens.get(i) {
             Some(SpannedToken {
                 token: Token::RightParen,
-                ..
+                span,
             }) => {
+                right_paren_span = span.clone();
                 i -= 1;
             }
             _ => {
-                return None;
+                return Ok(None);
             }
         }
         let end_span;
@@ -200,12 +211,18 @@ impl ParserContext {
                 i -= 1;
             }
             _ => {
-                return None;
+                return Ok(None);
             }
         }
 
         self.tokens.drain((i + 1)..);
-        Some((first, second, start_span + end_span))
+        unexpected_whitespace(
+            &right_paren_span,
+            &end_span,
+            &format!("({},{})", first, second),
+            "group",
+        )?;
+        Ok(Some((first, second, start_span + end_span)))
     }
 
     ///

--- a/parser/src/parser/file.rs
+++ b/parser/src/parser/file.rs
@@ -91,12 +91,7 @@ impl ParserContext {
             )));
         }
 
-        if start.col_stop != name.span.col_start {
-            let mut error_span = &start + &name.span;
-            error_span.col_start = start.col_stop - 1;
-            error_span.col_stop = name.span.col_start - 1;
-            return Err(SyntaxError::unexpected_whitespace("@", &name.name, &error_span));
-        }
+        unexpected_whitespace(&start, &name.span, &name.name, "@")?;
 
         let end_span;
         let arguments = if self.eat(Token::LeftParen).is_some() {

--- a/parser/src/parser/mod.rs
+++ b/parser/src/parser/mod.rs
@@ -41,3 +41,14 @@ pub fn parse(path: &str, source: &str) -> SyntaxResult<Program> {
 
     tokens.parse_program()
 }
+
+pub fn unexpected_whitespace(left_span: &Span, right_span: &Span, left: &str, right: &str) -> SyntaxResult<()> {
+    if left_span.col_stop != right_span.col_start {
+        let mut error_span = left_span + right_span;
+        error_span.col_start = left_span.col_stop - 1;
+        error_span.col_stop = right_span.col_start - 1;
+        return Err(SyntaxError::unexpected_whitespace(left, right, &error_span));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Resolves #779. Also does not allow white space between integer and field types.