### PR TITLE
Move format note to bottom of abnf grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ This will generate an executable under the `./target/release` directory. To run 
 Use the Leo CLI to create a new project
 
 ```bash
-# create a new `hello_world` Leo project
-leo new hello_world
-cd hello_world
+# create a new `hello-world` Leo project
+leo new hello-world
+cd hello-world
 
 # build & setup & prove & verify
 leo run
@@ -113,6 +113,7 @@ Congratulations! You've just run your first Leo program.
 
 * [Hello World - Next Steps](https://developer.aleo.org/developer/getting_started/hello_world)
 * [Leo Language Documentation](https://developer.aleo.org/developer/language/layout)
+* [Leo ABNF Grammar](./grammar/README.md)
 * [Leo CLI Documentation](https://developer.aleo.org/developer/cli/new)
 * [Homepage](https://developer.aleo.org/developer/getting_started/overview)
 

--- a/grammar/README.md
+++ b/grammar/README.md
@@ -1,9 +1,18 @@
-Leo Grammar
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Leo library.
 
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 
-Copyright (C) 2021 Aleo Systems Inc.
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
 
-
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 --------
 
 

--- a/grammar/README.md
+++ b/grammar/README.md
@@ -1,30 +1,7 @@
-Leo Library
-
+Leo Grammar
 
 
 Copyright (C) 2021 Aleo Systems Inc.
-
-
---------
-
-
-Format Note
------------
-
-The ABNF standard requires grammars to consist of lines terminated by CR LF
-(i.e. carriage return followed by line feed, DOS/Windows-style),
-as explained in the background on ABNF later in this file.
-This file's lines are therefore terminated by CR LF.
-To avoid losing this requirement across systems,
-this file is marked as 'text eol=crlf' in .gitattributes:
-this means that the file is textual, enabling visual diffs,
-but its lines will always be terminated by CR LF on any system.
-
-Note that this CR LF requirement only applies to the grammar files themselves.
-It does not apply to the lines of the languages described by the grammar.
-ABNF grammars may describe any kind of languages,
-with any kind of line terminators,
-or even without line terminators at all (e.g. for "binary" languages).
 
 
 --------
@@ -1723,4 +1700,26 @@ Go to: _[import-declaration](#user-content-import-declaration), [circuit-declara
 <a name="file"></a>
 ```abnf
 file = *declaration
+```
 
+
+--------
+
+
+Format Note
+-----------
+
+The ABNF standard requires grammars to consist of lines terminated by CR LF
+(i.e. carriage return followed by line feed, DOS/Windows-style),
+as explained in the background on ABNF later in this file.
+This file's lines are therefore terminated by CR LF.
+To avoid losing this requirement across systems,
+this file is marked as 'text eol=crlf' in .gitattributes:
+this means that the file is textual, enabling visual diffs,
+but its lines will always be terminated by CR LF on any system.
+
+Note that this CR LF requirement only applies to the grammar files themselves.
+It does not apply to the lines of the languages described by the grammar.
+ABNF grammars may describe any kind of languages,
+with any kind of line terminators,
+or even without line terminators at all (e.g. for "binary" languages).


### PR DESCRIPTION
Proposing to move the formatting note to the bottom of the markdown file.
This makes it more natural for readers.