### PR TITLE
Adds error when function defined more than once

### DIFF
--- a/asg/src/error/mod.rs
+++ b/asg/src/error/mod.rs
@@ -174,7 +174,7 @@ impl AsgConvertError {
 
     pub fn duplicate_function_definition(name: &str, span: &Span) -> Self {
         Self::new_from_span(
-            format!("duplicate definition, function with name \"{}\" already exists", name),
+            format!("a function named \"{}\" already exists in this scope", name),
             span,
         )
     }

--- a/asg/src/error/mod.rs
+++ b/asg/src/error/mod.rs
@@ -172,6 +172,13 @@ impl AsgConvertError {
         )
     }
 
+    pub fn duplicate_function_definition(name: &str, span: &Span) -> Self {
+        Self::new_from_span(
+            format!("duplicate definition, function with name \"{}\" already exists", name),
+            span,
+        )
+    }
+
     pub fn index_into_non_tuple(name: &str, span: &Span) -> Self {
         Self::new_from_span(format!("failed to index into non-tuple '{}'", name), span)
     }

--- a/asg/src/program/mod.rs
+++ b/asg/src/program/mod.rs
@@ -266,7 +266,13 @@ impl<'a> Program<'a> {
 
             asg_function.fill_from_ast(function)?;
 
-            functions.insert(name.name.to_string(), asg_function);
+            let name = name.name.to_string();
+
+            if functions.contains_key(&name) {
+                return Err(AsgConvertError::duplicate_function_definition(&name, &function.span));
+            }
+
+            functions.insert(name, asg_function);
         }
 
         let mut circuits = IndexMap::new();

--- a/compiler/tests/function/duplicate_definition.leo
+++ b/compiler/tests/function/duplicate_definition.leo
@@ -1,0 +1,7 @@
+function main() {
+    console.log("{}", 1u8);  
+}
+
+function main() {
+    console.log("{}", 2u8);  
+}

--- a/compiler/tests/function/mod.rs
+++ b/compiler/tests/function/mod.rs
@@ -211,3 +211,11 @@ fn test_array_params_direct_call() {
 
     assert_satisfied(program);
 }
+
+#[test]
+fn test_duplicate_function_definition() {
+    let program_string = include_str!("duplicate_definition.leo");
+    let error = parse_program(program_string).err().unwrap();
+
+    expect_asg_error(error);
+}


### PR DESCRIPTION
Closes #829.

## Motivation

Described in the issue. 
Short: we don't fail if main is defined more than once and it causes return type mismatch for main function (if there's more than one main with different signature).

## Test Plan

Contains a test for this scenario. Should fail on ASG level.
