### PR TITLE
[RFC] Add a way to define static members to circuits to accesses RFC

### DIFF
--- a/docs/rfc/011-scalar-type-accesses-and-methods.md
+++ b/docs/rfc/011-scalar-type-accesses-and-methods.md
@@ -49,7 +49,7 @@ postfix-expression = primary-expression
 ; Also need to add a new static member variable declaration rule to allow for static constant members.
 member-constant-declaration = %s"static" %s"const" identifier ":" type = literal ";"
 
-; We then need to modify the circuit declartion rule.
+; We then need to modify the circuit declaration rule.
 circuit-declaration = %s"circuit" identifier
                       "{" *member-constant-declaration
                       [ member-variable-declarations ]


### PR DESCRIPTION
Add's some grammar that would allow users to define static members on circuits that were previously missing.

This RFC already suggested adding a way to access these members but not a way to define them.
