### PR TITLE
Update status of strings RFC.

### DIFF
--- a/docs/rfc/001-initial-strings.md
+++ b/docs/rfc/001-initial-strings.md
@@ -14,7 +14,7 @@
 
 ## Status
 
-DRAFT
+IMPLEMENTED
 
 # Summary
 


### PR DESCRIPTION
I realized that we never updated the status of the strings RFC. We don't seem to have a designated enumeration of possible statuses of RFCs (e.g. draft, approved, etc.), but it looks like 'implemented' could be a good status for this.