### PR TITLE
[CLI] Allow setting custom API endpoint in ENV

### DIFF
--- a/leo/api.rs
+++ b/leo/api.rs
@@ -100,7 +100,7 @@ impl Api {
         };
 
         // only one error is possible here
-        let res = res.send().map_err(|_| anyhow!("Unable to connect to Aleo PM"))?;
+        let res = res.send().map_err(|_| anyhow!("Unable to connect to Aleo PM. Check URL if you specified custom API endpoint"))?;
 
         // where magic begins
         route.process(res)

--- a/leo/api.rs
+++ b/leo/api.rs
@@ -104,7 +104,9 @@ impl Api {
         };
 
         // only one error is possible here
-        let res = res.send().map_err(|_| anyhow!("Unable to connect to Aleo PM. Check URL if you specified custom API endpoint"))?;
+        let res = res
+            .send()
+            .map_err(|_| anyhow!("Unable to connect to Aleo PM. Check URL if you specified custom API endpoint"))?;
 
         // where magic begins
         route.process(res)

--- a/leo/api.rs
+++ b/leo/api.rs
@@ -149,7 +149,7 @@ impl Route for Fetch {
             // TODO: we should return 404 on not found author/package
             // and return BAD_REQUEST if data format is incorrect or some of the arguments
             // were not passed
-            StatusCode::NOT_FOUND => anyhow!("Package is hidden"),
+            StatusCode::NOT_FOUND => anyhow!("Package not found"),
             _ => anyhow!("Unknown API error: {}", status),
         }
     }

--- a/leo/api.rs
+++ b/leo/api.rs
@@ -70,6 +70,10 @@ impl Api {
         }
     }
 
+    pub fn host(&self) -> &str {
+        &*self.host
+    }
+
     /// Get token for bearer auth, should be passed into Api through Context
     pub fn auth_token(&self) -> Option<String> {
         self.auth_token.clone()

--- a/leo/api.rs
+++ b/leo/api.rs
@@ -22,25 +22,24 @@ use reqwest::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Trait describes API Routes and Request bodies, struct which implements
-/// Route MUST also support Serialize to be usable in Api::run_route(r: Route)
+/// API Routes and Request bodies.
+/// Structs that implement Route MUST also support Serialize to be usable in Api::run_route(r: Route)
 pub trait Route {
-    /// Whether to use bearer auth or not. Some routes may have additional
-    /// features for logged-in users, so authorization token should be sent
-    /// if it is created of course
+    /// [`true`] if a route supports bearer authentication.
+    /// For example, the login route.
     const AUTH: bool;
 
-    /// HTTP method to use when requesting
+    /// The HTTP method to use when requesting.
     const METHOD: Method;
 
-    /// URL path without first forward slash (e.g. v1/package/fetch)
+    /// The URL path without the first forward slash (e.g. v1/package/fetch)
     const PATH: &'static str;
 
-    /// Output type for this route. For login it is simple - String
+    /// The output type for this route. For example, the login route output is [`String`].
     /// But for other routes may be more complex.
     type Output;
 
-    /// Process reqwest Response and turn it into Output
+    /// Process the reqwest Response and turn it into an Output.
     fn process(&self, res: Response) -> Result<Self::Output>;
 
     /// Transform specific status codes into correct errors for this route.
@@ -50,18 +49,18 @@ pub trait Route {
     }
 }
 
-/// REST API handler with reqwest::blocking inside
+/// REST API handler with reqwest::blocking inside.
 #[derive(Clone, Debug)]
 pub struct Api {
     host: String,
     client: Client,
-    /// Authorization token for API requests
+    /// Authorization token for API requests.
     auth_token: Option<String>,
 }
 
 impl Api {
-    /// Create new instance of API, set host and Client is going to be
-    /// created and set automatically
+    /// Returns a new instance of API.
+    /// The set host and Client are created automatically.
     pub fn new(host: String, auth_token: Option<String>) -> Api {
         Api {
             client: Client::new(),
@@ -74,18 +73,19 @@ impl Api {
         &*self.host
     }
 
-    /// Get token for bearer auth, should be passed into Api through Context
+    /// Returns the token for bearer auth, otherwise None.
+    /// The [`auth_token`] should be passed into the Api through Context.
     pub fn auth_token(&self) -> Option<String> {
         self.auth_token.clone()
     }
 
-    /// Set authorization token for future requests
+    /// Set the authorization token for future requests.
     pub fn set_auth_token(&mut self, token: String) {
         self.auth_token = Some(token);
     }
 
     /// Run specific route struct. Turn struct into request body
-    /// and use type constants and Route implementation to get request params
+    /// and use type constants and Route implementation to get request params.
     pub fn run_route<T>(&self, route: T) -> Result<T::Output>
     where
         T: Route,
@@ -104,9 +104,9 @@ impl Api {
         };
 
         // only one error is possible here
-        let res = res
-            .send()
-            .map_err(|_| anyhow!("Unable to connect to Aleo PM. Check URL if you specified custom API endpoint"))?;
+        let res = res.send().map_err(|_| {
+            anyhow!("Unable to connect to Aleo PM. If you specified custom API endpoint, then check the URL for errors")
+        })?;
 
         // where magic begins
         route.process(res)
@@ -189,7 +189,7 @@ impl Route for Login {
 }
 
 /// Handler for 'my_profile' route. Meant to be used to get profile details but
-/// in current application is used to check if user is logged in. Any non-200 response
+/// in the current application it is used to check if the user is logged in. Any non-200 response
 /// is treated as Unauthorized.
 #[derive(Serialize)]
 pub struct Profile {}

--- a/leo/commands/package/publish.rs
+++ b/leo/commands/package/publish.rs
@@ -15,10 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::build::Build;
-use crate::{
-    commands::Command,
-    context::{Context},
-};
+use crate::{commands::Command, context::Context};
 use leo_package::{
     outputs::OutputsDirectory,
     root::{ZipFile, AUTHOR_PLACEHOLDER},

--- a/leo/commands/package/publish.rs
+++ b/leo/commands/package/publish.rs
@@ -17,7 +17,7 @@
 use super::build::Build;
 use crate::{
     commands::Command,
-    context::{Context, PACKAGE_MANAGER_URL},
+    context::{Context},
 };
 use leo_package::{
     outputs::OutputsDirectory,
@@ -118,7 +118,7 @@ impl Command for Publish {
 
         // Make a request to publish a package
         let response = client
-            .post(format!("{}{}", PACKAGE_MANAGER_URL, PUBLISH_URL).as_str())
+            .post(format!("{}{}", context.api.host(), PUBLISH_URL).as_str())
             .headers(headers)
             .multipart(form_data)
             .send();

--- a/leo/context.rs
+++ b/leo/context.rs
@@ -48,19 +48,19 @@ impl Context {
 }
 
 /// Create a new context for the current directory.
-pub fn create_context(path: PathBuf) -> Result<Context> {
+pub fn create_context(path: PathBuf, api_url: Option<String>) -> Result<Context> {
     let token = config::read_token().ok();
 
-    let api = Api::new(PACKAGE_MANAGER_URL.to_string(), token);
+    let api = Api::new(api_url.unwrap_or(PACKAGE_MANAGER_URL.to_string()), token);
 
     Ok(Context { api, path: Some(path) })
 }
 
 /// Returns project context.
-pub fn get_context() -> Result<Context> {
+pub fn get_context(api_url: Option<String>) -> Result<Context> {
     let token = config::read_token().ok();
 
-    let api = Api::new(PACKAGE_MANAGER_URL.to_string(), token);
+    let api = Api::new(api_url.unwrap_or(PACKAGE_MANAGER_URL.to_string()), token);
 
     Ok(Context { api, path: None })
 }

--- a/leo/context.rs
+++ b/leo/context.rs
@@ -51,7 +51,7 @@ impl Context {
 pub fn create_context(path: PathBuf, api_url: Option<String>) -> Result<Context> {
     let token = config::read_token().ok();
 
-    let api = Api::new(api_url.unwrap_or(PACKAGE_MANAGER_URL.to_string()), token);
+    let api = Api::new(api_url.unwrap_or_else(|| PACKAGE_MANAGER_URL.to_string()), token);
 
     Ok(Context { api, path: Some(path) })
 }
@@ -60,7 +60,7 @@ pub fn create_context(path: PathBuf, api_url: Option<String>) -> Result<Context>
 pub fn get_context(api_url: Option<String>) -> Result<Context> {
     let token = config::read_token().ok();
 
-    let api = Api::new(api_url.unwrap_or(PACKAGE_MANAGER_URL.to_string()), token);
+    let api = Api::new(api_url.unwrap_or_else(|| PACKAGE_MANAGER_URL.to_string()), token);
 
     Ok(Context { api, path: None })
 }

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -58,6 +58,13 @@ struct Opt {
     #[structopt(
         long,
         global = true,
+        help = "Aleo PM API Url"
+    )]
+    api: Option<String>,
+
+    #[structopt(
+        long,
+        global = true,
         help = "Optional path to Leo program root folder",
         parse(from_os_str)
     )]
@@ -192,8 +199,8 @@ fn main() {
     // Get custom root folder and create context for it.
     // If not specified, default context will be created in cwd.
     let context = handle_error(match opt.path {
-        Some(path) => context::create_context(path),
-        None => context::get_context(),
+        Some(path) => context::create_context(path, opt.api),
+        None => context::get_context(opt.api),
     });
 
     handle_error(match opt.command {

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -55,7 +55,7 @@ struct Opt {
     #[structopt(subcommand)]
     command: CommandOpts,
 
-    #[structopt(global = true, help = "URL to custom Aleo PM backend", env = "APM_URL")]
+    #[structopt(help = "Custom Aleo PM backend URL", env = "APM_URL")]
     api: Option<String>,
 
     #[structopt(

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -55,7 +55,7 @@ struct Opt {
     #[structopt(subcommand)]
     command: CommandOpts,
 
-    #[structopt(long, global = true, help = "Aleo PM API Url")]
+    #[structopt(global = true, help = "URL to custom Aleo PM backend", env = "APM_URL")]
     api: Option<String>,
 
     #[structopt(

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -55,11 +55,7 @@ struct Opt {
     #[structopt(subcommand)]
     command: CommandOpts,
 
-    #[structopt(
-        long,
-        global = true,
-        help = "Aleo PM API Url"
-    )]
+    #[structopt(long, global = true, help = "Aleo PM API Url")]
     api: Option<String>,
 
     #[structopt(

--- a/leo/tests/mod.rs
+++ b/leo/tests/mod.rs
@@ -152,7 +152,7 @@ pub fn leo_update_and_update_automatic() -> Result<()> {
 /// Create context for Pedersen Hash example
 fn context() -> Result<Context> {
     let path = PathBuf::from(&PEDERSEN_HASH_PATH);
-    let context = create_context(path)?;
+    let context = create_context(path, None)?;
 
     Ok(context)
 }


### PR DESCRIPTION
This PR adds `APM_URL` ENV setting which allows specifying custom API backend for Leo CLI:

```bash
export APM_URL=https://api.aleo.pm/
leo add justice-league/u8u32

# or
APM_URL=https://api.aleo.pm/ leo add justice-league/u8u32
```

This option is printed in help message only when calling global help:
```bash
leo help
# or
leo --help
```

> With our current API it is impossible to check if URL is correct, so some responses for websites like https://google.com/ may cause confusion. We heavily rely on *404 Not Found* in our API, so when google or any other website respond with 404, error is interpreted like something is wrong with data sent to API.

## Motivation

We need this feature to support multiple backends and different APIs.

## Test Plan

Open to any ideas on how to test this feature.
Tested manually.
