### PR TITLE
Feature/count untested errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,6 +1485,7 @@ dependencies = [
  "leo-compiler",
  "leo-imports",
  "leo-parser",
+ "regex",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1483,6 +1483,7 @@ dependencies = [
  "leo-ast",
  "leo-ast-passes",
  "leo-compiler",
+ "leo-errors",
  "leo-imports",
  "leo-parser",
  "regex",

--- a/errors/src/common/macros.rs
+++ b/errors/src/common/macros.rs
@@ -20,7 +20,6 @@
 #[macro_export]
 macro_rules! create_errors {
     (@step $code:expr,) => {
-
         #[inline(always)]
         // Returns the number of unique exit codes that this error type can take on.
         pub fn num_exit_codes() -> i32 {

--- a/errors/src/common/macros.rs
+++ b/errors/src/common/macros.rs
@@ -19,7 +19,14 @@
 /// with a unique error code.
 #[macro_export]
 macro_rules! create_errors {
-    (@step $_code:expr,) => {};
+    (@step $code:expr,) => {
+
+        #[inline(always)]
+        // Returns the number of unique exit codes that this error type can take on.
+        pub fn num_exit_codes() -> i32 {
+            $code
+        }
+    };
     ($(#[$error_type_docs:meta])* $error_type:ident, exit_code_mask: $exit_code_mask:expr, error_code_prefix: $error_code_prefix:expr, $($(#[$docs:meta])* @$formatted_or_backtraced_list:ident $names:ident { args: ($($arg_names:ident: $arg_types:ty$(,)?)*), msg: $messages:expr, help: $helps:expr, })*) => {
         #[allow(unused_imports)] // Allow unused for errors that only use formatted or backtraced errors.
         use crate::{BacktracedError, FormattedError, LeoErrorCode, Span};
@@ -62,6 +69,7 @@ macro_rules! create_errors {
                 $error_code_prefix.to_string()
             }
         }
+
 
         // Steps over the list of functions with an initial error code of 0.
         impl $error_type {
@@ -112,5 +120,4 @@ macro_rules! create_errors {
         // Steps the error code value by one and calls on the rest of the functions.
         create_errors!(@step $code + 1i32, $(($(#[$docs])* $formatted_or_backtraced_tail, $names($($tail_arg_names: $tail_arg_types,)*), $messages, $helps),)*);
     };
-
 }

--- a/test-framework/Cargo.toml
+++ b/test-framework/Cargo.toml
@@ -55,3 +55,7 @@ version = "1.5.2"
 
 [dependencies.structopt]
 version = "0.3"
+
+# List of dependencies for errcov
+[dependencies.regex]
+version = "1.5"

--- a/test-framework/Cargo.toml
+++ b/test-framework/Cargo.toml
@@ -57,5 +57,9 @@ version = "1.5.2"
 version = "0.3"
 
 # List of dependencies for errcov
+[dependencies.leo-errors]
+path = "../errors"
+version = "1.5.3"
+
 [dependencies.regex]
 version = "1.5"

--- a/test-framework/src/bin/errcov.rs
+++ b/test-framework/src/bin/errcov.rs
@@ -1,0 +1,117 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use leo_asg::Asg;
+use leo_ast::AstPass;
+use leo_compiler::{compiler::thread_leaked_context, TypeInferencePhase};
+use leo_imports::ImportParser;
+use leo_test_framework::{
+    fetch::find_tests,
+    output::TestExpectation,
+    test::{extract_test_config, TestExpectationMode as Expectation},
+};
+
+use regex::Regex;
+use std::{collections::HashSet, error::Error, fs, path::PathBuf};
+use structopt::{clap::AppSettings, StructOpt};
+
+#[derive(StructOpt)]
+#[structopt(name = "error-coverage", author = "The Aleo Team <hello@aleo.org>", setting = AppSettings::ColoredHelp)]
+struct Opt {
+    #[structopt(short, long, help = "Path to the output file", parse(from_os_str))]
+    output: PathBuf,
+}
+
+fn main() {
+    handle_error(run_with_args(Opt::from_args()));
+}
+
+fn run_with_args(opt: Opt) -> Result<(), Box<dyn Error>> {
+    // Variable that stores all the tests.
+    let mut tests = Vec::new();
+    let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    test_dir.push("../tests/");
+
+    let mut expectation_dir = test_dir.clone();
+    expectation_dir.push("expectations");
+
+    find_tests(&test_dir, &mut tests);
+
+    // Store all covered error codes
+    let mut codes = HashSet::new();
+    let re = Regex::new(r"Error \[(?P<code>.*)\]:.*").unwrap();
+
+    for (path, content) in tests.into_iter() {
+        if let Some(config) = extract_test_config(&content) {
+            // Skip passing tests.
+            if config.expectation == Expectation::Pass {
+                continue;
+            }
+
+            let mut expectation_path = expectation_dir.clone();
+
+            let path = PathBuf::from(path);
+            let relative_path = path.strip_prefix(&test_dir).expect("path error for test");
+
+            let mut relative_expectation_path = relative_path.to_str().unwrap().to_string();
+            relative_expectation_path += ".out";
+
+            // Add expectation category
+            if relative_expectation_path.starts_with("compiler") {
+                expectation_path.push("compiler");
+            } else {
+                expectation_path.push("parser");
+            }
+            expectation_path.push(&relative_expectation_path);
+
+            if expectation_path.exists() {
+                let raw = std::fs::read_to_string(&expectation_path).expect("failed to read expectations file");
+                let expectation: TestExpectation =
+                    serde_yaml::from_str(&raw).expect("invalid yaml in expectations file");
+
+                for value in expectation.outputs {
+                    if let serde_yaml::Value::String(message) = value {
+                        if let Some(caps) = re.captures(&message) {
+                            if let Some(code) = caps.name("code") {
+                                codes.insert(code.as_str().to_string());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut sorted: Vec<_> = codes.iter().collect();
+    sorted.sort();
+
+    println!("Found the following error codes");
+    for code in sorted {
+        println!("{}", code)
+    }
+
+    Ok(())
+}
+
+fn handle_error(res: Result<(), Box<dyn Error>>) {
+    match res {
+        Ok(_) => (),
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            std::process::exit(1);
+        }
+    }
+}

--- a/tests/expectations/compiler/compiler/array_without_size/length.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length.leo.out
@@ -17,6 +17,6 @@ outputs:
               type: bool
               value: "true"
     initial_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    imports_resolved_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    canonicalized_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    type_inferenced_ast: 06be9e7e193c4fcdca75ba8218de79dcc8317b1eb63d9c2f33ca790c614a472b
+    imports_resolved_ast: 37de52ab186133dccfc290bed3f417685ce9ee5de37c820e0e8e3d2a17804bcc
+    canonicalized_ast: 37de52ab186133dccfc290bed3f417685ce9ee5de37c820e0e8e3d2a17804bcc
+    type_inferenced_ast: 2f1b4e2127a33a02bea52ad28c0e9414268b401e11787bbde761820e8ac804e4

--- a/tests/expectations/compiler/compiler/array_without_size/length_function.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length_function.leo.out
@@ -17,6 +17,6 @@ outputs:
               type: bool
               value: "true"
     initial_ast: 9886d4d97c894fade697bd99ac9cbe2a56973037837f34884e3dbad4dd4d5d65
-    imports_resolved_ast: 9886d4d97c894fade697bd99ac9cbe2a56973037837f34884e3dbad4dd4d5d65
-    canonicalized_ast: 36dbb999756e8e8bb68c69388889f0cfc217fbdbb0467f43453e19feb5c55d22
-    type_inferenced_ast: 4fff72622455ea5bfc073c8e90e2266545b01e3004b73e4ee909b37b0bd75f46
+    imports_resolved_ast: afd08cb992e4004c551f936d4a5867bbc0a0c05fbb8997bffd2a082badbf03fc
+    canonicalized_ast: 462f0feb8e304b2644d1bbcf90663a03a9e8c53d9e9ae42836ad57d1f0de3165
+    type_inferenced_ast: 20f7f22df0d2826996233e2e513403f84be65d8db9e9a947df128c377299355c


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation
This would help developers write tests targeting uncovered areas, specifically errors, in the codebase.
See issues #1249 and #1250.

## Implementation and Usage
The easiest way to see what errors are currently tested would be to search by each error message in the test expectations.
Counting the errors tested is fairly straightforward since all we have to do is process `.out` files in  `/tests/expectations`.
Automatically getting the set of all possible errors is more difficult, since they are generated by a macro-based DSL.
We do this by modifying the `create_errors` macro so that it returns the number of unique exit codes for each error group. 

The error coverage report is generated by invoking the `errcov` binary in the following way.
```
cargo run -p leo-test-framework --bin errcov 
```

The coverage report provides the number of uncovered error codes and the codes themselves. For covered or unknown error codes, the report also lists the expectation file that they were found in. A general template of the output YAML is given below.
```
results:
    uncovered:
        count: <number>
        codes: 
            - <error_code>
            ...
            - <error_code>
    covered:
        count: <number>
        codes:
            - <error_code>
                - <expectation_filename>
                ...
                - <expectation_filename>
            ...
            - <error_code>
                - <expectation_filename>
                ...
                - <expectation_filename>
    unknown:
        count: <number>
        codes:
            - <error_code>
                - <expectation_filename>
                ...
                - <expectation_filename>
            ...
            - <error_code>
                - <expectation_filename>
                ...
                - <expectation_filename>
```


## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Testing was mainly done by visual inspection. 
It's sort of hard to write tests that test tests that test tests. :)

@reviewers Any suggestions on improving testing would be much appreciated.

## Additional Notes
As of now, the coverage information mainly references error codes. This is not necessarily the most useful for devs since they have to manually search for the corresponding error name. I took a stab at exporting that information through the `create_errors` macro but the code got very messy. I suspect the way to go about this is by using procedural macros for the error DSL but that would require a lot more code overhaul. It may not be worth going through all of that trouble as long as the current coverage information is useful for developers.
