### PR TITLE
Fix treating inputs as constants in to_usize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,50 +3,25 @@
 version = 3
 
 [[package]]
-name = "abnf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e669320c520d87931e752d603dd442b4709c73b1b8b1fcba838f9c5acc1791"
-dependencies = [
- "abnf-core",
- "nom",
-]
-
-[[package]]
-name = "abnf-core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b514944cb7199c4201f54406bc58676a3e4f37d40bf8e3dbe30652ca82e3ddb4"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "addr2line"
-version = "0.14.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
+checksum = "e7a2e47a1fbe209ee101dd6d61285226744c6c8d3c21c8dc878ba6cb9f467f3a"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
 name = "adler"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bedc89c5c7b5550ffb9372eb5c5ffc7f9f705cc3f4a128bd4669b9745f555093"
-
-[[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -74,12 +49,6 @@ name = "anyhow"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "assert_cmd"
@@ -114,14 +83,15 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.56"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
+checksum = "b7815ea54e4d821e791162e078acbebfd6d8c8939cd559c9335dceb1c8ca7282"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.4.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -161,9 +131,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.19.5"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+checksum = "5237f00a8c86130a0cc317830e558b966dd7850d48a953d998c813f01a41b527"
 dependencies = [
  "funty",
  "radium",
@@ -191,7 +161,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -214,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+checksum = "90682c8d613ad3373e66de8c6411e0ae2ab2571e879d2efbf73558cc66f21279"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -226,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
 
 [[package]]
 name = "byte-tools"
@@ -238,9 +208,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -271,18 +241,18 @@ dependencies = [
 
 [[package]]
 name = "cast"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+checksum = "57cdfa5d50aad6cb4d44dcab6101a7f79925bd59d82ca42f38a9856a28865374"
 dependencies = [
- "rustc_version 0.2.3",
+ "rustc_version",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
 
 [[package]]
 name = "cfg-if"
@@ -378,9 +348,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec1028182c380cc45a2e2c5ec841134f2dfd0f8f5f0a5bcd68004f81b5efdf4"
+checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]
@@ -432,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -453,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -466,11 +436,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
@@ -513,9 +482,9 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -530,7 +499,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array 0.12.3",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -621,9 +590,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "synstructure",
 ]
 
@@ -647,14 +616,14 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.14"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cfff41391129e0a856d6d822600b8d71179d46879e310417eb9c762eb178b42"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "miniz_oxide 0.3.7",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -741,9 +710,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "1847abb9cb65d566acd5942e94aea9c8f547ad02c98e1649326fc0e8910b8b1e"
 
 [[package]]
 name = "futf"
@@ -757,43 +726,44 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
 dependencies = [
+ "autocfg",
  "futures-core",
  "futures-io",
  "futures-task",
@@ -814,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
 ]
@@ -853,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -864,15 +834,15 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.23.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
+checksum = "0e4075386626662786ddb0ec9081e7c7eeb1ba31951f447ca780ef9f5d568189"
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
 dependencies = [
  "bytes",
  "fnv",
@@ -885,7 +855,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -902,9 +871,9 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -926,9 +895,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes",
  "fnv",
@@ -937,31 +906,32 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -973,7 +943,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -996,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1098,9 +1068,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1131,7 +1101,6 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 name = "leo-abnf"
 version = "1.5.0"
 dependencies = [
- "abnf",
  "anyhow",
 ]
 
@@ -1353,23 +1322,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21f866863575d0e1d654fbeeabdc927292fdf862873dc3c96c6f753357e13374"
-dependencies = [
- "arrayvec",
- "bitflags",
- "cfg-if 1.0.0",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.89"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "538c092e5586f4cdd7dd8078c4a79220e3e168880218124dcbce860f0ea938c6"
+checksum = "789da6d93f1b866ffe175afc5322a4d76c038605a1c3319bb57b06967ca98a36"
 
 [[package]]
 name = "linked-hash-map"
@@ -1415,15 +1371,15 @@ checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -1442,15 +1398,6 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
 ]
 
 [[package]]
@@ -1484,13 +1431,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2182a122f3b7f3f5329cb1972cee089ba2459a0a80a56935e6e674f096f8d839"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
+ "miow 0.3.7",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -1521,11 +1468,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi 0.3.9",
 ]
 
@@ -1569,19 +1515,6 @@ name = "nias"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
-
-[[package]]
-name = "nom"
-version = "6.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
-dependencies = [
- "bitvec",
- "funty",
- "lexical-core",
- "memchr",
- "version_check",
-]
 
 [[package]]
 name = "notify"
@@ -1658,9 +1591,12 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.23.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+checksum = "f8bc1d42047cf336f0f939c99e97183cf31551bf0f2865a2ec9c8d91fd4ffb5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -1688,9 +1624,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.33"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61075b62a23fef5a29815de7536d940aa35ce96d18ce0cc5076272db678a577"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1702,15 +1638,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.61"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313752393519e876837e09e1fa183ddef0be7735868dced3196f4472d536277f"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
  "autocfg",
  "cc",
@@ -1765,9 +1701,9 @@ checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
 dependencies = [
  "pest",
  "pest_meta",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -1782,30 +1718,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
-dependencies = [
- "proc-macro2 1.0.24",
- "quote 1.0.9",
- "syn 1.0.64",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1821,9 +1737,9 @@ checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
+checksum = "32a3fd9ec30b9749ce28cd91f255d569591cdf937fe280c312143e3c4bad6f2a"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -1855,9 +1771,9 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "predicates"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb433456c1a57cc93554dea3ce40b4c19c4057e41c55d4a0f3d84ea71c325aa"
+checksum = "f49cfaf7fdaa3bfacc6fa3e7054e65148878354a5cfddcf661df4c851f8021df"
 dependencies = [
  "difference",
  "predicates-core",
@@ -1895,9 +1811,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "version_check",
 ]
 
@@ -1907,7 +1823,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
  "version_check",
 ]
@@ -1923,11 +1839,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -1954,14 +1870,14 @@ version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
 ]
 
 [[package]]
 name = "radium"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -2023,7 +1939,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
 ]
 
 [[package]]
@@ -2055,9 +1971,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2067,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -2080,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
 dependencies = [
  "bitflags",
 ]
@@ -2093,15 +2009,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.2.2",
+ "getrandom 0.2.3",
  "redox_syscall",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2110,19 +2026,18 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 dependencies = [
- "byteorder",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -2171,18 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
+checksum = "410f7acf3cb3a44527c5d9546bad4bf4e6c460915d5f9f2fc524498bfe8f70ce"
 
 [[package]]
 name = "rustc_version"
@@ -2190,7 +2096,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
 dependencies = [
- "semver 0.11.0",
+ "semver",
 ]
 
 [[package]]
@@ -2238,9 +2144,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.1.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d493c5f39e02dfb062cd8f33301f90f9b13b650e8c1b1d0fd75c19dd64bff69d"
+checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2251,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "7e4effb91b4b8b6fb7732e670b6cee160278ff8e6bf485c7805d9e319d76e284"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2271,19 +2177,10 @@ dependencies = [
  "quick-xml",
  "regex",
  "reqwest",
- "semver 0.11.0",
+ "semver",
  "serde_json",
  "tempfile",
  "zip",
-]
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
 ]
 
 [[package]]
@@ -2292,14 +2189,8 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.2",
+ "semver-parser",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -2335,16 +2226,16 @@ version = "1.0.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43535db9747a4ba938c0ce0a98cc631a46ebf943c9e1d604e091df6007620bf6"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -2420,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
@@ -2432,10 +2323,11 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f8349fad4f4e9a05ab4fde6baa99aad8542fcaf10320128114fdc26798a0ad"
+checksum = "6f603fdc7bda72382ba25aeedbc6b86e4a0b8ec84d17aa355c4ec28e7655d3b6"
 dependencies = [
+ "bitvec",
  "blake2",
  "derivative",
  "digest 0.9.0",
@@ -2455,14 +2347,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8f71e6243e588507a7935512bcd79e28906ad89553671151eaf721e42b1513"
+checksum = "2b1a4b3cb0a68de48d3263a25fa63a3ae14df1f5042fdf536a207b616f1e4217"
 dependencies = [
  "derivative",
  "rand 0.8.3",
  "rand_xorshift",
- "rustc_version 0.3.3",
+ "rustc_version",
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
@@ -2471,36 +2363,40 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1b3ad83bcd981531a29e8e70bac4cf34126b1031f42bc529975a46e49100383"
+checksum = "a87c013ae803f616168939152836beb419cc7d76a12e17db3c723a0c11faa612"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54268e972e18e7a1508418f29fe3f64201f86acf2131ed28b1bc9f8891fc1bbb"
+checksum = "99b53fac158f2c002a0598b640a5e630cba11928399df94ec7c875545940dc77"
 dependencies = [
  "anyhow",
  "base58",
  "bech32",
+ "bincode",
  "blake2",
+ "chrono",
  "derivative",
  "hex",
  "itertools 0.10.0",
+ "once_cell",
  "rand 0.8.3",
+ "serde",
+ "sha2",
  "snarkvm-algorithms",
  "snarkvm-curves",
  "snarkvm-fields",
  "snarkvm-gadgets",
- "snarkvm-objects",
  "snarkvm-parameters",
  "snarkvm-profiler",
  "snarkvm-r1cs",
@@ -2510,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b885226e300d6a237905038fba681eaa2a851e5cb45a22b685c0bc87c574b6"
+checksum = "818e32f60d87abbe22e04d44ec358849e78393ae7e0a315334e3402dea909198"
 dependencies = [
  "bincode",
  "derivative",
@@ -2525,13 +2421,16 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0322e4fd5fe0b0b7499a6b1dbd47d20cf65e0904a23094ba087662253ed60ff0"
+checksum = "0ada1393bd60a1f0536a6cf7acf7f5b0baea3f60c272298381b36254ee02fe86"
 dependencies = [
  "derivative",
  "digest 0.9.0",
  "itertools 0.10.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "snarkvm-algorithms",
  "snarkvm-curves",
  "snarkvm-fields",
@@ -2541,31 +2440,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "snarkvm-objects"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b2dd86a3d036d09608e7493c7a14bf17a59648e567cd08414d2520a627d07"
-dependencies = [
- "anyhow",
- "bincode",
- "chrono",
- "hex",
- "once_cell",
- "rand 0.8.3",
- "serde",
- "sha2",
- "snarkvm-algorithms",
- "snarkvm-curves",
- "snarkvm-parameters",
- "snarkvm-utilities",
- "thiserror",
-]
-
-[[package]]
 name = "snarkvm-parameters"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7932c7d7fd7b9572a1acaad3c9622f6849c414e5ac8bdb599a504ef4330bb857"
+checksum = "423de9bd2138a73ae8eb7e7962d1c392adfb3c94f51f1a0de7ad0bd955a446d9"
 dependencies = [
  "hex",
  "snarkvm-algorithms",
@@ -2575,15 +2453,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877f7ee215903aa4da2343f6d82fd5ec7426210a33f4773770ab35dbdddd3bd9"
+checksum = "ce44449083a65a43271d39db5b219bc17eaf8f21b155edf6598ba8d3eb868ad0"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5695a57009b1b79f32df22d88f5d5dabf7a84f6a953280896ae4edb8b9db76d"
+checksum = "775650eb6ea9bec8b8b185a612ce99d91962af40579134cc9d4964902172ef51"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -2596,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.3.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996ba23293c9288d983003c224450db8a6acd875f9fe7f6d839ab91897023b5b"
+checksum = "e2c3439bd12599fcaca1d885eb9051c885f2276be2dd0e2692e5f90cc03466f1"
 dependencies = [
  "bincode",
  "rand 0.8.3",
@@ -2608,20 +2486,13 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -2648,9 +2519,9 @@ checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2672,13 +2543,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.64"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd9d1e9976102a03c542daa2eff1b43f9d72306342f3f8b3ed5fb8908195d6f"
+checksum = "a1e8cdbefb79a9a5a65e0db8b47b723ee907b7c7f8496c76a1770b5c310bab82"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "unicode-xid 0.2.1",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -2687,10 +2558,10 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
- "unicode-xid 0.2.1",
+ "syn 1.0.72",
+ "unicode-xid 0.2.2",
 ]
 
 [[package]]
@@ -2726,9 +2597,9 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ca8ced750734db02076f44132d802af0b33b09942331f4459dde8636fd2406"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -2767,9 +2638,9 @@ version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2803,9 +2674,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2818,15 +2689,15 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.3.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d56477f6ed99e10225f38f9f75f872f29b8b8bd8c0b946f63345bb144e9eeda"
+checksum = "0a38d31d7831c6ed7aad00aa4c12d9375fd225a6dd77da1d25b707346319a975"
 dependencies = [
  "autocfg",
  "bytes",
  "libc",
  "memchr",
- "mio 0.7.10",
+ "mio 0.7.11",
  "num_cpus",
  "pin-project-lite",
 ]
@@ -2843,9 +2714,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec31e5cc6b46e653cf57762f36f71d5e6386391d88a72fd6db4508f8f676fb29"
+checksum = "1caa0b0c8d94a049db56b5acf8cba99dc0623aab1b26d5b5f5e2d945846b3592"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2888,9 +2759,9 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -2900,16 +2771,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]
@@ -2996,18 +2857,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
+checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
@@ -3032,15 +2893,15 @@ checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3050,15 +2911,15 @@ dependencies = [
 
 [[package]]
 name = "utf-8"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e42f7c18b8f902290b009cde6d651262f956c98bc51bca4cd1d511c9cd85c7"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
+checksum = "025ce40a007e1907e58d5bc1a594def78e5573bb0b1160bc389634e8f12e4faa"
 
 [[package]]
 name = "vec_map"
@@ -3068,9 +2929,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "void"
@@ -3122,9 +2983,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -3134,24 +2995,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.20"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3de431a2910c86679c34283a33f66f4e4abd7e0aec27b6669060148872aadf94"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -3161,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
 dependencies = [
  "quote 1.0.9",
  "wasm-bindgen-macro-support",
@@ -3171,28 +3032,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
 dependencies = [
- "proc-macro2 1.0.24",
+ "proc-macro2 1.0.27",
  "quote 1.0.9",
- "syn 1.0.64",
+ "syn 1.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3262,9 +3123,12 @@ dependencies = [
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "129e027ad65ce1453680623c3fb5163cbf7107bfe1aa32257e7d0e63f9ced188"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,22 +70,22 @@ path = "./synthesizer"
 version = "1.5.0"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.5.4"
 
 [dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.5.4"
 
 [dependencies.anyhow]
 version = "1.0"

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -57,27 +57,27 @@ version = "1.5.0"
 version = "0.4"
 
 [dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.5.4"
 
 [dependencies.bincode]
 version = "1.3"
@@ -118,7 +118,7 @@ version = "0.3"
 default-features = false
 
 [dev-dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dev-dependencies.tempfile]

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -32,7 +32,7 @@ use leo_package::inputs::InputPairs;
 use leo_parser::parse_ast;
 use leo_state::verify_local_data_commitment;
 
-use snarkvm_dpc::{base_dpc::instantiated::Components, SystemParameters};
+use snarkvm_dpc::testnet1::{instantiated::Components, parameters::SystemParameters};
 use snarkvm_fields::PrimeField;
 use snarkvm_r1cs::{ConstraintSynthesizer, ConstraintSystem, SynthesisError};
 

--- a/compiler/src/console/assert.rs
+++ b/compiler/src/console/assert.rs
@@ -26,7 +26,7 @@ use crate::{
 use leo_asg::{Expression, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/console/console.rs
+++ b/compiler/src/console/console.rs
@@ -20,7 +20,7 @@ use crate::{errors::ConsoleError, program::ConstrainedProgram, statement::get_in
 use leo_asg::{ConsoleFunction, ConsoleStatement};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -29,7 +29,7 @@ use crate::{
 use leo_asg::{ConstInt, Expression, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::{
+use snarkvm_gadgets::{
     boolean::Boolean,
     eq::{EqGadget, EvaluateEqGadget},
     select::CondSelectGadget,

--- a/compiler/src/expression/conditional/conditional.rs
+++ b/compiler/src/expression/conditional/conditional.rs
@@ -20,7 +20,7 @@ use crate::{errors::ExpressionError, program::ConstrainedProgram, value::Constra
 use leo_asg::{Expression, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::select::CondSelectGadget;
+use snarkvm_gadgets::traits::select::CondSelectGadget;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/expression/expression.rs
+++ b/compiler/src/expression/expression.rs
@@ -30,7 +30,7 @@ use crate::{
 use leo_asg::{expression::*, ConstValue, Expression, Node, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/expression/logical/and.rs
+++ b/compiler/src/expression/logical/and.rs
@@ -20,7 +20,7 @@ use crate::{errors::BooleanError, value::ConstrainedValue, GroupType};
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn enforce_and<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/logical/or.rs
+++ b/compiler/src/expression/logical/or.rs
@@ -20,7 +20,7 @@ use crate::{errors::BooleanError, value::ConstrainedValue, GroupType};
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn enforce_or<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/relational/eq.rs
+++ b/compiler/src/expression/relational/eq.rs
@@ -20,7 +20,7 @@ use crate::{enforce_and, errors::ExpressionError, value::ConstrainedValue, Group
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{boolean::Boolean, eq::EvaluateEqGadget};
+use snarkvm_gadgets::{boolean::Boolean, eq::EvaluateEqGadget};
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn evaluate_eq<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/relational/ge.rs
+++ b/compiler/src/expression/relational/ge.rs
@@ -20,7 +20,7 @@ use crate::{errors::ExpressionError, value::ConstrainedValue, GroupType};
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::bits::ComparatorGadget;
+use snarkvm_gadgets::traits::bits::ComparatorGadget;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn evaluate_ge<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/relational/gt.rs
+++ b/compiler/src/expression/relational/gt.rs
@@ -20,7 +20,7 @@ use crate::{errors::ExpressionError, value::ConstrainedValue, GroupType};
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::bits::ComparatorGadget;
+use snarkvm_gadgets::traits::bits::ComparatorGadget;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn evaluate_gt<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/relational/le.rs
+++ b/compiler/src/expression/relational/le.rs
@@ -20,7 +20,7 @@ use crate::{errors::ExpressionError, value::ConstrainedValue, GroupType};
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::bits::ComparatorGadget;
+use snarkvm_gadgets::traits::bits::ComparatorGadget;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn evaluate_le<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/expression/relational/lt.rs
+++ b/compiler/src/expression/relational/lt.rs
@@ -20,7 +20,7 @@ use crate::{errors::ExpressionError, value::ConstrainedValue, GroupType};
 use leo_asg::Span;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::bits::EvaluateLtGadget;
+use snarkvm_gadgets::traits::bits::EvaluateLtGadget;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub fn evaluate_lt<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSystem<F>>(

--- a/compiler/src/function/function.rs
+++ b/compiler/src/function/function.rs
@@ -22,7 +22,7 @@ use leo_asg::{Expression, Function, FunctionQualifier};
 use std::cell::Cell;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/function/input/main_function_input.rs
+++ b/compiler/src/function/input/main_function_input.rs
@@ -36,7 +36,7 @@ use leo_asg::{ConstInt, Type};
 use leo_ast::{InputValue, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/function/mut_target.rs
+++ b/compiler/src/function/mut_target.rs
@@ -33,7 +33,7 @@ use leo_asg::{
 };
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/function/result/result.rs
+++ b/compiler/src/function/result/result.rs
@@ -27,7 +27,7 @@ use crate::{
 use leo_asg::{Span, Type};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{boolean::Boolean, select::CondSelectGadget};
+use snarkvm_gadgets::{boolean::Boolean, select::CondSelectGadget};
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/prelude/blake2s.rs
+++ b/compiler/src/prelude/blake2s.rs
@@ -17,13 +17,13 @@
 use super::CoreCircuit;
 use crate::{errors::ExpressionError, ConstrainedValue, GroupType, Integer};
 use leo_asg::{Function, Span};
+
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
     algorithms::prf::Blake2sGadget,
-    traits::{
-        algorithms::PRFGadget,
-        utilities::{uint::UInt8, ToBytesGadget},
-    },
+    bits::ToBytesGadget,
+    integers::uint::UInt8,
+    traits::algorithms::PRFGadget,
 };
 use snarkvm_r1cs::ConstraintSystem;
 

--- a/compiler/src/statement/assign/assign.rs
+++ b/compiler/src/statement/assign/assign.rs
@@ -20,7 +20,7 @@ use crate::{arithmetic::*, errors::StatementError, program::ConstrainedProgram, 
 use leo_asg::{AssignOperation, AssignStatement, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{boolean::Boolean, select::CondSelectGadget};
+use snarkvm_gadgets::{boolean::Boolean, traits::select::CondSelectGadget};
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/statement/assign/assignee/array_index.rs
+++ b/compiler/src/statement/assign/assignee/array_index.rs
@@ -28,7 +28,7 @@ use crate::{
 use leo_asg::{ConstInt, Expression, Node};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::{eq::EvaluateEqGadget, select::CondSelectGadget};
+use snarkvm_gadgets::{eq::EvaluateEqGadget, select::CondSelectGadget};
 use snarkvm_r1cs::ConstraintSystem;
 
 use super::ResolverContext;

--- a/compiler/src/statement/assign/assignee/mod.rs
+++ b/compiler/src/statement/assign/assignee/mod.rs
@@ -20,7 +20,7 @@ use crate::{errors::StatementError, program::ConstrainedProgram, value::Constrai
 use leo_asg::{AssignAccess, AssignOperation, AssignStatement, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 mod array_index;

--- a/compiler/src/statement/block/block.rs
+++ b/compiler/src/statement/block/block.rs
@@ -20,7 +20,7 @@ use crate::{program::ConstrainedProgram, GroupType, IndicatorAndConstrainedValue
 use leo_asg::BlockStatement;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -27,7 +27,7 @@ use crate::{
 use leo_asg::ConditionalStatement;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 fn indicator_to_string(indicator: &Boolean) -> String {

--- a/compiler/src/statement/iteration/iteration.rs
+++ b/compiler/src/statement/iteration/iteration.rs
@@ -29,7 +29,7 @@ use crate::{
 use leo_asg::IterationStatement;
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{boolean::Boolean, uint::UInt32};
+use snarkvm_gadgets::{boolean::Boolean, integers::uint::UInt32};
 use snarkvm_r1cs::ConstraintSystem;
 
 impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {

--- a/compiler/src/statement/statement.rs
+++ b/compiler/src/statement/statement.rs
@@ -20,7 +20,7 @@ use crate::{errors::StatementError, program::ConstrainedProgram, value::Constrai
 use leo_asg::{Node, Statement};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::boolean::Boolean;
+use snarkvm_gadgets::boolean::Boolean;
 use snarkvm_r1cs::ConstraintSystem;
 
 pub type StatementResult<T> = Result<T, StatementError>;

--- a/compiler/src/value/address/address.rs
+++ b/compiler/src/value/address/address.rs
@@ -17,14 +17,16 @@
 use crate::{errors::AddressError, ConstrainedValue, GroupType, IntegerTrait};
 use leo_ast::{InputValue, Span};
 
-use snarkvm_dpc::{account::AccountAddress, base_dpc::instantiated::Components};
+use snarkvm_dpc::{account::AccountAddress, testnet1::instantiated::Components};
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{
-    alloc::AllocGadget,
+use snarkvm_gadgets::{
     boolean::Boolean,
-    eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
-    select::CondSelectGadget,
-    uint::UInt8,
+    integers::uint::UInt8,
+    traits::{
+        alloc::AllocGadget,
+        eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
+        select::CondSelectGadget,
+    },
 };
 use snarkvm_r1cs::{Assignment, ConstraintSystem, SynthesisError};
 use snarkvm_utilities::ToBytes;

--- a/compiler/src/value/boolean/input.rs
+++ b/compiler/src/value/boolean/input.rs
@@ -20,7 +20,7 @@ use crate::{errors::BooleanError, value::ConstrainedValue, GroupType};
 use leo_ast::{InputValue, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{alloc::AllocGadget, boolean::Boolean};
+use snarkvm_gadgets::{boolean::Boolean, traits::alloc::AllocGadget};
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 pub(crate) fn allocate_bool<F: PrimeField, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/char/char.rs
+++ b/compiler/src/value/char/char.rs
@@ -23,11 +23,11 @@ use crate::{
 
 use leo_ast::{InputValue, Span};
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::utilities::{
-    bits::comparator::{ComparatorGadget, EvaluateLtGadget},
+use snarkvm_gadgets::{
     boolean::Boolean,
     eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget, NEqGadget},
     select::CondSelectGadget,
+    traits::bits::comparator::{ComparatorGadget, EvaluateLtGadget},
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 

--- a/compiler/src/value/field/field_type.rs
+++ b/compiler/src/value/field/field_type.rs
@@ -21,19 +21,16 @@ use leo_ast::Span;
 
 use snarkvm_fields::PrimeField;
 use snarkvm_gadgets::{
+    bits::{ToBitsBEGadget, ToBytesGadget},
+    boolean::Boolean,
     fields::FpGadget,
+    integers::uint::UInt8,
     traits::{
+        alloc::AllocGadget,
+        bits::comparator::{ComparatorGadget, EvaluateLtGadget},
+        eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget, NEqGadget},
         fields::FieldGadget,
-        utilities::{
-            alloc::AllocGadget,
-            bits::comparator::{ComparatorGadget, EvaluateLtGadget},
-            boolean::Boolean,
-            eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget, NEqGadget},
-            select::CondSelectGadget,
-            uint::UInt8,
-            ToBitsBEGadget,
-            ToBytesGadget,
-        },
+        select::CondSelectGadget,
     },
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};

--- a/compiler/src/value/field/input.rs
+++ b/compiler/src/value/field/input.rs
@@ -20,7 +20,7 @@ use crate::{errors::FieldError, number_string_typing, value::ConstrainedValue, F
 use leo_ast::{InputValue, Span};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::alloc::AllocGadget;
+use snarkvm_gadgets::traits::alloc::AllocGadget;
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 
 pub(crate) fn allocate_field<F: PrimeField, CS: ConstraintSystem<F>>(

--- a/compiler/src/value/group/group_type.rs
+++ b/compiler/src/value/group/group_type.rs
@@ -20,12 +20,13 @@ use crate::errors::GroupError;
 use leo_asg::{GroupValue, Span};
 
 use snarkvm_fields::{Field, One};
-use snarkvm_gadgets::traits::utilities::{
-    alloc::AllocGadget,
-    eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
-    select::CondSelectGadget,
-    ToBitsBEGadget,
-    ToBytesGadget,
+use snarkvm_gadgets::{
+    bits::{ToBitsBEGadget, ToBytesGadget},
+    traits::{
+        alloc::AllocGadget,
+        eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
+        select::CondSelectGadget,
+    },
 };
 use snarkvm_r1cs::ConstraintSystem;
 use std::fmt::{Debug, Display};

--- a/compiler/src/value/group/targets/edwards_bls12.rs
+++ b/compiler/src/value/group/targets/edwards_bls12.rs
@@ -25,21 +25,18 @@ use snarkvm_curves::{
 };
 use snarkvm_fields::{Fp256, One, Zero};
 use snarkvm_gadgets::{
+    bits::{ToBitsBEGadget, ToBytesGadget},
+    boolean::Boolean,
     curves::edwards_bls12::EdwardsBlsGadget,
     fields::{AllocatedFp, FpGadget},
+    integers::uint::UInt8,
     traits::{
+        alloc::AllocGadget,
         curves::GroupGadget,
+        eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
         fields::FieldGadget,
-        utilities::{
-            alloc::AllocGadget,
-            boolean::Boolean,
-            eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
-            select::CondSelectGadget,
-            uint::UInt8,
-            ToBitsBEGadget,
-            ToBytesGadget,
-        },
     },
+    CondSelectGadget,
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use std::{

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -91,7 +91,7 @@ impl Integer {
     }
 
     pub fn is_allocated(&self) -> bool {
-        self.get_bits().into_iter().any(|b| !matches!(b, Boolean::Constant(_)))
+        self.get_bits().into_iter().any(|b| matches!(b, Boolean::Is(_) | Boolean::Not(_)))
     }
 
     pub fn get_value(&self) -> Option<String> {

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -91,10 +91,7 @@ impl Integer {
     }
 
     pub fn is_allocated(&self) -> bool {
-        self.get_bits().into_iter().any(|b| match b {
-            Boolean::Constant(_) => false,
-            _ => true,
-        })
+        self.get_bits().into_iter().any(|b| !matches!(b, Boolean::Constant(_)))
     }
 
     pub fn get_value(&self) -> Option<String> {

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -90,25 +90,12 @@ impl Integer {
         match_integer!(integer => integer.to_bits_le())
     }
 
-    // pub fn get_bits_typed(&self) -> (Vec<Boolean>, IntegerType) {
-    //     let integer = self;
-    //     (match_integer!(integer => integer.to_bits_le()), self.get_type())
-    // }
-
-    // pub fn from_bits_typed(type_: &IntegerType, bits: &[Boolean]) -> Integer {
-    //     match type_ {
-    //         IntegerType::U8 => Integer::U8(UInt8::from_bits_le(bits)),
-    //         IntegerType::U16 => Integer::U16(UInt16::from_bits_le(bits)),
-    //         IntegerType::U32 => Integer::U32(UInt32::from_bits_le(bits)),
-    //         IntegerType::U64 => Integer::U64(UInt64::from_bits_le(bits)),
-    //         IntegerType::U128 => Integer::U128(UInt128::from_bits_le(bits)),
-    //         IntegerType::I8 => Integer::I8(Int8::from_bits_le(bits)),
-    //         IntegerType::I16 => Integer::I16(Int16::from_bits_le(bits)),
-    //         IntegerType::I32 => Integer::I32(Int32::from_bits_le(bits)),
-    //         IntegerType::I64 => Integer::I64(Int64::from_bits_le(bits)),
-    //         IntegerType::I128 => Integer::I128(Int128::from_bits_le(bits)),
-    //     }
-    // }
+    pub fn is_allocated(&self) -> bool {
+        self.get_bits().into_iter().any(|b| match b {
+            Boolean::Constant(_) => false,
+            _ => true,
+        })
+    }
 
     pub fn get_value(&self) -> Option<String> {
         let integer = self;
@@ -116,6 +103,9 @@ impl Integer {
     }
 
     pub fn to_usize(&self) -> Option<usize> {
+        if self.is_allocated() {
+            return None;
+        }
         let unsigned_integer = self;
         match_unsigned_integer!(unsigned_integer => unsigned_integer.value.map(|num| num.try_into().ok()).flatten())
     }

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -20,15 +20,19 @@ use leo_asg::{ConstInt, IntegerType, Span};
 use leo_ast::InputValue;
 
 use snarkvm_fields::{Field, PrimeField};
-use snarkvm_gadgets::traits::utilities::{
-    alloc::AllocGadget,
-    arithmetic::{Add, Div, Mul, Neg, Pow, Sub},
-    bits::comparator::{ComparatorGadget, EvaluateLtGadget},
+use snarkvm_gadgets::{
     boolean::Boolean,
-    eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
-    int::{Int128, Int16, Int32, Int64, Int8},
-    select::CondSelectGadget,
-    uint::{Sub as UIntSub, *},
+    integers::{
+        int::{Int128, Int16, Int32, Int64, Int8},
+        uint::{Sub as UIntSub, *},
+    },
+    traits::{
+        alloc::AllocGadget,
+        bits::comparator::{ComparatorGadget, EvaluateLtGadget},
+        eq::{ConditionalEqGadget, EqGadget, EvaluateEqGadget},
+        integers::{Add, Div, Mul, Neg, Pow, Sub},
+        select::CondSelectGadget,
+    },
 };
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use std::{convert::TryInto, fmt};

--- a/compiler/src/value/integer/integer.rs
+++ b/compiler/src/value/integer/integer.rs
@@ -91,7 +91,9 @@ impl Integer {
     }
 
     pub fn is_allocated(&self) -> bool {
-        self.get_bits().into_iter().any(|b| matches!(b, Boolean::Is(_) | Boolean::Not(_)))
+        self.get_bits()
+            .into_iter()
+            .any(|b| matches!(b, Boolean::Is(_) | Boolean::Not(_)))
     }
 
     pub fn get_value(&self) -> Option<String> {

--- a/compiler/src/value/integer/macros.rs
+++ b/compiler/src/value/integer/macros.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-pub use snarkvm_gadgets::traits::utilities::integer::Integer as IntegerTrait;
+pub use snarkvm_gadgets::integer::Integer as IntegerTrait;
 
 /// Useful macros to avoid duplicating `match` constructions.
 #[macro_export]

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -20,7 +20,10 @@ use crate::{errors::ValueError, Address, Char, FieldType, GroupType, Integer};
 use leo_asg::{Circuit, Identifier, Span, Type};
 
 use snarkvm_fields::PrimeField;
-use snarkvm_gadgets::traits::utilities::{boolean::Boolean, eq::ConditionalEqGadget, select::CondSelectGadget};
+use snarkvm_gadgets::{
+    bits::Boolean,
+    traits::{eq::ConditionalEqGadget, select::CondSelectGadget},
+};
 use snarkvm_r1cs::{ConstraintSystem, SynthesisError};
 use std::fmt;
 

--- a/docs/rfc/001-initial-strings.md
+++ b/docs/rfc/001-initial-strings.md
@@ -14,7 +14,7 @@
 
 ## Status
 
-DRAFT
+IMPLEMENTED
 
 # Summary
 

--- a/grammar/Cargo.toml
+++ b/grammar/Cargo.toml
@@ -17,6 +17,11 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2018"
 
-[dependencies]
-abnf = "0.11.3"
-anyhow = "1.0"
+#[dependencies.abnf]
+#version = "0.11.3"
+#default-features = false
+
+[dependencies.anyhow]
+version = "1.0"
+
+

--- a/grammar/src/main.rs
+++ b/grammar/src/main.rs
@@ -38,180 +38,180 @@
 // ;;;;;;;;;
 // ```
 //
-use abnf::types::{Node, Rule};
-use anyhow::Result;
-use std::collections::{HashMap, HashSet};
-
-/// Processor's scope. Used when code block or definition starts or ends.
-#[derive(Debug, Clone)]
-enum Scope {
-    Free,
-    Code,
-    Definition(Rule),
-}
-
-/// Transforms abnf file into Markdown.
-#[derive(Debug, Clone)]
-struct Processor<'a> {
-    rules: HashMap<String, Rule>,
-    grammar: &'a str,
-    scope: Scope,
-    line: u32,
-    out: String,
-}
-
-impl<'a> Processor<'a> {
-    fn new(grammar: &'a str, abnf: Vec<Rule>) -> Processor<'a> {
-        // we need a hashmap to pull rules easily
-        let rules: HashMap<String, Rule> = abnf.into_iter().map(|rule| (rule.name().to_string(), rule)).collect();
-
-        Processor {
-            grammar,
-            line: 0,
-            out: String::new(),
-            rules,
-            scope: Scope::Free,
-        }
-    }
-
-    /// Main function for this struct.
-    /// Goes through each line and transforms it into proper markdown.
-    fn process(&mut self) {
-        let lines = self.grammar.lines();
-        let mut prev = "";
-
-        for line in lines {
-            self.line += 1;
-
-            // code block in comment (not highlighted as abnf)
-            if let Some(code) = line.strip_prefix(";  ") {
-                self.enter_scope(Scope::Code);
-                self.append_str(code);
-
-            // just comment. end of code block
-            } else if let Some(code) = line.strip_prefix("; ") {
-                self.enter_scope(Scope::Free);
-                self.append_str(code);
-
-            // horizontal rule - section separator
-            } else if line.starts_with(";;;;;;;;;;") {
-                self.enter_scope(Scope::Free);
-                self.append_str("\n--------\n");
-
-            // empty line in comment. end of code block
-            } else if line.starts_with(';') {
-                self.enter_scope(Scope::Free);
-                self.append_str("\n\n");
-
-            // just empty line. end of doc, start of definition
-            } else if line.is_empty() {
-                self.enter_scope(Scope::Free);
-                self.append_str("");
-
-            // definition (may be multiline)
-            } else {
-                // if there's an equality sign and previous line was empty
-                if line.contains('=') && prev.is_empty() {
-                    let (def, _) = line.split_at(line.find('=').unwrap());
-                    let def = def.trim();
-
-                    // try to find rule matching definition or fail
-                    let rule = self.rules.get(&def.to_string()).cloned().unwrap();
-
-                    self.enter_scope(Scope::Definition(rule));
-                }
-
-                self.append_str(line);
-            }
-
-            prev = line;
-        }
-    }
-
-    /// Append new line into output, add newline character.
-    fn append_str(&mut self, line: &str) {
-        self.out.push_str(line);
-        self.out.push('\n');
-    }
-
-    /// Enter new scope (definition or code block). Allows customizing
-    /// pre and post lines for each scope entered or exited.
-    fn enter_scope(&mut self, new_scope: Scope) {
-        match (&self.scope, &new_scope) {
-            // exchange scopes between Free and Code
-            (Scope::Free, Scope::Code) => self.append_str("```"),
-            (Scope::Code, Scope::Free) => self.append_str("```"),
-            // exchange scopes between Free and Definition
-            (Scope::Free, Scope::Definition(rule)) => {
-                self.append_str(&format!("<a name=\"{}\"></a>", rule.name()));
-                self.append_str("```abnf");
-            }
-            (Scope::Definition(rule), Scope::Free) => {
-                let mut rules: Vec<String> = Vec::new();
-                parse_abnf_node(rule.node(), &mut rules);
-
-                // 1. leave only unique keys
-                // 2. map each rule into a link
-                // 3. join results as a list
-                // Note: GitHub only allows custom tags with 'user-content-' prefix
-                let keys = rules
-                    .into_iter()
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .map(|tag| format!("[{}](#user-content-{})", &tag, tag))
-                    .collect::<Vec<String>>()
-                    .join(", ");
-
-                self.append_str("```");
-
-                if !keys.is_empty() {
-                    self.append_str(&format!("\nGo to: _{}_;\n", keys));
-                }
-            }
-            (_, _) => (),
-        };
-
-        self.scope = new_scope;
-    }
-}
-
-/// Recursively parse ABNF Node and fill sum vec with found rule names.
-fn parse_abnf_node(node: &Node, sum: &mut Vec<String>) {
-    match node {
-        // these two are just vectors of rules
-        Node::Alternatives(vec) | Node::Concatenation(vec) => {
-            for node in vec {
-                parse_abnf_node(node, sum);
-            }
-        }
-        Node::Group(node) | Node::Optional(node) => parse_abnf_node(node.as_ref(), sum),
-
-        // push rulename if it is known
-        Node::Rulename(name) => sum.push(name.clone()),
-
-        // do nothing for other nodes
-        _ => (),
-    }
-}
-
-fn main() -> Result<()> {
-    // Take Leo ABNF grammar file.
-    let grammar = include_str!("../abnf-grammar.txt");
-
-    // Parse ABNF to get list of all definitions.
-    // Rust ABNF does not provide support for `%s` (case sensitive strings, part of
-    // the standard); so we need to remove all occurrences before parsing.
-    let parsed = abnf::rulelist(&str::replace(grammar, "%s", "")).map_err(|e| {
-        eprintln!("{}", &e);
-        anyhow::anyhow!(e)
-    })?;
-
-    // Init parser and run it. That's it.
-    let mut parser = Processor::new(grammar, parsed);
-    parser.process();
-
-    // Print result of conversion to STDOUT.
-    println!("{}", parser.out);
-
-    Ok(())
-}
+// use abnf::types::{Node, Rule};
+// use anyhow::Result;
+// use std::collections::{HashMap, HashSet};
+//
+// /// Processor's scope. Used when code block or definition starts or ends.
+// #[derive(Debug, Clone)]
+// enum Scope {
+//     Free,
+//     Code,
+//     Definition(Rule),
+// }
+//
+// /// Transforms abnf file into Markdown.
+// #[derive(Debug, Clone)]
+// struct Processor<'a> {
+//     rules: HashMap<String, Rule>,
+//     grammar: &'a str,
+//     scope: Scope,
+//     line: u32,
+//     out: String,
+// }
+//
+// impl<'a> Processor<'a> {
+//     fn new(grammar: &'a str, abnf: Vec<Rule>) -> Processor<'a> {
+//         // we need a hashmap to pull rules easily
+//         let rules: HashMap<String, Rule> = abnf.into_iter().map(|rule| (rule.name().to_string(), rule)).collect();
+//
+//         Processor {
+//             grammar,
+//             line: 0,
+//             out: String::new(),
+//             rules,
+//             scope: Scope::Free,
+//         }
+//     }
+//
+//     /// Main function for this struct.
+//     /// Goes through each line and transforms it into proper markdown.
+//     fn process(&mut self) {
+//         let lines = self.grammar.lines();
+//         let mut prev = "";
+//
+//         for line in lines {
+//             self.line += 1;
+//
+//             // code block in comment (not highlighted as abnf)
+//             if let Some(code) = line.strip_prefix(";  ") {
+//                 self.enter_scope(Scope::Code);
+//                 self.append_str(code);
+//
+//             // just comment. end of code block
+//             } else if let Some(code) = line.strip_prefix("; ") {
+//                 self.enter_scope(Scope::Free);
+//                 self.append_str(code);
+//
+//             // horizontal rule - section separator
+//             } else if line.starts_with(";;;;;;;;;;") {
+//                 self.enter_scope(Scope::Free);
+//                 self.append_str("\n--------\n");
+//
+//             // empty line in comment. end of code block
+//             } else if line.starts_with(';') {
+//                 self.enter_scope(Scope::Free);
+//                 self.append_str("\n\n");
+//
+//             // just empty line. end of doc, start of definition
+//             } else if line.is_empty() {
+//                 self.enter_scope(Scope::Free);
+//                 self.append_str("");
+//
+//             // definition (may be multiline)
+//             } else {
+//                 // if there's an equality sign and previous line was empty
+//                 if line.contains('=') && prev.is_empty() {
+//                     let (def, _) = line.split_at(line.find('=').unwrap());
+//                     let def = def.trim();
+//
+//                     // try to find rule matching definition or fail
+//                     let rule = self.rules.get(&def.to_string()).cloned().unwrap();
+//
+//                     self.enter_scope(Scope::Definition(rule));
+//                 }
+//
+//                 self.append_str(line);
+//             }
+//
+//             prev = line;
+//         }
+//     }
+//
+//     /// Append new line into output, add newline character.
+//     fn append_str(&mut self, line: &str) {
+//         self.out.push_str(line);
+//         self.out.push('\n');
+//     }
+//
+//     /// Enter new scope (definition or code block). Allows customizing
+//     /// pre and post lines for each scope entered or exited.
+//     fn enter_scope(&mut self, new_scope: Scope) {
+//         match (&self.scope, &new_scope) {
+//             // exchange scopes between Free and Code
+//             (Scope::Free, Scope::Code) => self.append_str("```"),
+//             (Scope::Code, Scope::Free) => self.append_str("```"),
+//             // exchange scopes between Free and Definition
+//             (Scope::Free, Scope::Definition(rule)) => {
+//                 self.append_str(&format!("<a name=\"{}\"></a>", rule.name()));
+//                 self.append_str("```abnf");
+//             }
+//             (Scope::Definition(rule), Scope::Free) => {
+//                 let mut rules: Vec<String> = Vec::new();
+//                 parse_abnf_node(rule.node(), &mut rules);
+//
+//                 // 1. leave only unique keys
+//                 // 2. map each rule into a link
+//                 // 3. join results as a list
+//                 // Note: GitHub only allows custom tags with 'user-content-' prefix
+//                 let keys = rules
+//                     .into_iter()
+//                     .collect::<HashSet<_>>()
+//                     .into_iter()
+//                     .map(|tag| format!("[{}](#user-content-{})", &tag, tag))
+//                     .collect::<Vec<String>>()
+//                     .join(", ");
+//
+//                 self.append_str("```");
+//
+//                 if !keys.is_empty() {
+//                     self.append_str(&format!("\nGo to: _{}_;\n", keys));
+//                 }
+//             }
+//             (_, _) => (),
+//         };
+//
+//         self.scope = new_scope;
+//     }
+// }
+//
+// /// Recursively parse ABNF Node and fill sum vec with found rule names.
+// fn parse_abnf_node(node: &Node, sum: &mut Vec<String>) {
+//     match node {
+//         // these two are just vectors of rules
+//         Node::Alternatives(vec) | Node::Concatenation(vec) => {
+//             for node in vec {
+//                 parse_abnf_node(node, sum);
+//             }
+//         }
+//         Node::Group(node) | Node::Optional(node) => parse_abnf_node(node.as_ref(), sum),
+//
+//         // push rulename if it is known
+//         Node::Rulename(name) => sum.push(name.clone()),
+//
+//         // do nothing for other nodes
+//         _ => (),
+//     }
+// }
+//
+// fn main() -> Result<()> {
+//     // Take Leo ABNF grammar file.
+//     let grammar = include_str!("../abnf-grammar.txt");
+//
+//     // Parse ABNF to get list of all definitions.
+//     // Rust ABNF does not provide support for `%s` (case sensitive strings, part of
+//     // the standard); so we need to remove all occurrences before parsing.
+//     let parsed = abnf::rulelist(&str::replace(grammar, "%s", "")).map_err(|e| {
+//         eprintln!("{}", &e);
+//         anyhow::anyhow!(e)
+//     })?;
+//
+//     // Init parser and run it. That's it.
+//     let mut parser = Processor::new(grammar, parsed);
+//     parser.process();
+//
+//     // Print result of conversion to STDOUT.
+//     println!("{}", parser.out);
+//
+//     Ok(())
+// }

--- a/leo/commands/setup.rs
+++ b/leo/commands/setup.rs
@@ -19,13 +19,14 @@ use crate::{commands::Command, context::Context};
 use leo_compiler::{compiler::Compiler, group::targets::edwards_bls12::EdwardsGroupType};
 use leo_package::outputs::{ProvingKeyFile, VerificationKeyFile};
 
-use anyhow::{anyhow, Result};
-use rand::thread_rng;
 use snarkvm_algorithms::{
-    snark::groth16::{Groth16, Parameters, PreparedVerifyingKey, VerifyingKey},
+    snark::groth16::{Groth16, PreparedVerifyingKey, ProvingKey, VerifyingKey},
     traits::snark::SNARK,
 };
 use snarkvm_curves::bls12_377::{Bls12_377, Fr};
+
+use anyhow::{anyhow, Result};
+use rand::thread_rng;
 use structopt::StructOpt;
 use tracing::span::Span;
 
@@ -44,7 +45,7 @@ impl Command for Setup {
     type Input = <Build as Command>::Output;
     type Output = (
         Compiler<'static, Fr, EdwardsGroupType>,
-        Parameters<Bls12_377>,
+        ProvingKey<Bls12_377>,
         PreparedVerifyingKey<Bls12_377>,
     );
 
@@ -108,7 +109,7 @@ impl Command for Setup {
                 tracing::info!("Skipping curve check");
             }
             let proving_key_bytes = ProvingKeyFile::new(&package_name).read_from(&path)?;
-            let proving_key = Parameters::<Bls12_377>::read(proving_key_bytes.as_slice(), !self.skip_key_check)?;
+            let proving_key = ProvingKey::<Bls12_377>::read(proving_key_bytes.as_slice(), !self.skip_key_check)?;
             tracing::info!("Complete");
 
             // Read the verification key file from the output directory

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -26,18 +26,19 @@ path = "../ast"
 version = "1.5.0"
 
 [dependencies.snarkvm-algorithms]
-version = "0.3.1"
+version = "0.5.4"
 
 [dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
+features = [ "testnet1" ]
 
 [dependencies.snarkvm-utilities]
-version = "0.3.1"
+version = "0.5.4"
 
 [dependencies.indexmap]
 version = "1.6.2"

--- a/state/src/local_data_commitment/local_data_commitment.rs
+++ b/state/src/local_data_commitment/local_data_commitment.rs
@@ -22,7 +22,7 @@ use snarkvm_algorithms::{
     traits::{CommitmentScheme, CRH},
 };
 use snarkvm_dpc::{
-    base_dpc::{
+    testnet1::{
         instantiated::{Components, LocalDataCRH, LocalDataCommitment},
         parameters::SystemParameters,
     },

--- a/state/src/record_commitment/dpc_record_values.rs
+++ b/state/src/record_commitment/dpc_record_values.rs
@@ -17,7 +17,7 @@
 use crate::{utilities::*, DPCRecordValuesError};
 use leo_ast::Record as AstRecord;
 
-use snarkvm_dpc::{base_dpc::instantiated::Components, AccountAddress};
+use snarkvm_dpc::{testnet1::instantiated::Components, AccountAddress};
 
 use std::{convert::TryFrom, str::FromStr};
 

--- a/state/src/record_commitment/record_commitment.rs
+++ b/state/src/record_commitment/record_commitment.rs
@@ -18,7 +18,7 @@ use crate::{DPCRecordValues, RecordVerificationError};
 use leo_ast::Record as AstRecord;
 
 use snarkvm_algorithms::traits::CommitmentScheme;
-use snarkvm_dpc::base_dpc::{
+use snarkvm_dpc::testnet1::{
     instantiated::{Components, RecordCommitment},
     parameters::SystemParameters,
 };

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -18,18 +18,18 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-curves]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.3.1"
+version = "0.5.4"
 
 [dependencies.snarkvm-r1cs]
-version = "0.3.1"
+version = "0.5.4"
 default-features = false
 
 [dependencies.num-bigint]

--- a/tests/expectations/compiler/compiler/array/registers.leo.out
+++ b/tests/expectations/compiler/compiler/array/registers.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 119
       num_constraints: 143
-      at: ae3e8a95d339433e8a11fc7a54536b8f56abacc03cffa1c4f4be8fa32bc4da8b
+      at: 144d1bd1f6756ac172ddddf3ca5cf4358ba8fc053fd754b56a425ab6566af47a
       bt: 43972815ec9d0ab821613fde2cd6a5df9ee42f50758a27a0fed6dc111b44f3ee
       ct: 5ed7a755b881aa851f3d3e966a4bd18dd48ce59be71b4ada39c9c891f8297201
     output:

--- a/tests/expectations/compiler/compiler/boolean/equal.leo.out
+++ b/tests/expectations/compiler/compiler/boolean/equal.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 3
       num_constraints: 3
-      at: d4e77c2cd10c964fbbc4ad4f374dc36b3a6bc7d6865b87ec5234076348308c2c
+      at: 01e9615846575e848deea9a9802ceed188fdbfc4660f6f22de41845adcce14ac
       bt: 49e8fa1fd3f85b0f486c49f194e4fff3da5e8039685fca1f3327389cbe9fc180
       ct: 7ca43d5c34997f3c866631161cb33186cc016972238c07771ae105ca1b05320d
     output:

--- a/tests/expectations/compiler/compiler/boolean/not_equal.leo.out
+++ b/tests/expectations/compiler/compiler/boolean/not_equal.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 3
       num_constraints: 3
-      at: d4e77c2cd10c964fbbc4ad4f374dc36b3a6bc7d6865b87ec5234076348308c2c
+      at: 01e9615846575e848deea9a9802ceed188fdbfc4660f6f22de41845adcce14ac
       bt: 49e8fa1fd3f85b0f486c49f194e4fff3da5e8039685fca1f3327389cbe9fc180
       ct: 7ca43d5c34997f3c866631161cb33186cc016972238c07771ae105ca1b05320d
     output:

--- a/tests/expectations/compiler/compiler/circuits/define_circuit_inside_circuit_function.leo.out
+++ b/tests/expectations/compiler/compiler/circuits/define_circuit_inside_circuit_function.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 95
       num_constraints: 95
-      at: 5267486d9db0d5d95b248da00196e1a6e5c6e165f8580eae4fbf20d8e1560fd7
+      at: a57d02fa8b8a2336cc5c407e6a9489a3cb89357e3a3d966f18d8f0f86c21602f
       bt: e0a9aa0cab882fb690b28137d24f271ccaa334521934a3badc07592a31b7be7f
-      ct: 5983ee7f60c1fc1ad4aaece7815002040cd4b5a7e019b3967f948d30f5d7ec96
+      ct: 7b8a2025971971c829b68fc994c6761496807e5b091ba4360d90fb6f35f4656e
     output:
       - input_file: func_circ.in
         output:

--- a/tests/expectations/compiler/compiler/circuits/member_function_nested.leo.out
+++ b/tests/expectations/compiler/compiler/circuits/member_function_nested.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 161
       num_constraints: 163
-      at: e35800570ea5a58f3587ffba2b1be2a1df1c5790a6cbe215083e3d5d5a13b2bf
+      at: 4251eba02c1be1eeb4193b08906095b69cdec831207fe2ddba09e783ad4725ce
       bt: 799dc824f6ba6a51959a395a3b5ebf05629aa241dbca9550190f32380b91ae1c
       ct: 2aa6128cdf932752c8864c26a6a3d4991f3e6a75b22c1261a3389efa67375b01
     output:

--- a/tests/expectations/compiler/compiler/console/log_conditional.leo.out
+++ b/tests/expectations/compiler/compiler/console/log_conditional.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 190
       num_constraints: 190
-      at: 50e55296085087c5ca1fd3d7c3894d10dd4bad60b83c4a7984e8dbf77126e92b
+      at: a1a80b7c355e1fa32c2136c4dc7a0fd0670affbdda869a9161a3a69f396c6b9a
       bt: fbf306d0d13bf3d40926ad7adc07f122cb8d065e7e5d55f3416ac30d7ebe7a7c
       ct: 97e2acff1b76912c52107342393ec04a09af81353a25f7ce330b8492f41381cf
     output:

--- a/tests/expectations/compiler/compiler/input_files/program_input/main_multiple.leo.out
+++ b/tests/expectations/compiler/compiler/input_files/program_input/main_multiple.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 3
       num_constraints: 3
-      at: d4e77c2cd10c964fbbc4ad4f374dc36b3a6bc7d6865b87ec5234076348308c2c
+      at: 01e9615846575e848deea9a9802ceed188fdbfc4660f6f22de41845adcce14ac
       bt: 49e8fa1fd3f85b0f486c49f194e4fff3da5e8039685fca1f3327389cbe9fc180
       ct: 7ca43d5c34997f3c866631161cb33186cc016972238c07771ae105ca1b05320d
     output:

--- a/tests/expectations/compiler/compiler/input_files/program_input_and_program_state/basic.leo.out
+++ b/tests/expectations/compiler/compiler/input_files/program_input_and_program_state/basic.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 3
       num_constraints: 3
-      at: c5f99f3b350445cd2709c7f76cda7a2ff158e972c58dc1294b346ab21b5c9100
+      at: 83b1bd5868cfd70d986276428ff81a9120e0848a6f44d7bd6d5a25d6063c7669
       bt: 5a01b0726c5b948a3b336179b77081865f51dc2f1de630ce95b03424a5ae7998
       ct: 7ca43d5c34997f3c866631161cb33186cc016972238c07771ae105ca1b05320d
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 1404
       num_constraints: 1405
-      at: 1de369da9f4704c5dfe4d6b415ef81ab0a16e02ccb89af770ab9083526d9db94
+      at: b738445f9fa8039b6d93543917f21faebabd70ce5f0fc95bc2b82f9a96653e78
       bt: 7d12a27b02e7c965ac1775f6711d6da181ea2a809f8bf644ab1755929013f7e4
       ct: e7b4e2f5a4e98c3a9016990ee3dd9bbf5e55e7a98e1dc3ac7d4b458ecdcdde7e
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 511
       num_constraints: 511
-      at: 7dcc86d79e1657a96155485d8aac78bca5392b8376b33faae47dfc973b4e810d
+      at: f130bde196ac7e190b505a42dfb30c41772c4c7eafe9e7203be9222892b767ce
       bt: 7ac37b347f82644239128aa66e9caf34375b1fd860069659581477883d92fb7a
       ct: 3e4c7833e73f9ee37e42c796e8af7a6d417a012b776b348abedbfd317110858d
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/div.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 506500
       num_constraints: 556546
-      at: 276ce56b48a5db9e546f468d1360d00b27728dc93b8632fd78a88db9efbfe1f8
+      at: 168dc7e5a5c91155b81d611ec03fe223c562493918fb29fc46ce84cb1f54b7f5
       bt: b9699f707750827fa2663e2e2c6ef82c786ed4c74556e3bed076d78eb1a896b1
-      ct: 9fe6835b23ef949becddbd4ec16c3fc389c72ee929e57a82a3336848e077758e
+      ct: ee951676608c1176ff532d3d37c5827e2180105104289b2b1b273333677227cc
     output:
       - input_file: i128.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i128/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 513
       num_constraints: 513
-      at: 1394ad70170ddf61787d75c37b0438dc380e73ed0570a0755e1ea121261f084b
+      at: 75b34d698fc2359df51943102062181aa5ee62b84a221747dfd7f8868bf48efd
       bt: c1e085f0d8047bc5b5f574ca9de7d79a0ce3b3235e3bfb83ff15aecf05ad1323
       ct: c224fec21cf5a2b24eb94033a20aeb4729d3d0cf596339145cb49ea6a44cc5d8
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: 05d7005b5fdaa7c459327b4c1d09041dcc226aaff499ee3885883ae499a450de
+      at: 96f20d0620bc9136e98bfe583ce40c6ad4359d33c7bafe02d1e121e411b1df50
       bt: bf4203445221fa42994f563865391d625b571513cf25a20cf465fbe26647ec5d
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: dc1301c93c3e7eff4464797dae66c49012deb970199561074fa23c7a0d8aeab3
+      at: 98a9cad46c764246288557ee4b5ded8e4f2ca8c99e07068d8e5cfef000e22e31
       bt: 7734cf8efdd437cd881763da604d9524fca91092bda9b6fc677ff9c30fa4b3c7
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: 8bee805269694137605d1f95f7824ed777f516e048d69e70e83236ee01c2ec03
+      at: e7341bd3736199176968e0d217b64de1913590fe3c69e32c4a398014df18f20f
       bt: 78d5b43e2c7d048af797f16a430d0ce5b99f8305fb1dbd0c7a0a6f36cbd6b046
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: 57c1d9c06091b82189025923173d4cdc95c8e8f741979d2a9102ff55d8d507a2
+      at: 9164a7c32351fa140180bb6aedc74fc291dde69bbff2b1e9c2191b3d155356dd
       bt: 9a46d23879218b3aa9d5b6575fc677aca1f7470b3b4e623a26f410a38200661b
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 393216
       num_constraints: 393217
-      at: e58d2cc579cdf111ac8fa1552f20b2c11c11aeaa9a9f0e009b1254b6369cd1a3
+      at: d5a0c9b374587e6c25f437a157bef0c152665743371172ba94d04e13a1a8f509
       bt: 2d0600e403e694d114c452c3e5c1ad2137e48b5344b3760dbec2e826420b8a9e
       ct: 76b519a48f8267fa180bc68f3e7a84fe7319a3ad2e76338916cb399d9cea22d8
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 513
       num_constraints: 513
-      at: 48bbe0018b41afb2e67252317f5b9562174680891247b191932e8c9ddfac6235
+      at: 8f9d3ef916a970cb762ca6f3829a8b4897dc65d493a2ea2eb4fa812a2062fe67
       bt: edc1de9388a8bb2c659c9b4e9deecd8406826abcfe220d295bf7d85a550c0c43
       ct: c224fec21cf5a2b24eb94033a20aeb4729d3d0cf596339145cb49ea6a44cc5d8
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/negate.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/negate.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 765
       num_constraints: 765
-      at: 98dd464444c8062f02a0911a1ddea0094fd3ebd3506ca2676979105087fe7397
+      at: 46af0432868923f7cad6e7db2de33a69ccad1a789e92d552ec26f8fc19a7d33d
       bt: f1167d856668e1efcd49f020430a704e62ad6e46006e7faf58acdac8bb8a5ba2
       ct: 075f6359a5dd933b671b42c06465f4c70f5ec152176c234fb4d3cdfbe6255daf
     output:

--- a/tests/expectations/compiler/compiler/integers/i128/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/sub.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 1658
       num_constraints: 1659
-      at: 6b875cb06d16a700f8d1b42d2c49142252ad34cf6d54f08ea232a0fe525d9085
+      at: bb46c735f0d1698aa6cf8637b23babcdf0df3ec6e64f4b2e7d3e86f6f461e961
       bt: 859297637693ebdf41005288cf212906c1d7619049b4305d34d9dededb24b5c5
-      ct: 97ce4bbb07278639ab86e5665c47e13e1156e2f338bc0048937eccb87f48e4b1
+      ct: 50293f70acfe4a8aadffa8b17c18b0411493c8760fc474dcdf26f5bc7d70ada4
     output:
       - input_file: i128.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i128/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 896
       num_constraints: 1024
-      at: 2ba7f5e796779d99922e1b044ce5614b7e35945ff743c2b54412f00570bb935f
+      at: 0830a3e788b536b36f271fadaadcc919281b2171d4e18814385b74f6820cb5c9
       bt: 1fb9bfc22c01a54c08602e7f3883c19b00de1070aa9bad9e9234e322f9043711
       ct: ee9facabe4c76f5eb89984d3c5cb15f92eaa0cc3b4bc4fdff261aeb36ad0101b
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 172
       num_constraints: 173
-      at: 723a4a49b4ef8819a93abd262d8ee19904417d6f8b6e9820cbc923e6953ce77c
+      at: 6b89cd61c27d609100734788caaf250a61c4e65e8bb53a70cb9a67bd3970d344
       bt: 3685748e2150def12598827c6d3217b7665ad912fcf517afafed7dd933dd68a2
       ct: acefb38d2e822ba8454f989fcdcfad22e9c15b0115cebecf3ec7f842412b0812
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 63
       num_constraints: 63
-      at: 4cac6455a624606970ebe776412ee9b9d5800577aea1fad0677b866e991b6181
+      at: 781fbf42db29f7fa9c21d99e21d8f011ec22b33ad26d3f80438687aafd462285
       bt: abee7b67c55170fc3341444203a9a70e68690dce751aa36d3e91f1cf7ceef73d
       ct: 51c18ee4216feeb01d0b0d661dfeb294e7e100873586edf79be89c8b54d9e168
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/div.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 7764
       num_constraints: 8642
-      at: 7ca6ba5e059aec2fb7bd4f8b0f6e37d6de7fbfa1f71ef7447f10a667aea9f7ca
+      at: 021e947acc78bbd99baa676d90f79998564e19d2b0478fb1e2e7946189d94bc2
       bt: eadd8a53b4c1d8efbd2015f9e358120b022061fc46b548fdab054b5a75a79757
-      ct: 5df37aa184759798530f98a25acc5b096300451053e7165286e3956c0d90c449
+      ct: 496912e80f22b87bffa4fcb70059f09f267d5edf5f85e42030b7bd3d65bc57d3
     output:
       - input_file: i16.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i16/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 65
       num_constraints: 65
-      at: d1e727ca124b8a409ccaa2404651441e669134e272d9d6635564d4e2509b7ebb
+      at: 8c8b795ef4142f2651625b90b3624d24de5138c3fb0981288a8cc5e12bf31f82
       bt: eba2113bdda3d667d9e8c87f545fe4e2a0143b18a3fff0c1aaa46dd376ed1735
       ct: f037d279ccea3ca689e05801ec3ba0053b5ce66a1763d4620262ea9b69873008
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 692a1e97a27ff41538ae2636fbc61e80056a629462752ec88e9992fe6c985b62
+      at: aacaa02fab172aad56801a9785e4265f42a5b7a8a90f3277508d9bdf9b71739e
       bt: dc20f75204b1fb858e1971441f24a4aa1780e545581c55ff3d52cec41be65b79
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 0f2769e8c910d59c929dc4ad4ef8599892ff8b1562de13a8440763e58d66bba5
+      at: 5c1bf4b2c0dcee44497206b68fafb1e2e98bc020688d260da3730723c0c90dd8
       bt: 07da85fcfccc58758d043e27b0aab5a749760c644824684c13befde258deb78c
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 52b091c77b6309726784221787aaf2a03110e4951a3f05e99f29d4f9b55f650c
+      at: a38a17fb5f40313343215b604602dfb492eb06cc8ac81d7d75443663398eb105
       bt: 34c1c5f1fd258fc5f18137e0cd367a6c3149958ec8b92123518e293db31afbe3
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 47043c58e00ec824b11a140b997e8346345dfd7dbbada1f6b4ea6cbd87474881
+      at: 882216b2b7d92dafe18a2ba6eefed789ba0084c92957772d0b1e3797ac391d8f
       bt: 564588048812d9300963caf70148f154c231faa3209aed2ee5f9dd51a31af0ef
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 6144
       num_constraints: 6145
-      at: e0ac196102c7e3dab5f8b99377bd64bdafc963706644e45cccf0e9e008d80654
+      at: a82b875e925052eba2aa8b33aaa6a654c144148e94e18bbe9649dcdd1fc0ad71
       bt: cd23bca179b84ca9238460e8de4ec0c0afdc0ce1e3d6669329fc4baf08e7e0db
       ct: f60e073d0353b71ab07769daa585ce03799bb2f4095a0dda5f9009b4f42162ed
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 65
       num_constraints: 65
-      at: 0fdea959dac884336ecafa3d6ae5bb268aaefacd91e099a206f2974681d6a0a8
+      at: 83a4d089927a9811a9d4ed5b3ee2e50e395cd598de865653be04a2c51904b072
       bt: 30bc7cfbc53a2e928ca0310b6041f1f1548ad7c1197ffc9301b46522122e5561
       ct: f037d279ccea3ca689e05801ec3ba0053b5ce66a1763d4620262ea9b69873008
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/negate.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/negate.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 93
       num_constraints: 93
-      at: 3f12aea0b23980da83e9b76f0f59c727d5ced82bd09ac8bcf9b26537b42bcbda
+      at: 29988ea86584610f4511315204ed49c45d0303c44e0fb59c0df19dc048cee369
       bt: 9bba1722080b8c396e72a645c5ca7dff2943c0b29a741569acdba3887e40c8af
       ct: 4f89ea4838bc4544e2767b7dc68a1e0fa0649d7401bb7ae8292bd6aa654eda28
     output:

--- a/tests/expectations/compiler/compiler/integers/i16/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/sub.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 202
       num_constraints: 203
-      at: e2596c361eae975f6e49b22e11f1776fb711d2b9e6a69041b230ebb3d9561a5e
+      at: 7b1b870d629fe64b117f0be092b7336e6b4149ac6778d0f4d02273e0c2b59a2a
       bt: 035e3e8f741942f4683b2262c8f0fc75c0c5a89252c069ed956abce34019b988
-      ct: 4d408b4df7a360a52a36a57c13e15711470bb854d599278e72f31cae00ddb347
+      ct: cd38769a0ae3aefd48815d80555886d23370399b29596b8433ad23be67afc55f
     output:
       - input_file: i16.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i16/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i16/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 112
       num_constraints: 128
-      at: 58c61c468b93481b5691b278622e567b5a718e6411cce53fdbe46e2839bdf8c3
+      at: b0a107f586de648c8446ae3246117de3b20ba9c0249d261f234106809d112f0a
       bt: 0e5faacb5d80488eeda9e7fa79ddd96e54c010e0e98571449f79cad816cc18a2
       ct: 2b3428d7c7335edc32ab219fe11c92e215d70a52c89434de349f4951561d5795
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 348
       num_constraints: 349
-      at: 623759513f511047731696dc641970503b3a71642eaf04c325203156d8ffb600
+      at: 2fe67b488b0f96f2f6be7e96dc7f102984b0132232e452f44e40cad21a1dc5f3
       bt: 8dd304125c8178327f11b0894be2788080258a5a80aab3c1df046fea9f262789
       ct: 8b73986e71edfc8b716f535eaa069b04cc15502adbd166ae713df42cb9d37a3c
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 127
       num_constraints: 127
-      at: e0e639bf48906da80759e2f98e3205a68a63ae175dcd7c198fe3bf6b1650a84e
+      at: 051151c1ab89f2c0ff0fe5d336668c3fcd6dc4744d1f5b8e135dcb7bf6a6195c
       bt: 6b92443726163ac0fc32f7c9edace0ec8369e793d24105d93d121cb0bd5c3128
       ct: 7cb2d3f0ccfb9a2e747c6a05bdb52812c4539c836ff62c4e555fac13ef2084d4
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/div.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 31396
       num_constraints: 34690
-      at: da21ab443f5a626be92c61f68a650ce70f13aebfe7e7f385490af4d8ff812311
+      at: c916998b93bc4ded6f989fe837aa04d3a2ea3c46c26bba70514d346ddf13f7dc
       bt: 2b765f5660bc847af13d6361ed89fbc296cfa094fd80972604f1745259c14289
-      ct: 037b7ecfb3a4477858f5587ac9671bc32d664e4ca55d311f1c77502f58321c85
+      ct: 3054de0adc6f09929e39a097dc66d9dace247ff1481254154c31e5416d6b82e7
     output:
       - input_file: i32.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i32/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 129
       num_constraints: 129
-      at: 669271745b6c4fd803216e0e59f47da168d7e5bb9f7058232265a79c62f67696
+      at: 4ce4f2bf481c4f7e47396527999e129066d1f157413884f91ced3d2b525a3187
       bt: e63628fc48d1e71ea44830c010e442f577239e29f7ffada0d8df34c28e67f107
       ct: 9f4c72431c0c7c03e216195a071c971c53deed8e3bfce450bffb3a6fad7418d5
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 56b3865e8aa1bfe3069fca36232a122eaa9430c642d17cfd2a51e07abe948ead
+      at: fba74e6ed7ae0c0cf0bd2c874940e7e9daf6c7c4e08cf9359b31279433ec0ef5
       bt: 3f23038cdf71876dea48b44b9cae993b3f649b628bcdaf6f1cb77bbafa92b600
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 5d29f27de2cc29c473be77bf193ab76c81325cf7379c8cb128f529dd2f8f2b75
+      at: fec1628688d454ab244e921b74f7f70ff6c7acf18280488dfb43cd0bb4bd70d2
       bt: 02fd44d092923c1a89fc492a9660926934e03005d8c3fa5f42ae2a3fbd7048ea
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 0e304c1ff4b2d054a884efec2b672faeb96edc095eb9092b1afe8161500dc7cd
+      at: 39f909848aee2ee744719f8692f58b9745aeaeededc431f1b06df839384bff07
       bt: 4e75a3c5fd91239e6bf32d96c6a4a702e040e4a3bddcc282706ca76facb9e942
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: ab78d207fa52f7931c697b9d6999ef4d6adde046baf32c1a85a90dbfd24f1cd1
+      at: fcca8f94beb99b6f86edd3f8c36b81043482e6c449fc4278d53d546c295810ed
       bt: 26e3dae4bf8fe37424b8ef7cc60b6136809286a8e64736e63b8b5dfacf774c21
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 24576
       num_constraints: 24577
-      at: fb4e2b915ecfd8fe94bb73daaa80c1b2ad75c155ecf96250fbe020cec4fb2bd9
+      at: 3f0c50eed51d601da1dd661e666f96fcf5285b7be20881d92b7fa14e6147c5fd
       bt: fc2efd0d73e1d0feb345c15515e796fcd289003e5e388d35be464e3ee76a0cb5
       ct: f720f62a8a58bc4a64c837cfad115c98d50ccfe3b208fb9fa346c5c17ff7ded4
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 129
       num_constraints: 129
-      at: 4886c2b717c624374dad0a9b657c2081663a6eb235c10b386bcaf117c0fdb004
+      at: 6cde17fb079861287679ad93d9ed9125cfc21000431bfeaf5a2054360ce51ef7
       bt: 1178e67ab79eac96592f17313168c4300d53e89ab571025054d53d19dfdfd1b8
       ct: 9f4c72431c0c7c03e216195a071c971c53deed8e3bfce450bffb3a6fad7418d5
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/negate.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/negate.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 189
       num_constraints: 189
-      at: 1f06616d7ab0f9397c33e23191bf4bcda843096a327c797c3149139ac7ad9e08
+      at: 2254172298dcedafc294b068f855ab0dd689491362b1b490a8c95435e4b159da
       bt: 244d201ae16e93cdd97ca56d698598a5a66e1bcb2794d58b5e24f6f9df9760a4
       ct: 1607b4ad7556c35957a6cbce85868f0f82d2c65e55f13350ef81738caec6e235
     output:

--- a/tests/expectations/compiler/compiler/integers/i32/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/sub.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 410
       num_constraints: 411
-      at: 7e15d23fe1f99f56b446ff52d2998286e031c68d26a3308ddfe6caf3271b9e31
+      at: 3293cb0f2e38fae78ca837de736471f6e36a372f92282123f6082e07648b412b
       bt: c342f65da421c48d402ba324062abbb064eb525a99fe5379fcb1654a33a11d68
-      ct: f9165fc0dbff251907271ea7256f90598d12e2dea3afdd1293099a08e9922fe6
+      ct: 8a37ed12cbab476be56f1dc175e38c689f5bde3909161865409085a34c4a19f1
     output:
       - input_file: i32.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i32/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 224
       num_constraints: 256
-      at: 9338a0dd9e836893acff2938b8ad85ab3255dd2f189dd4f2bc00fef2d38c073d
+      at: 45301188494f0c65b2e88eac9117ba7367e772ea34e9b8f34bf3d49dbd1dd067
       bt: 35d9c47cfd4fc137760d0ee411c0b097541cab7aae2b0a9ea83b368328fe5c23
       ct: 032da4c7df957d9ca89b5395be6e1c84cab7d19a78abe1b02bb37b26ca65b0e4
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 700
       num_constraints: 701
-      at: 2d074af82e5f1955746fb3ab5dde050a622ac0d1f55f76a97eee76419aaaebc2
+      at: cecef57cd6d6e05c1f08807f82c42ac9ab45def4542662ca606c2e8183f36c76
       bt: dbea824d3f892b3f86e08d05b68eecdc0de998bcd12186475d90ede9dfc5dfd8
       ct: 8bc1636c45d8da73bfa0c5a71972d9829c9954007eff5db6f8fa4672d5b57c4f
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 255
       num_constraints: 255
-      at: 085ed7b795cfdd2b367e0714e4f7c75cd84b99895bc7597ffc3134ab4b4fb47a
+      at: 68080cb19b62be7f91ee2118affb7b55ea272e15e17581869385053a5c6d3623
       bt: 2c1d031e57e285b1277f2c37853fc7fdff23711e1147d7b26ed74d3acd28ceff
       ct: 0b136215b60005ed17aa4eea76bc4e2b0349c0fecf57dc06f5dba31981f270d0
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/div.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 126276
       num_constraints: 139010
-      at: 08ca67f8f6a55a97c98376e47bdc55730ebf02eea500e26f3d21d8fcbd01eed8
+      at: 5569763c96399af86cb10f3f5658e82c52594a8b4bd085542d92a6090db5f83f
       bt: 2a2b1dfbe635b61460fcba331f7383edd70f065881804500e5c4068771b1b040
-      ct: 6bbd0c0bfca90f9c361b96367f77ea0c1efb042d3e60117944ff7d05fd50f2eb
+      ct: 4dab363af1609fb733af59eb97aed35a67429bfa2cdd45c8c2bc8fcfa1ae6268
     output:
       - input_file: i64.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i64/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 257
       num_constraints: 257
-      at: 4461f4148de047b81686ddce14909d0676354608816291b838209335b7b5040c
+      at: 30dc67aa22cadc6e5ec8c73e0096443263121e29adf46bb33ed310b07765ff6e
       bt: 1aaee32179419b6185d75c5745bd13c7c8ba869bad0132405ef1b28915bfe5d9
       ct: 8edd5528a862bbd5590cfbd0d52871e395cf73e3a22c70839571b36506fbe3a7
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: 732f88f6d74154902e8e9ccb6a4f52a7ff945ad78d37bbd769fcfd226e7d3261
+      at: 04829ad53a315f620a66d1fc8152176c29a250b57c54482f7e2fba84cad444c4
       bt: 46fa1dbc8f6cc62609913fe96ad20cff4ba8ba7ea886b3682c3b4dc9a491b334
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: 00e3111a40957b18c86be06041e0064425fee842c1d44ec540ba3ab7dbcde7d8
+      at: 2805d5c14f23da221eefbd223bafa37ae210f961594e020f8aeb1a9ff00d7287
       bt: 3947204249ecf9b6f7339e9c6409daf25d626f7e807ac182d3222e61fb4499dd
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: 583b2c56b8f6afe21b1853986324c698ae281b32af481dc24333125506210d63
+      at: 228ee4529b5cacfbd2dfbe9fe20088c9e8de89c4f80fcca316cd4ed3830ff633
       bt: b228ce69df9ccfd94eb2d43619a82e2720dc0b34666b6850f0cd42db04befdef
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: 6cd1a9d0201b57ab7f8618df8baa423bedbfc501b15cd6e1497867f15133ef8b
+      at: 639536c4b5bf6a7c935ad88f1b89a66819ee24afa34d949536ab84e9cddd7fa0
       bt: fcbfd8b9b01e1754f1023d94765533fb9199baa19fddcb89a4d2a010e7844284
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 98304
       num_constraints: 98305
-      at: 08ca93778574f4dd25706eddac7210062ffe0fc794108555bcc597892a739c8e
+      at: bad40272ae6cda7f44d2b892d1768eee85552b506921982eef405d5cc8d70e43
       bt: 2fc487f7ec79d8c33c89cf5c899ad0b56f7468af6aec96081b6f08344fbf872f
       ct: 37717cfdc15b44be3cd83355ff38227c8abc7aa09152746fe4cd7f42ae31ea9f
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 257
       num_constraints: 257
-      at: 94abff87eb8bfdc488ea06a67dcf479c6a05c779b40e11c40ee2c69d22030ba3
+      at: 2ba8d0827cc16bb5d0076549483425de1dd0da9b3fb06fd790c256ec8d1df36b
       bt: 7abc1550aed02405fe1d0951da294ee11583b4215ddc3889429f16ac75604766
       ct: 8edd5528a862bbd5590cfbd0d52871e395cf73e3a22c70839571b36506fbe3a7
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/negate.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/negate.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 381
       num_constraints: 381
-      at: 2cf8ec48b86767689e33a5c95b6e2badd7ee35497fada3d65a7bf5f67aa290ad
+      at: 417f4d29cfbc9a9a971f4d94932ac19b448b4b7407e37e0558c3e232b4dfa073
       bt: f99ae12913da76b1006f5da90b82a67453e4ade0ae3c1102088527b9165abfc3
       ct: e7cff3106d84b6f974711e728b4b6138785655ed58ad24bcd957a5fbbde6be62
     output:

--- a/tests/expectations/compiler/compiler/integers/i64/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/sub.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 826
       num_constraints: 827
-      at: 0940d7c32fa559933029626b467e1d1699273a7e4d04dcb4230911d0fc3cc283
+      at: 353e78ba99a7a4accd8ff4d7fee5562d844f55009ffb547ee95bc741f3b75bde
       bt: b2855c9d479f9679702723e00941392e8c7e3b66b48b997c2ff7e575b3b2a33d
-      ct: 3bb5ddec31f7c687baef9618ce0597888541de092319ce8f05576d71439e848e
+      ct: def36d63bd06a167e8b411f9f7a6208bd5da2233b7e44755d8f7fa3d483be554
     output:
       - input_file: i64.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i64/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 448
       num_constraints: 512
-      at: 690e01212c73d922dcb536db333646b61ef69ccbfbf86376f643586a130e5b90
+      at: e36c9bfd01fbf30c1f31d53e2b19d1a83989e86701ba58838688174b9ad804d7
       bt: edadcd06780bd97cb60d245565ce94697ee12b4d71ce9148f1546f1c4390b668
       ct: f1bb709127145aae7603feda04afbc3e401fdf290c1d549be8d2d4b21ece9b58
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 84
       num_constraints: 85
-      at: ba62118a12c05f58b2123b680ac6ae62e348ecc5f6f05bf7a280aa2f0227568a
+      at: 5d1a78f3ac820a4873a0602f69d7efb764135c6df25bfc4c182daee12402a595
       bt: 85916f4efb04caeb618ad35bc96528d6aeffd742b574cb93ed22ffcd46c87751
       ct: 846591a223fd860defb812adf90d4d103f16e168465e64986ac960819b4fae52
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 31
       num_constraints: 31
-      at: fc632b7c29294f7348e0fd778b0e144743a047f35498f3ab5cc30be48469100a
+      at: 8111e478f64beb722ec96fbd80076cb73b735813b20e8f2ed6e3c21febceaae7
       bt: c2cfac5aa6e125cb6cde720b0598fef7933c4aa62926fe99405bf1c2829dd4ce
       ct: a3fa97a403ebea95a47d7ded7c01cee45af74afbfa876c203e4e96f6054b8815
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/div.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 1900
       num_constraints: 2146
-      at: 41ed658cf94f79b70013f1f5a1919d528ce2e6e2a7a1b0282408fcf95cd146ff
+      at: 78254e9ffa335030ec73b144fe62ec20ae56e25f40dda07a761f8dae73d4a5ec
       bt: b857cea12f4b3716495ef7dffecf8cc30b26e4f560fa0464c4a04df43a1f18ef
-      ct: a3fb8f79411957360225b45151a3f8f0d164bbcac2724d2fee23eb694e1c3bbc
+      ct: b45ff088d9439c294745b670408d93a081733efdff5b80d9369e287974cd22b8
     output:
       - input_file: i8.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i8/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 33
       num_constraints: 33
-      at: 4560e85454c127fff9bff0d813b7598022e740537151444c2dca8fae4996c3b0
+      at: 424965aff58c62dd2bf38daa6426a3edcc19aa86bff3842fe4e73f743d37e1cb
       bt: 03d1b6a8fdf9f73f595cf97261f1bae81000c89364c7af58f4f7f04aba7bac30
       ct: 2aae7d6631260dcaafbfe9709ade84e75f5172a9baad48e108e7264d5fc17cf6
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 6def83ea22fb24fa8fca853bf170cf10a43ebe020a2ee7c752c67d876c967b4b
+      at: 0c041f98ae4465c405aa6cf9dfb23157cee029c4ba12162385a49d230eaea769
       bt: a55f11270f22104142bcee90897c9d9a8463b2fa9043957f85d82725f4bb075e
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 3c9089f44c96a904e368955385f3dc6a9218496a94c075c3539e19affe9ff650
+      at: fd43cbc2bdaa1e99408e9ca7bd13774576b88c884f64a153fbd8ba2a710c0b42
       bt: 4a959c05229442ca476ef20cfe1988fab90d5ca1b8f1c75f75719d475030c086
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 9098a9ff52eec6aa462e8c597e9960c76ef9cd120c991be323536dd15425dc11
+      at: 5a23ebca65ed09a730f98babb863f4b6c166d80b0e97790788b5b2c1ed0e3f8a
       bt: 13756f3827f4f5f9c3d57ac57364366b9716cd3474416861f9aa9fe7a79206d0
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 5ff97534b183c8eebdb2f94075cc246845fa5ee32d17e8e317c1fabeaa0fed7e
+      at: b93e8bf8fef6bb33a2552fc46f20f842010f187164d846f84b2a8618628c59a9
       bt: 2edb58dffc1fb55bd54dd589b8fb4cf15292f14cc2e9d478bb372b57c958ead9
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 1536
       num_constraints: 1537
-      at: 1b30f80430b27c3c9351fe58228246d6165079707117c819357c380f24bfa5b7
+      at: 245902065d66fcdaff6db49bdd20f72f3e3e85ef6afcf2e12435ee63df39b543
       bt: 0b017985fe9a0650c67351f1cc247871e9cc9e8c907f2cb47791c5ae1a5b324a
       ct: 3fb41ccb74d402bc413944e9eb543a7333552052b7781eb257d2b861659d5a09
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 33
       num_constraints: 33
-      at: cea5a73507043981fb288f2b6ab49a8b860029156ad1e126894c522207d53c02
+      at: 5e88cd940df2c48a53e64a9b8589045ef766371daa5cc885df982902d9fcc754
       bt: 10b52342f8c44eb9b3335b4df9ca4136de3ad35d5b580b2ab32ae5e10bcdf3b4
       ct: 2aae7d6631260dcaafbfe9709ade84e75f5172a9baad48e108e7264d5fc17cf6
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/negate.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/negate.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 45
       num_constraints: 45
-      at: 283e78462191d2c9a2855672a8a724df585a52240010455e1b84ed8376436d1e
+      at: e308c63d5f53aa3c65315a1d38ba5ee664cce7bb22aaeaab07a37a9006d909cc
       bt: 43214e3563d9bc921ffc9079215a945f8450cf3c02506bd6e23144b2e18944d3
       ct: a2352ad3a95bc4b0d0ca56ac5b1bcec0cc3b62077d2c3d883f90f8bf014a8e28
     output:

--- a/tests/expectations/compiler/compiler/integers/i8/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/sub.leo.out
@@ -6,9 +6,9 @@ outputs:
       num_public_variables: 0
       num_private_variables: 98
       num_constraints: 99
-      at: c86be150a5e08105db4ff033a70e55b82dccb76deed638930953bdbb7842f441
+      at: f5fc42455c37ae32df3b6d311ff2204dce57fa397f524fe0854ad9ffb3ff5c36
       bt: 35a61219fd7bf101cf1a1a66ad2f71df661d6dc9dda2ed9df12c7650164559aa
-      ct: 50f1a63551e44fb1f2ef29982d5b1580340dcda67d8d8caaa9c837353a950d8f
+      ct: 85ae6ad5b3f62dc914806dac5751645342d399c583d6b6b00cd9e67f738aab30
     output:
       - input_file: i8.in
         output:

--- a/tests/expectations/compiler/compiler/integers/i8/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i8/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 56
       num_constraints: 64
-      at: 74bc7b90c80770131152d547d67464f326973f075c0dc65ebc94d13fbeb2effa
+      at: a15ec92a38acf1a47952df144e5299f49dbde96fbe1a3f3b2af4bbca483d65aa
       bt: 90a2489533355ee3e27d5cf485612441ec10e21923eb78e6be21633ce11fa8f1
       ct: 4c2d67fc6e1c4ad44f323c1b958ed94313153573aa72a3c0f0d25b17b54e63bc
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 769
       num_constraints: 770
-      at: d8a4c69e3b90fec9af0a2534c6a0372e5ee816f28e315b9c3aa448b90abb7ba5
+      at: 46a7cb5b4abbe0c2a583d206d68549c1d2dacbc295a7e98ab603b1e589a748ed
       bt: 3bd68a594ade714a6dce154fa8fe1b206c3339d591863157d5d4a30e82be8c38
       ct: ee4814a6df109d34265d062047ac22141174bab478caf254c5623f917c5d7a66
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 766
       num_constraints: 766
-      at: 2c054edb296bccaaeb01e2eb08e8dceaeaeb5e24eb41807a3a7996ea5b56e53c
+      at: fc8f29e5d4a184ccde7548e9a88adf215d9745a7a1f38cb41e6046c00f684f92
       bt: a6020f3baa81181dab1735218a3d3c8a2504b7f30c6c73c0c12e8edf0aa403b6
       ct: 22bcd53d2a96f7cf838f37fb01781267764156a778d5b2df80572f5030de4b0f
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/div.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 50562
       num_constraints: 50946
-      at: 0f5d84d9873d45008f4e0feaf4b93323f33277677a9b2d48c6dc0431affbe0a3
+      at: 70bbe9c287066bbab7efc8c955d61d85862da186d3a0fe741fb3c7af670521f6
       bt: 5f17f32257e466ef51120fe4cb2d1d2039bcf5bf39c3c477ec09c966419719c9
       ct: d4285993ccb479eefff4da2590ce08924fe8d1750c916a794036f8131d1d720e
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 513
       num_constraints: 513
-      at: 1394ad70170ddf61787d75c37b0438dc380e73ed0570a0755e1ea121261f084b
+      at: 75b34d698fc2359df51943102062181aa5ee62b84a221747dfd7f8868bf48efd
       bt: c1e085f0d8047bc5b5f574ca9de7d79a0ce3b3235e3bfb83ff15aecf05ad1323
       ct: c224fec21cf5a2b24eb94033a20aeb4729d3d0cf596339145cb49ea6a44cc5d8
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: 983b6b8a791cffc8ccf2e04825e86de304bd5933050b17a9c9d163cea94ce39b
+      at: 8c535817cf7f33927b88bddc0b246636aea9421a249b5025229c513521a43cdd
       bt: 75543c2d7e977fd59df93d598b3ba1ab92b7e6048a823fb41969668e29286a6b
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: 3d6229f725268e89a402192cd8760652d20315a669e0ca8e13de703fc7a99bab
+      at: f53fbab433e2588176ab0a5677a6d546a108e5a98abe79ccb5abbc57a4181afd
       bt: 2005303715fb1fda8dbf03970acb45982b78b7c61034b172e9ea3cd363a013f8
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/input.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/input.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 511
       num_constraints: 511
-      at: 7dcc86d79e1657a96155485d8aac78bca5392b8376b33faae47dfc973b4e810d
+      at: f130bde196ac7e190b505a42dfb30c41772c4c7eafe9e7203be9222892b767ce
       bt: 7ac37b347f82644239128aa66e9caf34375b1fd860069659581477883d92fb7a
       ct: 3e4c7833e73f9ee37e42c796e8af7a6d417a012b776b348abedbfd317110858d
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: a0a7d9bb5470350ea51e092afebb394ef3bac50ae23c11dd856c76251d80bf06
+      at: 3898b682c2301fc8f7812b25fafec37b2382eede8f6e86d20bf9468c8b7e4a74
       bt: 8e0a2864aa6383434f6d7843e06d6594b85a65b2009c612f72b3d8c6f07fb4ef
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 897
       num_constraints: 897
-      at: 806020409e835c8ec9c66af54867f86d986a1ccb479d28cf63925fddd28fef1f
+      at: 8bc0a661fdc05173ef7b37762e7f6fdd9e5788a8fa17b7b7d485b8ffbbdeb7c5
       bt: 1669da8e0d67919ecf7e28a3727b73be52d08f9af5feb640a8cd6f2d302caa07
       ct: 8d7309bdb692a71de6c9efc246984ce389534e8fc31222a94d5217720c2d20e9
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 50431
       num_constraints: 66944
-      at: 89ff29ce1a3521c3820bb891428af41f569b3901bc24403db115c9dc73ecf82d
+      at: 76a413f70472403c5adeed7a79d4c2a43f5b24850b4874fff1f6a323d4396a65
       bt: 011ebf5dd53ae194c7135690f3bc6307a362ea10ba113e19ae7195be6ab375a9
       ct: 147b92b75d75f78bed11d65294d9ae2479b8ab32f98521755557fd54076f3c07
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 513
       num_constraints: 513
-      at: 48bbe0018b41afb2e67252317f5b9562174680891247b191932e8c9ddfac6235
+      at: 8f9d3ef916a970cb762ca6f3829a8b4897dc65d493a2ea2eb4fa812a2062fe67
       bt: edc1de9388a8bb2c659c9b4e9deecd8406826abcfe220d295bf7d85a550c0c43
       ct: c224fec21cf5a2b24eb94033a20aeb4729d3d0cf596339145cb49ea6a44cc5d8
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/sub.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 769
       num_constraints: 770
-      at: d8a4c69e3b90fec9af0a2534c6a0372e5ee816f28e315b9c3aa448b90abb7ba5
+      at: 46a7cb5b4abbe0c2a583d206d68549c1d2dacbc295a7e98ab603b1e589a748ed
       bt: 3bd68a594ade714a6dce154fa8fe1b206c3339d591863157d5d4a30e82be8c38
       ct: 950ff5f999ac2edfb80654ff5270b048ac8a19131c655af6d145533a9ef97c6f
     output:

--- a/tests/expectations/compiler/compiler/integers/u128/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 896
       num_constraints: 1024
-      at: 2ba7f5e796779d99922e1b044ce5614b7e35945ff743c2b54412f00570bb935f
+      at: 0830a3e788b536b36f271fadaadcc919281b2171d4e18814385b74f6820cb5c9
       bt: 1fb9bfc22c01a54c08602e7f3883c19b00de1070aa9bad9e9234e322f9043711
       ct: ee9facabe4c76f5eb89984d3c5cb15f92eaa0cc3b4bc4fdff261aeb36ad0101b
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 96
       num_constraints: 97
-      at: 0b612b91a5711faa9b25368b800ec27054f6bec2936b376f723c4e134750a358
+      at: 370387ad947bfe3a763fa62847b00f95580ec1c1b754cf600e06b313a84044ec
       bt: c404ca4ebed24418ea98c0994a710e335e65d373114e9e1be5ba5354ced20806
       ct: 7413addd13f168a5677d482e41bd131e5773eca1ab5c5bd62829ed0b67fd3508
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 94
       num_constraints: 94
-      at: e743cc2f3a0973d5f1b6cc60690a16fc51e6e7c622ce1317308f5f90f51e98ff
+      at: 6ed4469920fbabddf709f8603a84e89ce62e33de0c1728efada4b412dbc9efb6
       bt: 7a2ed9c91a2df8eed7704b5a71f92b9e20beeade151f02135169ab5f4ca69b6a
       ct: 09526721ae1dd7355e4608df2b3eabc5c7007bceb8c6b99389aa8160c63a8982
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/div.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 913
       num_constraints: 961
-      at: 38222d75f2dd22e5017b242315b139e3ffb62b3f1c7e62fb744b1fd2cdcd3b7b
+      at: d047f1835e03694527f9382bab398f5e463fdde613b59b26f060fd2a0e8e65d6
       bt: 9a48749a964cf80e8bacc149bcdc3524853fb3517f848522553e7da6e273f715
       ct: 82ac3f91dba2daec2992e4aaea085ff388f59e0e26330488e1dd2be11d79308d
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 65
       num_constraints: 65
-      at: d1e727ca124b8a409ccaa2404651441e669134e272d9d6635564d4e2509b7ebb
+      at: 8c8b795ef4142f2651625b90b3624d24de5138c3fb0981288a8cc5e12bf31f82
       bt: eba2113bdda3d667d9e8c87f545fe4e2a0143b18a3fff0c1aaa46dd376ed1735
       ct: f037d279ccea3ca689e05801ec3ba0053b5ce66a1763d4620262ea9b69873008
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 4c642bff63f8bf685dfd92e5c9688d445da4e9ec8e088a05845d59d20f3108d6
+      at: c3a94f401722187113083aa4cc5bf90ec46ae91b4ac1d0ba51d765590fe51410
       bt: 43d500d0bdcdf8461bd9605a2665bc17410cb0c7b1c743142aad3a41e74fcbe5
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: a6773378571451240e431a69892efae59e2a3a7fc48f0681cc43f89758ccb087
+      at: 800702d0776e95fee2689e79fcfe570db9fbd128310fc88565e72d322bea0407
       bt: 417dc25c14bf36db410808a30f2263083728f1158cbf74a81bd8d8b5cba878d9
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/input.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/input.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 63
       num_constraints: 63
-      at: 4cac6455a624606970ebe776412ee9b9d5800577aea1fad0677b866e991b6181
+      at: 781fbf42db29f7fa9c21d99e21d8f011ec22b33ad26d3f80438687aafd462285
       bt: abee7b67c55170fc3341444203a9a70e68690dce751aa36d3e91f1cf7ceef73d
       ct: 51c18ee4216feeb01d0b0d661dfeb294e7e100873586edf79be89c8b54d9e168
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 2caa8ab46e1a7425363292ccd1ebc91398ec8b9f2819b5678b8ce34aca296881
+      at: ae8d8223fa654f971c969e68e926621d014e80b200e28a3bcb53f7e0760af811
       bt: 7549aaa9e0eaa389b14dbf7a0c15122a1cd9707f492b8bedee98ae8f09bd9142
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 113
       num_constraints: 113
-      at: 9d8dfce3ccafba84f7f1244545ccdae9d7f7939ef1fb1b66d290f5c604050666
+      at: f7f35cbd164c83cc4421fe89d14a349b70962c362186e237daff824054459d17
       bt: 1bbe7b7f496597bd94e86ea0452146e8360ba0b2b2d922a81cfc51b4b5fa4fda
       ct: 92784334fb47e5a53eb972ec42d95f97470117bb6839cf2d46e8fcbd38a662f9
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 899
       num_constraints: 1172
-      at: 27bcf7c8bd272206f044bfb7ec1e3b8b69a86cd737d8818b12b9fa8235f7b94e
+      at: 26bd7cae34fa05bfe268e134e02dad80d3978fdbcf60cecc47f41102c659c539
       bt: f660e7fad189d6e454e78216e0128e07d47145da1eeb6b53ed5a73cdf4fe9888
       ct: 267549c071634baac2f681f050ede9777ca6d302d8a0ca04c60f6f60e497d64e
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 65
       num_constraints: 65
-      at: 0fdea959dac884336ecafa3d6ae5bb268aaefacd91e099a206f2974681d6a0a8
+      at: 83a4d089927a9811a9d4ed5b3ee2e50e395cd598de865653be04a2c51904b072
       bt: 30bc7cfbc53a2e928ca0310b6041f1f1548ad7c1197ffc9301b46522122e5561
       ct: f037d279ccea3ca689e05801ec3ba0053b5ce66a1763d4620262ea9b69873008
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/sub.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 96
       num_constraints: 97
-      at: 0b612b91a5711faa9b25368b800ec27054f6bec2936b376f723c4e134750a358
+      at: 370387ad947bfe3a763fa62847b00f95580ec1c1b754cf600e06b313a84044ec
       bt: c404ca4ebed24418ea98c0994a710e335e65d373114e9e1be5ba5354ced20806
       ct: 81a951fd0bc0072abf02978c9c6547c090936985ea19b50e3c148595d4870599
     output:

--- a/tests/expectations/compiler/compiler/integers/u16/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u16/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 112
       num_constraints: 128
-      at: 58c61c468b93481b5691b278622e567b5a718e6411cce53fdbe46e2839bdf8c3
+      at: b0a107f586de648c8446ae3246117de3b20ba9c0249d261f234106809d112f0a
       bt: 0e5faacb5d80488eeda9e7fa79ddd96e54c010e0e98571449f79cad816cc18a2
       ct: 2b3428d7c7335edc32ab219fe11c92e215d70a52c89434de349f4951561d5795
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 192
       num_constraints: 193
-      at: 844f8ddd185206ae97ce65d91e247a34cd7d12c6a2a6300bfefdeece068ccde6
+      at: 6cb7221b25d9868ec3dfc97292d22e7b9b7e7571ffd39a14523c2dcd6ee63c60
       bt: db97ec2b7f2b40889263b26fc6f01de19f78a4b007371ad2f54869e9a31d21db
       ct: 2773a172ee849b2e45b68f0c367651fc5a0715e9415d2d97601d41e540d713d0
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 190
       num_constraints: 190
-      at: 50e55296085087c5ca1fd3d7c3894d10dd4bad60b83c4a7984e8dbf77126e92b
+      at: a1a80b7c355e1fa32c2136c4dc7a0fd0670affbdda869a9161a3a69f396c6b9a
       bt: fbf306d0d13bf3d40926ad7adc07f122cb8d065e7e5d55f3416ac30d7ebe7a7c
       ct: 97e2acff1b76912c52107342393ec04a09af81353a25f7ce330b8492f41381cf
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/div.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 3361
       num_constraints: 3457
-      at: 2edc6d9666efc4ff81d37d73f724501de64288cbe5f9d888f48868c30f548688
+      at: b4586913c6db620e8148b90ba3be229f924a47980b735a0c4e2cece8f1334761
       bt: 4984a34e571417eb6ce209b1542beefad525200e782ec88e6f5c58c440402f33
       ct: a0b70b0006b80beff40b0f991739c129cdf3a759c4d7c85c274f59ad62e103d5
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 129
       num_constraints: 129
-      at: 669271745b6c4fd803216e0e59f47da168d7e5bb9f7058232265a79c62f67696
+      at: 4ce4f2bf481c4f7e47396527999e129066d1f157413884f91ced3d2b525a3187
       bt: e63628fc48d1e71ea44830c010e442f577239e29f7ffada0d8df34c28e67f107
       ct: 9f4c72431c0c7c03e216195a071c971c53deed8e3bfce450bffb3a6fad7418d5
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 589d7168d25ef5775b171257cb3677bb22c95d8b2ade148e8d70c20fed37161c
+      at: b09f4d28fdd36c49a340f1d95f86886acc00f8e584a50dd3c98bf6adc63bb13d
       bt: 37e95d209b9ca56b6ed5debe1d21d2c72e48d6a0898a59833bdf3daf2ce1c96b
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 77a5c3680e4d8961411b0b7384818f4a3d79a52e20d0ccb268ce820570b56e11
+      at: 63019ae9d78e708c481c3ed306a9fb7e5a4ddc8db20d1a2a48e2e161aca53542
       bt: 3a99f6fa32ac0358a66ac53d0cef7af442097730b5f56ec8f8d9974108f25215
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/input.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/input.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 127
       num_constraints: 127
-      at: e0e639bf48906da80759e2f98e3205a68a63ae175dcd7c198fe3bf6b1650a84e
+      at: 051151c1ab89f2c0ff0fe5d336668c3fcd6dc4744d1f5b8e135dcb7bf6a6195c
       bt: 6b92443726163ac0fc32f7c9edace0ec8369e793d24105d93d121cb0bd5c3128
       ct: 7cb2d3f0ccfb9a2e747c6a05bdb52812c4539c836ff62c4e555fac13ef2084d4
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 2037796c0ef82e5db53cf8ee4c92ccc0388b85b91d9112ec6c9ef0bd14658e21
+      at: be1f0e82bb31df7cf90717f08c3dc7f68f997c41433d5971d2d0f250faff6847
       bt: 6e596324acc04a48f980f6248f44cbf54a25671a41051bbffc087505edbf031f
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 225
       num_constraints: 225
-      at: 94d430d7b576bd44d770148d8bff7f5eb5ff3955f77b1263f22096e9a0c34168
+      at: aa2fc0bfe167bccae6c9eca820227eb4b981007c89579a32d3b5ec4a8268f30d
       bt: 953b00df7ba097904b71a60403e38d69eece1a6e0b6791b13214cb6ea803fbb3
       ct: d7067f500143a40e015fd1f4447a4ea5b9ee6ebdf007e08be51772a8a2b672c3
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 3332
       num_constraints: 4389
-      at: 0d533d5cba25194e61fb9b0fab6f0aef9114b2c570146d8cbccebc35dd3c1aa2
+      at: 2edbd98e47b4ed8cd7d7c761594353aa4ae9ca443e4d1e1f43c1e89e61955a13
       bt: 127cc198f6c432cd8add8297902708b759e48ff05fb8c042a356cb5bd81524a8
       ct: e4cb5fbafce0c6aae444c1ddf3f1883ca3df62c790a4baa8a3755bd75bb42f49
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 129
       num_constraints: 129
-      at: 4886c2b717c624374dad0a9b657c2081663a6eb235c10b386bcaf117c0fdb004
+      at: 6cde17fb079861287679ad93d9ed9125cfc21000431bfeaf5a2054360ce51ef7
       bt: 1178e67ab79eac96592f17313168c4300d53e89ab571025054d53d19dfdfd1b8
       ct: 9f4c72431c0c7c03e216195a071c971c53deed8e3bfce450bffb3a6fad7418d5
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/sub.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 192
       num_constraints: 193
-      at: 844f8ddd185206ae97ce65d91e247a34cd7d12c6a2a6300bfefdeece068ccde6
+      at: 6cb7221b25d9868ec3dfc97292d22e7b9b7e7571ffd39a14523c2dcd6ee63c60
       bt: db97ec2b7f2b40889263b26fc6f01de19f78a4b007371ad2f54869e9a31d21db
       ct: 0a2d17cb1ee78051a702abbb771d34100ff951ae893e69981ee2507b5aba6671
     output:

--- a/tests/expectations/compiler/compiler/integers/u32/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 224
       num_constraints: 256
-      at: 9338a0dd9e836893acff2938b8ad85ab3255dd2f189dd4f2bc00fef2d38c073d
+      at: 45301188494f0c65b2e88eac9117ba7367e772ea34e9b8f34bf3d49dbd1dd067
       bt: 35d9c47cfd4fc137760d0ee411c0b097541cab7aae2b0a9ea83b368328fe5c23
       ct: 032da4c7df957d9ca89b5395be6e1c84cab7d19a78abe1b02bb37b26ca65b0e4
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 384
       num_constraints: 385
-      at: 377dbd064ab8292845e80919eb529539cbedb4c28ff3c9b92f2cc4370bc92854
+      at: 03f552addf49f5f1c8402d8af8dd733983efa7fd3436d677d89d74a1c6548962
       bt: 8cbfb6559664a4d73354d718f19247484a98da79ddf83350c1a070cb14fda399
       ct: 0715661d18c8621f5c33eee669d8d659ee3a767d6ef515102191cdc19577ac02
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 382
       num_constraints: 382
-      at: 037bcdc9fba5f1f5890ceed8c3ca080e4d72f4b2ab1e72f616ca2797194fd149
+      at: 9d064db37e95194967d924cd23aecd5ddd20a17c31a48470f0b624f5937ff750
       bt: 21d30b45426d69b866ddb826df03348580bcd064b2586cd615e3c270d7b85397
       ct: bd9112f8b3135d07d5b5a2491f17add20c7ca9d7881df20e3ff47918d208e75d
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/div.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 12865
       num_constraints: 13057
-      at: 85a89926847b7763982dfe80fd15f00693f054e8bbb8c502ffdf2f9892ec95fd
+      at: 9d9258e2128a7d269df73826378edef9d92a54ddce7a119886b62b30792c6682
       bt: 37b9014d1049204c4dcc70c10ddba1f7cf576ac366850b6a839896ca106b5e45
       ct: 96c178c46c3d65d0d19f71fede0add7de947179c34ad70565bf34b80ca88fa4a
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 257
       num_constraints: 257
-      at: 4461f4148de047b81686ddce14909d0676354608816291b838209335b7b5040c
+      at: 30dc67aa22cadc6e5ec8c73e0096443263121e29adf46bb33ed310b07765ff6e
       bt: 1aaee32179419b6185d75c5745bd13c7c8ba869bad0132405ef1b28915bfe5d9
       ct: 8edd5528a862bbd5590cfbd0d52871e395cf73e3a22c70839571b36506fbe3a7
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: da4ed3fe37a309845d94cfe19b5e363f1e46a3689f11097214d3b8bc9d345ea7
+      at: 43b83eacdd7b17b700c040da76128375494a8f013882c2cd401cf5c9ceeef74a
       bt: bd9dd7ede35a39f80c5b4b97dca300dcd37110f2270cb25d8935d964db04e2ab
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: c380c2756c57968eff7775b22745a743e282670bfde1b06bcddf2f4a84bd6276
+      at: 961c527f11c9cd68f1dff327e550127f82fc974a4b92c1dedc47a2f7426590a9
       bt: fcf7dc96d2a270e2f93cf6e19151e06c10a1b5361d5ac92a8cb2a2ba36c19067
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/input.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/input.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 255
       num_constraints: 255
-      at: 085ed7b795cfdd2b367e0714e4f7c75cd84b99895bc7597ffc3134ab4b4fb47a
+      at: 68080cb19b62be7f91ee2118affb7b55ea272e15e17581869385053a5c6d3623
       bt: 2c1d031e57e285b1277f2c37853fc7fdff23711e1147d7b26ed74d3acd28ceff
       ct: 0b136215b60005ed17aa4eea76bc4e2b0349c0fecf57dc06f5dba31981f270d0
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: f5d0a1e668ad75aafbe69353ed7ae68a130f85cfb3d0704477bc60a81b33a94a
+      at: d8041c17d69554c3c06ad3d72f58df129a6df56184fd121c815b1ddfe0951d52
       bt: 20b7ff1d5fb8aeb0ff37cde558c4da0c1949885789a23bdf21a415cefb159e16
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 449
       num_constraints: 449
-      at: 463fe45adee0c8a9f698f25f5abb731f42ea06688233a422d13ec9b9efdf051a
+      at: 6fad339784c0e41ffb56fc6d4b5949563cf1a7e53e91cf1c643df2dd798c9cf8
       bt: ac1a1706eaf7c384375eebf95d38ab272e9c27745c6a9f5feed56e6ecbe28e8b
       ct: 7b765314986bd8a51a62dabdef866c5fe05ad9bf392fb0e25b7ce3b9969f81e1
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 12805
       num_constraints: 16966
-      at: 8f78296a499e79bdee1ee3c7aa5be45436dbd25859176f3d95fff2c55d6ec92a
+      at: 94607d20548e2b4a046e0f3eb55624da27ec73bcaeee0e8258b3d2e2e607b2fd
       bt: 8063dc2ec3957d32cb243785803b1fe280885ae5bbb7b50ae5dd71b4a5b404dd
       ct: 5c2a423f5d488da02561837d1ae9e5b86ede29cd64555ebc88229ab4ef9d8fa2
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 257
       num_constraints: 257
-      at: 94abff87eb8bfdc488ea06a67dcf479c6a05c779b40e11c40ee2c69d22030ba3
+      at: 2ba8d0827cc16bb5d0076549483425de1dd0da9b3fb06fd790c256ec8d1df36b
       bt: 7abc1550aed02405fe1d0951da294ee11583b4215ddc3889429f16ac75604766
       ct: 8edd5528a862bbd5590cfbd0d52871e395cf73e3a22c70839571b36506fbe3a7
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/sub.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 384
       num_constraints: 385
-      at: 377dbd064ab8292845e80919eb529539cbedb4c28ff3c9b92f2cc4370bc92854
+      at: 03f552addf49f5f1c8402d8af8dd733983efa7fd3436d677d89d74a1c6548962
       bt: 8cbfb6559664a4d73354d718f19247484a98da79ddf83350c1a070cb14fda399
       ct: 4906d35acd2d4c5fda24a10932dbccfb9c814de0b6160b29fa57540935c864ee
     output:

--- a/tests/expectations/compiler/compiler/integers/u64/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 448
       num_constraints: 512
-      at: 690e01212c73d922dcb536db333646b61ef69ccbfbf86376f643586a130e5b90
+      at: e36c9bfd01fbf30c1f31d53e2b19d1a83989e86701ba58838688174b9ad804d7
       bt: edadcd06780bd97cb60d245565ce94697ee12b4d71ce9148f1546f1c4390b668
       ct: f1bb709127145aae7603feda04afbc3e401fdf290c1d549be8d2d4b21ece9b58
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/add.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/add.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 48
       num_constraints: 49
-      at: 47ad61cbbd19835d1bad8f3543217313ee841a18dfa224995e5a4e7a9802fc6e
+      at: 69fb3c4168c95acd03a37f194310a3c4650940b98570ed2354b4cf40a46c3cdc
       bt: 0864b812eb8b0fd3cb3173bde347790cd9975d1117accb115141afe0444cea3c
       ct: 463f6e3dc8e5ed795eb81d0b200c7f8d7ee4294ef49dc7469646067364331ccf
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/console_assert.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/console_assert.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 46
       num_constraints: 46
-      at: c7c833c325c07232393d6adac2c5b3028e69fde20b546115f417e71586c16b7c
+      at: 829f4510ef3fb07e4ffecffe519507a8c6790309f86f349e2b8c5c42cc09e1c9
       bt: 10f68596bcedd566b8eecf0bd255093865e9652e35d141d868fcba35ed67b24a
       ct: 547830d9a13714ce4f3490f83aeafb5faa68aac46614867b7c19beb99eb908ff
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/div.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/div.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 265
       num_constraints: 289
-      at: eddd4269143fb8b2c128fe0694337f34f867573279288e8dc02480eb2aa7790b
+      at: 0dc1e93afeaa315465d5b3b595255d51ec60c250628f6240753c8108ab9e8053
       bt: 781b0b03c0008f52efceb5be0abe02d4ac135ac1df6cda486eb941e9e6df53f5
       ct: c137ae93c16c69c41bc1758702a1b64e14ed572dab2f1461552c328dfb4b173a
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/eq.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/eq.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 33
       num_constraints: 33
-      at: 4560e85454c127fff9bff0d813b7598022e740537151444c2dca8fae4996c3b0
+      at: 424965aff58c62dd2bf38daa6426a3edcc19aa86bff3842fe4e73f743d37e1cb
       bt: 03d1b6a8fdf9f73f595cf97261f1bae81000c89364c7af58f4f7f04aba7bac30
       ct: 2aae7d6631260dcaafbfe9709ade84e75f5172a9baad48e108e7264d5fc17cf6
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/ge.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/ge.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 891a7122f212dca6faf409e15ed5dd81f970ff9ebd32609298d9501a037e7979
+      at: bc8380502907fbf4dc375e6ffc6ff09063dfb74d4bf1deb5c0a822f892e73acb
       bt: 6af90ba76909462a3da873fbb2276b4020df6b3318671bd44aef4572df6326fc
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/gt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/gt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 8f8994ac4185be57f63a1bc7a1812c3da7099f2323edab3be3eb8c2060258b74
+      at: 38f7f88206d5c28524fd286b4d4eff928bc29bf167f9ccdb1459377fcdee677f
       bt: 0edd7a2aa1dabdeb3cd270d78086cb74dfc5f4c957e6f2ce7546daed614a3579
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/input.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/input.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 31
       num_constraints: 31
-      at: fc632b7c29294f7348e0fd778b0e144743a047f35498f3ab5cc30be48469100a
+      at: 8111e478f64beb722ec96fbd80076cb73b735813b20e8f2ed6e3c21febceaae7
       bt: c2cfac5aa6e125cb6cde720b0598fef7933c4aa62926fe99405bf1c2829dd4ce
       ct: a3fa97a403ebea95a47d7ded7c01cee45af74afbfa876c203e4e96f6054b8815
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/le.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/le.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: e46ad137d5e17ca6959751f6acd5b2bf830e0804c864314eed80d1bbb172b622
+      at: 4f2c1500ec12fc38d3a05a67cab6066e0bedda66bdd2a9b81b58189a4e2efb44
       bt: 7166372193964d2e6e881f4178c1a8fd80afe2c60584af277e73e606f4ac4efd
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/lt.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/lt.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 57
       num_constraints: 57
-      at: 6048fc53fef2d92ab69d9150e4caf32daa4e87c1ded6adfa85e0cc322a771143
+      at: 6a0450b269677ab3f038f68befed6b3dd7e4471cba20c9b3cbb1987d11623de2
       bt: 1c92f5790ff308be2d3a812b0b14b7445192b9b9fb271cabd8a18dc925deb34d
       ct: 5a4c4f077603c1f7c4b31cf17fee281ab3cb7d2a9571be40a2f3a88577759477
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/mul.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/mul.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 258
       num_constraints: 331
-      at: 8380d2144479ab1cc948b8961b8778ac82dc9eb1fab4f24c1af69e3bb75e681c
+      at: 9db6e7fa73b98bf7623bed5997bf61d51f348aaf43d9249b629a866a9085f08b
       bt: a9bb86254052a3c5b275213180e89108aea721369a9d32cbd837a1cb974d76b3
       ct: 4dc6b4ca7c3bcedbbe8abbaee96615345e08b304dd65b217319ece1224721b57
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/ne.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/ne.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 33
       num_constraints: 33
-      at: cea5a73507043981fb288f2b6ab49a8b860029156ad1e126894c522207d53c02
+      at: 5e88cd940df2c48a53e64a9b8589045ef766371daa5cc885df982902d9fcc754
       bt: 10b52342f8c44eb9b3335b4df9ca4136de3ad35d5b580b2ab32ae5e10bcdf3b4
       ct: 2aae7d6631260dcaafbfe9709ade84e75f5172a9baad48e108e7264d5fc17cf6
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/sub.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/sub.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 48
       num_constraints: 49
-      at: 47ad61cbbd19835d1bad8f3543217313ee841a18dfa224995e5a4e7a9802fc6e
+      at: 69fb3c4168c95acd03a37f194310a3c4650940b98570ed2354b4cf40a46c3cdc
       bt: 0864b812eb8b0fd3cb3173bde347790cd9975d1117accb115141afe0444cea3c
       ct: a09cd762cf1db927d99cef196452f092d030aa05851fe466816535ac34c6188f
     output:

--- a/tests/expectations/compiler/compiler/integers/u8/ternary.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u8/ternary.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 56
       num_constraints: 64
-      at: 74bc7b90c80770131152d547d67464f326973f075c0dc65ebc94d13fbeb2effa
+      at: a15ec92a38acf1a47952df144e5299f49dbde96fbe1a3f3b2af4bbca483d65aa
       bt: 90a2489533355ee3e27d5cf485612441ec10e21923eb78e6be21633ce11fa8f1
       ct: 4c2d67fc6e1c4ad44f323c1b958ed94313153573aa72a3c0f0d25b17b54e63bc
     output:

--- a/tests/expectations/compiler/compiler/mutability/array_dyn_mut.leo.out
+++ b/tests/expectations/compiler/compiler/mutability/array_dyn_mut.leo.out
@@ -4,11 +4,11 @@ expectation: Pass
 outputs:
   - circuit:
       num_public_variables: 0
-      num_private_variables: 65
-      num_constraints: 66
-      at: 0c8cb242ee3815f5ea6fdd08873577a6cc51fcfbda8cb5671f0b4dc851939d07
-      bt: 32bbce55a7ed95a5b0277ef5ddfa171ad065c5c7c743031d8b0bd8e50e51b0af
-      ct: b0a68f3915594800e43cb144dc499a002fd302374532313e835dfa163d38f0f1
+      num_private_variables: 1087
+      num_constraints: 1350
+      at: aae29cb6b4a71a5cf49d3de006b415b9a7818a2e23191819692e8d2ee69d8be2
+      bt: 11262f31fcaa7950be43eded328287305e7cbcb73c19455808f08f38116cfdd6
+      ct: 4e43ba7d47ceae1f9e594eb314deb4044ee658d18e3732baba6488d451c784a4
     output:
       - input_file: input/index1.in
         output:

--- a/tests/expectations/compiler/compiler/mutability/array_dyn_mut.leo.out
+++ b/tests/expectations/compiler/compiler/mutability/array_dyn_mut.leo.out
@@ -8,7 +8,7 @@ outputs:
       num_constraints: 1350
       at: aae29cb6b4a71a5cf49d3de006b415b9a7818a2e23191819692e8d2ee69d8be2
       bt: 11262f31fcaa7950be43eded328287305e7cbcb73c19455808f08f38116cfdd6
-      ct: 4e43ba7d47ceae1f9e594eb314deb4044ee658d18e3732baba6488d451c784a4
+      ct: 01dfba9e0754ad9890117694c9b03f4646642140aa7b6c393b2e264e701c323e
     output:
       - input_file: input/index1.in
         output:

--- a/tests/expectations/compiler/compiler/mutability/array_dyn_mut_indirect.leo.out
+++ b/tests/expectations/compiler/compiler/mutability/array_dyn_mut_indirect.leo.out
@@ -4,11 +4,11 @@ expectation: Pass
 outputs:
   - circuit:
       num_public_variables: 0
-      num_private_variables: 32
-      num_constraints: 32
-      at: 4f36fe54f989d60bb9c279120800f4f44596c2efb7ba703669d4c4d591569780
-      bt: d378030968a64801f66d95699329086ca17e676d8bffcf73f6b431cbda7c7005
-      ct: dbd098af6556ed79650d149b1691be336a46f8bad6f327e942508dd11342575e
+      num_private_variables: 924
+      num_constraints: 1310
+      at: f4c2d999e3cfce5433bbde762d8c826c8df8764b9223dd5d7147cd09810f25b7
+      bt: fa02e90dd0bde30bc5feab46c3ea4fae0493dc6808d56bc6a1d937eb17297981
+      ct: 8f6f484310918a186286820e4efd1e7494774c314e9e5c6f78bb60bdeae948f4
     output:
       - input_file: input/index1_tuple.in
         output:

--- a/tests/expectations/compiler/compiler/statements/chain.leo.out
+++ b/tests/expectations/compiler/compiler/statements/chain.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 319
       num_constraints: 415
-      at: 7758de8b887d66c54fef4affc72141544bcc9762eaabe77639dcbb72d02aaa67
+      at: 910d51dc69b7ed7e2dfe1a786fad9b226b2ff30c7678f397cb8d8850fd76442e
       bt: 3ae01a0af5534bca6ad67bd2609a5370a4982c7f6d17fb8c285054c3d08f9c4f
       ct: 67836f65a02c595fcbf6d6a6d223a15e138d99a542390693ac4f582d073869e6
     output:

--- a/tests/expectations/compiler/compiler/statements/for_loop.leo.out
+++ b/tests/expectations/compiler/compiler/statements/for_loop.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 512
       num_constraints: 675
-      at: da107701a842d40fe2af68152622ca69aa3496c7952cdbeb1b5f4fe69b2661ab
+      at: 5d537a7963ae43ff2b7b0222c18a237015c858d7203554574a785cd56d4d24c5
       bt: 192ca0dd8a20d69b443b952a7226e8c82936fedd2c9735d2b792883a01e46e3b
       ct: 04609638ad65317edb75529646b34f10a846b39b3ddb783e4aeceddde17b79f9
     output:

--- a/tests/expectations/compiler/compiler/statements/nested_mutate.leo.out
+++ b/tests/expectations/compiler/compiler/statements/nested_mutate.leo.out
@@ -6,7 +6,7 @@ outputs:
       num_public_variables: 0
       num_private_variables: 481
       num_constraints: 547
-      at: b23dee30e3d6dc6d95933170ea18b5680aa3f859e808328599c3de9027bdbc5f
+      at: 2f636d0f9b9af543c900753ff89b3eb0bd5cc4f81f8afc19c5cb0901b4b51b0a
       bt: 86e567b4b178b61f7a2ae29ac78c6f60fc1b6c9cdfdbb6c896c8b059b68a90b6
       ct: eb4c6eaa123567ee0a5b12a2812f90b4f532e657b59249aaad97092bd32cdbe9
     output:


### PR DESCRIPTION
Fixes #935.
Additional fix necessary for ternarys in snarkVM.

Major credit and thanks to @collinc97 for helping to debug this.