### PR TITLE
[Bugfix] canonicalize imports

### DIFF
--- a/asg/src/error/mod.rs
+++ b/asg/src/error/mod.rs
@@ -17,7 +17,7 @@
 //! Errors encountered when attempting to convert to an asg from an ast.
 
 use crate::Span;
-use leo_ast::{FormattedError, LeoError};
+use leo_ast::{AstError, FormattedError, LeoError};
 use leo_parser::SyntaxError;
 
 #[derive(Debug, Error)]
@@ -27,6 +27,9 @@ pub enum AsgConvertError {
 
     #[error("{}", _0)]
     ImportError(FormattedError),
+
+    #[error("{}", _0)]
+    AstError(#[from] AstError),
 
     #[error("{}", _0)]
     InternalError(String),

--- a/imports/src/errors/import_parser.rs
+++ b/imports/src/errors/import_parser.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 use leo_asg::AsgConvertError;
-use leo_ast::{FormattedError, Identifier, LeoError, Span};
+use leo_ast::{AstError, FormattedError, Identifier, LeoError, Span};
 use leo_parser::SyntaxError;
 
 use std::{io, path::Path};
@@ -26,6 +26,10 @@ pub enum ImportParserError {
 
     #[error("{}", _0)]
     SyntaxError(#[from] SyntaxError),
+
+    #[error("{}", _0)]
+    AstError(#[from] AstError),
+
     #[error("{}", _0)]
     AsgConvertError(#[from] AsgConvertError),
 }
@@ -37,6 +41,7 @@ impl Into<AsgConvertError> for ImportParserError {
         match self {
             ImportParserError::Error(x) => AsgConvertError::ImportError(x),
             ImportParserError::SyntaxError(x) => x.into(),
+            ImportParserError::AstError(x) => AsgConvertError::AstError(x),
             ImportParserError::AsgConvertError(x) => x,
         }
     }

--- a/imports/src/parser/parse_symbol.rs
+++ b/imports/src/parser/parse_symbol.rs
@@ -54,8 +54,10 @@ impl<'a> ImportParser<'a> {
         // Build the package abstract syntax tree.
         let program_string =
             &std::fs::read_to_string(&file_path).map_err(|x| ImportParserError::io_error(span, file_path_str, x))?;
-        let mut ast = leo_parser::parse(&file_path_str, &program_string)?;
-        ast.name = file_name;
-        Ok(ast)
+        let mut program = leo_parser::parse(&file_path_str, &program_string)?;
+        program.name = file_name;
+        let mut ast = leo_ast::Ast::new(program);
+        ast.canonicalize()?;
+        Ok(ast.into_repr())
     }
 }

--- a/tests/compiler/import/imports/lib.leo
+++ b/tests/compiler/import/imports/lib.leo
@@ -1,0 +1,3 @@
+function ello() -> [char; 4] {
+  return "ello";
+}

--- a/tests/compiler/import/string_import.leo
+++ b/tests/compiler/import/string_import.leo
@@ -1,0 +1,12 @@
+// namespace: Compile
+// expectation: Pass
+// input_file: input/dummy.in
+// cwd: imports
+
+import lib.ello;
+
+function main(y: bool) -> bool {
+    let ello_str = ello();
+    console.log("{}", ello_str);
+    return ello_str == "ello" && y;
+}


### PR DESCRIPTION
Closes #1180.

I also noticed that our test framework does not generate or maybe even test the ones in the import folder? It might be due to the wrong type of comments in the Leo files? Or do we not support importing through the test framework yet? Either way, we should file another bug to fix that.