### PR TITLE
[Feature] Add M1 build, keep target-cpu=native only for MacOS builds

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,7 +1,2 @@
-[target.'cfg(
-    all(
-        not(target_arch = "wasm32"), 
-        not(feature = "noconfig")
-    )
-)']
+[target.'cfg(all(not(target_arch = "wasm32"), not(feature = "noconfig")))']
 rustflags = ["-C", "target-cpu=native"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,7 @@
-# [target.'cfg(any(not(target_arch = "wasm32"), feature = "noconfig"))']
-# rustflags = ["-C", "target-cpu=native"]
+[target.'cfg(
+    all(
+        not(target_arch = "wasm32"), 
+        not(feature = "noconfig")
+    )
+)']
+rustflags = ["-C", "target-cpu=native"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
-[target.'cfg(any(not(target_arch = "wasm32"), feature = "noconfig"))']
-rustflags = ["-C", "target-cpu=native"]
+# [target.'cfg(any(not(target_arch = "wasm32"), feature = "noconfig"))']
+# rustflags = ["-C", "target-cpu=native"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
-[target.'cfg(all(not(target_arch = "wasm32"), not(feature = "noconfig")))']
+[target.'cfg(all(target_arch = "x86_64", target_os = "macos", not(feature = "noconfig)))']
 rustflags = ["-C", "target-cpu=native"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --package leo-lang --release --features noconfig && strip target/release/leo
+          cargo build --package leo-lang --release && strip target/release/leo
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,6 @@ jobs:
 
   macos_m1:
     name: macOS M1
-    strategy:
-      matrix:
-        compiler: [gcc, clang]
     runs-on: macos-latest
     steps:
       - name: Xcode Select

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,10 +102,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # - name: Brew...
-      #   run: |
-      #     brew install gcc
-
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --all --release --features noconfig && strip target/release/leo
+          cargo build --package leo-lang --release --features noconfig && strip target/release/leo
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --all --release --features noconfig && strip target/release/leo
+          cargo build --package leo-lang --release --features noconfig && strip target/release/leo
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 
@@ -92,12 +92,67 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  macos_m1:
+    name: macOS M1
+    strategy:
+      matrix:
+        compiler: [gcc, clang]
+    runs-on: macos-latest
+    steps:
+      - name: Xcode Select
+        uses: devbotsxyz/xcode-select@v1.1.0
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # - name: Brew...
+      #   run: |
+      #     brew install gcc
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: aarch64-apple-darwin
+          toolchain: stable
+          override: true
+          components: rustfmt
+
+      - name: Build Leo
+        run: |
+          SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) \
+          MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.1 --show-sdk-platform-version) \
+          cargo build -p leo-lang --release --target=aarch64-apple-darwin --features noconfig && strip target/aarch64-apple-darwin/release/leo
+        env:
+          CARGO_NET_GIT_FETCH_WITH_CLI: true
+
+      - id: get_version
+        uses: battila7/get-version-action@v2
+
+      - name: Zip
+        run: |
+          mkdir tempdir
+          mv target/aarch64-apple-darwin/release/leo tempdir
+          cd tempdir
+          zip -r leo-${{ steps.get_version.outputs.version }}-aarch64-apple-darwin.zip leo
+          cd ..
+          mv tempdir/leo-${{ steps.get_version.outputs.version }}-aarch64-apple-darwin.zip .
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            leo-${{ steps.get_version.outputs.version }}-aarch64-apple-darwin.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   windows:
     name: Windows
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -118,7 +173,7 @@ jobs:
 
       - name: Build Leo
         run: |
-          cargo build --all --release --features noconfig
+          cargo build --package leo-lang --release --features noconfig
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
 


### PR DESCRIPTION
## Motivation

To cover Apple Silicon users of Aleo Studio, we need M1 builds. 

- Adds cross-compilation for `aarch64-apple-darwin` target;
- Compiles only `leo-lang` because it's the only binary that we need (optimize build time);
- Also closes #635 by keeping `target-cpu=native` only for `x64_86` builds for MacOS;
- Disables `grammar` package from workspace until we got dependency conflict resolved

## Test Plan

Tested in a fork, release builds can be seen here: https://github.com/damirka/leo/releases/tag/v1.5.7
