### PR TITLE
Migrate ast pass canonicalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,8 +1162,10 @@ name = "leo-compiler"
 version = "1.5.3"
 dependencies = [
  "leo-ast",
+ "leo-ast-passes",
  "leo-errors",
  "leo-parser",
+ "leo-span",
  "sha2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,6 +1106,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "leo-asg"
+version = "1.5.3"
+dependencies = [
+ "criterion",
+ "indexmap",
+ "leo-ast",
+ "leo-ast-passes",
+ "leo-errors",
+ "leo-parser",
+ "num-bigint",
+ "serde",
+ "serde_json",
+ "tendril",
+ "typed-arena",
+]
+
+[[package]]
+name = "leo-asg-passes"
+version = "1.5.3"
+dependencies = [
+ "leo-asg",
+ "leo-errors",
+]
+
+[[package]]
 name = "leo-ast"
 version = "1.5.3"
 dependencies = [
@@ -1119,6 +1144,17 @@ dependencies = [
  "serde_json",
  "smallvec",
  "tendril",
+]
+
+[[package]]
+name = "leo-ast-passes"
+version = "1.5.3"
+dependencies = [
+ "indexmap",
+ "leo-ast",
+ "leo-errors",
+ "leo-parser",
+ "leo-span",
 ]
 
 [[package]]
@@ -2624,6 +2660,12 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1106,31 +1106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leo-asg"
-version = "1.5.3"
-dependencies = [
- "criterion",
- "indexmap",
- "leo-ast",
- "leo-ast-passes",
- "leo-errors",
- "leo-parser",
- "num-bigint",
- "serde",
- "serde_json",
- "tendril",
- "typed-arena",
-]
-
-[[package]]
-name = "leo-asg-passes"
-version = "1.5.3"
-dependencies = [
- "leo-asg",
- "leo-errors",
-]
-
-[[package]]
 name = "leo-ast"
 version = "1.5.3"
 dependencies = [
@@ -2662,12 +2637,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "typed-arena"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0685c84d5d54d1c26f7d3eb96cd41550adb97baed141a761cf335d3d33bcd0ae"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ path = "leo/main.rs"
 [workspace]
 members = [
 #  "asg",
-#  "asg-passes",
+  "asg-passes",
   "ast",
 #  "ast-passes",
   "compiler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,9 @@ path = "leo/main.rs"
 [workspace]
 members = [
 #  "asg",
-  "asg-passes",
+#  "asg-passes",
   "ast",
-#  "ast-passes",
+  "ast-passes",
   "compiler",
   "errors",
   "grammar",

--- a/ast-passes/Cargo.toml
+++ b/ast-passes/Cargo.toml
@@ -36,6 +36,10 @@ version = "1.5.3"
 path = "../parser"
 version = "1.5.3"
 
+[dependencies.leo-span]
+path = "../span"
+version = "1.5.3"
+
 #[dependencies.leo-stdlib]
 #path = "../stdlib"
 #version = "1.5.3"

--- a/ast-passes/src/canonicalization/canonicalizer.rs
+++ b/ast-passes/src/canonicalization/canonicalizer.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 Aleo Systems Inc.
+// Copyright (C) 2019-2022 Aleo Systems Inc.
 // This file is part of the Leo library.
 
 // The Leo library is free software: you can redistribute it and/or modify
@@ -15,7 +15,10 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use leo_ast::*;
-use leo_errors::{AstError, Result, Span};
+use leo_errors::{AstError, Result};
+use leo_span::{sym, Span, Symbol};
+
+use indexmap::IndexMap;
 
 /// Replace Self when it is in a enclosing circuit type.
 /// Error when Self is outside an enclosing circuit type.
@@ -30,14 +33,6 @@ pub struct Canonicalizer {
     in_circuit: bool,
 }
 
-impl AstPass for Canonicalizer {
-    fn do_pass(ast: Program) -> Result<Ast> {
-        Ok(Ast::new(
-            ReconstructingDirector::new(Self::default()).reduce_program(&ast)?,
-        ))
-    }
-}
-
 impl Canonicalizer {
     pub fn canonicalize_accesses(
         &mut self,
@@ -50,34 +45,34 @@ impl Canonicalizer {
         for access in accesses.iter() {
             match self.canonicalize_assignee_access(access) {
                 AssigneeAccess::ArrayIndex(index) => {
-                    left = Box::new(Expression::ArrayAccess(ArrayAccessExpression {
+                    left = Box::new(Expression::Access(AccessExpression::Array(ArrayAccess {
                         array: left,
                         index: Box::new(index),
                         span: span.clone(),
-                    }));
+                    })));
                 }
                 AssigneeAccess::ArrayRange(start, stop) => {
-                    left = Box::new(Expression::ArrayRangeAccess(ArrayRangeAccessExpression {
+                    left = Box::new(Expression::Access(AccessExpression::ArrayRange(ArrayRangeAccess {
                         array: left,
                         left: start.map(Box::new),
                         right: stop.map(Box::new),
                         span: span.clone(),
-                    }));
+                    })));
                 }
                 AssigneeAccess::Tuple(positive_number, _) => {
-                    left = Box::new(Expression::TupleAccess(TupleAccessExpression {
+                    left = Box::new(Expression::Access(AccessExpression::Tuple(TupleAccess {
                         tuple: left,
                         index: positive_number,
                         span: span.clone(),
-                    }));
+                    })));
                 }
                 AssigneeAccess::Member(identifier) => {
-                    left = Box::new(Expression::CircuitMemberAccess(CircuitMemberAccessExpression {
-                        circuit: left,
+                    left = Box::new(Expression::Access(AccessExpression::Member(MemberAccess {
+                        inner: left,
                         name: identifier,
                         span: span.clone(),
                         type_: None,
-                    }));
+                    })));
                 }
             }
         }
@@ -85,7 +80,7 @@ impl Canonicalizer {
         Ok(left)
     }
 
-    pub fn compound_operation_converstion(&mut self, operation: &AssignOperation) -> Result<BinaryOperation> {
+    pub fn compound_operation_conversion(&mut self, operation: &AssignOperation) -> Result<BinaryOperation> {
         match operation {
             AssignOperation::Assign => unreachable!(),
             AssignOperation::Add => Ok(BinaryOperation::Add),
@@ -125,11 +120,11 @@ impl Canonicalizer {
         }
     }
 
-    fn canonicalize_circuit_implied_variable_definition(
+    fn canonicalize_circuit_variable_initializer(
         &mut self,
-        member: &CircuitImpliedVariableDefinition,
-    ) -> CircuitImpliedVariableDefinition {
-        CircuitImpliedVariableDefinition {
+        member: &CircuitVariableInitializer,
+    ) -> CircuitVariableInitializer {
+        CircuitVariableInitializer {
             identifier: member.identifier.clone(),
             expression: member
                 .expression
@@ -156,7 +151,7 @@ impl Canonicalizer {
                 return Expression::Binary(BinaryExpression {
                     left,
                     right,
-                    op: binary.op.clone(),
+                    op: binary.op,
                     span: binary.span.clone(),
                 });
             }
@@ -182,6 +177,62 @@ impl Canonicalizer {
                     target_type,
                     span: cast.span.clone(),
                 });
+            }
+
+            Expression::Access(access) => {
+                let access = match access {
+                    AccessExpression::Array(array_access) => {
+                        let array = Box::new(self.canonicalize_expression(&array_access.array));
+                        let index = Box::new(self.canonicalize_expression(&array_access.index));
+
+                        AccessExpression::Array(ArrayAccess {
+                            array,
+                            index,
+                            span: array_access.span.clone(),
+                        })
+                    }
+                    AccessExpression::ArrayRange(array_range_access) => {
+                        let array = Box::new(self.canonicalize_expression(&array_range_access.array));
+                        let left = array_range_access
+                            .left
+                            .as_ref()
+                            .map(|left| Box::new(self.canonicalize_expression(left)));
+                        let right = array_range_access
+                            .right
+                            .as_ref()
+                            .map(|right| Box::new(self.canonicalize_expression(right)));
+
+                        AccessExpression::ArrayRange(ArrayRangeAccess {
+                            array,
+                            left,
+                            right,
+                            span: array_range_access.span.clone(),
+                        })
+                    }
+                    AccessExpression::Member(member_access) => AccessExpression::Member(MemberAccess {
+                        inner: Box::new(self.canonicalize_expression(&member_access.inner)),
+                        name: member_access.name.clone(),
+                        span: member_access.span.clone(),
+                        type_: None,
+                    }),
+                    AccessExpression::Tuple(tuple_access) => {
+                        let tuple = Box::new(self.canonicalize_expression(&tuple_access.tuple));
+
+                        AccessExpression::Tuple(TupleAccess {
+                            tuple,
+                            index: tuple_access.index.clone(),
+                            span: tuple_access.span.clone(),
+                        })
+                    }
+                    AccessExpression::Static(static_access) => AccessExpression::Static(StaticAccess {
+                        inner: Box::new(self.canonicalize_expression(&static_access.inner)),
+                        name: static_access.name.clone(),
+                        type_: self.canonicalize_self_type(static_access.type_.as_ref()),
+                        span: static_access.span.clone(),
+                    }),
+                };
+
+                return Expression::Access(access);
             }
 
             Expression::ArrayInline(array_inline) => {
@@ -214,36 +265,6 @@ impl Canonicalizer {
                 });
             }
 
-            Expression::ArrayAccess(array_access) => {
-                let array = Box::new(self.canonicalize_expression(&array_access.array));
-                let index = Box::new(self.canonicalize_expression(&array_access.index));
-
-                return Expression::ArrayAccess(ArrayAccessExpression {
-                    array,
-                    index,
-                    span: array_access.span.clone(),
-                });
-            }
-
-            Expression::ArrayRangeAccess(array_range_access) => {
-                let array = Box::new(self.canonicalize_expression(&array_range_access.array));
-                let left = array_range_access
-                    .left
-                    .as_ref()
-                    .map(|left| Box::new(self.canonicalize_expression(left)));
-                let right = array_range_access
-                    .right
-                    .as_ref()
-                    .map(|right| Box::new(self.canonicalize_expression(right)));
-
-                return Expression::ArrayRangeAccess(ArrayRangeAccessExpression {
-                    array,
-                    left,
-                    right,
-                    span: array_range_access.span.clone(),
-                });
-            }
-
             Expression::TupleInit(tuple_init) => {
                 let elements = tuple_init
                     .elements
@@ -257,20 +278,10 @@ impl Canonicalizer {
                 });
             }
 
-            Expression::TupleAccess(tuple_access) => {
-                let tuple = Box::new(self.canonicalize_expression(&tuple_access.tuple));
-
-                return Expression::TupleAccess(TupleAccessExpression {
-                    tuple,
-                    index: tuple_access.index.clone(),
-                    span: tuple_access.span.clone(),
-                });
-            }
-
             Expression::CircuitInit(circuit_init) => {
                 let mut name = circuit_init.name.clone();
-                if name.name.as_ref() == "Self" && self.circuit_name.is_some() {
-                    name = self.circuit_name.as_ref().unwrap().clone();
+                if name.name == sym::SelfUpper && self.circuit_name.is_some() {
+                    name = self.circuit_name.clone().unwrap();
                 }
 
                 return Expression::CircuitInit(CircuitInitExpression {
@@ -278,24 +289,9 @@ impl Canonicalizer {
                     members: circuit_init
                         .members
                         .iter()
-                        .map(|member| self.canonicalize_circuit_implied_variable_definition(member))
+                        .map(|member| self.canonicalize_circuit_variable_initializer(member))
                         .collect(),
                     span: circuit_init.span.clone(),
-                });
-            }
-            Expression::CircuitMemberAccess(circuit_member_access) => {
-                return Expression::CircuitMemberAccess(CircuitMemberAccessExpression {
-                    circuit: Box::new(self.canonicalize_expression(&circuit_member_access.circuit)),
-                    name: circuit_member_access.name.clone(),
-                    span: circuit_member_access.span.clone(),
-                    type_: None,
-                });
-            }
-            Expression::CircuitStaticFunctionAccess(circuit_static_func_access) => {
-                return Expression::CircuitStaticFunctionAccess(CircuitStaticFunctionAccessExpression {
-                    circuit: Box::new(self.canonicalize_expression(&circuit_static_func_access.circuit)),
-                    name: circuit_static_func_access.name.clone(),
-                    span: circuit_static_func_access.span.clone(),
                 });
             }
             Expression::Call(call) => {
@@ -310,7 +306,7 @@ impl Canonicalizer {
                 });
             }
             Expression::Identifier(identifier) => {
-                if identifier.name.as_ref() == "Self" && self.circuit_name.is_some() {
+                if identifier.name == sym::SelfUpper && self.circuit_name.is_some() {
                     return Expression::Identifier(self.circuit_name.as_ref().unwrap().clone());
                 }
             }
@@ -478,6 +474,13 @@ impl Canonicalizer {
 
     fn canonicalize_circuit_member(&mut self, circuit_member: &CircuitMember) -> CircuitMember {
         match circuit_member {
+            CircuitMember::CircuitConst(identifier, type_, value) => {
+                return CircuitMember::CircuitConst(
+                    identifier.clone(),
+                    type_.clone(),
+                    self.canonicalize_expression(value),
+                );
+            }
             CircuitMember::CircuitVariable(_, _) => {}
             CircuitMember::CircuitFunction(function) => {
                 let input = function
@@ -488,14 +491,16 @@ impl Canonicalizer {
                 let output = self.canonicalize_self_type(function.output.as_ref());
                 let block = self.canonicalize_block(&function.block);
 
-                return CircuitMember::CircuitFunction(Function {
+                return CircuitMember::CircuitFunction(Box::new(Function {
                     annotations: function.annotations.clone(),
                     identifier: function.identifier.clone(),
+                    const_: function.const_,
                     input,
                     output,
                     block,
+                    core_mapping: function.core_mapping.clone(),
                     span: function.span.clone(),
-                });
+                }));
             }
         }
 
@@ -513,35 +518,18 @@ impl ReconstructingReducer for Canonicalizer {
     }
 
     fn reduce_type(&mut self, _type_: &Type, new: Type, span: &Span) -> Result<Type> {
-        match new {
-            Type::Array(type_, dimensions) => {
-                if let Some(mut dimensions) = dimensions {
-                    if dimensions.is_zero() {
-                        return Err(AstError::invalid_array_dimension_size(span).into());
-                    }
-
-                    let mut next = Type::Array(type_, Some(ArrayDimensions(vec![dimensions.remove_last().unwrap()])));
-                    let mut array = next.clone();
-
-                    loop {
-                        if dimensions.is_empty() {
-                            break;
-                        }
-
-                        array = Type::Array(
-                            Box::new(next),
-                            Some(ArrayDimensions(vec![dimensions.remove_last().unwrap()])),
-                        );
-                        next = array.clone();
-                    }
-
-                    Ok(array)
-                } else {
-                    Ok(Type::Array(type_, None))
-                }
+        match new.clone() {
+            Type::Array(base, dims) if dims.is_empty() => Ok(Type::Array(base, dims)),
+            // Reduce `ArrayDimensions` into nested `Array` types.
+            Type::Array(base, dims) => {
+                let mut iter = dims.0.into_iter().rev();
+                let ctor = |ty, dim| Type::Array(ty, ArrayDimensions::single(dim));
+                let dim = iter.next().unwrap();
+                let base = ctor(base, dim);
+                Ok(iter.fold(base, |ty, dim| ctor(Box::new(ty), dim)))
             }
             Type::SelfType if !self.in_circuit => Err(AstError::big_self_outside_of_circuit(span).into()),
-            _ => Ok(new.clone()),
+            _ => Ok(new),
         }
     }
 
@@ -609,43 +597,16 @@ impl ReconstructingReducer for Canonicalizer {
             return Err(AstError::invalid_array_dimension_size(&array_init.span).into());
         }
 
-        let element = Box::new(element);
-
-        if array_init.dimensions.0.len() == 1 {
-            return Ok(ArrayInitExpression {
-                element,
-                dimensions: array_init.dimensions.clone(),
-                span: array_init.span.clone(),
-            });
-        }
-
-        let mut dimensions = array_init.dimensions.clone();
-
-        let mut next = Expression::ArrayInit(ArrayInitExpression {
+        let mk_expr = |element, dim| ArrayInitExpression {
             element,
-            dimensions: ArrayDimensions(vec![dimensions.remove_last().unwrap()]),
+            dimensions: ArrayDimensions::single(dim),
             span: array_init.span.clone(),
-        });
+        };
 
-        let mut outer_element = Box::new(next.clone());
-        for (index, dimension) in dimensions.0.iter().rev().enumerate() {
-            if index == dimensions.0.len() - 1 {
-                break;
-            }
-
-            next = Expression::ArrayInit(ArrayInitExpression {
-                element: outer_element,
-                dimensions: ArrayDimensions(vec![dimension.clone()]),
-                span: array_init.span.clone(),
-            });
-            outer_element = Box::new(next.clone());
-        }
-
-        Ok(ArrayInitExpression {
-            element: outer_element,
-            dimensions: ArrayDimensions(vec![dimensions.remove_first().unwrap()]),
-            span: array_init.span.clone(),
-        })
+        let mut iter = array_init.dimensions.iter().rev().cloned();
+        // We know the array has non-zero dimensions.
+        let init = mk_expr(Box::new(element), iter.next().unwrap());
+        Ok(iter.fold(init, |elem, dim| mk_expr(Box::new(Expression::ArrayInit(elem)), dim)))
     }
 
     fn reduce_assign(
@@ -662,7 +623,7 @@ impl ReconstructingReducer for Canonicalizer {
                     &assign.span,
                 )?;
                 let right = Box::new(value);
-                let op = self.compound_operation_converstion(&assign.operation)?;
+                let op = self.compound_operation_conversion(&assign.operation)?;
 
                 let new_value = Expression::Binary(BinaryExpression {
                     left,
@@ -691,8 +652,9 @@ impl ReconstructingReducer for Canonicalizer {
         &mut self,
         function: &Function,
         identifier: Identifier,
-        annotations: Vec<Annotation>,
+        annotations: IndexMap<Symbol, Annotation>,
         input: Vec<FunctionInput>,
+        const_: bool,
         output: Option<Type>,
         block: Block,
     ) -> Result<Function> {
@@ -705,22 +667,23 @@ impl ReconstructingReducer for Canonicalizer {
             identifier,
             annotations,
             input,
+            const_,
             output: new_output,
             block,
+            core_mapping: function.core_mapping.clone(),
             span: function.span.clone(),
         })
     }
 
     fn reduce_circuit(
         &mut self,
-        circuit: &Circuit,
+        _circuit: &Circuit,
         circuit_name: Identifier,
         members: Vec<CircuitMember>,
     ) -> Result<Circuit> {
         self.circuit_name = Some(circuit_name.clone());
         let circ = Circuit {
             circuit_name,
-            core_mapping: circuit.core_mapping.clone(),
             members: members
                 .iter()
                 .map(|member| self.canonicalize_circuit_member(member))

--- a/ast-passes/src/canonicalization/mod.rs
+++ b/ast-passes/src/canonicalization/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (C) 2019-2021 Aleo Systems Inc.
+// Copyright (C) 2019-2022 Aleo Systems Inc.
 // This file is part of the Leo library.
 
 // The Leo library is free software: you can redistribute it and/or modify
@@ -16,3 +16,12 @@
 
 pub mod canonicalizer;
 pub use canonicalizer::*;
+
+use leo_ast::{Ast, AstPass, Program, ReconstructingDirector};
+use leo_errors::Result;
+
+impl AstPass for Canonicalizer {
+    fn do_pass(self, ast: Program) -> Result<Ast> {
+        Ok(Ast::new(ReconstructingDirector::new(self).reduce_program(&ast)?))
+    }
+}

--- a/ast-passes/src/lib.rs
+++ b/ast-passes/src/lib.rs
@@ -19,5 +19,7 @@
 pub mod canonicalization;
 pub use canonicalization::*;
 
-pub mod import_resolution;
-pub use import_resolution::*;
+// Temporarily disable import resolution
+// until we migrate stdlib and then import resolution.
+/* pub mod import_resolution;
+pub use import_resolution::*; */

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -22,12 +22,20 @@ rust-version = "1.56.1"
 path = "../ast"
 version = "1.5.3"
 
+[dependencies.leo-ast-passes]
+path = "../ast-passes"
+version = "1.5.3"
+
 [dependencies.leo-errors]
 path = "../errors"
 version = "1.5.3"
 
 [dependencies.leo-parser]
 path = "../parser"
+version = "1.5.3"
+
+[dependencies.leo-span]
+path = "../span"
 version = "1.5.3"
 
 [dependencies.sha2]

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -24,6 +24,7 @@
 
 use leo_errors::emitter::Handler;
 use leo_errors::{CompilerError, Result};
+use leo_span::symbol::create_session_if_not_set_then;
 
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -63,9 +64,9 @@ impl<'a> Compiler<'a> {
     }
 
     ///
-    /// Returns a compiled Leo program.
-    ///
-    pub fn compile(self) -> Result<leo_ast::Ast> {
+    /// Runs the compiler stages.
+    /// 
+    fn compiler_stages(self) -> Result<leo_ast::Ast> {
         // Load the program file.
         let program_string = fs::read_to_string(&self.main_file_path)
             .map_err(|e| CompilerError::file_read_error(self.main_file_path.clone(), e))?;
@@ -78,5 +79,12 @@ impl<'a> Compiler<'a> {
         )?;
 
         Ok(ast)
+    }
+
+    ///
+    /// Returns a compiled Leo program.
+    ///
+    pub fn compile(self) -> Result<leo_ast::Ast> {
+        create_session_if_not_set_then(|_| self.compiler_stages())
     }
 }

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -68,7 +68,7 @@ impl<'a> Compiler<'a> {
 
     ///
     /// Runs the compiler stages.
-    /// 
+    ///
     fn compiler_stages(self) -> Result<leo_ast::Ast> {
         // Load the program file.
         let program_string = fs::read_to_string(&self.main_file_path)
@@ -86,7 +86,7 @@ impl<'a> Compiler<'a> {
         // Canonicalize the AST.
         ast = leo_ast_passes::Canonicalizer::do_pass(Default::default(), ast.into_repr())?;
         // Write the AST snapshot post parsing
-        ast.to_json_file_without_keys(self.output_directory.clone(), "canonicalization_ast.json", &["span"])?;
+        ast.to_json_file_without_keys(self.output_directory, "canonicalization_ast.json", &["span"])?;
 
         Ok(ast)
     }

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -178,7 +178,7 @@ impl Command for Build {
         // Initialize error handler
         let handler = leo_errors::emitter::Handler::default();
 
-        let program = Compiler::new(&handler, main_file_path);
+        let program = Compiler::new(&handler, main_file_path, output_directory);
 
         // Compute the current program checksum
         let program_checksum = program.checksum()?;

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -18,8 +18,9 @@ use crate::{commands::Command, context::Context};
 use leo_compiler::Compiler;
 use leo_errors::{CliError, Result};
 use leo_package::{
-    inputs::*,
-    outputs::{ChecksumFile, CircuitFile, OutputsDirectory, OUTPUTS_DIRECTORY_NAME},
+    // inputs::*,
+    // outputs::CircuitFile
+    outputs::{ChecksumFile, OutputsDirectory, OUTPUTS_DIRECTORY_NAME},
     source::{MainFile, MAIN_FILENAME, SOURCE_DIRECTORY_NAME},
 };
 
@@ -93,6 +94,7 @@ pub struct BuildOptions {
 #[derive(StructOpt, Debug)]
 #[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
 pub struct Build {
+    #[allow(dead_code)]
     #[structopt(flatten)]
     pub(crate) compiler_options: BuildOptions,
 }

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -29,7 +29,7 @@ use commands::{
     // Deploy, Init, Lint, New, Prove, Run, Setup, Test, Update, Watch,
 };
 use leo_errors::Result;
-use snarkvm_utilities::Write;
+// use snarkvm_utilities::Write;
 
 use std::{path::PathBuf, process::exit};
 use structopt::{clap::AppSettings, StructOpt};

--- a/leo/tests/mod.rs
+++ b/leo/tests/mod.rs
@@ -15,9 +15,9 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use leo_errors::Result;
-use std::path::PathBuf;
+// use std::path::PathBuf;
 
-use crate::{
+/* use crate::{
     commands::{
         // package::{Login, Logout},
         Build,
@@ -25,11 +25,11 @@ use crate::{
         // Prove, Run, Setup, Test,
     },
     context::{create_context, Context},
-};
+}; */
 
 /// Path to the only complex Leo program that we have
 /// - relative to source dir - where Cargo.toml is located
-const PEDERSEN_HASH_PATH: &str = "./examples/pedersen-hash/";
+// const PEDERSEN_HASH_PATH: &str = "./examples/pedersen-hash/";
 
 #[test]
 pub fn init_logger() -> Result<()> {
@@ -218,10 +218,10 @@ pub fn format_event() -> Result<()> {
 //     Ok(())
 // }
 
-/// Create context for Pedersen Hash example
-fn context() -> Result<Context> {
+// /// Create context for Pedersen Hash example
+/* fn context() -> Result<Context> {
     let path = PathBuf::from(&PEDERSEN_HASH_PATH);
     let context = create_context(path, None)?;
 
     Ok(context)
-}
+} */


### PR DESCRIPTION
Migrates the Canonicalization AST Pass.

Also fixes that the compiler would panic due to not having set up a context.

Re adds writing AST snapshots, but with no compiler flags, this was mostly done so I could test.