### PR TITLE
[CLI] Adds tests for imports

### DIFF
--- a/leo/main.rs
+++ b/leo/main.rs
@@ -359,6 +359,23 @@ mod cli_tests {
     }
 
     #[test]
+    fn test_import() {
+        let dir = testdir("test");
+        let path = dir.path("test");
+
+        assert!(run_cmd("leo new import", &Some(path.clone())).is_ok());
+
+        let import_path = &Some(path.join("import"));
+
+        assert!(run_cmd("leo add no-package/definitely-no", import_path).is_err());
+        assert!(run_cmd("leo add justice-league/u8u32", import_path).is_ok());
+        assert!(run_cmd("leo remove u8u32", import_path).is_ok());
+        assert!(run_cmd("leo add --author justice-league --package u8u32", import_path).is_ok());
+        assert!(run_cmd("leo remove u8u32", import_path).is_ok());
+        assert!(run_cmd("leo remove u8u32", import_path).is_err());
+    }
+
+    #[test]
     fn test_missing_file() {
         let dir = testdir("test");
         let path = dir.path("test");


### PR DESCRIPTION
## Motivation

The last drop into recent activity - tests for imports. Recent test improvements showed that some areas were not covered, and it's better to test as much as possible covering edge cases.
 
Adds test for `leo add` and `leo remove` with most of the possible options and arguments. 

## Test Plan

This is test-only PR.