### PR TITLE
[ABNF] Simplify a grammar rule.

### DIFF
--- a/grammar/README.md
+++ b/grammar/README.md
@@ -1456,12 +1456,10 @@ Finally we have conditional expressions.
 <a name="conditional-expression"></a>
 ```abnf
 conditional-expression = disjunctive-expression
-                       / disjunctive-expression
-                         "?" expression
-                         ":" conditional-expression
+                       / disjunctive-expression "?" expression ":" expression
 ```
 
-Go to: _[conditional-expression](#user-content-conditional-expression), [disjunctive-expression](#user-content-disjunctive-expression), [expression](#user-content-expression)_;
+Go to: _[disjunctive-expression](#user-content-disjunctive-expression), [expression](#user-content-expression)_;
 
 
 Those above are all the expressions.

--- a/grammar/abnf-grammar.txt
+++ b/grammar/abnf-grammar.txt
@@ -890,9 +890,7 @@ disjunctive-expression = conjunctive-expression
 ; Finally we have conditional expressions.
 
 conditional-expression = disjunctive-expression
-                       / disjunctive-expression
-                         "?" expression
-                         ":" conditional-expression
+                       / disjunctive-expression "?" expression ":" expression
 
 ; Those above are all the expressions.
 ; Recall that conditional expressions


### PR DESCRIPTION
Given that we have the rule

  expression = conditional-expression

there seems to be no need for using conditional-expression in the 'else' branch
of a ternary expression, instead using the shorter expression.

This does not change the language or the abstract syntax.

If we merge this PR, we may want to also change the call of `parse_conditional_expression` to a call of `parse_expression` [here](https://github.com/AleoHQ/leo/blob/ede173ca7d6c4fca8e13b750cd0c4446a1e95ca4/parser/src/parser/expression.rs#L74) to keep things more aligned,  but it is not strictly necessary. Also, we may want to defer this until the parser migration to the testnet2 branch is completed.


