### PR TITLE
[Fix] Fixes the random flying bug with duplicates

### DIFF
--- a/ast/src/common/identifier.rs
+++ b/ast/src/common/identifier.rs
@@ -66,6 +66,11 @@ impl Identifier {
             span,
         }
     }
+
+    /// Check if the Identifier name matches the other name
+    pub fn matches(&self, other: &Self) -> bool {
+        self.name == other.name
+    }
 }
 
 impl<'ast> From<InputIdentifier<'ast>> for Identifier {

--- a/compiler/src/statement/assign/assignee/member.rs
+++ b/compiler/src/statement/assign/assignee/member.rs
@@ -36,7 +36,7 @@ impl<'a, F: PrimeField, G: GroupType<F>> ConstrainedProgram<'a, F, G> {
         match context.input.remove(0) {
             ConstrainedValue::CircuitExpression(_variable, members) => {
                 // Modify the circuit variable in place
-                let matched_variable = members.iter_mut().find(|member| &member.0 == name);
+                let matched_variable = members.iter_mut().find(|member| member.0.matches(name));
 
                 match matched_variable {
                     Some(member) => {


### PR DESCRIPTION
Fixes the well known #1398.

## Motivation

This bug was distracting us when verifying correctness of the CIs. 😆 
Statistically it appeared once in a hundred runs ~ roughly 1% of all runs.

## Implementation and Whys

After few hours of debugging I found that the bug was in keys comparison inside IndexMap crate, and we use it as a storage for all top-level objects, so the bug randomly appeared at different compiler stages: mostly in parser and canonicalization.

It happened because of the hash collisions that rarely appeared on `indexmap.insert()` call. In that case IndexMap was falling back to `PartialEq` implementation, and it was only "partially" implemented causing wrong behavior. Hash trait implementation was implemented correctly though.

## Tests

Ways of testing are described in #1398 in comments section. Locally tested on a 1000 runs which should be enough to say that it's a success.

Oh and thanks to @Protryon for the tip with collisions and eq impl.