### PR TITLE
[tgc CI] make log more readable; allow tgc type inference to run even…

### DIFF
--- a/.github/workflows/acl2.yml
+++ b/.github/workflows/acl2.yml
@@ -1,6 +1,6 @@
 name: Leo-ACL2
 on: workflow_dispatch
-env: 
+env:
   RUST_BACKTRACE: 1
 
 # This job can only be run on linux (Ubuntu)
@@ -28,35 +28,37 @@ jobs:
       - name: Pull tgc executable
         run: |
           mkdir acl2 && cd acl2;
-          wget $(curl -s https://api.github.com/repos/AleoHQ/leo-acl2-bin/releases/latest \
-              | grep "browser_download_url.*.tgz"  \
-              | cut -d : -f 2,3 \
-              | tr -d \" \
-              | xargs)
+          wget $( curl -s https://api.github.com/repos/AleoHQ/leo-acl2-bin/releases/latest \
+                  | jq -r '.assets[0].browser_download_url' )
 
+          echo "Unpacking $(ls):"
           tar -xvzf $(ls)
-      
-      # Using the prepared ASTs and the pulled and unzipped tgc run theorem generation.
+
+      # Run theorem generation and checking using the prepared ASTs and the pulled and unzipped leo-acl2 tarball.
       - name: Run tgc over ASTs
         run: |
           canonicalization_errors=();
           type_inference_errors=();
+          num_dirs=0;
           for dir in `ls tmp/tgc`;
           do
             cd tmp/tgc/$dir; # enter the directory
+            num_dirs=$((num_dirs + 1));
             ./../../../acl2/tgc canonicalization initial_ast.json canonicalization_ast.json canonicalization-theorem.lisp > canonicalization_result.out || canonicalization_errors+=("$dir");
-            # Disabling Type inference for now
             ./../../../acl2/tgc type-inference canonicalization_ast.json type_inferenced_ast.json type-inference-theorem.lisp > type_inference_result.out || type_inference_errors+=("$dir");
             cd ../../..
           done;
 
+          echo "----------------"
+          echo "Ran tgc in ${num_dirs} directories."
+          echo "----------------"
           if [ ${#canonicalization_errors[@]} -eq 0 ]; then
             echo "Canonicalization - Success!"
           else
-            echo "Canonicalization Failures:";
+            echo "Canonicalization Failures (total: ${#canonicalization_errors[@]}):"
             for dir in ${canonicalization_errors[@]};
             do
-              echo $dir;
+              echo $dir
             done;
 
             #echo "Attaching logs:"
@@ -65,16 +67,16 @@ jobs:
             # cat tmp/tgc/$dir/canonicalization_result.out
             # cat tmp/tgc/$dir/canonicalization-theorem.lisp
             #done;
-            exit 1
           fi
 
+          echo "----------------"
           if [ ${#type_inference_errors[@]} -eq 0 ]; then
             echo "Type Inference - Success!"
           else
-            echo "Type Inference Failures:";
+            echo "Type Inference Failures (total: ${#type_inference_errors[@]}):"
             for dir in ${type_inference_errors[@]};
             do
-              echo $dir;
+              echo $dir
             done;
 
             #echo "Attaching logs:"
@@ -82,6 +84,10 @@ jobs:
             #do
             # cat tmp/tgc/$dir/type_inference_result.out
             #done;
+          fi
 
+          if [[ ${#canonicalization_errors[@]} -ne 0 || ${#type_inference_errors[@]} -ne 0 ]]; then
+            echo "----------------"
+            echo "Exiting with status 1 due to at least one tgc error."
             exit 1
           fi

--- a/tests/expectations/compiler/compiler/array_without_size/length.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length.leo.out
@@ -17,6 +17,6 @@ outputs:
               type: bool
               value: "true"
     initial_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    imports_resolved_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    canonicalized_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    type_inferenced_ast: 06be9e7e193c4fcdca75ba8218de79dcc8317b1eb63d9c2f33ca790c614a472b
+    imports_resolved_ast: 37de52ab186133dccfc290bed3f417685ce9ee5de37c820e0e8e3d2a17804bcc
+    canonicalized_ast: 37de52ab186133dccfc290bed3f417685ce9ee5de37c820e0e8e3d2a17804bcc
+    type_inferenced_ast: 2f1b4e2127a33a02bea52ad28c0e9414268b401e11787bbde761820e8ac804e4

--- a/tests/expectations/compiler/compiler/array_without_size/length_fail.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length_fail.leo.out
@@ -1,5 +1,0 @@
----
-namespace: Compile
-expectation: Fail
-outputs:
-  - "Error [EASG0373025]: unexpected type, expected: '()', received: 'bool'\n    --> compiler-test:4:13\n     |\n   4 |     return (10u8.len() == 10u32) == y;\n     |             ^^^^^^^^^^^^^^^^^^^^^^^^^"

--- a/tests/expectations/compiler/compiler/array_without_size/length_function.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length_function.leo.out
@@ -17,6 +17,6 @@ outputs:
               type: bool
               value: "true"
     initial_ast: 9886d4d97c894fade697bd99ac9cbe2a56973037837f34884e3dbad4dd4d5d65
-    imports_resolved_ast: 9886d4d97c894fade697bd99ac9cbe2a56973037837f34884e3dbad4dd4d5d65
-    canonicalized_ast: 36dbb999756e8e8bb68c69388889f0cfc217fbdbb0467f43453e19feb5c55d22
-    type_inferenced_ast: 4fff72622455ea5bfc073c8e90e2266545b01e3004b73e4ee909b37b0bd75f46
+    imports_resolved_ast: afd08cb992e4004c551f936d4a5867bbc0a0c05fbb8997bffd2a082badbf03fc
+    canonicalized_ast: 462f0feb8e304b2644d1bbcf90663a03a9e8c53d9e9ae42836ad57d1f0de3165
+    type_inferenced_ast: 20f7f22df0d2826996233e2e513403f84be65d8db9e9a947df128c377299355c


### PR DESCRIPTION
… if there is a tgc canonicalization failure

## Motivation

* Allow tgc type-inference to run after tgc canonicalization, regardless if there are any canonicalization failures
* Count the directories and count how many failures there are of both types of tgc
* Output more details and separators so it is easy to see at a glance
* Switch from grep|cut|tr of the json result to using jq (when finding release tarball)

## Test Plan

Already ran Leo-ACL2 workflow on the `tgc-ci-formatting` branch.  Results are currently 2 canonicalization failures and 21 type inference failures, which is an improvement from previous result.

