### PR TITLE
[Fix] Allows stdlib in tgc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,7 @@ dependencies = [
  "leo-imports",
  "leo-parser",
  "leo-span",
+ "leo-stdlib",
  "regex",
  "serde",
  "serde_json",

--- a/test-framework/Cargo.toml
+++ b/test-framework/Cargo.toml
@@ -59,6 +59,10 @@ version = "1.5.2"
 path = "../span"
 version = "1.5.3"
 
+[dependencies.leo-stdlib]
+path = "../stdlib"
+version = "1.5.3"
+
 [dependencies.structopt]
 version = "0.3"
 

--- a/test-framework/src/bin/tgc.rs
+++ b/test-framework/src/bin/tgc.rs
@@ -52,6 +52,9 @@ fn main() {
 }
 
 fn run_with_args(opt: Opt) -> Result<(), Box<dyn Error>> {
+    // Load static stdlib files.
+    leo_stdlib::static_include_stdlib();
+
     // Variable that stores all the tests.
     let mut tests = Vec::new();
     let mut test_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
## Motivation

Closes #1578.

## Test Plan

Tested locally, tgc is not a part of our test suite. 