### PR TITLE
[Fix] Fixes command descriptions

### DIFF
--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -35,8 +35,8 @@ use snarkvm_r1cs::ConstraintSystem;
 use structopt::StructOpt;
 use tracing::span::Span;
 
-/// Compiler Options wrapper for Build command. Also used by other commands which
-/// require Build command output as their input.
+// Compiler Options wrapper for Build command. Also used by other commands which
+// require Build command output as their input.
 #[derive(StructOpt, Clone, Debug)]
 pub struct BuildOptions {
     #[structopt(long, help = "Disable constant folding compiler optimization.")]


### PR DESCRIPTION
Simple as never. Structopt uses docstrings to insert CLI help.

Closes #1437.
