### PR TITLE
updates snarkvm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,15 +160,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "bitvec"
 version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,20 +1063,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "im"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "111c1983f3c5bb72732df25cddacee9b546d08325fb584b5ebd38148be7b0246"
-dependencies = [
- "bitmaps",
- "rand_core 0.5.1",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2281,15 +2258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
 name = "rayon"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,16 +2602,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sized-chunks"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
-dependencies = [
- "bitmaps",
- "typenum",
-]
-
-[[package]]
 name = "slab"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,7 +2616,7 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -2685,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "derivative",
  "rand 0.8.4",
@@ -2700,7 +2658,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-derives"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "proc-macro-crate 0.1.5",
  "proc-macro-error",
@@ -2712,7 +2670,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-dpc"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "anyhow",
  "base58",
@@ -2743,10 +2701,9 @@ dependencies = [
 [[package]]
 name = "snarkvm-eval"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "anyhow",
- "im",
  "indexmap",
  "snarkvm-curves",
  "snarkvm-dpc",
@@ -2762,7 +2719,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "anyhow",
  "bincode",
@@ -2777,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-gadgets"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2796,7 +2753,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ir"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -2804,12 +2761,13 @@ dependencies = [
  "num_enum",
  "prost",
  "prost-build",
+ "serde",
 ]
 
 [[package]]
 name = "snarkvm-marlin"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "blake2",
  "derivative",
@@ -2832,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "curl",
  "hex",
@@ -2844,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-polycommit"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "derivative",
  "digest 0.9.0",
@@ -2862,12 +2820,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-profiler"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 
 [[package]]
 name = "snarkvm-r1cs"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "cfg-if 1.0.0",
  "fxhash",
@@ -2881,7 +2839,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.7.9"
-source = "git+https://github.com/AleoHQ/snarkVM?branch=master#7ed56dd679931f14471b157857b701e6bb6bde41"
+source = "git+https://github.com/AleoHQ/snarkVM?branch=master#98ac3559f44688ed810d48ad3fef9ee6ccbb175a"
 dependencies = [
  "anyhow",
  "bincode",


### PR DESCRIPTION
Updates cargo lock to point towards lastest snarkvm master commit as this fixes an issue due to an anyhow update.