### PR TITLE
Fix package name checks

### DIFF
--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -71,7 +71,7 @@ impl Package {
         // Iterate and check that the package name is valid.
         for current in package_name.chars() {
             // Check that the package name is lowercase.
-            if !current.is_ascii_lowercase() && current != '-' {
+            if current.is_ascii_uppercase() && current != '-' {
                 tracing::error!("Project names must be all lowercase");
                 return false;
             }

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -68,6 +68,12 @@ impl Package {
             return false;
         }
 
+        // Check that the first character is not a number.
+        if previous.is_numeric() {
+            tracing::error!("Project names cannot begin with a number");
+            return false;
+        }
+
         // Iterate and check that the package name is valid.
         for current in package_name.chars() {
             // Check that the package name is lowercase.
@@ -267,6 +273,8 @@ mod tests {
         assert!(Package::is_package_name_valid("foo"));
         assert!(Package::is_package_name_valid("foo-bar"));
         assert!(Package::is_package_name_valid("foo-bar-baz"));
+        assert!(Package::is_package_name_valid("foo1"));
+        assert!(Package::is_package_name_valid("foo-1"));
 
         assert!(!Package::is_package_name_valid(""));
         assert!(!Package::is_package_name_valid("-"));
@@ -279,5 +287,6 @@ mod tests {
         assert!(!Package::is_package_name_valid("foo*bar"));
         assert!(!Package::is_package_name_valid("foo,bar"));
         assert!(!Package::is_package_name_valid("foo_bar"));
+        assert!(!Package::is_package_name_valid("1-foo"));
     }
 }


### PR DESCRIPTION


leo package names should allow numbers except for the first digit.

```rust
// Valid
"foo"
"foo-bar"
"foo-bar-baz"
"foo1"
"foo-1"


// Invalid
""
"-"
"-foo"
"foo--bar"
"foo*bar"
"foo,bar"
"1-foo"
```

Closes #833