### PR TITLE
[Tests] Adds .len() parser tests, sanitizes some tests 

### DIFF
--- a/tests/expectations/compiler/compiler/array_without_size/length.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length.leo.out
@@ -17,6 +17,6 @@ outputs:
               type: bool
               value: "true"
     initial_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    imports_resolved_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    canonicalized_ast: d8e3de13a7f12866871e4117b7c4cf9872350154b19e82087fe8100adeba1354
-    type_inferenced_ast: 06be9e7e193c4fcdca75ba8218de79dcc8317b1eb63d9c2f33ca790c614a472b
+    imports_resolved_ast: 37de52ab186133dccfc290bed3f417685ce9ee5de37c820e0e8e3d2a17804bcc
+    canonicalized_ast: 37de52ab186133dccfc290bed3f417685ce9ee5de37c820e0e8e3d2a17804bcc
+    type_inferenced_ast: 2f1b4e2127a33a02bea52ad28c0e9414268b401e11787bbde761820e8ac804e4

--- a/tests/expectations/compiler/compiler/array_without_size/length_fail.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length_fail.leo.out
@@ -1,5 +1,0 @@
----
-namespace: Compile
-expectation: Fail
-outputs:
-  - "Error [EASG0373025]: unexpected type, expected: '()', received: 'bool'\n    --> compiler-test:4:13\n     |\n   4 |     return (10u8.len() == 10u32) == y;\n     |             ^^^^^^^^^^^^^^^^^^^^^^^^^"

--- a/tests/expectations/compiler/compiler/array_without_size/length_function.leo.out
+++ b/tests/expectations/compiler/compiler/array_without_size/length_function.leo.out
@@ -17,6 +17,6 @@ outputs:
               type: bool
               value: "true"
     initial_ast: 9886d4d97c894fade697bd99ac9cbe2a56973037837f34884e3dbad4dd4d5d65
-    imports_resolved_ast: 9886d4d97c894fade697bd99ac9cbe2a56973037837f34884e3dbad4dd4d5d65
-    canonicalized_ast: 36dbb999756e8e8bb68c69388889f0cfc217fbdbb0467f43453e19feb5c55d22
-    type_inferenced_ast: 4fff72622455ea5bfc073c8e90e2266545b01e3004b73e4ee909b37b0bd75f46
+    imports_resolved_ast: afd08cb992e4004c551f936d4a5867bbc0a0c05fbb8997bffd2a082badbf03fc
+    canonicalized_ast: 462f0feb8e304b2644d1bbcf90663a03a9e8c53d9e9ae42836ad57d1f0de3165
+    type_inferenced_ast: 20f7f22df0d2826996233e2e513403f84be65d8db9e9a947df128c377299355c

--- a/tests/expectations/compiler/compiler/core/core_circuit_invalid.leo.out
+++ b/tests/expectations/compiler/compiler/core/core_circuit_invalid.leo.out
@@ -1,5 +1,0 @@
----
-namespace: Compile
-expectation: Fail
-outputs:
-  - "Error [EASG0373043]: failed to resolve import: 'core.unstable.blake2s'\n    --> compiler-test:3:30\n     |\n   3 | import core.unstable.blake2s.BadCircuit; // `BadCircuit` is not included in the blake2s package\n     |                              ^^^^^^^^^^"

--- a/tests/expectations/compiler/compiler/core/core_circuit_star_fail.leo.out
+++ b/tests/expectations/compiler/compiler/core/core_circuit_star_fail.leo.out
@@ -1,5 +1,0 @@
----
-namespace: Compile
-expectation: Fail
-outputs:
-  - "Error [EAST0372011]: failed to resolve import: 'core'\n    --> compiler-test:3:13\n     |\n   3 | import core.*; // You cannot import all dependencies from core at once\n     |             ^"

--- a/tests/expectations/compiler/compiler/core/core_package_invalid.leo.out
+++ b/tests/expectations/compiler/compiler/core/core_package_invalid.leo.out
@@ -1,5 +1,0 @@
----
-namespace: Compile
-expectation: Fail
-outputs:
-  - "Error [EAST0372011]: failed to resolve import: 'core'\n    --> compiler-test:3:13\n     |\n   3 | import core.bad_circuit; // `bad_circuit` is not a core package\n     |             ^^^^^^^^^^^"

--- a/tests/expectations/compiler/compiler/core/core_unstable_package_invalid.leo.out
+++ b/tests/expectations/compiler/compiler/core/core_unstable_package_invalid.leo.out
@@ -1,5 +1,0 @@
----
-namespace: Compile
-expectation: Fail
-outputs:
-  - "Error [EAST0372011]: failed to resolve import: 'core.unstable'\n    --> compiler-test:3:22\n     |\n   3 | import core.unstable.bad_circuit; // `bad_circuit` is not a core unstable package\n     |                      ^^^^^^^^^^^"

--- a/tests/expectations/parser/parser/expression/array_len.leo.out
+++ b/tests/expectations/parser/parser/expression/array_len.leo.out
@@ -1,0 +1,204 @@
+---
+namespace: ParseExpression
+expectation: Pass
+outputs:
+  - LengthOf:
+      inner:
+        ArrayInit:
+          element:
+            Value:
+              Integer:
+                - U8
+                - "0"
+                - line_start: 1
+                  line_stop: 1
+                  col_start: 2
+                  col_stop: 5
+                  path: ""
+                  content: "[0u8; 1].len()"
+          dimensions:
+            - value: "1"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 1
+            col_stop: 9
+            path: ""
+            content: "[0u8; 1].len()"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 9
+        path: ""
+        content: "[0u8; 1].len()"
+  - LengthOf:
+      inner:
+        ArrayInit:
+          element:
+            Value:
+              Implicit:
+                - "0"
+                - line_start: 1
+                  line_stop: 1
+                  col_start: 2
+                  col_stop: 3
+                  path: ""
+                  content: "[0; 1].len()"
+          dimensions:
+            - value: "1"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 1
+            col_stop: 7
+            path: ""
+            content: "[0; 1].len()"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 7
+        path: ""
+        content: "[0; 1].len()"
+  - LengthOf:
+      inner:
+        ArrayInit:
+          element:
+            Value:
+              Implicit:
+                - "0"
+                - line_start: 1
+                  line_stop: 1
+                  col_start: 2
+                  col_stop: 3
+                  path: ""
+                  content: "[0; (1)].len()"
+          dimensions:
+            - value: "1"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 1
+            col_stop: 9
+            path: ""
+            content: "[0; (1)].len()"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 9
+        path: ""
+        content: "[0; (1)].len()"
+  - LengthOf:
+      inner:
+        ArrayInit:
+          element:
+            Value:
+              Implicit:
+                - "0"
+                - line_start: 1
+                  line_stop: 1
+                  col_start: 2
+                  col_stop: 3
+                  path: ""
+                  content: "[0; (1, 2)].len()"
+          dimensions:
+            - value: "1"
+            - value: "2"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 1
+            col_stop: 12
+            path: ""
+            content: "[0; (1, 2)].len()"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 12
+        path: ""
+        content: "[0; (1, 2)].len()"
+  - LengthOf:
+      inner:
+        ArrayInit:
+          element:
+            Value:
+              Implicit:
+                - "0"
+                - line_start: 1
+                  line_stop: 1
+                  col_start: 2
+                  col_stop: 3
+                  path: ""
+                  content: "[0; (1, 2, 3)].len()"
+          dimensions:
+            - value: "1"
+            - value: "2"
+            - value: "3"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 1
+            col_stop: 15
+            path: ""
+            content: "[0; (1, 2, 3)].len()"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 15
+        path: ""
+        content: "[0; (1, 2, 3)].len()"
+  - LengthOf:
+      inner:
+        ArrayInit:
+          element:
+            ArrayInit:
+              element:
+                ArrayInit:
+                  element:
+                    Value:
+                      Implicit:
+                        - "0"
+                        - line_start: 1
+                          line_stop: 1
+                          col_start: 4
+                          col_stop: 5
+                          path: ""
+                          content: "[[[0; 3]; 2]; 1].len()"
+                  dimensions:
+                    - value: "3"
+                  span:
+                    line_start: 1
+                    line_stop: 1
+                    col_start: 3
+                    col_stop: 9
+                    path: ""
+                    content: "[[[0; 3]; 2]; 1].len()"
+              dimensions:
+                - value: "2"
+              span:
+                line_start: 1
+                line_stop: 1
+                col_start: 2
+                col_stop: 13
+                path: ""
+                content: "[[[0; 3]; 2]; 1].len()"
+          dimensions:
+            - value: "1"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 1
+            col_stop: 17
+            path: ""
+            content: "[[[0; 3]; 2]; 1].len()"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 17
+        path: ""
+        content: "[[[0; 3]; 2]; 1].len()"

--- a/tests/expectations/parser/parser/functions/param_array_unsized.leo.out
+++ b/tests/expectations/parser/parser/functions/param_array_unsized.leo.out
@@ -1,0 +1,66 @@
+---
+namespace: Parse
+expectation: Pass
+outputs:
+  - name: ""
+    expected_input: []
+    import_statements: []
+    imports: {}
+    aliases: {}
+    circuits: {}
+    global_consts: {}
+    functions:
+      "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":3,\\\"line_stop\\\":3,\\\"col_start\\\":10,\\\"col_stop\\\":11,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"function x(x: [u8; _]) {\\\"}\"}":
+        annotations: []
+        identifier: "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":3,\\\"line_stop\\\":3,\\\"col_start\\\":10,\\\"col_stop\\\":11,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"function x(x: [u8; _]) {\\\"}\"}"
+        input:
+          - Variable:
+              identifier: "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":3,\\\"line_stop\\\":3,\\\"col_start\\\":12,\\\"col_stop\\\":13,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"function x(x: [u8; _]) {\\\"}\"}"
+              const_: false
+              mutable: true
+              type_:
+                Array:
+                  - IntegerType: U8
+                  - - value: "0"
+              span:
+                line_start: 3
+                line_stop: 3
+                col_start: 12
+                col_stop: 13
+                path: ""
+                content: "function x(x: [u8; _]) {"
+        output: ~
+        block:
+          statements:
+            - Return:
+                expression:
+                  TupleInit:
+                    elements: []
+                    span:
+                      line_start: 4
+                      line_stop: 4
+                      col_start: 12
+                      col_stop: 14
+                      path: ""
+                      content: "    return ();"
+                span:
+                  line_start: 4
+                  line_stop: 4
+                  col_start: 5
+                  col_stop: 14
+                  path: ""
+                  content: "    return ();"
+          span:
+            line_start: 3
+            line_stop: 5
+            col_start: 24
+            col_stop: 2
+            path: ""
+            content: "function x(x: [u8; _]) {\n     ...\n}"
+        span:
+          line_start: 3
+          line_stop: 5
+          col_start: 1
+          col_stop: 2
+          path: ""
+          content: "function x(x: [u8; _]) {\n     ...\n}"

--- a/tests/expectations/parser/parser/statement/definition.leo.out
+++ b/tests/expectations/parser/parser/statement/definition.leo.out
@@ -1471,3 +1471,143 @@ outputs:
         col_stop: 14
         path: ""
         content: "let (x,) = ();"
+  - Definition:
+      declaration_type: Let
+      variable_names:
+        - mutable: true
+          identifier: "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":5,\\\"col_stop\\\":6,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x: [char; _] = \\\\\\\"Hello, World!\\\\\\\";\\\"}\"}"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 5
+            col_stop: 6
+            path: ""
+            content: "let x: [char; _] = \"Hello, World!\";"
+      type_:
+        Array:
+          - Char
+          - - value: "0"
+      value:
+        Value:
+          String:
+            - - Scalar: 72
+              - Scalar: 101
+              - Scalar: 108
+              - Scalar: 108
+              - Scalar: 111
+              - Scalar: 44
+              - Scalar: 32
+              - Scalar: 87
+              - Scalar: 111
+              - Scalar: 114
+              - Scalar: 108
+              - Scalar: 100
+              - Scalar: 33
+            - line_start: 1
+              line_stop: 1
+              col_start: 20
+              col_stop: 35
+              path: ""
+              content: "let x: [char; _] = \"Hello, World!\";"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 35
+        path: ""
+        content: "let x: [char; _] = \"Hello, World!\";"
+  - Definition:
+      declaration_type: Let
+      variable_names:
+        - mutable: true
+          identifier: "{\"name\":\"x\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":5,\\\"col_stop\\\":6,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x: [[u8; 2]; 2] = [[0,0], [0,0]];\\\"}\"}"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 5
+            col_stop: 6
+            path: ""
+            content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+      type_:
+        Array:
+          - Array:
+              - IntegerType: U8
+              - - value: "2"
+          - - value: "2"
+      value:
+        ArrayInline:
+          elements:
+            - Expression:
+                ArrayInline:
+                  elements:
+                    - Expression:
+                        Value:
+                          Implicit:
+                            - "0"
+                            - line_start: 1
+                              line_stop: 1
+                              col_start: 25
+                              col_stop: 26
+                              path: ""
+                              content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+                    - Expression:
+                        Value:
+                          Implicit:
+                            - "0"
+                            - line_start: 1
+                              line_stop: 1
+                              col_start: 27
+                              col_stop: 28
+                              path: ""
+                              content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+                  span:
+                    line_start: 1
+                    line_stop: 1
+                    col_start: 24
+                    col_stop: 29
+                    path: ""
+                    content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+            - Expression:
+                ArrayInline:
+                  elements:
+                    - Expression:
+                        Value:
+                          Implicit:
+                            - "0"
+                            - line_start: 1
+                              line_stop: 1
+                              col_start: 32
+                              col_stop: 33
+                              path: ""
+                              content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+                    - Expression:
+                        Value:
+                          Implicit:
+                            - "0"
+                            - line_start: 1
+                              line_stop: 1
+                              col_start: 34
+                              col_stop: 35
+                              path: ""
+                              content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+                  span:
+                    line_start: 1
+                    line_stop: 1
+                    col_start: 31
+                    col_stop: 36
+                    path: ""
+                    content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+          span:
+            line_start: 1
+            line_stop: 1
+            col_start: 23
+            col_stop: 37
+            path: ""
+            content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+      span:
+        line_start: 1
+        line_stop: 1
+        col_start: 1
+        col_stop: 37
+        path: ""
+        content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"

--- a/tests/parser/expression/array_len.leo
+++ b/tests/parser/expression/array_len.leo
@@ -1,0 +1,16 @@
+/*
+namespace: ParseExpression
+expectation: Pass
+*/
+
+[0u8; 1].len()
+
+[0; 1].len()
+
+[0; (1)].len()
+
+[0; (1, 2)].len()
+
+[0; (1, 2, 3)].len()
+
+[[[0; 3]; 2]; 1].len()

--- a/tests/parser/functions/param_array_unsized.leo
+++ b/tests/parser/functions/param_array_unsized.leo
@@ -1,0 +1,8 @@
+/*
+namespace: Parse
+expectation: Pass
+*/
+
+function x(x: [u8; _]) {
+    return ();
+}

--- a/tests/parser/statement/definition.leo
+++ b/tests/parser/statement/definition.leo
@@ -98,3 +98,8 @@ const (x, y): u32 = x();
 let (x,y,) = ();
 
 let (x,) = ();
+
+
+let x: [char; _] = "Hello, World!";
+
+let x: [[u8; 2]; 2] = [[0,0], [0,0]];


### PR DESCRIPTION
## Motivation

- @gluax noticed that I missed parser tests for `.len()`, now they're added
- removes unstable core test expectations which are not used
- fixes failing CIs 

## Test Plan

This PR is tests.