### PR TITLE
Fix test framework failed tests message

### DIFF
--- a/test-framework/src/runner.rs
+++ b/test-framework/src/runner.rs
@@ -211,7 +211,7 @@ pub fn run_tests<T: Runner>(runner: &T, expectation_category: &str) {
         }
         panic!(
             "failed {}/{} tests in {}/{} categories",
-            pass_tests,
+            fail_tests,
             fail_tests + pass_tests,
             fail_categories.len(),
             fail_categories.len() + pass_categories


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The test framework has the misleading output message: `failed {number_passing_tests}/{number_tests}`

## Test Plan

Run the test framework with an incorrect test.

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/leo,
    and link to your PR here.
-->

(Link your related PRs here)
