### PR TITLE
consolidating snarkvm patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,29 +86,25 @@ path = "./synthesizer"
 version = "1.5.3"
 
 [dependencies.snarkvm-algorithms]
-version = "0.7.6"
+version = "0.7.9"
 
 [dependencies.snarkvm-curves]
 version = "0.7.9"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.7.8"
+version = "0.7.9"
 default-features = false
 
 [dependencies.snarkvm-r1cs]
-version = "0.7.8"
+version = "0.7.9"
 default-features = false
 
 [dependencies.snarkvm-utilities]
-version = "0.7.6"
+version = "0.7.9"
 
-#todo 0rphon replace once snarkvm releases and before merging staging to master.
 [dependencies.snarkvm-eval]
 version = "0.7.9"
-# path = "D:\\Work\\leo_repos\\snarkVM\\eval"
-git = "https://github.com/AleoHQ/snarkVM"
-branch = "master"
 
 [dependencies.structopt]
 version = "0.3"
@@ -215,20 +211,24 @@ debug = true
 
 # Remove on pr from staging to master once snarkvm does a release.
 [patch.crates-io]
-snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
-snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
-snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
-snarkvm-r1cs = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
-snarkvm-gadgets = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
-snarkvm-parameters = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
-snarkvm-dpc = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
 snarkvm-algorithms = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-curves = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-dpc = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-eval = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-fields = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-gadgets = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-ir = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-parameters = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-r1cs = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
+snarkvm-utilities = { git = "https://github.com/AleoHQ/snarkVM", branch = "master" }
 
-# snarkvm-curves = { path = "D:\\Work\\leo_repos\\snarkVM\\curves" }
-# snarkvm-fields = { path = "D:\\Work\\leo_repos\\snarkVM\\fields" }
-# snarkvm-utilities = { path = "D:\\Work\\leo_repos\\snarkVM\\utilities" }
-# snarkvm-r1cs = { path = "D:\\Work\\leo_repos\\snarkVM\\r1cs" }
-# snarkvm-gadgets = { path = "D:\\Work\\leo_repos\\snarkVM\\gadgets" }
-# snarkvm-parameters = { path = "D:\\Work\\leo_repos\\snarkVM\\parameters" }
-# snarkvm-dpc = { path = "D:\\Work\\leo_repos\\snarkVM\\dpc" }
 # snarkvm-algorithms = { path = "D:\\Work\\leo_repos\\snarkVM\\algorithms" }
+# snarkvm-curves = { path = "D:\\Work\\leo_repos\\snarkVM\\curves" }
+# snarkvm-dpc = { path = "D:\\Work\\leo_repos\\snarkVM\\dpc" }
+# snarkvm-eval = { path = "D:\\Work\\leo_repos\\snarkVM\\eval" }
+# snarkvm-fields = { path = "D:\\Work\\leo_repos\\snarkVM\\fields" }
+# snarkvm-gadgets = { path = "D:\\Work\\leo_repos\\snarkVM\\gadgets" }
+# snarkvm-ir = { path = "D:\\Work\\leo_repos\\snarkVM\\ir" }
+# snarkvm-parameters = { path = "D:\\Work\\leo_repos\\snarkVM\\parameters" }
+# snarkvm-r1cs = { path = "D:\\Work\\leo_repos\\snarkVM\\r1cs" }
+# snarkvm-utilities = { path = "D:\\Work\\leo_repos\\snarkVM\\utilities" }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -68,15 +68,17 @@ version = "1.5.3"
 [dependencies.tendril]
 version = "0.4"
 
-#todo 0rphon
 [dependencies.snarkvm-ir]
 version = "0.7.9"
-# path = "D:\\Work\\leo_repos\\snarkVM\\ir"
-git = "https://github.com/AleoHQ/snarkVM"
-branch = "master"
 
 [dependencies.snarkvm-r1cs]
-version = "0.7.8"
+version = "0.7.9"
+
+[dependencies.snarkvm-eval]
+version = "0.7.9"
+
+[dependencies.snarkvm-curves]
+version = "0.7.9"
 
 [dependencies.bincode]
 version = "1.3"
@@ -109,16 +111,6 @@ version = "0.8"
 
 [dependencies.num-bigint]
 version = "0.4"
-
-#todo 0rphon replace once snarkvm releases and before merging staging to master.
-[dependencies.snarkvm-eval]
-version = "0.7.9"
-# path = "D:\\Work\\leo_repos\\snarkVM\\eval"
-git = "https://github.com/AleoHQ/snarkVM"
-branch = "master"
-
-[dependencies.snarkvm-curves]
-version = "0.7.9"
 
 [dev-dependencies.rand_core]
 version = "0.6.3"

--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -30,7 +30,7 @@ path = "../input"
 version = "1.5.3"
 
 [dependencies.snarkvm-algorithms]
-version = "0.7.6"
+version = "0.7.9"
 
 [dependencies.snarkvm-curves]
 version = "0.7.9"
@@ -41,7 +41,7 @@ version = "0.7.9"
 features = [ "testnet1" ]
 
 [dependencies.snarkvm-utilities]
-version = "0.7.6"
+version = "0.7.9"
 
 [dependencies.indexmap]
 version = "1.7.0"

--- a/synthesizer/Cargo.toml
+++ b/synthesizer/Cargo.toml
@@ -30,14 +30,14 @@ version = "0.6.5"
 default-features = false
 
 [dependencies.snarkvm-fields]
-version = "0.7.7"
+version = "0.7.9"
 default-features = false
 
 [dependencies.snarkvm-gadgets]
-version = "0.7.8"
+version = "0.7.9"
 
 [dependencies.snarkvm-r1cs]
-version = "0.7.8"
+version = "0.7.9"
 default-features = false
 
 [dependencies.num-bigint]


### PR DESCRIPTION
cleans up snarkvm patches so that only the root `Cargo.toml` needs to be changed when merging to master. this should have been done when the staging repo was initially made