### PR TITLE
[ABNF] Improve terminology.

### DIFF
--- a/grammar/README.md
+++ b/grammar/README.md
@@ -625,23 +625,39 @@ identifier = letter *( letter / decimal-digit / "_" )
 Go to: _[letter](#user-content-letter)_;
 
 
-A package name consists of one or more segments separated by single dashes,
+An external identifier consists of
+one or more segments separated by single dashes,
 where each segment is a non-empty sequence of
-lowercase letters and (decimal) digits.
-Similarly to an identifier, a package name must not be a keyword
+lowercase letters and (decimal) digits;
+the first segment must start with a a letter.
+Similarly to an identifier, an external identifier
+must not be a keyword or a boolean literal
 and must not be or start with `aleo1`.
 
-<a name="package-name"></a>
+<a name="external-identifier"></a>
 ```abnf
-package-name = lowercase-letter *( lowercase-letter / decimal-digit )
-               *( "-" 1*( lowercase-letter / decimal-digit ) )
-               ; but not a keyword or a boolean literal or aleo1...
+external-identifier = lowercase-letter *( lowercase-letter / decimal-digit )
+                      *( "-" 1*( lowercase-letter / decimal-digit ) )
+                      ; but not a keyword or a boolean literal or aleo1...
 ```
 
 Go to: _[lowercase-letter](#user-content-lowercase-letter)_;
 
 
-Note that, grammatically, identifiers are also package names.
+External identifiers are used to name
+packages, directories, files, and other entities
+that exist (i.e. are defined) outside of Leo files, so to speak.
+In contrast, (plain) identifiers are used to name
+entities that exist inside of Leo files, e.g. types and functions.
+In natural language, we consistently use
+the unqualified term 'identifier' for plain identifiers
+as defined by the rule `identifier`
+(including the extra-grammatical requirement in the ABNF comment),
+and the qualified term 'external identifier' for external identifiers
+as defined by the rule `external-identifier`
+(including the extra-grammatical requirement in the ABNF comment).
+
+Note that, grammatically, identifiers are also external identifiers.
 They are disambiguated from context, based on the syntactic grammar.
 
 Annotations have names, which are identifiers immediately preceded by `@`.
@@ -918,12 +934,12 @@ is a token, as defined by the following rule.
 token = keyword
       / identifier
       / atomic-literal
-      / package-name
+      / external-identifier
       / annotation-name
       / symbol
 ```
 
-Go to: _[annotation-name](#user-content-annotation-name), [atomic-literal](#user-content-atomic-literal), [identifier](#user-content-identifier), [keyword](#user-content-keyword), [package-name](#user-content-package-name), [symbol](#user-content-symbol)_;
+Go to: _[annotation-name](#user-content-annotation-name), [atomic-literal](#user-content-atomic-literal), [external-identifier](#user-content-external-identifier), [identifier](#user-content-identifier), [keyword](#user-content-keyword), [symbol](#user-content-symbol)_;
 
 
 Tokens, comments, and whitespace are lexemes, i.e. lexical units.
@@ -1795,33 +1811,33 @@ An import declaration consists of the `import` keyword
 followed by a package path, which may be one of the following:
 a single wildcard;
 an identifier, optionally followed by a local renamer;
-a package name followed by a path, recursively;
+an external identifier followed by a package path, recursively;
 or a parenthesized list of package paths,
 which are "fan out" of the initial path.
 Note that we allow the last element of the parenthesized list
 to be followed by a comma, for convenience.
-The package path in the import declaration must start with a package name
-(e.g. it cannot be a `*`):
-the rule for import declaration expresses this requirement
-by using an explicit package name before the package path.
+The package path in the import declaration
+must start with an external identifier (e.g. it cannot be a `*`):
+the rule for import declarations expresses this requirement
+by using an explicit external identifier before the package path.
 
 <a name="import-declaration"></a>
 ```abnf
-import-declaration = %s"import" package-name "." package-path ";"
+import-declaration = %s"import" external-identifier "." package-path ";"
 ```
 
-Go to: _[package-name](#user-content-package-name), [package-path](#user-content-package-path)_;
+Go to: _[external-identifier](#user-content-external-identifier), [package-path](#user-content-package-path)_;
 
 
 <a name="package-path"></a>
 ```abnf
 package-path = "*"
              / identifier [ %s"as" identifier ]
-             / package-name "." package-path
+             / external-identifier "." package-path
              / "(" package-path *( "," package-path ) [","] ")"
 ```
 
-Go to: _[identifier](#user-content-identifier), [package-name](#user-content-package-name), [package-path](#user-content-package-path)_;
+Go to: _[external-identifier](#user-content-external-identifier), [identifier](#user-content-identifier), [package-path](#user-content-package-path)_;
 
 
 A type alias declaration defines an identifier to stand for a type.

--- a/grammar/abnf-grammar.txt
+++ b/grammar/abnf-grammar.txt
@@ -447,17 +447,33 @@ hexadecimal-digit = decimal-digit / "a" / "b" / "c" / "d" / "e" / "f"
 identifier = letter *( letter / decimal-digit / "_" )
              ; but not a keyword or a boolean literal or aleo1...
 
-; A package name consists of one or more segments separated by single dashes,
+; An external identifier consists of
+; one or more segments separated by single dashes,
 ; where each segment is a non-empty sequence of
-; lowercase letters and (decimal) digits.
-; Similarly to an identifier, a package name must not be a keyword
+; lowercase letters and (decimal) digits;
+; the first segment must start with a a letter.
+; Similarly to an identifier, an external identifier
+; must not be a keyword or a boolean literal
 ; and must not be or start with `aleo1`.
 
-package-name = lowercase-letter *( lowercase-letter / decimal-digit )
-               *( "-" 1*( lowercase-letter / decimal-digit ) )
-               ; but not a keyword or a boolean literal or aleo1...
+external-identifier = lowercase-letter *( lowercase-letter / decimal-digit )
+                      *( "-" 1*( lowercase-letter / decimal-digit ) )
+                      ; but not a keyword or a boolean literal or aleo1...
 
-; Note that, grammatically, identifiers are also package names.
+; External identifiers are used to name
+; packages, directories, files, and other entities
+; that exist (i.e. are defined) outside of Leo files, so to speak.
+; In contrast, (plain) identifiers are used to name
+; entities that exist inside of Leo files, e.g. types and functions.
+; In natural language, we consistently use
+; the unqualified term 'identifier' for plain identifiers
+; as defined by the rule `identifier`
+; (including the extra-grammatical requirement in the ABNF comment),
+; and the qualified term 'external identifier' for external identifiers
+; as defined by the rule `external-identifier`
+; (including the extra-grammatical requirement in the ABNF comment).
+
+; Note that, grammatically, identifiers are also external identifiers.
 ; They are disambiguated from context, based on the syntactic grammar.
 
 ; Annotations have names, which are identifiers immediately preceded by `@`.
@@ -606,7 +622,7 @@ symbol = "!" / "&" / "&&" / "||"
 token = keyword
       / identifier
       / atomic-literal
-      / package-name
+      / external-identifier
       / annotation-name
       / symbol
 
@@ -1063,21 +1079,21 @@ circuit-declaration = %s"circuit" identifier
 ; followed by a package path, which may be one of the following:
 ; a single wildcard;
 ; an identifier, optionally followed by a local renamer;
-; a package name followed by a path, recursively;
+; an external identifier followed by a package path, recursively;
 ; or a parenthesized list of package paths,
 ; which are "fan out" of the initial path.
 ; Note that we allow the last element of the parenthesized list
 ; to be followed by a comma, for convenience.
-; The package path in the import declaration must start with a package name
-; (e.g. it cannot be a `*`):
-; the rule for import declaration expresses this requirement
-; by using an explicit package name before the package path.
+; The package path in the import declaration
+; must start with an external identifier (e.g. it cannot be a `*`):
+; the rule for import declarations expresses this requirement
+; by using an explicit external identifier before the package path.
 
-import-declaration = %s"import" package-name "." package-path ";"
+import-declaration = %s"import" external-identifier "." package-path ";"
 
 package-path = "*"
              / identifier [ %s"as" identifier ]
-             / package-name "." package-path
+             / external-identifier "." package-path
              / "(" package-path *( "," package-path ) [","] ")"
 
 ; A type alias declaration defines an identifier to stand for a type.


### PR DESCRIPTION
This commit does not change the Leo language, but renames `package-name` to
`external-identifier`, at the same time establishing this nomenclature for
referring to these syntactic entities as 'external identifiers' instead of
'package names'.

Recall that these consist of lowercase letters, digits, and dashes, starting
with a letter, not ending with a dash, and with no two consecutive dashes.

The reason for the renaming is that these former package names, now external
identifiers, are used to name not only packages proper, but also directories and
files (the latter without the .leo extension): paths in import declarations use
these external identifiers to denote all these three kinds of entities
(packages, directories, and files). Recall that a Leo package is the whole
directory tree with the Leo.toml file: subdirectories of src/, and .leo files
under src/ or subdirectories, are not packages.

These external identifiers are also used to name package authors, in the
Leo.toml file. It's awkward to say that a package author is a package name; it's
cleaner to say that a package name is an external identifier, and that a package
author is also an external identifier.

In other words, this is just another kind of identifier, different from the ones
used to name entities declared within Leo files like functions and variables,
that is used to name things defined "outside" Leo files (packages, directories,
files, authors), which justifies the attribute 'external'.

It is a separate question whether we want Leo import declarations to use
identifiers instead of external identifiers. Even if we do that, this notion of
external identifier is still needed to describe the format of the Leo.toml file.
