### PR TITLE
fix character selection during `unexpected_token` error handling

### DIFF
--- a/parser/src/tokenizer/mod.rs
+++ b/parser/src/tokenizer/mod.rs
@@ -84,7 +84,7 @@ pub(crate) fn tokenize(path: &str, input: StrTendril) -> Result<Vec<SpannedToken
                     break;
                 } else if token_len == 0 {
                     return Err(ParserError::unexpected_token(
-                        &input[index..index + 1],
+                        &input[index..].chars().next().unwrap(),
                         &Span::new(
                             line_no,
                             line_no,


### PR DESCRIPTION
closes #1588

using a multi-byte character outside of a string now fails properly. ie:

```
function main () {
    let 🦀: u8 = 0;
}
```

```
Error [EPAR0370000]: 🦀
    --> D:\Work\leo-playground\src/main.leo:2:9
     |
   2 |     let 🦀: u8 = 0;
     |         ^
```
