### PR TITLE
Ast Proof Generation In CLI

### DIFF
--- a/ast/src/errors/ast.rs
+++ b/ast/src/errors/ast.rs
@@ -14,19 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-pub mod ast;
-pub use ast::*;
+use crate::{FormattedError, LeoError, ReducerError, Span};
 
-pub mod canonicalization;
-pub use canonicalization::*;
+#[derive(Debug, Error)]
+pub enum AstError {
+    #[error("{}", _0)]
+    Error(#[from] FormattedError),
 
-pub mod combiner;
-pub use combiner::*;
+    #[error("{}", _0)]
+    IOError(#[from] std::io::Error),
 
-pub mod error;
-pub use error::*;
+    #[error("{}", _0)]
+    ReducerError(#[from] ReducerError),
 
-pub mod reducer;
-pub use reducer::*;
+    #[error("{}", _0)]
+    SerdeJsonError(#[from] ::serde_json::Error),
+}
 
-pub trait LeoError {}
+impl LeoError for AstError {}
+
+impl AstError {
+    fn _new_from_span(message: String, span: &Span) -> Self {
+        AstError::Error(FormattedError::new_from_span(message, span))
+    }
+}

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -86,7 +86,7 @@ impl Ast {
     }
 
     /// Mutates the program ast by preforming canonicalization on it.
-    pub fn canonicalize(&mut self) -> Result<(), ReducerError> {
+    pub fn canonicalize(&mut self) -> Result<(), AstError> {
         self.ast = ReconstructingDirector::new(Canonicalizer::default()).reduce_program(self.as_repr())?;
         Ok(())
     }
@@ -101,12 +101,20 @@ impl Ast {
     }
 
     /// Serializes the ast into a JSON string.
-    pub fn to_json_string(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string_pretty(&self.ast)
+    pub fn to_json_string(&self) -> Result<String, AstError> {
+        Ok(serde_json::to_string_pretty(&self.ast)?)
+    }
+
+    pub fn to_json_file(&self, mut path: std::path::PathBuf, file_name: &str) -> Result<(), AstError> {
+        path.push(file_name);
+        let file = std::fs::File::create(path)?;
+        let writer = std::io::BufWriter::new(file);
+        serde_json::to_writer_pretty(writer, &self.ast)?;
+        Ok(())
     }
 
     /// Deserializes the JSON string into a ast.
-    pub fn from_json_string(json: &str) -> Result<Self, serde_json::Error> {
+    pub fn from_json_string(json: &str) -> Result<Self, AstError> {
         let ast: Program = serde_json::from_str(json)?;
         Ok(Self { ast })
     }

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -22,7 +22,7 @@ use crate::{
     GroupType,
     Output,
     OutputFile,
-    ProofOptions,
+    TheoremOptions,
     TypeInferencePhase,
 };
 pub use leo_asg::{new_context, AsgContext as Context, AsgContext};
@@ -67,7 +67,7 @@ pub struct Compiler<'a, F: PrimeField, G: GroupType<F>> {
     context: AsgContext<'a>,
     asg: Option<AsgProgram<'a>>,
     options: CompilerOptions,
-    proof_options: ProofOptions,
+    proof_options: TheoremOptions,
     _engine: PhantomData<F>,
     _group: PhantomData<G>,
 }
@@ -82,7 +82,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
         output_directory: PathBuf,
         context: AsgContext<'a>,
         options: Option<CompilerOptions>,
-        proof_options: Option<ProofOptions>,
+        proof_options: Option<TheoremOptions>,
     ) -> Self {
         Self {
             program_name: package_name.clone(),
@@ -112,7 +112,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
         output_directory: PathBuf,
         context: AsgContext<'a>,
         options: Option<CompilerOptions>,
-        proof_options: Option<ProofOptions>,
+        proof_options: Option<TheoremOptions>,
     ) -> Result<Self, CompilerError> {
         let mut compiler = Self::new(
             package_name,
@@ -151,7 +151,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
         state_path: &Path,
         context: AsgContext<'a>,
         options: Option<CompilerOptions>,
-        proof_options: Option<ProofOptions>,
+        proof_options: Option<TheoremOptions>,
     ) -> Result<Self, CompilerError> {
         let mut compiler = Self::new(
             package_name,

--- a/compiler/src/errors/compiler.rs
+++ b/compiler/src/errors/compiler.rs
@@ -16,7 +16,7 @@
 
 use crate::errors::{ExpressionError, FunctionError, ImportError, StatementError};
 use leo_asg::{AsgConvertError, FormattedError};
-use leo_ast::{LeoError, ReducerError};
+use leo_ast::{AstError, LeoError};
 use leo_input::InputParserError;
 use leo_parser::SyntaxError;
 use leo_state::LocalDataVerificationError;
@@ -62,7 +62,7 @@ pub enum CompilerError {
     AsgConvertError(#[from] AsgConvertError),
 
     #[error("{}", _0)]
-    ReducerError(#[from] ReducerError),
+    AstError(#[from] AstError),
 
     #[error("{}", _0)]
     StatementError(#[from] StatementError),

--- a/compiler/src/option.rs
+++ b/compiler/src/option.rs
@@ -38,13 +38,13 @@ impl Default for CompilerOptions {
 }
 
 #[derive(Clone)]
-pub struct ProofOptions {
+pub struct TheoremOptions {
     pub initial: bool,
     pub canonicalized: bool,
     pub type_inferenced: bool,
 }
 
-impl Default for ProofOptions {
+impl Default for TheoremOptions {
     fn default() -> Self {
         Self {
             initial: false,

--- a/compiler/src/option.rs
+++ b/compiler/src/option.rs
@@ -36,3 +36,20 @@ impl Default for CompilerOptions {
         }
     }
 }
+
+#[derive(Clone)]
+pub struct ProofOptions {
+    pub initial: bool,
+    pub canonicalized: bool,
+    pub type_inferenced: bool,
+}
+
+impl Default for ProofOptions {
+    fn default() -> Self {
+        Self {
+            initial: false,
+            canonicalized: false,
+            type_inferenced: false,
+        }
+    }
+}

--- a/compiler/tests/mod.rs
+++ b/compiler/tests/mod.rs
@@ -52,7 +52,7 @@ fn new_compiler() -> EdwardsTestCompiler {
     let path = PathBuf::from("/test/src/main.leo");
     let output_dir = PathBuf::from(TEST_OUTPUT_DIRECTORY);
 
-    EdwardsTestCompiler::new(program_name, path, output_dir, make_test_context(), None)
+    EdwardsTestCompiler::new(program_name, path, output_dir, make_test_context(), None, None)
 }
 
 pub(crate) fn parse_program(program_string: &str) -> Result<EdwardsTestCompiler, CompilerError> {

--- a/compiler/tests/test.rs
+++ b/compiler/tests/test.rs
@@ -40,7 +40,7 @@ fn new_compiler(path: PathBuf) -> EdwardsTestCompiler {
     let program_name = "test".to_string();
     let output_dir = PathBuf::from("/output/");
 
-    EdwardsTestCompiler::new(program_name, path, output_dir, make_test_context(), None)
+    EdwardsTestCompiler::new(program_name, path, output_dir, make_test_context(), None, None)
 }
 
 pub(crate) fn parse_program(program_string: &str) -> Result<EdwardsTestCompiler, CompilerError> {

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -19,7 +19,7 @@ use leo_compiler::{
     compiler::{thread_leaked_context, Compiler},
     group::targets::edwards_bls12::EdwardsGroupType,
     CompilerOptions,
-    ProofOptions,
+    TheoremOptions,
 };
 use leo_package::{
     inputs::*,
@@ -44,14 +44,14 @@ pub struct BuildOptions {
     pub disable_code_elimination: bool,
     #[structopt(long, help = "Disable all compiler optimizations")]
     pub disable_all_optimizations: bool,
-    #[structopt(long, help = "Enables all json ast proof generations.")]
-    pub enable_all_proofs: bool,
-    #[structopt(long, help = "Enables the initial parsed json ast proof generation.")]
-    pub enable_initial_proof: bool,
-    #[structopt(long, help = "Enables the post canonicalization json ast proof generation.")]
-    pub enable_canonicalized_proof: bool,
-    #[structopt(long, help = "Enables the post canonicalization json ast proof generation.")]
-    pub enable_type_inferenced_proof: bool,
+    #[structopt(long, help = "Writes all theorem input AST files.")]
+    pub enable_all_theorems: bool,
+    #[structopt(long, help = "Writes AST files needed for the initial theorem before any changes.")]
+    pub enable_initial_theorem: bool,
+    #[structopt(long, help = "Writes AST files needed for canonicalization theorem.")]
+    pub enable_canonicalized_theorem: bool,
+    #[structopt(long, help = "Writes AST files needed for type inference theorem.")]
+    pub enable_type_inferenced_theorem: bool,
 }
 
 impl Default for BuildOptions {
@@ -60,10 +60,10 @@ impl Default for BuildOptions {
             disable_constant_folding: true,
             disable_code_elimination: true,
             disable_all_optimizations: true,
-            enable_all_proofs: false,
-            enable_initial_proof: false,
-            enable_canonicalized_proof: false,
-            enable_type_inferenced_proof: false,
+            enable_all_theorems: false,
+            enable_initial_theorem: false,
+            enable_canonicalized_theorem: false,
+            enable_type_inferenced_theorem: false,
         }
     }
 }
@@ -86,19 +86,19 @@ impl From<BuildOptions> for CompilerOptions {
     }
 }
 
-impl From<BuildOptions> for ProofOptions {
+impl From<BuildOptions> for TheoremOptions {
     fn from(options: BuildOptions) -> Self {
-        if options.enable_all_proofs {
-            ProofOptions {
+        if options.enable_all_theorems {
+            TheoremOptions {
                 initial: true,
                 canonicalized: true,
                 type_inferenced: true,
             }
         } else {
-            ProofOptions {
-                initial: options.enable_initial_proof,
-                canonicalized: options.enable_canonicalized_proof,
-                type_inferenced: options.enable_type_inferenced_proof,
+            TheoremOptions {
+                initial: options.enable_initial_theorem,
+                canonicalized: options.enable_canonicalized_theorem,
+                type_inferenced: options.enable_type_inferenced_theorem,
             }
         }
     }

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -19,6 +19,7 @@ use leo_compiler::{
     compiler::{thread_leaked_context, Compiler},
     group::targets::edwards_bls12::EdwardsGroupType,
     CompilerOptions,
+    ProofOptions,
 };
 use leo_package::{
     inputs::*,
@@ -43,6 +44,14 @@ pub struct BuildOptions {
     pub disable_code_elimination: bool,
     #[structopt(long, help = "Disable all compiler optimizations")]
     pub disable_all_optimizations: bool,
+    #[structopt(long, help = "Enables all json ast proof generations.")]
+    pub enable_all_proofs: bool,
+    #[structopt(long, help = "Enables the initial parsed json ast proof generation.")]
+    pub enable_initial_proof: bool,
+    #[structopt(long, help = "Enables the post canonicalization json ast proof generation.")]
+    pub enable_canonicalized_proof: bool,
+    #[structopt(long, help = "Enables the post canonicalization json ast proof generation.")]
+    pub enable_type_inferenced_proof: bool,
 }
 
 impl Default for BuildOptions {
@@ -51,6 +60,10 @@ impl Default for BuildOptions {
             disable_constant_folding: true,
             disable_code_elimination: true,
             disable_all_optimizations: true,
+            enable_all_proofs: false,
+            enable_initial_proof: false,
+            enable_canonicalized_proof: false,
+            enable_type_inferenced_proof: false,
         }
     }
 }
@@ -68,6 +81,24 @@ impl From<BuildOptions> for CompilerOptions {
                 canonicalization_enabled: true,
                 constant_folding_enabled: !options.disable_constant_folding,
                 dead_code_elimination_enabled: !options.disable_code_elimination,
+            }
+        }
+    }
+}
+
+impl From<BuildOptions> for ProofOptions {
+    fn from(options: BuildOptions) -> Self {
+        if options.enable_all_proofs {
+            ProofOptions {
+                initial: true,
+                canonicalized: true,
+                type_inferenced: true,
+            }
+        } else {
+            ProofOptions {
+                initial: options.enable_initial_proof,
+                canonicalized: options.enable_canonicalized_proof,
+                type_inferenced: options.enable_type_inferenced_proof,
             }
         }
     }
@@ -141,6 +172,7 @@ impl Command for Build {
             &state_string,
             &state_path,
             thread_leaked_context(),
+            Some(self.compiler_options.clone().into()),
             Some(self.compiler_options.into()),
         )?;
 

--- a/leo/commands/test.rs
+++ b/leo/commands/test.rs
@@ -112,6 +112,7 @@ impl Command for Test {
                 output_directory.clone(),
                 thread_leaked_context(),
                 Some(self.compiler_options.clone().into()),
+                Some(self.compiler_options.clone().into()),
             )?;
 
             let temporary_program = program;


### PR DESCRIPTION
It goes towards feature #745,
Creates a new type of option the compiler uses: ProofOptions.
It generates the named JSON files in the `outputs` folder.
There are 4 new options for when running leo run/build/etc.
See the screenshot below for the new options, as well as the file names generated.
![image](https://user-images.githubusercontent.com/16431709/124079517-1d370e00-d9fe-11eb-8a2c-4c6685f25321.png)
