### PR TITLE
[ABNF] Relax rule for end-of-line comments.

### DIFF
--- a/grammar/README.md
+++ b/grammar/README.md
@@ -526,11 +526,8 @@ Go to: _[not-star-or-slash](#user-content-not-star-or-slash), [rest-of-block-com
 
 <a name="end-of-line-comment"></a>
 ```abnf
-end-of-line-comment = "//" *not-line-feed-or-carriage-return newline
+end-of-line-comment = "//" *not-line-feed-or-carriage-return
 ```
-
-Go to: _[newline](#user-content-newline)_;
-
 
 Below are the keywords in the Leo language.
 They cannot be used as identifiers.

--- a/grammar/abnf-grammar.txt
+++ b/grammar/abnf-grammar.txt
@@ -382,7 +382,7 @@ rest-of-block-comment-after-star = "/"
                                  / "*" rest-of-block-comment-after-star
                                  / not-star-or-slash rest-of-block-comment
 
-end-of-line-comment = "//" *not-line-feed-or-carriage-return newline
+end-of-line-comment = "//" *not-line-feed-or-carriage-return
 
 ; Below are the keywords in the Leo language.
 ; They cannot be used as identifiers.


### PR DESCRIPTION
This was suggested by @bendyarm.

There is no need to require an end-of-line comment to terminate with an explicit
newline, which also prevents a file to end with and end-of-line comment without
a final newline. It suffices for an end-of-line comment to end when there is no
longer a non-newline character, which may happen either when there is a newline
character, or when the end of the file is reached.

This requires no change to the Leo lexer/parser, which is already implementing
the more relaxed rule.
