### PR TITLE
[RFC] Add an RFC for const functions.

### DIFF
--- a/docs/rfc/013-const-functions.md
+++ b/docs/rfc/013-const-functions.md
@@ -62,7 +62,7 @@ the evaluation involves the bounded recursion analysis described in a separate R
 ASTs for function declarations are extended with a boolean flag `const_`.
 
 If a `const` function has a non-`const` parameter,
-an AST error occurs.
+an ASG error occurs.
 
 If the body of a `const` function references the `input` variable or calls a non-`const` function,
 an ASG error occurs.


### PR DESCRIPTION
The purpose of this RFC is to:
- Provide user documentation for this feature in a more accessible way than
  in the text for https://github.com/AleoHQ/leo/pull/1410, particularly after
  that PR is closed.
- Record the discussion in a recent meeting about broadening the notion of const
  function to map const arguments to const results rather than requiring const
  arguments, as a possible future extension.

NOTE: This is based on @damirka's text in https://github.com/AleoHQ/leo/pull/1410, so credit for this RFC goes to him too.