### PR TITLE
[Examples] Adds 2 more examples, updates manifests

### DIFF
--- a/examples/hello-world/Leo.toml
+++ b/examples/hello-world/Leo.toml
@@ -6,3 +6,7 @@ license = "LICENSE-MIT"
 
 [remote]
 author = "aleo"
+
+[target]
+curve = "bls12_377"
+proving_system = "groth16"

--- a/examples/linear-regression/.gitignore
+++ b/examples/linear-regression/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/examples/linear-regression/Leo.toml
+++ b/examples/linear-regression/Leo.toml
@@ -1,8 +1,8 @@
 [project]
-name = "pedersen-hash"
+name = "linear-regression"
 version = "0.1.0"
-description = "A 256bit hash function"
-license = "LICENSE-MIT"
+description = "The linear-regression package"
+license = "MIT"
 
 [remote]
 author = "aleo"

--- a/examples/linear-regression/README.md
+++ b/examples/linear-regression/README.md
@@ -1,0 +1,20 @@
+# linear-regression
+
+## Build Guide
+
+To compile this Leo program, run:
+```bash
+leo build
+```
+
+To test this Leo program, run:
+```bash
+leo test
+```
+
+## Development
+
+To output the number of constraints, run:
+```bash
+leo build -d
+```

--- a/examples/linear-regression/inputs/linear-regression.in
+++ b/examples/linear-regression/inputs/linear-regression.in
@@ -1,0 +1,7 @@
+// The program input for light-cuddly-cyan-polo/src/main.leo
+[main]
+x: i32 = 1i32;
+y: i32 = 2i32;
+
+[registers]
+r0: [i32; 2] = [1i32, 2i32];

--- a/examples/linear-regression/inputs/linear-regression.state
+++ b/examples/linear-regression/inputs/linear-regression.state
@@ -1,0 +1,26 @@
+// The program state for linear-regression/src/main.leo
+[[public]]
+
+[state]
+leaf_index: u32 = 0;
+root: [u8; 32] = [0; 32];
+
+[[private]]
+
+[record]
+serial_number: [u8; 64] = [0; 64];
+commitment: [u8; 32] = [0; 32];
+owner: address = aleo1daxej63vwrmn2zhl4dymygagh89k5d2vaw6rjauueme7le6k2q8sjn0ng9;
+is_dummy: bool = false;
+value: u64 = 0;
+payload: [u8; 32] = [0; 32];
+birth_program_id: [u8; 48] = [0; 48];
+death_program_id: [u8; 48] = [0; 48];
+serial_number_nonce: [u8; 32] = [0; 32];
+commitment_randomness: [u8; 32] = [0; 32];
+
+[state_leaf]
+path: [u8; 128] = [0; 128];
+memo: [u8; 32] = [0; 32];
+network_id: u8 = 0;
+leaf_randomness: [u8; 32] = [0; 32];

--- a/examples/linear-regression/src/main.leo
+++ b/examples/linear-regression/src/main.leo
@@ -1,0 +1,65 @@
+circuit Point {
+    x: i32,
+    y: i32,
+    
+    function new(x: i32, y: i32) -> Self { 
+        return Self { x, y };
+    }
+}
+
+circuit LinearRegression {
+    points: [Point; 5],
+    
+    // Instantiates a linear regression circuit.
+    function new(points: [Point; 5]) -> Self { 
+        return Self { points };
+    }
+    
+    // Return the slope of the linear regression.
+    function slope(self) -> i32 { 
+        
+        let num_points = 5i32;
+        // Calculate the sums.
+        let x_sum = 0i32; 
+        let y_sum = 0i32; 
+        let xy_sum = 0i32; 
+        let x2_sum = 0i32; 
+        for i in 0..5 {
+            x_sum += self.points[i].x;
+            y_sum += self.points[i].y;
+            xy_sum += self.points[i].x * self.points[i].y;
+            x2_sum += self.points[i].x * self.points[i].x;
+        }
+        let numerator = (num_points * xy_sum) - (x_sum * y_sum); 
+        let denominator = (num_points * x2_sum) - (x_sum * x_sum);
+        let slope = numerator / denominator;
+        return slope;
+    }
+    // Return the offset of the linear regression.
+    function offset(self, slope: i32) -> i32 {
+        let num_points = 5i32; 
+        // Calculate the sum. 
+        let x_sum = 0i32;
+        let y_sum = 0i32;
+        for i in 0..5 {
+            x_sum += self.points[i].x;
+            y_sum += self.points[i].y; 
+        }
+        return (y_sum - slope * x_sum) / num_points;
+    }
+}
+
+
+function main (x: i32, y: i32) -> [i32; 2] {
+  let points: [Point; 5] = [
+      Point{x: x + 1, y: y + 1},
+      Point{x: x + 2, y: y + 2},
+      Point{x: x + 3, y: y + 3},
+      Point{x: x + 4, y: y + 4},
+      Point{x: x + 5, y: y + 5}
+  ];
+  let reg = LinearRegression::new(points);
+  let slope = reg.slope();
+  let offset = reg.offset(slope);
+  return [slope, offset];
+}

--- a/examples/palindrome/.gitignore
+++ b/examples/palindrome/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/examples/palindrome/Leo.toml
+++ b/examples/palindrome/Leo.toml
@@ -1,8 +1,8 @@
 [project]
-name = "pedersen-hash"
+name = "palindrome"
 version = "0.1.0"
-description = "A 256bit hash function"
-license = "LICENSE-MIT"
+description = "The palindrome package"
+license = "MIT"
 
 [remote]
 author = "aleo"
@@ -10,3 +10,6 @@ author = "aleo"
 [target]
 curve = "bls12_377"
 proving_system = "groth16"
+
+[dependencies]
+# none

--- a/examples/palindrome/README.md
+++ b/examples/palindrome/README.md
@@ -1,0 +1,20 @@
+# palindrome
+
+## Build Guide
+
+To compile this Leo program, run:
+```bash
+leo build
+```
+
+To test this Leo program, run:
+```bash
+leo test
+```
+
+## Development
+
+To output the number of constraints, run:
+```bash
+leo build -d
+```

--- a/examples/palindrome/inputs/palindrome.in
+++ b/examples/palindrome/inputs/palindrome.in
@@ -1,0 +1,5 @@
+[main]
+str: [char; 20] = "borrow   or rob     "; // char array can be defined as a string
+
+[registers]
+r0: bool = false;

--- a/examples/palindrome/inputs/palindrome.state
+++ b/examples/palindrome/inputs/palindrome.state
@@ -1,0 +1,26 @@
+// The program state for palindrome/src/main.leo
+[[public]]
+
+[state]
+leaf_index: u32 = 0;
+root: [u8; 32] = [0; 32];
+
+[[private]]
+
+[record]
+serial_number: [u8; 64] = [0; 64];
+commitment: [u8; 32] = [0; 32];
+owner: address = aleo1daxej63vwrmn2zhl4dymygagh89k5d2vaw6rjauueme7le6k2q8sjn0ng9;
+is_dummy: bool = false;
+value: u64 = 0;
+payload: [u8; 32] = [0; 32];
+birth_program_id: [u8; 48] = [0; 48];
+death_program_id: [u8; 48] = [0; 48];
+serial_number_nonce: [u8; 32] = [0; 32];
+commitment_randomness: [u8; 32] = [0; 32];
+
+[state_leaf]
+path: [u8; 128] = [0; 128];
+memo: [u8; 32] = [0; 32];
+network_id: u8 = 0;
+leaf_randomness: [u8; 32] = [0; 32];

--- a/examples/palindrome/src/main.leo
+++ b/examples/palindrome/src/main.leo
@@ -1,0 +1,59 @@
+// This Program takes in any 20-byte low register string and tells 
+// whether a string is a palindrome ignoring any spaces.
+
+function main(str: [char; 20]) -> bool {
+    return is_palindrome(str);
+}
+
+function is_palindrome(str: [char; 20]) -> bool {
+    const str_len = 20u32; // saving const for convenience
+
+    // By default we assume that input is a palindrome.
+    let result = true;
+    let processed = 0u8;
+
+    for start in 0..(str_len / 2) {
+        let start_sym = str[start];
+        if start_sym != ' ' {
+            let skipped = 0u8;
+            let end_empty = 0u8;
+            let end_sym = ' ';
+
+            for end in (str_len - 1)..start {
+                if str[end] != ' ' && skipped == processed && end_sym == ' ' {
+                    end_sym = str[end];
+                } else {
+                    end_empty = end_empty + 1;
+                    if str[end] != ' ' {
+                        skipped = skipped + 1;
+                    }
+                }
+            }
+
+            // If there are symbols left to the right from the start.
+            if end_sym != ' ' {
+                console.log("Comparing: {} ? {}", start_sym, end_sym);
+
+                if result {
+                    result = (start_sym == end_sym);
+                }
+
+                processed = processed + 1;
+            }
+        }
+    }
+
+    console.log("Result is: {}", result);
+
+    return result;
+}
+
+@test
+function test_is_palindrome() {
+    console.assert(is_palindrome("a           b   a   "));
+    console.assert(is_palindrome("😀😀😀😀😀          😀😀😀😀😀"));
+    console.assert(is_palindrome("borrow or rob       "));
+    console.assert(is_palindrome("bbbb aaaa  aaaa bbbb"));
+    console.assert(is_palindrome("aaaaaaaaaaaaaaaaaaaa"));
+    console.assert(is_palindrome("taco cat            "));
+}

--- a/examples/silly-sudoku/Leo.toml
+++ b/examples/silly-sudoku/Leo.toml
@@ -6,3 +6,7 @@ license = "MIT"
 
 [remote]
 author = "howard"
+
+[target]
+curve = "bls12_377"
+proving_system = "groth16"


### PR DESCRIPTION
We discussed it somewhere a while ago. 
Examples in the repo are a nice way to showcase the language to developers .

## What's inside

- Adds 2 more examples to the repo: `palindrome` and `linear-regression`. We have them on play.leo-lang.org, why not have them in the repo as well.
- Updates Leo manifests - adds target section following recent changes in import management

