### PR TITLE
Fixes import bug found in Aleo Studio

### DIFF
--- a/imports/src/errors/import_parser.rs
+++ b/imports/src/errors/import_parser.rs
@@ -94,10 +94,10 @@ impl ImportParserError {
     }
 
     ///
-    /// Failed to find a library file for the current package.
+    /// Failed to find a main file for the current package.
     ///
-    pub fn expected_lib_file(entry: String, span: &Span) -> Self {
-        let message = format!("Expected library file `{}`.", entry,);
+    pub fn expected_main_file(entry: String, span: &Span) -> Self {
+        let message = format!("Expected main file at `{}`.", entry,);
 
         Self::new_from_span(message, span)
     }

--- a/imports/src/parser/parse_package.rs
+++ b/imports/src/parser/parse_package.rs
@@ -72,6 +72,7 @@ impl<'a> ImportParser<'a> {
 
         // Search for package name in `imports` directory
         let mut imports_directory = path.clone();
+        imports_directory.pop(); // path leads to src/ folder, imports is one level below
         imports_directory.push(IMPORTS_DIRECTORY_NAME);
 
         // Read from local `src` directory or the current path

--- a/imports/src/parser/parse_symbol.rs
+++ b/imports/src/parser/parse_symbol.rs
@@ -19,7 +19,7 @@ use leo_ast::{Program, Span};
 
 use std::fs::DirEntry;
 
-static LIBRARY_FILE: &str = "src/lib.leo";
+static MAIN_FILE: &str = "src/main.leo";
 
 impl<'a> ImportParser<'a> {
     ///
@@ -39,10 +39,10 @@ impl<'a> ImportParser<'a> {
 
         let mut file_path = package.path();
         if file_type.is_dir() {
-            file_path.push(LIBRARY_FILE);
+            file_path.push(MAIN_FILE);
 
             if !file_path.exists() {
-                return Err(ImportParserError::expected_lib_file(
+                return Err(ImportParserError::expected_main_file(
                     format!("{:?}", file_path.as_path()),
                     span,
                 ));


### PR DESCRIPTION
## Motivation

Originally found by Yuri's team. 
This bug appeared somewhere between v1.2.0 and v1.3.0 and wasn't covered by tests.

## Steps to reproduce

Use this code:
```ts
import u8u32.u8_u32;
function main() { }
```

Then add dependency:
```
leo add justice-league/u8u32
```

And finally run the code:
```
leo build
```

## Error log

```

Error:     --> package/src/main.leo:3:5
     |
   3 |     u8_u32
     |     ^^^^^^
     |
     = Cannot find imported package `u8u32` in source files or import directory.
```

## Changes to UX

We forgot to change imported file: `src/lib.leo` was deprecated long time ago, and we still had code that relied on that file to exist. This has been changed to import main file `src/main.leo` instead.

## Test Plan

Tests for imports currently disabled, and they didn't cover scenario for importing from Aleo PM. We should consider adding test or CI which would cover this case. 

TBD

