### PR TITLE
Fix subcommand help messages

### DIFF
--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -40,8 +40,13 @@ fn parse_excluded_names(src: &str) -> Box<str> {
     Box::from(src)
 }
 
-// Compiler Options wrapper for Build command. Also used by other commands which
-// require Build command output as their input.
+#[cfg_attr(
+    doc,
+    doc = r#"
+/// Compiler Options wrapper for Build command. Also used by other commands which
+/// require Build command output as their input.
+"#
+)]
 #[derive(StructOpt, Clone, Debug)]
 pub struct BuildOptions {
     #[structopt(long, help = "Disable constant folding compiler optimization.")]

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -42,10 +42,7 @@ fn parse_excluded_names(src: &str) -> Box<str> {
 
 #[cfg_attr(
     doc,
-    doc = r#"
-/// Compiler Options wrapper for Build command. Also used by other commands which
-/// require Build command output as their input.
-"#
+    doc = "Compiler Options wrapper for Build command. Also used by other commands whichrequire Build command output as their input."
 )]
 #[derive(StructOpt, Clone, Debug)]
 pub struct BuildOptions {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes https://github.com/AleoHQ/leo/issues/1562

It's a upstream bug. See https://github.com/TeXitoi/structopt/issues/333

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

Run `leo -h` and see if it works

After the fix:

```
leo 1.5.3
The Aleo Team <hello@aleo.org>
Leo compiler and package manager

USAGE:
    leo [FLAGS] [OPTIONS] [api] <SUBCOMMAND>

FLAGS:
    -d               Print additional information for debugging
    -h, --help       Prints help information
    -q               Suppress CLI output
    -V, --version    Prints version information

OPTIONS:
        --path <path>    Optional path to Leo program root folder

ARGS:
    <api>    Custom Aleo PM backend URL [env: APM_URL=]

SUBCOMMANDS:
    build      Compile and build program command
    clean      Clean outputs folder command
    clone      Clone a package from Aleo Package Manager
    deploy     Deploy Leo program to the network
    fetch      Pull dependencies specified in Leo toml
    help       Prints this message or the help of the given subcommand(s)
    init       Init Leo project command within current directory
    lint       Lint Leo code command
    login      Login to Aleo PM and store credentials locally
    logout     Remove credentials for Aleo PM from .leo directory
    new        Create new Leo project
    prove      Run the program and produce a proof
    publish    Publish package to Aleo Package Manager
    run        Build, Prove and Run Leo program with inputs
    setup      Executes the setup command for a Leo program
    test       Build program and run tests command
    update     Setting for automatic updates of Leo
    watch      Watch file changes in src/ directory and run Build Command
```

Help messages are good now! :)

