### PR TITLE
[ABNF] Keep rules to 80 columns max.

### DIFF
--- a/grammar/README.md
+++ b/grammar/README.md
@@ -1059,7 +1059,7 @@ Go to: _[natural](#user-content-natural)_;
 ```abnf
 array-type-dimensions = array-type-dimension
                       / "(" array-type-dimension
-                            *( "," array-type-dimension ) ")"
+                            *( "," array-type-dimension ) [","] ")"
 ```
 
 Go to: _[array-type-dimension](#user-content-array-type-dimension)_;
@@ -1733,13 +1733,14 @@ Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;
 
 
 A circuit member constant declaration consists of
-the static and const keywords followed by
-an identifier and a type, then an assignment
+the `static` and `const` keywords followed by
+an identifier and a type, then an initializer
 with a literal terminated by semicolon.
 
 <a name="member-constant-declaration"></a>
 ```abnf
-member-constant-declaration = %s"static" %s"const" identifier ":" type "=" literal ";"
+member-constant-declaration = %s"static" %s"const" identifier ":" type
+                              "=" literal ";"
 ```
 
 Go to: _[identifier](#user-content-identifier), [literal](#user-content-literal), [type](#user-content-type)_;

--- a/grammar/abnf-grammar.txt
+++ b/grammar/abnf-grammar.txt
@@ -672,7 +672,8 @@ array-type = "[" type ";" array-type-dimensions "]"
 array-type-dimension = natural / "_"
 
 array-type-dimensions = array-type-dimension
-                      / "(" array-type-dimension *( "," array-type-dimension ) [","] ")"
+                      / "(" array-type-dimension
+                            *( "," array-type-dimension ) [","] ")"
 
 ; The keyword `Self` denotes the enclosing circuit type.
 ; It is only allowed inside a circuit type declaration.
@@ -1021,11 +1022,12 @@ function-inputs = function-input *( "," function-input )
 function-input = [ %s"const" ] identifier ":" type
 
 ; A circuit member constant declaration consists of
-; the static and const keywords followed by
-; an identifier and a type, then an assignment
+; the `static` and `const` keywords followed by
+; an identifier and a type, then an initializer
 ; with a literal terminated by semicolon.
 
-member-constant-declaration = %s"static" %s"const" identifier ":" type "=" literal ";"
+member-constant-declaration = %s"static" %s"const" identifier ":" type
+                              "=" literal ";"
 
 ; A circuit member variable declaration consists of
 ; an identifier and a type, terminated by semicolon.


### PR DESCRIPTION
So they display well in the LLFS LaTeX.

Also add some markdown for two keywords in the comments.

Note: The generated README.md also includes a change from a previous commit, but that's just because that previous commit updated abnf-grammar.txt but not README.md.