### PR TITLE
[ABNF] Fix rule for console statements.

### DIFF
--- a/grammar/README.md
+++ b/grammar/README.md
@@ -1613,7 +1613,7 @@ There are three kinds of print commands.
 
 <a name="console-statement"></a>
 ```abnf
-console-statement = %s"console" "." console-call
+console-statement = %s"console" "." console-call ";"
 ```
 
 Go to: _[console-call](#user-content-console-call)_;

--- a/grammar/abnf-grammar.txt
+++ b/grammar/abnf-grammar.txt
@@ -972,7 +972,7 @@ assignment-statement = expression assignment-operator expression ";"
 ; Note that the console function names are identifiers, not keywords.
 ; There are three kinds of print commands.
 
-console-statement = %s"console" "." console-call
+console-statement = %s"console" "." console-call ";"
 
 console-call = assert-call
              / print-call


### PR DESCRIPTION
The ending semicolon was missing.

This was found by @bendyarm, while investigating a discrepancy between the Leo
parser in Rust and the Leo parser in ACL2: the latter was correctly following
the erroneous grammar rule; it will be changed to be consistent with the fixed
rule.
