### PR TITLE
[Fix] Adds Self canonicalization for static calls

### DIFF
--- a/asg/src/const_value.rs
+++ b/asg/src/const_value.rs
@@ -315,16 +315,16 @@ impl ConstInt {
 
     pub fn parse(int_type: &IntegerType, value: &str, span: &Span) -> Result<ConstInt, AsgConvertError> {
         Ok(match int_type {
-            IntegerType::I8 => ConstInt::I8(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::I16 => ConstInt::I16(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::I32 => ConstInt::I32(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::I64 => ConstInt::I64(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::I128 => ConstInt::I128(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::U8 => ConstInt::U8(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::U16 => ConstInt::U16(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::U32 => ConstInt::U32(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::U64 => ConstInt::U64(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
-            IntegerType::U128 => ConstInt::U128(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
+            IntegerType::I8 => ConstInt::I8(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::I16 => ConstInt::I16(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::I32 => ConstInt::I32(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::I64 => ConstInt::I64(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::I128 => ConstInt::I128(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::U8 => ConstInt::U8(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::U16 => ConstInt::U16(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::U32 => ConstInt::U32(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::U64 => ConstInt::U64(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
+            IntegerType::U128 => ConstInt::U128(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
         })
     }
 }

--- a/asg/src/expression/constant.rs
+++ b/asg/src/expression/constant.rs
@@ -115,7 +115,7 @@ impl<'a> FromAst<'a, leo_ast::ValueExpression> for Constant<'a> {
                     value: ConstValue::Boolean(
                         value
                             .parse::<bool>()
-                            .map_err(|_| AsgConvertError::invalid_boolean(&value, span))?,
+                            .map_err(|_| AsgConvertError::invalid_boolean(value, span))?,
                     ),
                 }
             }
@@ -151,7 +151,7 @@ impl<'a> FromAst<'a, leo_ast::ValueExpression> for Constant<'a> {
                 Constant {
                     parent: Cell::new(None),
                     span: Some(span.clone()),
-                    value: ConstValue::Field(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
+                    value: ConstValue::Field(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
                 }
             }
             Group(value) => {
@@ -188,7 +188,7 @@ impl<'a> FromAst<'a, leo_ast::ValueExpression> for Constant<'a> {
                 Some(PartialType::Type(Type::Field)) => Constant {
                     parent: Cell::new(None),
                     span: Some(span.clone()),
-                    value: ConstValue::Field(value.parse().map_err(|_| AsgConvertError::invalid_int(&value, span))?),
+                    value: ConstValue::Field(value.parse().map_err(|_| AsgConvertError::invalid_int(value, span))?),
                 },
                 Some(PartialType::Type(Type::Group)) => Constant {
                     parent: Cell::new(None),

--- a/asg/src/expression/mod.rs
+++ b/asg/src/expression/mod.rs
@@ -341,7 +341,7 @@ impl<'a> FromAst<'a, leo_ast::Expression> for &'a Expression<'a> {
                 .context
                 .alloc_expression(CallExpression::from_ast(scope, call, expected_type).map(Expression::Call)?),
         };
-        expression.enforce_parents(&expression);
+        expression.enforce_parents(expression);
         Ok(expression)
     }
 }

--- a/asg/src/program/function.rs
+++ b/asg/src/program/function.rs
@@ -101,7 +101,7 @@ impl<'a> Function<'a> {
                         let variable = scope.context.alloc_variable(RefCell::new(crate::InnerVariable {
                             id: scope.context.get_id(),
                             name: identifier.clone(),
-                            type_: scope.resolve_ast_type(&type_)?,
+                            type_: scope.resolve_ast_type(type_)?,
                             mutable: *mutable,
                             const_: *const_,
                             declaration: crate::VariableDeclaration::Parameter,

--- a/asg/src/program/mod.rs
+++ b/asg/src/program/mod.rs
@@ -127,7 +127,7 @@ fn resolve_import_package_access(
         PackageAccess::Multiple(packages) => {
             package_segments.push(packages.name.name.to_string());
             for subaccess in packages.accesses.iter() {
-                resolve_import_package_access(output, package_segments.clone(), &subaccess);
+                resolve_import_package_access(output, package_segments.clone(), subaccess);
             }
         }
     }

--- a/asg/src/reducer/monoidal_director.rs
+++ b/asg/src/reducer/monoidal_director.rs
@@ -308,6 +308,6 @@ impl<'a, T: Monoid, R: MonoidalReducerProgram<'a, T>> MonoidalDirector<'a, T, R>
         let circuits = input.circuits.iter().map(|(_, c)| self.reduce_circuit(c)).collect();
 
         self.reducer
-            .reduce_program(&input, imported_modules, functions, circuits)
+            .reduce_program(input, imported_modules, functions, circuits)
     }
 }

--- a/asg/src/statement/assign.rs
+++ b/asg/src/statement/assign.rs
@@ -79,12 +79,12 @@ impl<'a> FromAst<'a, leo_ast::AssignStatement> for &'a Statement<'a> {
             }
         } else {
             scope
-                .resolve_variable(&name)
-                .ok_or_else(|| AsgConvertError::unresolved_reference(name, &span))?
+                .resolve_variable(name)
+                .ok_or_else(|| AsgConvertError::unresolved_reference(name, span))?
         };
 
         if !variable.borrow().mutable {
-            return Err(AsgConvertError::immutable_assignment(&name, &statement.span));
+            return Err(AsgConvertError::immutable_assignment(name, &statement.span));
         }
         let mut target_type: Option<PartialType> = Some(variable.borrow().type_.clone().into());
 
@@ -123,13 +123,13 @@ impl<'a> FromAst<'a, leo_ast::AssignStatement> for &'a Statement<'a> {
                             ) {
                                 let left = match left {
                                     ConstValue::Int(x) => x.to_usize().ok_or_else(|| {
-                                        AsgConvertError::invalid_assign_index(&name, &x.to_string(), &statement.span)
+                                        AsgConvertError::invalid_assign_index(name, &x.to_string(), &statement.span)
                                     })?,
                                     _ => unimplemented!(),
                                 };
                                 let right = match right {
                                     ConstValue::Int(x) => x.to_usize().ok_or_else(|| {
-                                        AsgConvertError::invalid_assign_index(&name, &x.to_string(), &statement.span)
+                                        AsgConvertError::invalid_assign_index(name, &x.to_string(), &statement.span)
                                     })?,
                                     _ => unimplemented!(),
                                 };
@@ -137,7 +137,7 @@ impl<'a> FromAst<'a, leo_ast::AssignStatement> for &'a Statement<'a> {
                                     target_type = Some(PartialType::Array(item.clone(), Some((right - left) as usize)))
                                 } else {
                                     return Err(AsgConvertError::invalid_backwards_assignment(
-                                        &name,
+                                        name,
                                         left,
                                         right,
                                         &statement.span,
@@ -145,7 +145,7 @@ impl<'a> FromAst<'a, leo_ast::AssignStatement> for &'a Statement<'a> {
                                 }
                             }
                         }
-                        _ => return Err(AsgConvertError::index_into_non_array(&name, &statement.span)),
+                        _ => return Err(AsgConvertError::index_into_non_array(name, &statement.span)),
                     }
 
                     AssignAccess::ArrayRange(Cell::new(left), Cell::new(right))
@@ -153,7 +153,7 @@ impl<'a> FromAst<'a, leo_ast::AssignStatement> for &'a Statement<'a> {
                 AstAssigneeAccess::ArrayIndex(index) => {
                     target_type = match target_type.clone() {
                         Some(PartialType::Array(item, _)) => item.map(|x| *x),
-                        _ => return Err(AsgConvertError::index_into_non_array(&name, &statement.span)),
+                        _ => return Err(AsgConvertError::index_into_non_array(name, &statement.span)),
                     };
                     AssignAccess::ArrayIndex(Cell::new(<&Expression<'a>>::from_ast(
                         scope,
@@ -171,7 +171,7 @@ impl<'a> FromAst<'a, leo_ast::AssignStatement> for &'a Statement<'a> {
                             .get(index)
                             .cloned()
                             .ok_or_else(|| AsgConvertError::tuple_index_out_of_bounds(index, &statement.span))?,
-                        _ => return Err(AsgConvertError::index_into_non_tuple(&name, &statement.span)),
+                        _ => return Err(AsgConvertError::index_into_non_tuple(name, &statement.span)),
                     };
                     AssignAccess::Tuple(index)
                 }

--- a/asg/src/statement/block.rs
+++ b/asg/src/statement/block.rs
@@ -42,7 +42,7 @@ impl<'a> FromAst<'a, leo_ast::Block> for BlockStatement<'a> {
 
         let mut output = vec![];
         for item in statement.statements.iter() {
-            output.push(Cell::new(<&'a Statement<'a>>::from_ast(&new_scope, item, None)?));
+            output.push(Cell::new(<&'a Statement<'a>>::from_ast(new_scope, item, None)?));
         }
         Ok(BlockStatement {
             parent: Cell::new(None),

--- a/asg/src/statement/definition.rs
+++ b/asg/src/statement/definition.rs
@@ -70,7 +70,7 @@ impl<'a> FromAst<'a, leo_ast::DefinitionStatement> for &'a Statement<'a> {
         let type_ = statement
             .type_
             .as_ref()
-            .map(|x| scope.resolve_ast_type(&x))
+            .map(|x| scope.resolve_ast_type(x))
             .transpose()?;
 
         let value = <&Expression<'a>>::from_ast(scope, &statement.value, type_.clone().map(Into::into))?;

--- a/ast/src/reducer/canonicalization.rs
+++ b/ast/src/reducer/canonicalization.rs
@@ -276,6 +276,11 @@ impl Canonicalizer {
                     span: call.span.clone(),
                 });
             }
+            Expression::Identifier(identifier) => {
+                if identifier.name.as_ref() == "Self" && self.circuit_name.is_some() {
+                    return Expression::Identifier(self.circuit_name.as_ref().unwrap().clone());
+                }
+            }
             _ => {}
         }
 

--- a/ast/src/reducer/canonicalization.rs
+++ b/ast/src/reducer/canonicalization.rs
@@ -47,7 +47,7 @@ impl Canonicalizer {
         let mut left = Box::new(start);
 
         for access in accesses.iter() {
-            match self.canonicalize_assignee_access(&access) {
+            match self.canonicalize_assignee_access(access) {
                 AssigneeAccess::ArrayIndex(index) => {
                     left = Box::new(Expression::ArrayAccess(ArrayAccessExpression {
                         array: left,
@@ -295,7 +295,7 @@ impl Canonicalizer {
 
                 AssigneeAccess::ArrayRange(left, right)
             }
-            AssigneeAccess::ArrayIndex(index) => AssigneeAccess::ArrayIndex(self.canonicalize_expression(&index)),
+            AssigneeAccess::ArrayIndex(index) => AssigneeAccess::ArrayIndex(self.canonicalize_expression(index)),
             _ => access.clone(),
         }
     }
@@ -318,7 +318,7 @@ impl Canonicalizer {
         let statements = block
             .statements
             .iter()
-            .map(|block_statement| self.canonicalize_statement(&block_statement))
+            .map(|block_statement| self.canonicalize_statement(block_statement))
             .collect();
 
         Block {

--- a/ast/src/reducer/reconstructing_director.rs
+++ b/ast/src/reducer/reconstructing_director.rs
@@ -50,34 +50,32 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
     // Expressions
     pub fn reduce_expression(&mut self, expression: &Expression) -> Result<Expression, ReducerError> {
         let new = match expression {
-            Expression::Identifier(identifier) => Expression::Identifier(self.reduce_identifier(&identifier)?),
-            Expression::Value(value) => self.reduce_value(&value)?,
-            Expression::Binary(binary) => Expression::Binary(self.reduce_binary(&binary)?),
-            Expression::Unary(unary) => Expression::Unary(self.reduce_unary(&unary)?),
-            Expression::Ternary(ternary) => Expression::Ternary(self.reduce_ternary(&ternary)?),
-            Expression::Cast(cast) => Expression::Cast(self.reduce_cast(&cast)?),
+            Expression::Identifier(identifier) => Expression::Identifier(self.reduce_identifier(identifier)?),
+            Expression::Value(value) => self.reduce_value(value)?,
+            Expression::Binary(binary) => Expression::Binary(self.reduce_binary(binary)?),
+            Expression::Unary(unary) => Expression::Unary(self.reduce_unary(unary)?),
+            Expression::Ternary(ternary) => Expression::Ternary(self.reduce_ternary(ternary)?),
+            Expression::Cast(cast) => Expression::Cast(self.reduce_cast(cast)?),
 
-            Expression::ArrayInline(array_inline) => Expression::ArrayInline(self.reduce_array_inline(&array_inline)?),
-            Expression::ArrayInit(array_init) => Expression::ArrayInit(self.reduce_array_init(&array_init)?),
-            Expression::ArrayAccess(array_access) => Expression::ArrayAccess(self.reduce_array_access(&array_access)?),
+            Expression::ArrayInline(array_inline) => Expression::ArrayInline(self.reduce_array_inline(array_inline)?),
+            Expression::ArrayInit(array_init) => Expression::ArrayInit(self.reduce_array_init(array_init)?),
+            Expression::ArrayAccess(array_access) => Expression::ArrayAccess(self.reduce_array_access(array_access)?),
             Expression::ArrayRangeAccess(array_range_access) => {
-                Expression::ArrayRangeAccess(self.reduce_array_range_access(&array_range_access)?)
+                Expression::ArrayRangeAccess(self.reduce_array_range_access(array_range_access)?)
             }
 
-            Expression::TupleInit(tuple_init) => Expression::TupleInit(self.reduce_tuple_init(&tuple_init)?),
-            Expression::TupleAccess(tuple_access) => Expression::TupleAccess(self.reduce_tuple_access(&tuple_access)?),
+            Expression::TupleInit(tuple_init) => Expression::TupleInit(self.reduce_tuple_init(tuple_init)?),
+            Expression::TupleAccess(tuple_access) => Expression::TupleAccess(self.reduce_tuple_access(tuple_access)?),
 
-            Expression::CircuitInit(circuit_init) => Expression::CircuitInit(self.reduce_circuit_init(&circuit_init)?),
+            Expression::CircuitInit(circuit_init) => Expression::CircuitInit(self.reduce_circuit_init(circuit_init)?),
             Expression::CircuitMemberAccess(circuit_member_access) => {
-                Expression::CircuitMemberAccess(self.reduce_circuit_member_access(&circuit_member_access)?)
+                Expression::CircuitMemberAccess(self.reduce_circuit_member_access(circuit_member_access)?)
             }
             Expression::CircuitStaticFunctionAccess(circuit_static_fn_access) => {
-                Expression::CircuitStaticFunctionAccess(
-                    self.reduce_circuit_static_fn_access(&circuit_static_fn_access)?,
-                )
+                Expression::CircuitStaticFunctionAccess(self.reduce_circuit_static_fn_access(circuit_static_fn_access)?)
             }
 
-            Expression::Call(call) => Expression::Call(self.reduce_call(&call)?),
+            Expression::Call(call) => Expression::Call(self.reduce_call(call)?),
         };
 
         self.reducer.reduce_expression(expression, new)
@@ -93,7 +91,7 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
 
     pub fn reduce_group_value(&mut self, group_value: &GroupValue) -> Result<GroupValue, ReducerError> {
         let new = match group_value {
-            GroupValue::Tuple(group_tuple) => GroupValue::Tuple(self.reduce_group_tuple(&group_tuple)?),
+            GroupValue::Tuple(group_tuple) => GroupValue::Tuple(self.reduce_group_tuple(group_tuple)?),
             _ => group_value.clone(),
         };
 
@@ -107,9 +105,9 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
     pub fn reduce_value(&mut self, value: &ValueExpression) -> Result<Expression, ReducerError> {
         let new = match value {
             ValueExpression::Group(group_value) => {
-                Expression::Value(ValueExpression::Group(Box::new(self.reduce_group_value(&group_value)?)))
+                Expression::Value(ValueExpression::Group(Box::new(self.reduce_group_value(group_value)?)))
             }
-            ValueExpression::String(string, span) => self.reduce_string(string, &span)?,
+            ValueExpression::String(string, span) => self.reduce_string(string, span)?,
             _ => Expression::Value(value.clone()),
         };
 
@@ -284,14 +282,14 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
     // Statements
     pub fn reduce_statement(&mut self, statement: &Statement) -> Result<Statement, ReducerError> {
         let new = match statement {
-            Statement::Return(return_statement) => Statement::Return(self.reduce_return(&return_statement)?),
-            Statement::Definition(definition) => Statement::Definition(self.reduce_definition(&definition)?),
-            Statement::Assign(assign) => Statement::Assign(self.reduce_assign(&assign)?),
-            Statement::Conditional(conditional) => Statement::Conditional(self.reduce_conditional(&conditional)?),
-            Statement::Iteration(iteration) => Statement::Iteration(self.reduce_iteration(&iteration)?),
-            Statement::Console(console) => Statement::Console(self.reduce_console(&console)?),
-            Statement::Expression(expression) => Statement::Expression(self.reduce_expression_statement(&expression)?),
-            Statement::Block(block) => Statement::Block(self.reduce_block(&block)?),
+            Statement::Return(return_statement) => Statement::Return(self.reduce_return(return_statement)?),
+            Statement::Definition(definition) => Statement::Definition(self.reduce_definition(definition)?),
+            Statement::Assign(assign) => Statement::Assign(self.reduce_assign(assign)?),
+            Statement::Conditional(conditional) => Statement::Conditional(self.reduce_conditional(conditional)?),
+            Statement::Iteration(iteration) => Statement::Iteration(self.reduce_iteration(iteration)?),
+            Statement::Console(console) => Statement::Console(self.reduce_console(console)?),
+            Statement::Expression(expression) => Statement::Expression(self.reduce_expression_statement(expression)?),
+            Statement::Block(block) => Statement::Block(self.reduce_block(block)?),
         };
 
         self.reducer.reduce_statement(statement, new)
@@ -334,8 +332,8 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
 
                 AssigneeAccess::ArrayRange(left, right)
             }
-            AssigneeAccess::ArrayIndex(index) => AssigneeAccess::ArrayIndex(self.reduce_expression(&index)?),
-            AssigneeAccess::Member(identifier) => AssigneeAccess::Member(self.reduce_identifier(&identifier)?),
+            AssigneeAccess::ArrayIndex(index) => AssigneeAccess::ArrayIndex(self.reduce_expression(index)?),
+            AssigneeAccess::Member(identifier) => AssigneeAccess::Member(self.reduce_identifier(identifier)?),
             _ => access.clone(),
         };
 
@@ -456,7 +454,7 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
 
         let mut global_consts = IndexMap::new();
         for (name, definition) in program.global_consts.iter() {
-            global_consts.insert(name.clone(), self.reduce_definition(&definition)?);
+            global_consts.insert(name.clone(), self.reduce_definition(definition)?);
         }
 
         self.reducer
@@ -513,12 +511,10 @@ impl<R: ReconstructingReducer> ReconstructingDirector<R> {
     pub fn reduce_circuit_member(&mut self, circuit_member: &CircuitMember) -> Result<CircuitMember, ReducerError> {
         let new = match circuit_member {
             CircuitMember::CircuitVariable(identifier, type_) => CircuitMember::CircuitVariable(
-                self.reduce_identifier(&identifier)?,
-                self.reduce_type(&type_, &identifier.span)?,
+                self.reduce_identifier(identifier)?,
+                self.reduce_type(type_, &identifier.span)?,
             ),
-            CircuitMember::CircuitFunction(function) => {
-                CircuitMember::CircuitFunction(self.reduce_function(&function)?)
-            }
+            CircuitMember::CircuitFunction(function) => CircuitMember::CircuitFunction(self.reduce_function(function)?),
         };
 
         self.reducer.reduce_circuit_member(circuit_member, new)

--- a/ast/src/types/type_.rs
+++ b/ast/src/types/type_.rs
@@ -70,8 +70,8 @@ impl Type {
             (Type::Char, Type::Char) => true,
             (Type::Field, Type::Field) => true,
             (Type::Group, Type::Group) => true,
-            (Type::IntegerType(left), Type::IntegerType(right)) => left.eq(&right),
-            (Type::Circuit(left), Type::Circuit(right)) => left.eq(&right),
+            (Type::IntegerType(left), Type::IntegerType(right)) => left.eq(right),
+            (Type::Circuit(left), Type::Circuit(right)) => left.eq(right),
             (Type::SelfType, Type::SelfType) => true,
             (Type::Array(left_type, left_dim), Type::Array(right_type, right_dim)) => {
                 // Convert array dimensions to owned.

--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -181,7 +181,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
         state_string: &str,
         state_path: &Path,
     ) -> Result<(), CompilerError> {
-        let input_syntax_tree = LeoInputParser::parse_file(&input_string).map_err(|mut e| {
+        let input_syntax_tree = LeoInputParser::parse_file(input_string).map_err(|mut e| {
             e.set_path(
                 input_path.to_str().unwrap_or_default(),
                 &input_string.lines().map(|x| x.to_string()).collect::<Vec<String>>()[..],
@@ -189,7 +189,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
 
             e
         })?;
-        let state_syntax_tree = LeoInputParser::parse_file(&state_string).map_err(|mut e| {
+        let state_syntax_tree = LeoInputParser::parse_file(state_string).map_err(|mut e| {
             e.set_path(
                 state_path.to_str().unwrap_or_default(),
                 &state_string.lines().map(|x| x.to_string()).collect::<Vec<String>>()[..],
@@ -308,14 +308,14 @@ impl<'a, F: PrimeField, G: GroupType<F>> Compiler<'a, F, G> {
     /// Synthesizes the circuit with program input to verify correctness.
     ///
     pub fn compile_constraints<CS: ConstraintSystem<F>>(&self, cs: &mut CS) -> Result<Output, CompilerError> {
-        generate_constraints::<F, G, CS>(cs, &self.asg.as_ref().unwrap(), &self.program_input)
+        generate_constraints::<F, G, CS>(cs, self.asg.as_ref().unwrap(), &self.program_input)
     }
 
     ///
     /// Synthesizes the circuit for test functions with program input.
     ///
     pub fn compile_test_constraints(self, input_pairs: InputPairs) -> Result<(u32, u32), CompilerError> {
-        generate_test_constraints::<F, G>(&self.asg.as_ref().unwrap(), input_pairs, &self.output_directory)
+        generate_test_constraints::<F, G>(self.asg.as_ref().unwrap(), input_pairs, &self.output_directory)
     }
 
     ///

--- a/compiler/src/constraints/constraints.rs
+++ b/compiler/src/constraints/constraints.rs
@@ -44,7 +44,7 @@ pub fn generate_constraints<'a, F: PrimeField, G: GroupType<F>, CS: ConstraintSy
 
     match main {
         Some(function) => {
-            let result = resolved_program.enforce_main_function(cs, &function, input)?;
+            let result = resolved_program.enforce_main_function(cs, function, input)?;
             Ok(result)
         }
         _ => Err(CompilerError::NoMainFunction),

--- a/compiler/src/expression/array/access.rs
+++ b/compiler/src/expression/array/access.rs
@@ -94,7 +94,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                     .len()
                     .try_into()
                     .map_err(|_| ExpressionError::array_length_out_of_bounds(span))?;
-                self.array_bounds_check(cs, &&index_resolved, array_len, span)?;
+                self.array_bounds_check(cs, &index_resolved, array_len, span)?;
             }
 
             let mut current_value = array.pop().unwrap();

--- a/compiler/src/expression/function/function.rs
+++ b/compiler/src/expression/function/function.rs
@@ -44,7 +44,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         };
 
         let return_value = self
-            .enforce_function(&mut cs.ns(name_unique), &function, target, arguments)
+            .enforce_function(&mut cs.ns(name_unique), function, target, arguments)
             .map_err(|error| ExpressionError::from(Box::new(error)))?;
 
         Ok(return_value)

--- a/compiler/src/function/input/main_function_input.rs
+++ b/compiler/src/function/input/main_function_input.rs
@@ -62,7 +62,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                 span,
             )?)),
             Type::Array(type_, len) => self.allocate_array(cs, name, &*type_, *len, input_option, span),
-            Type::Tuple(types) => self.allocate_tuple(cs, &name, types, input_option, span),
+            Type::Tuple(types) => self.allocate_tuple(cs, name, types, input_option, span),
             _ => unimplemented!("main function input not implemented for type {}", type_), // Should not happen.
         }
     }

--- a/compiler/src/function/main_function.rs
+++ b/compiler/src/function/main_function.rs
@@ -39,7 +39,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
 
         if let Some(asg_input) = asg_input {
             let value =
-                self.allocate_input_keyword(cs, &function.name.borrow().span, &asg_input.container_circuit, input)?;
+                self.allocate_input_keyword(cs, &function.name.borrow().span, asg_input.container_circuit, input)?;
 
             self.store(asg_input.container.borrow().id, value);
         }

--- a/compiler/src/function/result/result.rs
+++ b/compiler/src/function/result/result.rs
@@ -82,7 +82,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                         cs.ns(|| format!("select result {} {}:{}", i, span.line_start, span.col_start)),
                         &indicator,
                         &result,
-                        &value,
+                        value,
                     )
                     .map_err(|_| StatementError::select_fail(result.to_string(), value.to_string(), span))?,
                 );
@@ -94,7 +94,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         if expected_return.is_unit() {
             Ok(ConstrainedValue::Tuple(vec![]))
         } else {
-            return_value.ok_or_else(|| StatementError::no_returns(&expected_return, span))
+            return_value.ok_or_else(|| StatementError::no_returns(expected_return, span))
         }
     }
 }

--- a/compiler/src/phases/reducing_director.rs
+++ b/compiler/src/phases/reducing_director.rs
@@ -155,49 +155,49 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
         asg: &AsgExpression,
     ) -> Result<AstExpression, ReducerError> {
         let new = match (ast, asg) {
-            (AstExpression::Value(value), AsgExpression::Constant(const_)) => self.reduce_value(&value, &const_)?,
+            (AstExpression::Value(value), AsgExpression::Constant(const_)) => self.reduce_value(value, const_)?,
             (AstExpression::Binary(ast), AsgExpression::Binary(asg)) => {
-                AstExpression::Binary(self.reduce_binary(&ast, &asg)?)
+                AstExpression::Binary(self.reduce_binary(ast, asg)?)
             }
             (AstExpression::Unary(ast), AsgExpression::Unary(asg)) => {
-                AstExpression::Unary(self.reduce_unary(&ast, &asg)?)
+                AstExpression::Unary(self.reduce_unary(ast, asg)?)
             }
             (AstExpression::Ternary(ast), AsgExpression::Ternary(asg)) => {
-                AstExpression::Ternary(self.reduce_ternary(&ast, &asg)?)
+                AstExpression::Ternary(self.reduce_ternary(ast, asg)?)
             }
-            (AstExpression::Cast(ast), AsgExpression::Cast(asg)) => AstExpression::Cast(self.reduce_cast(&ast, &asg)?),
+            (AstExpression::Cast(ast), AsgExpression::Cast(asg)) => AstExpression::Cast(self.reduce_cast(ast, asg)?),
 
             (AstExpression::ArrayInline(ast), AsgExpression::ArrayInline(asg)) => {
-                AstExpression::ArrayInline(self.reduce_array_inline(&ast, &asg)?)
+                AstExpression::ArrayInline(self.reduce_array_inline(ast, asg)?)
             }
             (AstExpression::ArrayInit(ast), AsgExpression::ArrayInit(asg)) => {
-                AstExpression::ArrayInit(self.reduce_array_init(&ast, &asg)?)
+                AstExpression::ArrayInit(self.reduce_array_init(ast, asg)?)
             }
             (AstExpression::ArrayAccess(ast), AsgExpression::ArrayAccess(asg)) => {
-                AstExpression::ArrayAccess(self.reduce_array_access(&ast, &asg)?)
+                AstExpression::ArrayAccess(self.reduce_array_access(ast, asg)?)
             }
             (AstExpression::ArrayRangeAccess(ast), AsgExpression::ArrayRangeAccess(asg)) => {
-                AstExpression::ArrayRangeAccess(self.reduce_array_range_access(&ast, &asg)?)
+                AstExpression::ArrayRangeAccess(self.reduce_array_range_access(ast, asg)?)
             }
 
             (AstExpression::TupleInit(ast), AsgExpression::TupleInit(asg)) => {
-                AstExpression::TupleInit(self.reduce_tuple_init(&ast, &asg)?)
+                AstExpression::TupleInit(self.reduce_tuple_init(ast, asg)?)
             }
             (AstExpression::TupleAccess(ast), AsgExpression::TupleAccess(asg)) => {
-                AstExpression::TupleAccess(self.reduce_tuple_access(&ast, &asg)?)
+                AstExpression::TupleAccess(self.reduce_tuple_access(ast, asg)?)
             }
 
             (AstExpression::CircuitInit(ast), AsgExpression::CircuitInit(asg)) => {
-                AstExpression::CircuitInit(self.reduce_circuit_init(&ast, &asg)?)
+                AstExpression::CircuitInit(self.reduce_circuit_init(ast, asg)?)
             }
             (AstExpression::CircuitMemberAccess(ast), AsgExpression::CircuitAccess(asg)) => {
-                AstExpression::CircuitMemberAccess(self.reduce_circuit_member_access(&ast, &asg)?)
+                AstExpression::CircuitMemberAccess(self.reduce_circuit_member_access(ast, asg)?)
             }
             (AstExpression::CircuitStaticFunctionAccess(ast), AsgExpression::CircuitAccess(asg)) => {
-                AstExpression::CircuitStaticFunctionAccess(self.reduce_circuit_static_fn_access(&ast, &asg)?)
+                AstExpression::CircuitStaticFunctionAccess(self.reduce_circuit_static_fn_access(ast, asg)?)
             }
 
-            (AstExpression::Call(ast), AsgExpression::Call(asg)) => AstExpression::Call(self.reduce_call(&ast, &asg)?),
+            (AstExpression::Call(ast), AsgExpression::Call(asg)) => AstExpression::Call(self.reduce_call(ast, asg)?),
             _ => ast.clone(),
         };
 
@@ -299,7 +299,7 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
         ast: &AstCastExpression,
         asg: &AsgCastExpression,
     ) -> Result<AstCastExpression, ReducerError> {
-        let inner = self.reduce_expression(&ast.inner, &asg.inner.get())?;
+        let inner = self.reduce_expression(&ast.inner, asg.inner.get())?;
         let target_type = self.reduce_type(&ast.target_type, &asg.target_type, &ast.span)?;
 
         self.ast_reducer.reduce_cast(ast, inner, target_type)
@@ -524,7 +524,7 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
                 AstAssignAccess::ArrayRange(left, right)
             }
             (AstAssignAccess::ArrayIndex(ast_index), AsgAssignAccess::ArrayIndex(asg_index)) => {
-                let index = self.reduce_expression(&ast_index, asg_index.get())?;
+                let index = self.reduce_expression(ast_index, asg_index.get())?;
                 AstAssignAccess::ArrayIndex(index)
             }
             _ => ast.clone(),
@@ -577,7 +577,7 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
             block = self.reduce_block(&ast.block, asg_block)?;
         } else {
             return Err(ReducerError::from(CombinerError::asg_statement_not_block(
-                &asg.span.as_ref().unwrap(),
+                asg.span.as_ref().unwrap(),
             )));
         }
         let next = match (ast.next.as_ref(), asg.next.get()) {
@@ -595,7 +595,7 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
     ) -> Result<AstConsoleStatement, ReducerError> {
         let function = match (&ast.function, &asg.function) {
             (AstConsoleFunction::Assert(ast_expression), AsgConsoleFunction::Assert(asg_expression)) => {
-                AstConsoleFunction::Assert(self.reduce_expression(&ast_expression, asg_expression.get())?)
+                AstConsoleFunction::Assert(self.reduce_expression(ast_expression, asg_expression.get())?)
             }
             (AstConsoleFunction::Error(ast_console_args), AsgConsoleFunction::Error(asg_format))
             | (AstConsoleFunction::Log(ast_console_args), AsgConsoleFunction::Log(asg_format)) => {
@@ -603,7 +603,7 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
                 for (ast_parameter, asg_parameter) in
                     ast_console_args.parameters.iter().zip(asg_format.parameters.iter())
                 {
-                    parameters.push(self.reduce_expression(&ast_parameter, asg_parameter.get())?);
+                    parameters.push(self.reduce_expression(ast_parameter, asg_parameter.get())?);
                 }
 
                 let args = AstConsoleArgs {
@@ -640,14 +640,14 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
             let asg_type = AsgType::Tuple(types);
 
             type_ = match &ast.type_ {
-                Some(ast_type) => Some(self.reduce_type(&ast_type, &asg_type, &ast.span)?),
+                Some(ast_type) => Some(self.reduce_type(ast_type, &asg_type, &ast.span)?),
                 None if self.options.type_inference_enabled() => Some((&asg_type).into()),
                 _ => None,
             };
         } else {
             type_ = match &ast.type_ {
                 Some(ast_type) => {
-                    Some(self.reduce_type(&ast_type, &asg.variables.first().unwrap().borrow().type_, &ast.span)?)
+                    Some(self.reduce_type(ast_type, &asg.variables.first().unwrap().borrow().type_, &ast.span)?)
                 }
                 None if self.options.type_inference_enabled() => {
                     Some((&asg.variables.first().unwrap().borrow().type_).into())
@@ -683,7 +683,7 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
             block = self.reduce_block(&ast.block, asg_block)?;
         } else {
             return Err(ReducerError::from(CombinerError::asg_statement_not_block(
-                &asg.span.as_ref().unwrap(),
+                asg.span.as_ref().unwrap(),
             )));
         }
 

--- a/compiler/src/statement/assign/assignee/array_index.rs
+++ b/compiler/src/statement/assign/assignee/array_index.rs
@@ -69,7 +69,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                                 .len()
                                 .try_into()
                                 .map_err(|_| ExpressionError::array_length_out_of_bounds(&span))?;
-                            self.array_bounds_check(cs, &&index_resolved, array_len, &span)?;
+                            self.array_bounds_check(cs, &index_resolved, array_len, &span)?;
                         }
 
                         for (i, item) in input.iter_mut().enumerate() {
@@ -116,7 +116,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                                 unique_namespace,
                                 &index_comparison,
                                 &temp_item,
-                                &item,
+                                item,
                             )
                             .map_err(|e| ExpressionError::cannot_enforce("conditional select".to_string(), e, &span))?;
                             *item = value;
@@ -153,7 +153,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                         .len()
                         .try_into()
                         .map_err(|_| ExpressionError::array_length_out_of_bounds(&span))?;
-                    self.array_bounds_check(cs, &&index_resolved, array_len, &span)?;
+                    self.array_bounds_check(cs, &index_resolved, array_len, &span)?;
                 }
 
                 for (i, item) in context.input.iter_mut().enumerate() {
@@ -197,7 +197,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
                         item
                     };
                     let value =
-                        ConstrainedValue::conditionally_select(unique_namespace, &index_comparison, &temp_item, &item)
+                        ConstrainedValue::conditionally_select(unique_namespace, &index_comparison, &temp_item, item)
                             .map_err(|e| ExpressionError::cannot_enforce("conditional select".to_string(), e, &span))?;
                     **item = value;
                 }

--- a/compiler/src/statement/conditional/conditional.rs
+++ b/compiler/src/statement/conditional/conditional.rs
@@ -91,7 +91,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         );
         let branch_2_indicator = Boolean::and(
             &mut cs.ns(|| format!("branch 2 {}:{}", &span.line_start, &span.col_start)),
-            &outer_indicator,
+            outer_indicator,
             &inner_indicator,
         )
         .map_err(|_| StatementError::indicator_calculation(branch_2_name, &span))?;

--- a/compiler/src/value/value.rs
+++ b/compiler/src/value/value.rs
@@ -124,7 +124,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> fmt::Display for ConstrainedValue<'a, F
 
                 write!(f, "({})", values)
             }
-            ConstrainedValue::CircuitExpression(ref circuit, ref members) => {
+            ConstrainedValue::CircuitExpression(circuit, ref members) => {
                 write!(f, "{} {{", circuit.name.borrow())?;
                 for (i, member) in members.iter().enumerate() {
                     write!(f, "{}: {}", member.0, member.1)?;

--- a/imports/src/parser/parse_symbol.rs
+++ b/imports/src/parser/parse_symbol.rs
@@ -54,7 +54,7 @@ impl<'a> ImportParser<'a> {
         // Build the package abstract syntax tree.
         let program_string =
             &std::fs::read_to_string(&file_path).map_err(|x| ImportParserError::io_error(span, file_path_str, x))?;
-        let mut program = leo_parser::parse(&file_path_str, &program_string)?;
+        let mut program = leo_parser::parse(file_path_str, program_string)?;
         program.name = file_name;
         let mut ast = leo_ast::Ast::new(program);
         ast.canonicalize()?;

--- a/input/src/errors/parser.rs
+++ b/input/src/errors/parser.rs
@@ -191,7 +191,7 @@ impl InputParserError {
             expected, actual
         );
 
-        Self::new_from_span(message, &span)
+        Self::new_from_span(message, span)
     }
 
     pub fn section(header: Header) -> Self {

--- a/input/src/values/group_coordinate.rs
+++ b/input/src/values/group_coordinate.rs
@@ -32,7 +32,7 @@ pub enum GroupCoordinate<'ast> {
 impl<'ast> GroupCoordinate<'ast> {
     pub fn span(&self) -> &Span<'ast> {
         match self {
-            GroupCoordinate::Number(number) => &number.span(),
+            GroupCoordinate::Number(number) => number.span(),
             GroupCoordinate::SignHigh(sign_high) => &sign_high.span,
             GroupCoordinate::SignLow(sign_low) => &sign_low.span,
             GroupCoordinate::Inferred(inferred) => &inferred.span,

--- a/input/src/values/value.rs
+++ b/input/src/values/value.rs
@@ -39,13 +39,13 @@ pub enum Value<'ast> {
 impl<'ast> Value<'ast> {
     pub fn span(&self) -> &Span<'ast> {
         match self {
-            Value::Address(value) => &value.span(),
+            Value::Address(value) => value.span(),
             Value::Boolean(value) => &value.span,
             Value::Char(value) => &value.span,
             Value::Field(value) => &value.span,
             Value::Group(value) => &value.span,
-            Value::Implicit(value) => &value.span(),
-            Value::Integer(value) => &value.span(),
+            Value::Implicit(value) => value.span(),
+            Value::Integer(value) => value.span(),
         }
     }
 }

--- a/leo/config.rs
+++ b/leo/config.rs
@@ -144,10 +144,10 @@ pub fn write_token_and_username(token: &str, username: &str) -> Result<(), io::E
     }
 
     let mut credentials = File::create(&LEO_CREDENTIALS_PATH.to_path_buf())?;
-    credentials.write_all(&token.as_bytes())?;
+    credentials.write_all(token.as_bytes())?;
 
     let mut username_file = File::create(&LEO_USERNAME_PATH.to_path_buf())?;
-    username_file.write_all(&username.as_bytes())?;
+    username_file.write_all(username.as_bytes())?;
 
     Ok(())
 }

--- a/leo/updater.rs
+++ b/leo/updater.rs
@@ -53,7 +53,7 @@ impl Updater {
             .repo_owner(Self::LEO_REPO_OWNER)
             .repo_name(Self::LEO_REPO_NAME)
             .bin_name(Self::LEO_BIN_NAME)
-            .current_version(&env!("CARGO_PKG_VERSION"))
+            .current_version(env!("CARGO_PKG_VERSION"))
             .show_download_progress(show_output)
             .no_confirm(true)
             .show_output(show_output)
@@ -69,7 +69,7 @@ impl Updater {
             .repo_owner(Self::LEO_REPO_OWNER)
             .repo_name(Self::LEO_REPO_NAME)
             .bin_name(Self::LEO_BIN_NAME)
-            .current_version(&env!("CARGO_PKG_VERSION"))
+            .current_version(env!("CARGO_PKG_VERSION"))
             .build()?;
 
         let current_version = updater.current_version();

--- a/package/src/package.rs
+++ b/package/src/package.rs
@@ -123,14 +123,14 @@ impl Package {
         }
 
         // Check if the input file already exists.
-        let input_file = InputFile::new(&package_name);
+        let input_file = InputFile::new(package_name);
         if input_file.exists_at(path) {
             existing_files.push(input_file.filename());
             result = false;
         }
 
         // Check if the state file already exists.
-        let state_file = StateFile::new(&package_name);
+        let state_file = StateFile::new(package_name);
         if state_file.exists_at(path) {
             existing_files.push(state_file.filename());
             result = false;
@@ -157,24 +157,24 @@ impl Package {
         }
 
         // Check if the manifest file exists.
-        if !Manifest::exists_at(&path) {
+        if !Manifest::exists_at(path) {
             return false;
         }
 
         // Check if the input file exists.
-        let input_file = InputFile::new(&package_name);
-        if !input_file.exists_at(&path) {
+        let input_file = InputFile::new(package_name);
+        if !input_file.exists_at(path) {
             return false;
         }
 
         // Check if the state file exists.
-        let state_file = StateFile::new(&package_name);
-        if !state_file.exists_at(&path) {
+        let state_file = StateFile::new(package_name);
+        if !state_file.exists_at(path) {
             return false;
         }
 
         // Check if the main file exists.
-        if !MainFile::exists_at(&path) {
+        if !MainFile::exists_at(path) {
             return false;
         }
 
@@ -195,34 +195,34 @@ impl Package {
         // Next, initialize this directory as a Leo package.
         {
             // Create the manifest file.
-            Manifest::new(&package_name, author)?.write_to(&path)?;
+            Manifest::new(package_name, author)?.write_to(path)?;
 
             // Verify that the .gitignore file does not exist.
-            if !Gitignore::exists_at(&path) {
+            if !Gitignore::exists_at(path) {
                 // Create the .gitignore file.
-                Gitignore::new().write_to(&path)?;
+                Gitignore::new().write_to(path)?;
             }
 
             // Verify that the README.md file does not exist.
-            if !README::exists_at(&path) {
+            if !README::exists_at(path) {
                 // Create the README.md file.
-                README::new(package_name).write_to(&path)?;
+                README::new(package_name).write_to(path)?;
             }
 
             // Create the source directory.
-            SourceDirectory::create(&path)?;
+            SourceDirectory::create(path)?;
 
             // Create the input directory.
-            InputsDirectory::create(&path)?;
+            InputsDirectory::create(path)?;
 
             // Create the input file in the inputs directory.
-            InputFile::new(&package_name).write_to(&path)?;
+            InputFile::new(package_name).write_to(path)?;
 
             // Create the state file in the inputs directory.
-            StateFile::new(&package_name).write_to(&path)?;
+            StateFile::new(package_name).write_to(path)?;
 
             // Create the main file in the source directory.
-            MainFile::new(&package_name).write_to(&path)?;
+            MainFile::new(package_name).write_to(path)?;
         }
         // Next, verify that a valid Leo package has been initialized in this directory
         {

--- a/parser/examples/parser.rs
+++ b/parser/examples/parser.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), SyntaxError> {
     let input_filepath = Path::new(&cli_arguments[1]);
 
     // Construct the serialized syntax tree.
-    let serialized_leo_tree = to_leo_tree(&input_filepath)?;
+    let serialized_leo_tree = to_leo_tree(input_filepath)?;
     println!("{}", serialized_leo_tree);
 
     // Determine the output directory.

--- a/parser/src/parser/file.rs
+++ b/parser/src/parser/file.rs
@@ -227,7 +227,7 @@ impl ParserContext {
                     base.name = format_tendril!("{}{}", base.name, next.name);
                     base.span = base.span + next.span;
                 }
-                x if KEYWORD_TOKENS.contains(&x) => {
+                x if KEYWORD_TOKENS.contains(x) => {
                     let next = self.expect_loose_identifier()?;
                     base.name = format_tendril!("{}{}", base.name, next.name);
                     base.span = base.span + next.span;

--- a/parser/src/parser/statement.rs
+++ b/parser/src/parser/statement.rs
@@ -281,7 +281,7 @@ impl ParserContext {
             "log" => ConsoleFunction::Log(self.parse_console_args()?),
             x => {
                 return Err(SyntaxError::unexpected_ident(
-                    &x,
+                    x,
                     &["assert", "error", "log"],
                     &function.span,
                 ));

--- a/parser/src/tokenizer/lexer.rs
+++ b/parser/src/tokenizer/lexer.rs
@@ -101,7 +101,7 @@ impl Token {
                 return None;
             }
 
-            if let Ok(ascii_number) = u8::from_str_radix(&hex_string, 16) {
+            if let Ok(ascii_number) = u8::from_str_radix(hex_string, 16) {
                 // According to RFC, we allow only values less than 128.
                 if ascii_number > 127 {
                     return None;
@@ -123,7 +123,7 @@ impl Token {
                 return None;
             }
 
-            if let Ok(hex) = u32::from_str_radix(&unicode_number, 16) {
+            if let Ok(hex) = u32::from_str_radix(unicode_number, 16) {
                 if let Some(character) = std::char::from_u32(hex) {
                     // scalar
                     return Some(Char::Scalar(character));

--- a/tests/expectations/compiler/compiler/circuits/member_static_function_nested.leo.out
+++ b/tests/expectations/compiler/compiler/circuits/member_static_function_nested.leo.out
@@ -17,5 +17,5 @@ outputs:
               type: bool
               value: "true"
     initial_ast: 4c74b65863cddde8ce523495358ab619ec48645dcb8409658a3fb3d7a3821d6d
-    canonicalized_ast: b5697d5884139da5a68861213ff3c7660f694e682078e1bd350856206e0289b8
-    type_inferenced_ast: ff4b8f91f014277d6bb2d8d82c31361e5a5c5a46ed87a1e61f0c2e2e8d5fd254
+    canonicalized_ast: 45dc35a683e14503f8a1fc40280f05e7d096b49896f115ffa649e76b9cd80941
+    type_inferenced_ast: 11af72cfc90adc12c3412e3067ad285a2279de0f4f12af5081dbe27c58b5a3bf


### PR DESCRIPTION
## Motivation

Closes #1217. 
Fixes clippy warning after we switched to Rust 1.54.

## Test Plan

This bug was found by the incoming acl2-ci, hopefully we'll be able to use it to verify canonicalization fixes.
CI in #1216 passes after the same fix has been done there.
