### PR TITLE
[CLI] Makes import path relative to program directory

### DIFF
--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -229,7 +229,11 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
         tracing::debug!("Program parsing complete\n{:#?}", self.program);
 
         // Create a new symbol table from the program, imported_programs, and program_input.
-        let asg = Asg::new(self.context, &self.program, &mut leo_imports::ImportParser::default())?;
+        let asg = Asg::new(
+            self.context,
+            &self.program,
+            &mut leo_imports::ImportParser::new(self.main_file_path.clone()),
+        )?;
 
         tracing::debug!("ASG generation complete");
 

--- a/imports/src/parser/import_parser.rs
+++ b/imports/src/parser/import_parser.rs
@@ -18,7 +18,7 @@ use crate::errors::ImportParserError;
 use leo_asg::{AsgContext, AsgConvertError, ImportResolver, Program, Span};
 
 use indexmap::{IndexMap, IndexSet};
-use std::env::current_dir;
+use std::path::PathBuf;
 
 /// Stores imported packages.
 ///
@@ -26,11 +26,21 @@ use std::env::current_dir;
 /// directory, foreign in the imports directory, or part of the core package list.
 #[derive(Clone, Default)]
 pub struct ImportParser<'a> {
+    program_path: PathBuf,
     partial_imports: IndexSet<String>,
     imports: IndexMap<String, Program<'a>>,
 }
 
-//todo: handle relative imports relative to file...
+impl<'a> ImportParser<'a> {
+    pub fn new(program_path: PathBuf) -> Self {
+        ImportParser {
+            program_path,
+            partial_imports: Default::default(),
+            imports: Default::default(),
+        }
+    }
+}
+
 impl<'a> ImportResolver<'a> for ImportParser<'a> {
     fn resolve_package(
         &mut self,
@@ -46,8 +56,7 @@ impl<'a> ImportResolver<'a> for ImportParser<'a> {
             return Ok(Some(program.clone()));
         }
         let mut imports = Self::default();
-        let path =
-            current_dir().map_err(|x| -> AsgConvertError { ImportParserError::current_directory_error(x).into() })?;
+        let path = self.program_path.clone();
 
         self.partial_imports.insert(full_path.clone());
         let program = imports

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -361,13 +361,12 @@ mod cli_tests {
     }
 
     #[test]
-    #[ignore] // ignore until imports path is fixed #875
     fn test_sudoku() {
         let path = &Some(PathBuf::from("examples/silly-sudoku"));
 
         assert!(run_cmd("leo build", path).is_ok());
         assert!(run_cmd("leo test", path).is_ok());
-        assert!(run_cmd("leo test -f src/lib.leo", path).is_ok());
-        assert!(run_cmd("leo test -f src/main.leo", path).is_ok());
+        assert!(run_cmd("leo test -f examples/silly-sudoku/src/lib.leo", path).is_ok());
+        assert!(run_cmd("leo test -f examples/silly-sudoku/src/main.leo", path).is_ok());
     }
 }


### PR DESCRIPTION
Closes #875.

## Motivation

Import path should be handled relatively to program source directory. 
Now all features using `--path` in Leo CLI are working.

So basically this is now possible:
```bash
# it has imports in it and this line failed previously
leo build --path examples/silly-sudoku 
```

## Test Plan

Includes tests which were blocked by this issue.
