### PR TITLE
[CLI, Feature] Adds username substitution to manifest, improves login and error messages

### DIFF
--- a/.circleci/leo-login-logout.sh
+++ b/.circleci/leo-login-logout.sh
@@ -4,11 +4,11 @@ $LEO login -u "$ALEO_PM_USERNAME" -p "$ALEO_PM_PASSWORD"
 $LEO new my-app && cd my-app || exit 1
 
 cat Leo.toml
-which wc
 
-# verify that in Leo.toml there's a line with $ALEO_PM_USERNAME;
-# because at the time of calling `leo new` user is logged in and we're expecting substitution
-[[ $(cat Leo.toml | grep "\[$ALEO_PM_USERNAME\]" | wc -l) -eq 1 ]] || exit 1
+# verify that in Leo.toml there's no line with [AUTHOR];
+# since CI does not allow showing credentials, we won't see it in the file;
+# so the only way to test is to make sure that there's just no [AUTHOR] there
+[[ $(cat Leo.toml | grep "\[AUTHOR\]" | wc -l) -eq 0 ]] || exit 1
 
 $LEO add howard/silly-sudoku
 $LEO remove silly-sudoku

--- a/.circleci/leo-login-logout.sh
+++ b/.circleci/leo-login-logout.sh
@@ -3,6 +3,9 @@
 $LEO login -u "$ALEO_PM_USERNAME" -p "$ALEO_PM_PASSWORD"
 $LEO new my-app && cd my-app || exit 1
 
+cat Leo.toml
+which wc
+
 # verify that in Leo.toml there's a line with $ALEO_PM_USERNAME;
 # because at the time of calling `leo new` user is logged in and we're expecting substitution
 [[ $(cat Leo.toml | grep "\[$ALEO_PM_USERNAME\]" | wc -l) -eq 1 ]] || exit 1

--- a/.circleci/leo-login-logout.sh
+++ b/.circleci/leo-login-logout.sh
@@ -1,7 +1,12 @@
 # leo login & logout
 
-$LEO new my-app && cd my-app || exit 1
 $LEO login -u "$ALEO_PM_USERNAME" -p "$ALEO_PM_PASSWORD"
+$LEO new my-app && cd my-app || exit 1
+
+# verify that in Leo.toml there's a line with $ALEO_PM_USERNAME;
+# because at the time of calling `leo new` user is logged in and we're expecting substitution
+[[ $(cat Leo.toml | grep "\[$ALEO_PM_USERNAME\]" | wc -l) -eq 1 ]] || exit 1
+
 $LEO add howard/silly-sudoku
 $LEO remove silly-sudoku
 $LEO logout

--- a/.circleci/leo-new.sh
+++ b/.circleci/leo-new.sh
@@ -1,4 +1,9 @@
 $LEO new hello-world
 ls -la
 cd hello-world && ls -la
+
+# verify that in Leo.toml there's a placeholder for author
+# because at the time of calling `leo new` user is not logged in
+[[ $(cat Leo.toml | grep "\[AUTHOR\]" | wc -l) -eq 1 ]] || exit 1
+
 $LEO run

--- a/leo/commands/init.rs
+++ b/leo/commands/init.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{commands::Command, context::Context};
+use crate::{commands::Command, config::*, context::Context};
 use leo_package::LeoPackage;
 
 use anyhow::{anyhow, Result};
@@ -43,6 +43,11 @@ impl Command for Init {
         // Derive the package directory path.
         let path = current_dir()?;
 
+        // Check that the current package directory path exists.
+        if !path.exists() {
+            return Err(anyhow!("Directory does not exist"));
+        }
+
         // Check that the given package name is valid.
         let package_name = path
             .file_stem()
@@ -53,12 +58,9 @@ impl Command for Init {
             return Err(anyhow!("Invalid Leo project name"));
         }
 
-        // Check that the current package directory path exists.
-        if !path.exists() {
-            return Err(anyhow!("Directory does not exist"));
-        }
+        let username = read_username().ok();
 
-        LeoPackage::initialize(&package_name, false, &path)?;
+        LeoPackage::initialize(&package_name, false, &path, username)?;
 
         Ok(())
     }

--- a/leo/commands/new.rs
+++ b/leo/commands/new.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{commands::Command, context::Context};
+use crate::{commands::Command, config::*, context::Context};
 use leo_package::LeoPackage;
 
 use anyhow::{anyhow, Result};
@@ -49,6 +49,8 @@ impl Command for New {
             return Err(anyhow!("Invalid Leo project name"));
         }
 
+        let username = read_username().ok();
+
         // Derive the package directory path.
         let mut path = current_dir()?;
         path.push(&package_name);
@@ -61,7 +63,7 @@ impl Command for New {
         // Create the package directory
         fs::create_dir_all(&path).map_err(|err| anyhow!("Could not create directory {}", err))?;
 
-        LeoPackage::initialize(&package_name, false, &path)?;
+        LeoPackage::initialize(&package_name, false, &path, username)?;
 
         Ok(())
     }

--- a/leo/commands/package/logout.rs
+++ b/leo/commands/package/logout.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{commands::Command, config::remove_token, context::Context};
+use crate::{commands::Command, config::remove_token_and_username, context::Context};
 
 use anyhow::Result;
 use std::io::ErrorKind;
@@ -41,7 +41,7 @@ impl Command for Logout {
     fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
         // the only error we're interested here is NotFound
         // however err in this case can also be of kind PermissionDenied or other
-        if let Err(err) = remove_token() {
+        if let Err(err) = remove_token_and_username() {
             match err.kind() {
                 ErrorKind::NotFound => {
                     tracing::info!("you are not logged in");

--- a/leo/config.rs
+++ b/leo/config.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 
 pub const LEO_CREDENTIALS_FILE: &str = "credentials";
 pub const LEO_CONFIG_FILE: &str = "config.toml";
+pub const LEO_USERNAME_FILE: &str = "username";
 
 lazy_static! {
     pub static ref LEO_CONFIG_DIRECTORY: PathBuf = {
@@ -42,6 +43,11 @@ lazy_static! {
     pub static ref LEO_CREDENTIALS_PATH: PathBuf = {
         let mut path = LEO_CONFIG_DIRECTORY.to_path_buf();
         path.push(LEO_CREDENTIALS_FILE);
+        path
+    };
+    pub static ref LEO_USERNAME_PATH: PathBuf = {
+        let mut path = LEO_CONFIG_DIRECTORY.to_path_buf();
+        path.push(LEO_USERNAME_FILE);
         path
     };
     pub static ref LEO_CONFIG_PATH: PathBuf = {
@@ -129,7 +135,7 @@ impl Config {
     }
 }
 
-pub fn write_token(token: &str) -> Result<(), io::Error> {
+pub fn write_token_and_username(token: &str, username: &str) -> Result<(), io::Error> {
     let config_dir = LEO_CONFIG_DIRECTORY.clone();
 
     // Create Leo config directory if it not exists
@@ -139,6 +145,10 @@ pub fn write_token(token: &str) -> Result<(), io::Error> {
 
     let mut credentials = File::create(&LEO_CREDENTIALS_PATH.to_path_buf())?;
     credentials.write_all(&token.as_bytes())?;
+
+    let mut username_file = File::create(&LEO_USERNAME_PATH.to_path_buf())?;
+    username_file.write_all(&username.as_bytes())?;
+
     Ok(())
 }
 
@@ -149,7 +159,15 @@ pub fn read_token() -> Result<String, io::Error> {
     Ok(buf)
 }
 
-pub fn remove_token() -> Result<(), io::Error> {
+pub fn read_username() -> Result<String, io::Error> {
+    let mut username = File::open(&LEO_USERNAME_PATH.to_path_buf())?;
+    let mut buf = String::new();
+    username.read_to_string(&mut buf)?;
+    Ok(buf)
+}
+
+pub fn remove_token_and_username() -> Result<(), io::Error> {
     fs::remove_file(&LEO_CREDENTIALS_PATH.to_path_buf())?;
+    fs::remove_file(&LEO_USERNAME_PATH.to_path_buf())?;
     Ok(())
 }

--- a/package/src/lib.rs
+++ b/package/src/lib.rs
@@ -33,8 +33,13 @@ pub struct LeoPackage;
 
 impl LeoPackage {
     /// Initializes a Leo package at the given path.
-    pub fn initialize(package_name: &str, is_lib: bool, path: &Path) -> Result<(), PackageError> {
-        package::Package::initialize(package_name, is_lib, path)
+    pub fn initialize(
+        package_name: &str,
+        is_lib: bool,
+        path: &Path,
+        author: Option<String>,
+    ) -> Result<(), PackageError> {
+        package::Package::initialize(package_name, is_lib, path, author)
     }
 
     /// Returns `true` if the given Leo package name is valid.

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -197,7 +197,12 @@ impl Package {
     }
 
     /// Creates a package at the given path
-    pub fn initialize(package_name: &str, is_lib: bool, path: &Path) -> Result<(), PackageError> {
+    pub fn initialize(
+        package_name: &str,
+        is_lib: bool,
+        path: &Path,
+        author: Option<String>,
+    ) -> Result<(), PackageError> {
         // First, verify that this directory is not already initialized as a Leo package.
         {
             if !Self::can_initialize(package_name, is_lib, path) {
@@ -210,7 +215,7 @@ impl Package {
         // Next, initialize this directory as a Leo package.
         {
             // Create the manifest file.
-            Manifest::new(&package_name)?.write_to(&path)?;
+            Manifest::new(&package_name, author)?.write_to(&path)?;
 
             // Verify that the .gitignore file does not exist.
             if !Gitignore::exists_at(&path) {

--- a/package/src/root/manifest.rs
+++ b/package/src/root/manifest.rs
@@ -26,6 +26,7 @@ use std::{
 };
 
 pub const MANIFEST_FILENAME: &str = "Leo.toml";
+pub const AUTHOR_PLACEHOLDER: &str = "[AUTHOR]";
 
 #[derive(Clone, Deserialize)]
 pub struct Remote {
@@ -39,10 +40,10 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    pub fn new(package_name: &str) -> Result<Self, ManifestError> {
+    pub fn new(package_name: &str, author: Option<String>) -> Result<Self, ManifestError> {
         Ok(Self {
             project: Package::new(package_name)?,
-            remote: None,
+            remote: author.map(|author| Remote { author }),
         })
     }
 
@@ -90,6 +91,11 @@ impl Manifest {
     }
 
     fn template(&self) -> String {
+        let author = self
+            .remote
+            .clone()
+            .map_or(AUTHOR_PLACEHOLDER.to_string(), |remote| remote.author);
+
         format!(
             r#"[project]
 name = "{name}"
@@ -98,9 +104,10 @@ description = "The {name} package"
 license = "MIT"
 
 [remote]
-author = "[AUTHOR]" # Add your Aleo Package Manager username, team's name, or organization's name.
+author = "{author}" # Add your Aleo Package Manager username, team's name, or organization's name.
 "#,
-            name = self.project.name
+            name = self.project.name,
+            author = author
         )
     }
 }

--- a/package/tests/initialize/initialize.rs
+++ b/package/tests/initialize/initialize.rs
@@ -32,7 +32,29 @@ fn initialize_valid_package() {
     assert!(Package::can_initialize(TEST_PACKAGE_NAME, false, &test_directory));
 
     // Initialize a package at the `test_directory`
-    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory).is_ok());
+    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory, None).is_ok());
+
+    // Ensure a package is initialized at the `test_directory`
+    assert!(Package::is_initialized(TEST_PACKAGE_NAME, false, &test_directory));
+}
+
+#[test]
+fn initialize_valid_package_with_author() {
+    let test_directory = test_dir();
+
+    // Ensure a package can be initialized at the `test_directory`
+    assert!(Package::can_initialize(TEST_PACKAGE_NAME, false, &test_directory));
+
+    // Initialize a package at the `test_directory`
+    assert!(
+        Package::initialize(
+            TEST_PACKAGE_NAME,
+            false,
+            &test_directory,
+            Some(String::from("test_user"))
+        )
+        .is_ok()
+    );
 
     // Ensure a package is initialized at the `test_directory`
     assert!(Package::is_initialized(TEST_PACKAGE_NAME, false, &test_directory));
@@ -52,13 +74,13 @@ fn initialize_fails_with_existing_manifest() {
     assert!(Package::can_initialize(TEST_PACKAGE_NAME, false, &test_directory));
 
     // Manually add a manifest file to the `test_directory`
-    Manifest::new(TEST_PACKAGE_NAME)
+    Manifest::new(TEST_PACKAGE_NAME, None)
         .unwrap()
         .write_to(&test_directory)
         .unwrap();
 
     // Attempt to initialize a package at the `test_directory`
-    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory).is_err());
+    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory, None).is_err());
 
     // Ensure package is not initialized at the `test_directory`
     assert!(!Package::is_initialized(TEST_PACKAGE_NAME, false, &test_directory));
@@ -76,7 +98,7 @@ fn initialize_fails_with_existing_library_file() {
     LibraryFile::new(TEST_PACKAGE_NAME).write_to(&test_directory).unwrap();
 
     // Attempt to initialize a package at the `test_directory`
-    assert!(Package::initialize(TEST_PACKAGE_NAME, true, &test_directory).is_err());
+    assert!(Package::initialize(TEST_PACKAGE_NAME, true, &test_directory, None).is_err());
 
     // Ensure package is not initialized at the `test_directory`
     assert!(!Package::is_initialized(TEST_PACKAGE_NAME, true, &test_directory));
@@ -94,7 +116,15 @@ fn initialize_fails_with_existing_input_file() {
     InputFile::new(TEST_PACKAGE_NAME).write_to(&test_directory).unwrap();
 
     // Attempt to initialize a package at the `test_directory`
-    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory).is_err());
+    assert!(
+        Package::initialize(
+            TEST_PACKAGE_NAME,
+            false,
+            &test_directory,
+            Some(String::from("test_user"))
+        )
+        .is_err()
+    );
 
     // Ensure package is not initialized at the `test_directory`
     assert!(!Package::is_initialized(TEST_PACKAGE_NAME, false, &test_directory));
@@ -112,7 +142,7 @@ fn initialize_fails_with_existing_state_file() {
     StateFile::new(TEST_PACKAGE_NAME).write_to(&test_directory).unwrap();
 
     // Attempt to initialize a package at the `test_directory`
-    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory).is_err());
+    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory, None).is_err());
 
     // Ensure package is not initialized at the `test_directory`
     assert!(!Package::is_initialized(TEST_PACKAGE_NAME, false, &test_directory));
@@ -130,7 +160,7 @@ fn initialize_fails_with_existing_main_file() {
     MainFile::new(TEST_PACKAGE_NAME).write_to(&test_directory).unwrap();
 
     // Attempt to initialize a package at the `test_directory`
-    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory).is_err());
+    assert!(Package::initialize(TEST_PACKAGE_NAME, false, &test_directory, None).is_err());
 
     // Ensure package is not initialized at the `test_directory`
     assert!(!Package::is_initialized(TEST_PACKAGE_NAME, false, &test_directory));


### PR DESCRIPTION
## Motivation

Closes #836.
Closes #847.

This PR adds few improvements to CLI.

### Author substitution

If user is logged in and runs `leo new` or `leo init`, Leo.toml will contain his username by default.
```
leo login
leo new # Leo.toml has %username% in it
leo publish 
```

If user is not logged in or logged in after creating an empty package/program, nothing happens.
```
leo new
leo login # Leo.toml contains [AUTHOR] - default value
leo publish
```

So once user is logged in, substitution always happens and it's one time issue.

### Change of login logic

1. Previously we checked that token exists and that led to @0rphon catching "invalid token". Now running `leo login` over existing credentials will check that token is valid and not expired, and if it is not valid, local credentials are removed and user is asked to login again.

2. Also we now allow user to re-login over existing credentials (therefore rewriting locally stored data) if token or username-password pair is passed into `leo login`. Before it was impossible.

### Better error message

"Invalid Author" on package publish was the most confusing error message. Now we check that `Leo.toml` contains anything but "[AUTHOR]" which is a placeholder and tell user to edit package manifest. 

## Test Plan

- adds new tests to package/manifest
- improves existing CI workflows to test new behavior 