### PR TITLE
Bump snarkvm to 0.7.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "10:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 20
   ignore:
   - dependency-name: snarkvm-curves
     versions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
- "rustc_version 0.4.0",
+ "rustc_version",
 ]
 
 [[package]]
@@ -2191,15 +2191,6 @@ checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
 
 [[package]]
 name = "rustc_version"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
-dependencies = [
- "semver 0.11.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
@@ -2465,14 +2456,14 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fdf07998a6e88fce7a8139e8282fb6b2702e49624b6d7e10a5cc1c9f014264"
+checksum = "6a67bf9f77ce8db3e88fd58241ec7d0a0ad80097c42d0bd4e53b123106605249"
 dependencies = [
  "derivative",
  "rand 0.8.4",
  "rand_xorshift",
- "rustc_version 0.3.3",
+ "rustc_version",
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
@@ -2481,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-derives"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d42f4d5abda149130149ce3865aef23d380dfcdd97fea7f75fd79b0aee369b29"
+checksum = "3cbe69096a11cdc3f0b069e0313d47fbcabf45532d58435ef0a03d35d2805dc5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro-error",
@@ -2526,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ecd058b3608140610276be1eb1139a032a1bb171969b3ad70550c471d3ae503"
+checksum = "502d750651111b5d399a3b29b770fe821fdac87614335b4814ab5a0d014634bc"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2639,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b7ecf6a7afdd60a45cbd5ffab75185c296d8a4bf5eb20f3912384b1d4027c2"
+checksum = "fcb1462993e1d189c75f88f2482f18ae4bcccb5ea5a7a93a25de92907305af8f"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,9 +2428,9 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8bbefe6252ed85bb073f8ecbc402830e3d119b1aaadcea5a9c9e7a21a99cd2"
+checksum = "d8db2338bd30c4f5f08f27cae89bccd9ba48b06166e1cddcc4e845de0390229f"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2485,9 +2485,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-dpc"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8dd1b815a1101c4014c17cbdffadecb1032e8662fdf5fd4bd67a3c149d8449"
+checksum = "c65b21cece03e1191989230062d8773d5dd7b848099fd0380e35d3f920b7c77e"
 dependencies = [
  "anyhow",
  "base58",
@@ -2533,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-gadgets"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b462bb5e5ac219eafd1a828c73c181e7b23692ade5c49fd72d71bfe4250a6b1"
+checksum = "753400eccfb80757e90daaf077c37ce8988bf163816ded6eb884e725290a78f1"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2553,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-marlin"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5b1bb7923a757053c0a544072ec6b298585f83c9f4a3ae777ca048bb6e5589"
+checksum = "abcc01851cf4cee0de8c4fda76f8096789cab813c738703ec67fe2d19d89a204"
 dependencies = [
  "blake2",
  "derivative",
@@ -2577,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14356edda788a3e52ac6e809e6fdbfd5cf7558249bf6051525843b045a73d12a"
+checksum = "7f21f3b1fc09bff0e3a352a2e30927a3fbfbe183ef658cbb42bd2805db7d6420"
 dependencies = [
  "curl",
  "hex",
@@ -2590,9 +2590,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-polycommit"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fac50de72680316fe57fbbbde2874ae28de7191a3f23ff9e541119951ddaa8"
+checksum = "920e188506d5036cca0fdae46d63ad1779d3f49c671ea2339b9cda0c0ab8751a"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2609,15 +2609,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-profiler"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebfa546f0376a1348b857a9defdb3f4505a0420d82f8caa2b0cebbe197245fa"
+checksum = "1a060c67f5c11015465721bdbbaf71f8c5132fdc885cb2e7307f8c936dd43ca1"
 
 [[package]]
 name = "snarkvm-r1cs"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aca9bb7105244ebc91f964b11a1ae63f173a77181307d1fa94f04e15dbde137"
+checksum = "8b87182d37dc6665816e1dcd480820f6c6494d1d9604c481b756eb0771956265"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ version = "1.5.3"
 version = "0.7.4"
 
 [dependencies.snarkvm-curves]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
@@ -89,7 +89,7 @@ version = "0.7.5"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.7.4"
+version = "0.7.6"
 
 [dependencies.anyhow]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,18 +74,18 @@ path = "./synthesizer"
 version = "1.5.3"
 
 [dependencies.snarkvm-algorithms]
-version = "0.7.4"
+version = "0.7.6"
 
 [dependencies.snarkvm-curves]
 version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-utilities]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -65,7 +65,7 @@ version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-gadgets]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -69,12 +69,12 @@ version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 features = [ "curves" ]
 
 [dependencies.snarkvm-r1cs]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-utilities]
@@ -119,7 +119,7 @@ version = "0.3"
 default-features = false
 
 [dev-dependencies.snarkvm-algorithms]
-version = "0.7.4"
+version = "0.7.6"
 default-features = false
 
 [dev-dependencies.tempfile]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -57,11 +57,11 @@ version = "1.5.3"
 version = "0.4"
 
 [dependencies.snarkvm-curves]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-dpc]
@@ -78,7 +78,7 @@ version = "0.7.5"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.7.4"
+version = "0.7.6"
 
 [dependencies.bincode]
 version = "1.3"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -29,7 +29,7 @@ version = "1.5.3"
 version = "0.7.4"
 
 [dependencies.snarkvm-curves]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-dpc]
@@ -37,7 +37,7 @@ version = "0.7.5"
 features = [ "testnet1" ]
 
 [dependencies.snarkvm-utilities]
-version = "0.7.4"
+version = "0.7.6"
 
 [dependencies.indexmap]
 version = "1.7.0"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -33,7 +33,7 @@ version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-dpc]
-version = "0.7.5"
+version = "0.7.6"
 features = [ "testnet1" ]
 
 [dependencies.snarkvm-utilities]

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -26,7 +26,7 @@ path = "../ast"
 version = "1.5.3"
 
 [dependencies.snarkvm-algorithms]
-version = "0.7.4"
+version = "0.7.6"
 
 [dependencies.snarkvm-curves]
 version = "0.7.6"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -26,10 +26,10 @@ version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.7.5"
+version = "0.7.6"
 
 [dependencies.snarkvm-r1cs]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.num-bigint]

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -18,11 +18,11 @@ license = "GPL-3.0"
 edition = "2018"
 
 [dependencies.snarkvm-curves]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.7.5"
+version = "0.7.6"
 default-features = false
 
 [dependencies.snarkvm-gadgets]


### PR DESCRIPTION
## Motivation

Update SnarkVM version to 0.7.6.

Clippy CI will pass once #1225 is merged.

## Test Plan

CI tests should be enough.