### PR TITLE
[Bugfix] Ternary Type Check

### DIFF
--- a/asg/src/error/mod.rs
+++ b/asg/src/error/mod.rs
@@ -204,6 +204,12 @@ impl AsgConvertError {
         Self::new_from_span(format!("array index out of bounds: '{}'", index), span)
     }
 
+    pub fn ternary_different_types(left: &str, right: &str, span: &Span) -> Self {
+        let message = format!("ternary sides had different types: left {}, right {}", left, right);
+
+        Self::new_from_span(message, span)
+    }
+
     pub fn unknown_array_size(span: &Span) -> Self {
         Self::new_from_span("array size cannot be inferred, add explicit types".to_string(), span)
     }

--- a/tests/compiler/statements/assign_ternary.leo
+++ b/tests/compiler/statements/assign_ternary.leo
@@ -1,0 +1,9 @@
+/*
+namespace: Compile
+expectation: Fail
+input_file: inputs/u32_3.in
+*/
+
+function main(x: u32) {
+    let x = true ? x: true;
+}

--- a/tests/expectations/compiler/compiler/statements/assign_ternary.leo.out
+++ b/tests/expectations/compiler/compiler/statements/assign_ternary.leo.out
@@ -1,0 +1,5 @@
+---
+namespace: Compile
+expectation: Fail
+outputs:
+  - "    --> compiler-test:4:13\n     |\n   4 |     let x = true ? x: true;\n     |             ^^^^^^^^^^^^^^\n     |\n     = ternary sides had different types: left u32, right bool"


### PR DESCRIPTION
Closes #1176.

It seems we just never checked the types were the same at all, rather than a type inference bug.