### PR TITLE
[WIP] Feature unsized arrays

### DIFF
--- a/asg/src/expression/array_access.rs
+++ b/asg/src/expression/array_access.rs
@@ -91,7 +91,8 @@ impl<'a> FromAst<'a, leo_ast::ArrayAccessExpression> for ArrayAccessExpression<'
             Some(PartialType::Array(expected_type.map(Box::new), None)),
         )?;
         let array_len = match array.get_type() {
-            Some(Type::Array(_, len)) => len,
+            Some(Type::Array(_, len)) => Some(len),
+            Some(Type::UnsizedArray(_arr)) => None, // TODO: @damirka - try to find workaround for this place
             type_ => {
                 return Err(AsgError::unexpected_type(
                     "array",
@@ -113,10 +114,12 @@ impl<'a> FromAst<'a, leo_ast::ArrayAccessExpression> for ArrayAccessExpression<'
             .map(|x| x.int().map(|x| x.to_usize()).flatten())
             .flatten()
         {
-            if index >= array_len {
-                return Err(
-                    AsgError::array_index_out_of_bounds(index, &array.span().cloned().unwrap_or_default()).into(),
-                );
+            if let Some(array_len) = array_len {
+                if index >= array_len {
+                    return Err(
+                        AsgError::array_index_out_of_bounds(index, &array.span().cloned().unwrap_or_default()).into(),
+                    );
+                }
             }
         }
 

--- a/asg/src/expression/array_init.rs
+++ b/asg/src/expression/array_init.rs
@@ -78,10 +78,6 @@ impl<'a> FromAst<'a, leo_ast::ArrayInitExpression> for ArrayInitExpression<'a> {
             }
         };
 
-        if let PartialType::Array(_item, dims) = expected_type.clone().unwrap() {
-            dbg!(dims);
-        }
-
         let dimensions = value
             .dimensions
             .0

--- a/asg/src/expression/array_init.rs
+++ b/asg/src/expression/array_init.rs
@@ -70,13 +70,18 @@ impl<'a> FromAst<'a, leo_ast::ArrayInitExpression> for ArrayInitExpression<'a> {
         value: &leo_ast::ArrayInitExpression,
         expected_type: Option<PartialType<'a>>,
     ) -> Result<ArrayInitExpression<'a>> {
-        let (mut expected_item, expected_len) = match expected_type {
+        let (mut expected_item, expected_len) = match expected_type.clone() {
             Some(PartialType::Array(item, dims)) => (item.map(|x| *x), dims),
             None => (None, None),
             Some(type_) => {
                 return Err(AsgError::unexpected_type(type_, "array", &value.span).into());
             }
         };
+
+        if let PartialType::Array(_item, dims) = expected_type.clone().unwrap() {
+            dbg!(dims);
+        }
+
         let dimensions = value
             .dimensions
             .0

--- a/asg/src/expression/array_inline.rs
+++ b/asg/src/expression/array_inline.rs
@@ -105,6 +105,8 @@ impl<'a> FromAst<'a, leo_ast::ArrayInlineExpression> for ArrayInlineExpression<'
         value: &leo_ast::ArrayInlineExpression,
         expected_type: Option<PartialType<'a>>,
     ) -> Result<ArrayInlineExpression<'a>> {
+        // println!("{}", expected_type.clone().unwrap());
+
         let (mut expected_item, expected_len) = match expected_type {
             Some(PartialType::Array(item, dims)) => (item.map(|x| *x), dims),
             None => (None, None),

--- a/asg/src/expression/array_inline.rs
+++ b/asg/src/expression/array_inline.rs
@@ -108,6 +108,7 @@ impl<'a> FromAst<'a, leo_ast::ArrayInlineExpression> for ArrayInlineExpression<'
         let (mut expected_item, expected_len) = match expected_type {
             Some(PartialType::Array(item, dims)) => (item.map(|x| *x), dims),
             None => (None, None),
+            Some(PartialType::Type(Type::UnsizedArray(item))) => (Some(item.clone().partial()), None),
             Some(type_) => {
                 return Err(AsgError::unexpected_type(type_, "array", &value.span).into());
             }

--- a/asg/src/expression/array_inline.rs
+++ b/asg/src/expression/array_inline.rs
@@ -105,8 +105,6 @@ impl<'a> FromAst<'a, leo_ast::ArrayInlineExpression> for ArrayInlineExpression<'
         value: &leo_ast::ArrayInlineExpression,
         expected_type: Option<PartialType<'a>>,
     ) -> Result<ArrayInlineExpression<'a>> {
-        // println!("{}", expected_type.clone().unwrap());
-
         let (mut expected_item, expected_len) = match expected_type {
             Some(PartialType::Array(item, dims)) => (item.map(|x| *x), dims),
             None => (None, None),

--- a/asg/src/expression/variable_ref.rs
+++ b/asg/src/expression/variable_ref.rs
@@ -159,6 +159,7 @@ impl<'a> FromAst<'a, leo_ast::Identifier> for &'a Expression<'a> {
             let type_ = expression
                 .get_type()
                 .ok_or_else(|| AsgError::unresolved_reference(&value.name, &value.span))?;
+
             if !expected_type.matches(&type_) {
                 return Err(AsgError::unexpected_type(expected_type, type_, &value.span).into());
             }

--- a/asg/src/scope.rs
+++ b/asg/src/scope.rs
@@ -171,6 +171,8 @@ impl<'a> Scope<'a> {
                             .map_err(|_| AsgError::parse_index_error(span))?;
                         item = Box::new(Type::Array(item, dimension));
                     }
+                } else {
+                    item = Box::new(Type::UnsizedArray(item));
                 }
                 *item
             }

--- a/asg/src/scope.rs
+++ b/asg/src/scope.rs
@@ -163,12 +163,14 @@ impl<'a> Scope<'a> {
             IntegerType(int_type) => Type::Integer(int_type.clone()),
             Array(sub_type, dimensions) => {
                 let mut item = Box::new(self.resolve_ast_type(&*sub_type, span)?);
-                for dimension in dimensions.0.iter().rev() {
-                    let dimension = dimension
-                        .value
-                        .parse::<usize>()
-                        .map_err(|_| AsgError::parse_index_error(span))?;
-                    item = Box::new(Type::Array(item, dimension));
+                if let Some(dimensions) = dimensions {
+                    for dimension in dimensions.0.iter().rev() {
+                        let dimension = dimension
+                            .value
+                            .parse::<usize>()
+                            .map_err(|_| AsgError::parse_index_error(span))?;
+                        item = Box::new(Type::Array(item, dimension));
+                    }
                 }
                 *item
             }

--- a/asg/src/type_.rs
+++ b/asg/src/type_.rs
@@ -30,7 +30,7 @@ pub enum Type<'a> {
     Group,
     Integer(IntegerType),
 
-    // Data type wrappers
+    // Data type wrappersf
     Array(Box<Type<'a>>, usize),
     Tuple(Vec<Type<'a>>),
     Circuit(&'a Circuit<'a>),
@@ -207,9 +207,9 @@ impl<'a> Into<leo_ast::Type> for &Type<'a> {
             Integer(int_type) => leo_ast::Type::IntegerType(int_type.clone()),
             Array(type_, len) => leo_ast::Type::Array(
                 Box::new(type_.as_ref().into()),
-                leo_ast::ArrayDimensions(vec![leo_ast::PositiveNumber {
+                Some(leo_ast::ArrayDimensions(vec![leo_ast::PositiveNumber {
                     value: len.to_string().into(),
-                }]),
+                }])),
             ),
             Tuple(subtypes) => leo_ast::Type::Tuple(subtypes.iter().map(Into::into).collect()),
             Circuit(circuit) => leo_ast::Type::Circuit(circuit.name.borrow().clone()),

--- a/asg/src/type_.rs
+++ b/asg/src/type_.rs
@@ -30,7 +30,7 @@ pub enum Type<'a> {
     Group,
     Integer(IntegerType),
 
-    // Data type wrappersf
+    // Data type wrappers
     Array(Box<Type<'a>>, usize),
     Tuple(Vec<Type<'a>>),
     Circuit(&'a Circuit<'a>),

--- a/ast/src/reducer/canonicalization.rs
+++ b/ast/src/reducer/canonicalization.rs
@@ -471,24 +471,31 @@ impl ReconstructingReducer for Canonicalizer {
 
     fn reduce_type(&mut self, _type_: &Type, new: Type, span: &Span) -> Result<Type> {
         match new {
-            Type::Array(type_, mut dimensions) => {
-                if dimensions.is_zero() {
-                    return Err(AstError::invalid_array_dimension_size(span).into());
-                }
-
-                let mut next = Type::Array(type_, ArrayDimensions(vec![dimensions.remove_last().unwrap()]));
-                let mut array = next.clone();
-
-                loop {
-                    if dimensions.is_empty() {
-                        break;
+            Type::Array(type_, dimensions) => {
+                if let Some(mut dimensions) = dimensions {
+                    if dimensions.is_zero() {
+                        return Err(AstError::invalid_array_dimension_size(span).into());
                     }
 
-                    array = Type::Array(Box::new(next), ArrayDimensions(vec![dimensions.remove_last().unwrap()]));
-                    next = array.clone();
-                }
+                    let mut next = Type::Array(type_, Some(ArrayDimensions(vec![dimensions.remove_last().unwrap()])));
+                    let mut array = next.clone();
 
-                Ok(array)
+                    loop {
+                        if dimensions.is_empty() {
+                            break;
+                        }
+
+                        array = Type::Array(
+                            Box::new(next),
+                            Some(ArrayDimensions(vec![dimensions.remove_last().unwrap()])),
+                        );
+                        next = array.clone();
+                    }
+
+                    Ok(array)
+                } else {
+                    Ok(Type::Array(type_, None))
+                }
             }
             Type::SelfType if !self.in_circuit => Err(AstError::big_self_outside_of_circuit(span).into()),
             _ => Ok(new.clone()),

--- a/ast/src/types/type_.rs
+++ b/ast/src/types/type_.rs
@@ -34,7 +34,7 @@ pub enum Type {
     IntegerType(IntegerType),
 
     // Data type wrappers
-    Array(Box<Type>, ArrayDimensions),
+    Array(Box<Type>, Option<ArrayDimensions>),
     Tuple(Vec<Type>),
     Circuit(Identifier),
     SelfType,
@@ -72,8 +72,17 @@ impl Type {
             (Type::SelfType, Type::SelfType) => true,
             (Type::Array(left_type, left_dim), Type::Array(right_type, right_dim)) => {
                 // Convert array dimensions to owned.
-                let mut left_dim_owned = left_dim.to_owned();
-                let mut right_dim_owned = right_dim.to_owned();
+                let left_dim_owned = left_dim.to_owned();
+                let right_dim_owned = right_dim.to_owned();
+
+                // Unable to compare arrays with unspecified sizes.
+                if left_dim_owned.is_none() || right_dim_owned.is_none() {
+                    return false;
+                }
+
+                // We know that values are Some, safe to unwrap.
+                let mut left_dim_owned = left_dim_owned.unwrap();
+                let mut right_dim_owned = right_dim_owned.unwrap();
 
                 // Remove the first element from both dimensions.
                 let left_first = left_dim_owned.remove_first();
@@ -120,7 +129,7 @@ impl<'ast> From<InputArrayType<'ast>> for Type {
         let element_type = Box::new(Type::from(*array_type.type_));
         let dimensions = ArrayDimensions::from(array_type.dimensions);
 
-        Type::Array(element_type, dimensions)
+        Type::Array(element_type, Some(dimensions))
     }
 }
 
@@ -153,7 +162,13 @@ impl fmt::Display for Type {
             Type::IntegerType(ref integer_type) => write!(f, "{}", integer_type),
             Type::Circuit(ref variable) => write!(f, "circuit {}", variable),
             Type::SelfType => write!(f, "SelfType"),
-            Type::Array(ref array, ref dimensions) => write!(f, "[{}; {}]", *array, dimensions),
+            Type::Array(ref array, ref dimensions) => {
+                if let Some(dimensions) = dimensions {
+                    write!(f, "[{}; {}]", *array, dimensions)
+                } else {
+                    write!(f, "[{}; _]", *array)
+                }
+            }
             Type::Tuple(ref tuple) => {
                 let types = tuple.iter().map(|x| x.to_string()).collect::<Vec<_>>().join(", ");
 
@@ -179,6 +194,6 @@ pub fn inner_array_type(element_type: Type, dimensions: ArrayDimensions) -> Type
         element_type
     } else {
         // The array has multiple dimensions.
-        Type::Array(Box::new(element_type), dimensions)
+        Type::Array(Box::new(element_type), Some(dimensions))
     }
 }

--- a/compiler/src/phases/reducing_director.rs
+++ b/compiler/src/phases/reducing_director.rs
@@ -76,9 +76,9 @@ impl<R: ReconstructingReducer, O: CombinerOptions> CombineAstAsgDirector<R, O> {
                 if self.options.type_inference_enabled() {
                     AstType::Array(
                         Box::new(self.reduce_type(ast_type, asg_type, span)?),
-                        ArrayDimensions(vec![PositiveNumber {
+                        Some(ArrayDimensions(vec![PositiveNumber {
                             value: StrTendril::from(format!("{}", asg_dimensions)),
-                        }]),
+                        }])),
                     )
                 } else {
                     AstType::Array(

--- a/errors/src/parser/parser_errors.rs
+++ b/errors/src/parser/parser_errors.rs
@@ -120,14 +120,6 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser failed to parse array dimensions.
-    @formatted
-    unable_to_parse_array_dimensions {
-        args: (),
-        msg: "unable to parse array dimensions",
-        help: None,
-    }
-
     /// For when the parser encountered an invalid assignment target.
     @formatted
     invalid_assignment_target {
@@ -181,6 +173,14 @@ create_errors!(
     context_annotation {
         args: (),
         msg: "\"@context(...)\" is deprecated. Did you mean @test annotation?",
+        help: None,
+    }
+
+    /// For when the parser failed to parse array dimensions.
+    @formatted
+    unable_to_parse_array_dimensions {
+        args: (),
+        msg: "unable to parse array dimensions",
         help: None,
     }
 );

--- a/errors/src/parser/parser_errors.rs
+++ b/errors/src/parser/parser_errors.rs
@@ -32,7 +32,7 @@ create_errors!(
         help: Some(help),
     }
 
-    /// For when the parser encoutnered an invalid address literal.
+    /// For when the parser encountered an invalid address literal.
     @formatted
     invalid_address_lit {
         args: (token: impl Display),
@@ -40,7 +40,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an empty import list.
+    /// For when the parser encountered an empty import list.
     @formatted
     invalid_import_list {
         args: (),
@@ -48,7 +48,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected End of File.
+    /// For when the parser encountered an unexpected End of File.
     @formatted
     unexpected_eof {
         args: (),
@@ -56,7 +56,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected whitespace.
+    /// For when the parser encountered an unexpected whitespace.
     @formatted
     unexpected_whitespace {
         args: (left: impl Display, right: impl Display),
@@ -64,7 +64,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected list of tokens.
+    /// For when the parser encountered an unexpected list of tokens.
     @formatted
     unexpected {
         args: (got: impl Display, expected: impl Display),
@@ -72,7 +72,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered a mix of commas and semi-colons in circuit member variables.
+    /// For when the parser encountered a mix of commas and semi-colons in circuit member variables.
     @formatted
     mixed_commas_and_semicolons {
         args: (),
@@ -80,7 +80,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected identifier.
+    /// For when the parser encountered an unexpected identifier.
     @formatted
     unexpected_ident {
         args: (got: impl Display, expected: &[impl Display]),
@@ -96,7 +96,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected statement.
+    /// For when the parser encountered an unexpected statement.
     @formatted
     unexpected_statement {
         args: (got: impl Display, expected: impl Display),
@@ -104,7 +104,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected string.
+    /// For when the parser encountered an unexpected string.
     @formatted
     unexpected_str {
         args: (got: impl Display, expected: impl Display),
@@ -112,7 +112,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an unexpected spread in an array init expression.
+    /// For when the parser encountered an unexpected spread in an array init expression.
     @formatted
     spread_in_array_init {
         args: (),
@@ -120,7 +120,15 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an invalid assignment target.
+    /// For when the parser failed to parse array dimensions.
+    @formatted
+    unable_to_parse_array_dimensions {
+        args: (),
+        msg: "unable to parse array dimensions",
+        help: None,
+    }
+
+    /// For when the parser encountered an invalid assignment target.
     @formatted
     invalid_assignment_target {
         args: (),
@@ -128,7 +136,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an invalid package name.
+    /// For when the parser encountered an invalid package name.
     @formatted
     invalid_package_name {
         args: (),
@@ -136,7 +144,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered an illegal `const self` argument.
+    /// For when the parser encountered an illegal `const self` argument.
     @formatted
     illegal_self_const {
         args: (),
@@ -144,7 +152,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered a deprecated `mut` argument in a function.
+    /// For when the parser encountered a deprecated `mut` argument in a function.
     @formatted
     mut_function_input {
         args: (),
@@ -152,7 +160,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered a deprecated `mut` argument in a let statement.
+    /// For when the parser encountered a deprecated `mut` argument in a let statement.
     @formatted
     let_mut_statement {
         args: (),
@@ -160,7 +168,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered a deprecated `test function`.
+    /// For when the parser encountered a deprecated `test function`.
     @formatted
     test_function {
         args: (),
@@ -168,7 +176,7 @@ create_errors!(
         help: None,
     }
 
-    /// For when the parser encoutnered a deprecated `@context(...)` annotation.
+    /// For when the parser encountered a deprecated `@context(...)` annotation.
     @formatted
     context_annotation {
         args: (),

--- a/parser/src/parser/expression.rs
+++ b/parser/src/parser/expression.rs
@@ -606,7 +606,7 @@ impl ParserContext {
             // TODO: @damirka change the error
             let dimensions = self
                 .parse_array_dimensions()?
-                .ok_or(ParserError::spread_in_array_init(&span))?;
+                .ok_or_else(|| ParserError::spread_in_array_init(span))?;
             let end = self.expect(Token::RightSquare)?;
             let first = match first {
                 SpreadOrExpression::Spread(first) => {

--- a/parser/src/parser/expression.rs
+++ b/parser/src/parser/expression.rs
@@ -603,10 +603,9 @@ impl ParserContext {
         }
         let first = self.parse_spread_or_expression()?;
         if self.eat(Token::Semicolon).is_some() {
-            // TODO: @damirka change the error
             let dimensions = self
                 .parse_array_dimensions()?
-                .ok_or_else(|| ParserError::spread_in_array_init(span))?;
+                .ok_or_else(|| ParserError::unable_to_parse_array_dimensions(span))?;
             let end = self.expect(Token::RightSquare)?;
             let first = match first {
                 SpreadOrExpression::Spread(first) => {

--- a/parser/src/parser/expression.rs
+++ b/parser/src/parser/expression.rs
@@ -603,7 +603,10 @@ impl ParserContext {
         }
         let first = self.parse_spread_or_expression()?;
         if self.eat(Token::Semicolon).is_some() {
-            let dimensions = self.parse_array_dimensions()?;
+            // TODO: @damirka change the error
+            let dimensions = self
+                .parse_array_dimensions()?
+                .ok_or(ParserError::spread_in_array_init(&span))?;
             let end = self.expect(Token::RightSquare)?;
             let first = match first {
                 SpreadOrExpression::Spread(first) => {

--- a/parser/src/parser/type_.rs
+++ b/parser/src/parser/type_.rs
@@ -61,7 +61,7 @@ impl ParserContext {
     pub fn parse_array_dimensions(&mut self) -> Result<Option<ArrayDimensions>> {
         Ok(if let Some((int, _)) = self.eat_int() {
             Some(ArrayDimensions(vec![int]))
-        } else if let Some(_) = self.eat(Token::Underscore) {
+        } else if self.eat(Token::Underscore).is_some() {
             None
         } else {
             self.expect(Token::LeftParen)?;

--- a/parser/src/parser/type_.rs
+++ b/parser/src/parser/type_.rs
@@ -58,9 +58,11 @@ impl ParserContext {
     ///
     /// Returns an [`ArrayDimensions`] AST node if the next tokens represent dimensions for an array type.
     ///
-    pub fn parse_array_dimensions(&mut self) -> Result<ArrayDimensions> {
+    pub fn parse_array_dimensions(&mut self) -> Result<Option<ArrayDimensions>> {
         Ok(if let Some((int, _)) = self.eat_int() {
-            ArrayDimensions(vec![int])
+            Some(ArrayDimensions(vec![int]))
+        } else if let Some(_) = self.eat(Token::Underscore) {
+            None
         } else {
             self.expect(Token::LeftParen)?;
             let mut dimensions = Vec::new();
@@ -76,7 +78,7 @@ impl ParserContext {
                 }
             }
             self.expect(Token::RightParen)?;
-            ArrayDimensions(dimensions)
+            Some(ArrayDimensions(dimensions))
         })
     }
 

--- a/tests/compiler/array/array_unspecified_size.leo
+++ b/tests/compiler/array/array_unspecified_size.leo
@@ -1,0 +1,12 @@
+/*
+namespace: Compile
+expectation: Pass
+input_file:
+ - input/dummy.in
+*/
+
+function main(y: bool) -> bool {
+    let x: [char; _] = ['a', 'b', 'c', 'y'];
+
+    return x[3] == 'y';
+}

--- a/tests/expectations/compiler/compiler/array/array_unspecified_size.leo.out
+++ b/tests/expectations/compiler/compiler/array/array_unspecified_size.leo.out
@@ -18,4 +18,4 @@ outputs:
               value: "true"
     initial_ast: 4483823ad88ca4c56f6699b5f6908409afee0bd7aee7d5070d34ac5411653c8a
     canonicalized_ast: 4483823ad88ca4c56f6699b5f6908409afee0bd7aee7d5070d34ac5411653c8a
-    type_inferenced_ast: e30307360ae54ced0ab13272ea00ddbcf94735c8f0ba990404f8b54aa72e4e17
+    type_inferenced_ast: 8970a54468b7ceda90bda7c6ba26ac8da595b14cfd252035aae99f5d949ab97b

--- a/tests/expectations/compiler/compiler/array/array_unspecified_size.leo.out
+++ b/tests/expectations/compiler/compiler/array/array_unspecified_size.leo.out
@@ -1,0 +1,21 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - circuit:
+      num_public_variables: 0
+      num_private_variables: 1
+      num_constraints: 1
+      at: 042610d0fd1fe6d6ac112138f8755752f44c7d2a00f1b5960574d6da5cda393f
+      bt: e97756698880ab7555a959a5fb5c6b4e15bd64612aa677adbfe2d0bd91f0a83c
+      ct: cf1cbb66a638b4860a516671fb74850e6ccf787fe6c4c8d29e9c04efe880bd05
+    output:
+      - input_file: input/dummy.in
+        output:
+          registers:
+            r0:
+              type: bool
+              value: "true"
+    initial_ast: 4483823ad88ca4c56f6699b5f6908409afee0bd7aee7d5070d34ac5411653c8a
+    canonicalized_ast: 4483823ad88ca4c56f6699b5f6908409afee0bd7aee7d5070d34ac5411653c8a
+    type_inferenced_ast: e30307360ae54ced0ab13272ea00ddbcf94735c8f0ba990404f8b54aa72e4e17

--- a/tests/expectations/parser/parser/statement/definition.leo.out
+++ b/tests/expectations/parser/parser/statement/definition.leo.out
@@ -1471,3 +1471,55 @@ outputs:
         col_stop: 14
         path: ""
         content: "let (x,) = ();"
+  - Definition:
+      declaration_type: Let
+      variable_names:
+        - mutable: true
+          identifier: "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":5,\\\"col_stop\\\":6,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x: [u32; _] = expr;\\\"}\"}"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 5
+            col_stop: 6
+            path: ""
+            content: "let x: [u32; _] = expr;"
+      type_:
+        Array:
+          - IntegerType: U32
+          - ~
+      value:
+        Identifier: "{\"name\":\"expr\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":19,\\\"col_stop\\\":23,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x: [u32; _] = expr;\\\"}\"}"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 23
+        path: ""
+        content: "let x: [u32; _] = expr;"
+  - Definition:
+      declaration_type: Let
+      variable_names:
+        - mutable: true
+          identifier: "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":5,\\\"col_stop\\\":6,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x: [[char; _]; _] = expr;\\\"}\"}"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 5
+            col_stop: 6
+            path: ""
+            content: "let x: [[char; _]; _] = expr;"
+      type_:
+        Array:
+          - Array:
+              - Char
+              - ~
+          - ~
+      value:
+        Identifier: "{\"name\":\"expr\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":25,\\\"col_stop\\\":29,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x: [[char; _]; _] = expr;\\\"}\"}"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 29
+        path: ""
+        content: "let x: [[char; _]; _] = expr;"

--- a/tests/expectations/parser/parser/statement/definition_fail.leo.out
+++ b/tests/expectations/parser/parser/statement/definition_fail.leo.out
@@ -25,3 +25,5 @@ outputs:
   - "Error [EPAR0370009]: unexpected string: expected 'ident', got ','\n    --> test:1:10\n     |\n   1 | let (x,y,,) = ();\n     |          ^"
   - "Error [EPAR0370009]: unexpected string: expected 'ident', got ','\n    --> test:1:6\n     |\n   1 | let (,x,y) = ();\n     |      ^"
   - "Error [EPAR0370009]: unexpected string: expected 'ident', got ','\n    --> test:1:8\n     |\n   1 | let (x,,y) = ();\n     |        ^"
+  - "Error [EPAR0370005]: expected ; -- got ':'\n    --> test:1:12\n     |\n   1 | let x: [u32: aa] = expr;\n     |            ^"
+  - "Error [EPAR0370005]: expected ] -- got '2'\n    --> test:1:16\n     |\n   1 | let x: [u32; _ 2] = expr;\n     |                ^"

--- a/tests/parser/statement/definition.leo
+++ b/tests/parser/statement/definition.leo
@@ -98,3 +98,8 @@ const (x, y): u32 = x();
 let (x,y,) = ();
 
 let (x,) = ();
+
+
+let x: [u32; _] = expr;
+
+let x: [[char; _]; _] = expr;

--- a/tests/parser/statement/definition_fail.leo
+++ b/tests/parser/statement/definition_fail.leo
@@ -52,3 +52,8 @@ let (x,y,,) = ();
 let (,x,y) = ();
 
 let (x,,y) = ();
+
+
+let x: [u32: aa] = expr;
+
+let x: [u32; _ 2] = expr;


### PR DESCRIPTION
Closes #1045.
Follows RFC 006.

## Motivation

Arrays with unspecified sizes are part of a string type implementation. Length of those arrays is defined at ASG stage by array expressions.

## Test Plan

Tests are in progress.

## Related PRs

Should probably be merged after we deal with #1294.