### PR TITLE
[Fix] Disallow 1 element tuple types and variables

### DIFF
--- a/ast-passes/src/canonicalization/canonicalizer.rs
+++ b/ast-passes/src/canonicalization/canonicalizer.rs
@@ -524,6 +524,7 @@ impl ReconstructingReducer for Canonicalizer {
     fn reduce_type(&mut self, _type_: &Type, new: Type, span: &Span) -> Result<Type> {
         match new.clone() {
             Type::Array(base, dims) if dims.is_empty() => Ok(Type::Array(base, dims)),
+            Type::Array(_, dims) if dims.is_zero() => Err(AstError::invalid_array_dimension_size(span).into()),
             // Reduce `ArrayDimensions` into nested `Array` types.
             Type::Array(base, dims) => {
                 let mut iter = dims.0.into_iter().rev();
@@ -533,6 +534,7 @@ impl ReconstructingReducer for Canonicalizer {
                 Ok(iter.fold(base, |ty, dim| ctor(Box::new(ty), dim)))
             }
             Type::SelfType if !self.in_circuit => Err(AstError::big_self_outside_of_circuit(span).into()),
+            Type::Tuple(types) if types.len() == 1 => Err(AstError::invalid_tuple_dimension_size(span).into()),
             _ => Ok(new),
         }
     }
@@ -586,6 +588,10 @@ impl ReconstructingReducer for Canonicalizer {
             )));
         }
 
+        if elements.is_empty() {
+            return Err(AstError::invalid_array_dimension_size(span).into());
+        }
+
         Ok(Expression::ArrayInline(ArrayInlineExpression {
             elements,
             span: span.clone(),
@@ -597,10 +603,6 @@ impl ReconstructingReducer for Canonicalizer {
         array_init: &ArrayInitExpression,
         element: Expression,
     ) -> Result<ArrayInitExpression> {
-        if array_init.dimensions.is_zero() {
-            return Err(AstError::invalid_array_dimension_size(&array_init.span).into());
-        }
-
         let mk_expr = |element, dim| ArrayInitExpression {
             element,
             dimensions: ArrayDimensions::single(dim),
@@ -612,7 +614,7 @@ impl ReconstructingReducer for Canonicalizer {
         let init = mk_expr(Box::new(element), iter.next().unwrap());
         Ok(iter.fold(init, |elem, dim| mk_expr(Box::new(Expression::ArrayInit(elem)), dim)))
     }
-
+    
     fn reduce_assign(
         &mut self,
         assign: &AssignStatement,

--- a/ast/src/reducer/reconstructing_reducer.rs
+++ b/ast/src/reducer/reconstructing_reducer.rs
@@ -286,6 +286,7 @@ pub trait ReconstructingReducer {
         Ok(DefinitionStatement {
             declaration_type: definition.declaration_type.clone(),
             variable_names,
+            parened: definition.parened,
             type_,
             value,
             span: definition.span.clone(),

--- a/ast/src/statements/definition/mod.rs
+++ b/ast/src/statements/definition/mod.rs
@@ -33,6 +33,8 @@ pub struct DefinitionStatement {
     pub declaration_type: Declare,
     /// The bindings / variable names to declare.
     pub variable_names: Vec<VariableName>,
+    /// Tracks whether the variable(s) are in parens.
+    pub parened: bool,
     /// The types of the bindings, if specified, or inferred otherwise.
     pub type_: Option<Type>,
     /// An initializer value for the bindings.

--- a/errors/src/ast/ast_errors.rs
+++ b/errors/src/ast/ast_errors.rs
@@ -130,4 +130,12 @@ create_errors!(
         msg: format!("failed to convert ast to a json value {}", error),
         help: None,
     }
+
+    /// For when a user tries to define a tuple dimension of 1.
+    @formatted
+    invalid_tuple_dimension_size {
+        args: (),
+        msg: "tuples of 1 element are not allowed",
+        help: None,
+    }
 );

--- a/errors/src/ast/ast_errors.rs
+++ b/errors/src/ast/ast_errors.rs
@@ -138,4 +138,12 @@ create_errors!(
         msg: "tuples of 1 element are not allowed",
         help: None,
     }
+
+    /// For when a user puts parens around a single defined variable.
+    @formatted
+    invalid_parens_around_single_variable {
+        args: (),
+        msg: "do not put parens around single variable names",
+        help: None,
+    }
 );

--- a/parser/src/parser/statement.rs
+++ b/parser/src/parser/statement.rs
@@ -295,11 +295,14 @@ impl ParserContext<'_> {
         let declare = self.expect_oneof(&[Token::Let, Token::Const])?;
 
         // Parse variable names.
-        let variable_names = if self.peek_is_left_par() {
-            self.parse_paren_comma_list(|p| p.parse_variable_name(&declare).map(Some))
-                .map(|(vars, ..)| vars)?
+        let (variable_names, parened) = if self.peek_is_left_par() {
+            (
+                self.parse_paren_comma_list(|p| p.parse_variable_name(&declare).map(Some))
+                    .map(|(vars, ..)| vars)?,
+                true,
+            )
         } else {
-            vec![self.parse_variable_name(&declare)?]
+            (vec![self.parse_variable_name(&declare)?], false)
         };
 
         // Parse an optional type ascription.
@@ -320,6 +323,7 @@ impl ParserContext<'_> {
                 _ => unreachable!("parse_definition_statement_ shouldn't produce this"),
             },
             variable_names,
+            parened,
             type_,
             value: expr,
         })

--- a/tests/expectations/parser/parser/serialize/linear_regression.leo.out
+++ b/tests/expectations/parser/parser/serialize/linear_regression.leo.out
@@ -95,6 +95,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"num_points\",\"span\":\"{\\\"line_start\\\":23,\\\"line_stop\\\":23,\\\"col_start\\\":13,\\\"col_stop\\\":23,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let num_points = 5i32;\\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -106,6 +107,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"x_sum\",\"span\":\"{\\\"line_start\\\":25,\\\"line_stop\\\":25,\\\"col_start\\\":13,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let x_sum = 0i32; \\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -117,6 +119,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"y_sum\",\"span\":\"{\\\"line_start\\\":26,\\\"line_stop\\\":26,\\\"col_start\\\":13,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let y_sum = 0i32; \\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -128,6 +131,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"xy_sum\",\"span\":\"{\\\"line_start\\\":27,\\\"line_stop\\\":27,\\\"col_start\\\":13,\\\"col_stop\\\":19,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let xy_sum = 0i32; \\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -139,6 +143,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"x2_sum\",\"span\":\"{\\\"line_start\\\":28,\\\"line_stop\\\":28,\\\"col_start\\\":13,\\\"col_stop\\\":19,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let x2_sum = 0i32; \\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -289,6 +294,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"numerator\",\"span\":\"{\\\"line_start\\\":35,\\\"line_stop\\\":35,\\\"col_start\\\":13,\\\"col_stop\\\":22,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let numerator = (num_points * xy_sum) - (x_sum * y_sum); \\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Binary:
@@ -312,6 +318,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"denominator\",\"span\":\"{\\\"line_start\\\":36,\\\"line_stop\\\":36,\\\"col_start\\\":13,\\\"col_stop\\\":24,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let denominator = (num_points * x2_sum) - (x_sum * x_sum);\\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Binary:
@@ -335,6 +342,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"slope\",\"span\":\"{\\\"line_start\\\":37,\\\"line_stop\\\":37,\\\"col_start\\\":13,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let slope = numerator / denominator;\\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Binary:
@@ -368,6 +376,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"num_points\",\"span\":\"{\\\"line_start\\\":42,\\\"line_stop\\\":42,\\\"col_start\\\":13,\\\"col_stop\\\":23,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let num_points = 5i32; \\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -379,6 +388,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"x_sum\",\"span\":\"{\\\"line_start\\\":44,\\\"line_stop\\\":44,\\\"col_start\\\":13,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let x_sum = 0i32;\\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -390,6 +400,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"y_sum\",\"span\":\"{\\\"line_start\\\":45,\\\"line_stop\\\":45,\\\"col_start\\\":13,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let y_sum = 0i32;\\\"}\"}"
+                      parened: false
                       type_: ~
                       value:
                         Value:
@@ -500,6 +511,7 @@ outputs:
                 variable_names:
                   - mutable: true
                     identifier: "{\"name\":\"points\",\"span\":\"{\\\"line_start\\\":56,\\\"line_stop\\\":56,\\\"col_start\\\":7,\\\"col_stop\\\":13,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"  let points: [Point; 5] = [\\\"}\"}"
+                parened: false
                 type_:
                   Array:
                     - Identifier: "{\"name\":\"Point\",\"span\":\"{\\\"line_start\\\":56,\\\"line_stop\\\":56,\\\"col_start\\\":16,\\\"col_stop\\\":21,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"  let points: [Point; 5] = [\\\"}\"}"
@@ -622,6 +634,7 @@ outputs:
                 variable_names:
                   - mutable: true
                     identifier: "{\"name\":\"reg\",\"span\":\"{\\\"line_start\\\":63,\\\"line_stop\\\":63,\\\"col_start\\\":7,\\\"col_stop\\\":10,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"  let reg = LinearRegression::new(points);\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Call:
@@ -639,6 +652,7 @@ outputs:
                 variable_names:
                   - mutable: true
                     identifier: "{\"name\":\"slope\",\"span\":\"{\\\"line_start\\\":64,\\\"line_stop\\\":64,\\\"col_start\\\":7,\\\"col_stop\\\":12,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"  let slope = reg.slope();\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Call:
@@ -655,6 +669,7 @@ outputs:
                 variable_names:
                   - mutable: true
                     identifier: "{\"name\":\"offset\",\"span\":\"{\\\"line_start\\\":65,\\\"line_stop\\\":65,\\\"col_start\\\":7,\\\"col_stop\\\":13,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"  let offset = reg.offset(slope);\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Call:

--- a/tests/expectations/parser/parser/serialize/palindrome.leo.out
+++ b/tests/expectations/parser/parser/serialize/palindrome.leo.out
@@ -56,6 +56,7 @@ outputs:
                 variable_names:
                   - mutable: false
                     identifier: "{\"name\":\"str_len\",\"span\":\"{\\\"line_start\\\":11,\\\"line_stop\\\":11,\\\"col_start\\\":11,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"    const str_len = 20u32; // saving const for convenience\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Value:
@@ -67,6 +68,7 @@ outputs:
                 variable_names:
                   - mutable: true
                     identifier: "{\"name\":\"result\",\"span\":\"{\\\"line_start\\\":14,\\\"line_stop\\\":14,\\\"col_start\\\":9,\\\"col_stop\\\":15,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"    let result = true;\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Value:
@@ -76,6 +78,7 @@ outputs:
                 variable_names:
                   - mutable: true
                     identifier: "{\"name\":\"processed\",\"span\":\"{\\\"line_start\\\":15,\\\"line_stop\\\":15,\\\"col_start\\\":9,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"    let processed = 0u8;\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Value:
@@ -103,6 +106,7 @@ outputs:
                         variable_names:
                           - mutable: true
                             identifier: "{\"name\":\"start_sym\",\"span\":\"{\\\"line_start\\\":18,\\\"line_stop\\\":18,\\\"col_start\\\":13,\\\"col_stop\\\":22,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let start_sym = str[start];\\\"}\"}"
+                        parened: false
                         type_: ~
                         value:
                           Access:
@@ -129,6 +133,7 @@ outputs:
                                 variable_names:
                                   - mutable: true
                                     identifier: "{\"name\":\"skipped\",\"span\":\"{\\\"line_start\\\":20,\\\"line_stop\\\":20,\\\"col_start\\\":17,\\\"col_stop\\\":24,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"            let skipped = 0u8;\\\"}\"}"
+                                parened: false
                                 type_: ~
                                 value:
                                   Value:
@@ -140,6 +145,7 @@ outputs:
                                 variable_names:
                                   - mutable: true
                                     identifier: "{\"name\":\"end_empty\",\"span\":\"{\\\"line_start\\\":21,\\\"line_stop\\\":21,\\\"col_start\\\":17,\\\"col_stop\\\":26,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"            let end_empty = 0u8;\\\"}\"}"
+                                parened: false
                                 type_: ~
                                 value:
                                   Value:
@@ -151,6 +157,7 @@ outputs:
                                 variable_names:
                                   - mutable: true
                                     identifier: "{\"name\":\"end_sym\",\"span\":\"{\\\"line_start\\\":22,\\\"line_stop\\\":22,\\\"col_start\\\":17,\\\"col_stop\\\":24,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"            let end_sym = ' ';\\\"}\"}"
+                                parened: false
                                 type_: ~
                                 value:
                                   Value:

--- a/tests/expectations/parser/parser/serialize/pedersen_hash.leo.out
+++ b/tests/expectations/parser/parser/serialize/pedersen_hash.leo.out
@@ -64,6 +64,7 @@ outputs:
                       variable_names:
                         - mutable: true
                           identifier: "{\"name\":\"digest\",\"span\":\"{\\\"line_start\\\":12,\\\"line_stop\\\":12,\\\"col_start\\\":13,\\\"col_stop\\\":19,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"        let digest: group = 0group;\\\"}\"}"
+                      parened: false
                       type_: Group
                       value:
                         Value:
@@ -143,6 +144,7 @@ outputs:
                 variable_names:
                   - mutable: false
                     identifier: "{\"name\":\"pedersen\",\"span\":\"{\\\"line_start\\\":24,\\\"line_stop\\\":24,\\\"col_start\\\":11,\\\"col_stop\\\":19,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"    const pedersen = PedersenHash::new(parameters);\\\"}\"}"
+                parened: false
                 type_: ~
                 value:
                   Call:

--- a/tests/expectations/parser/parser/statement/definition.leo.out
+++ b/tests/expectations/parser/parser/statement/definition.leo.out
@@ -14,6 +14,7 @@ outputs:
             col_stop: 6
             path: ""
             content: let x = expr;
+      parened: false
       type_: ~
       value:
         Identifier: "{\"name\":\"expr\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":9,\\\"col_stop\\\":13,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let x = expr;\\\"}\"}"
@@ -36,6 +37,7 @@ outputs:
             col_stop: 6
             path: ""
             content: let x = ();
+      parened: false
       type_: ~
       value:
         TupleInit:
@@ -66,6 +68,7 @@ outputs:
             col_stop: 6
             path: ""
             content: let x = x+y;
+      parened: false
       type_: ~
       value:
         Binary:
@@ -100,6 +103,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x = (x,y);"
+      parened: false
       type_: ~
       value:
         TupleInit:
@@ -132,6 +136,7 @@ outputs:
             col_stop: 6
             path: ""
             content: let x = x();
+      parened: false
       type_: ~
       value:
         Call:
@@ -164,6 +169,7 @@ outputs:
             col_stop: 8
             path: ""
             content: const x = expr;
+      parened: false
       type_: ~
       value:
         Identifier: "{\"name\":\"expr\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":11,\\\"col_stop\\\":15,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"const x = expr;\\\"}\"}"
@@ -186,6 +192,7 @@ outputs:
             col_stop: 8
             path: ""
             content: const x = ();
+      parened: false
       type_: ~
       value:
         TupleInit:
@@ -216,6 +223,7 @@ outputs:
             col_stop: 8
             path: ""
             content: const x = x+y;
+      parened: false
       type_: ~
       value:
         Binary:
@@ -250,6 +258,7 @@ outputs:
             col_stop: 8
             path: ""
             content: "const x = (x,y);"
+      parened: false
       type_: ~
       value:
         TupleInit:
@@ -282,6 +291,7 @@ outputs:
             col_stop: 8
             path: ""
             content: const x = x();
+      parened: false
       type_: ~
       value:
         Call:
@@ -314,6 +324,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: u32 = expr;"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -337,6 +348,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: u32 = ();"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -368,6 +380,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: u32 = x+y;"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -403,6 +416,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: u32 = (x,y);"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -436,6 +450,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: u32 = x();"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -469,6 +484,7 @@ outputs:
             col_stop: 8
             path: ""
             content: "const x: u32 = expr;"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -492,6 +508,7 @@ outputs:
             col_stop: 8
             path: ""
             content: "const x: u32 = ();"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -523,6 +540,7 @@ outputs:
             col_stop: 8
             path: ""
             content: "const x: u32 = x+y;"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -558,6 +576,7 @@ outputs:
             col_stop: 8
             path: ""
             content: "const x: u32 = (x,y);"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -591,6 +610,7 @@ outputs:
             col_stop: 8
             path: ""
             content: "const x: u32 = x();"
+      parened: false
       type_:
         IntegerType: U32
       value:
@@ -633,6 +653,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y) = expr;"
+      parened: true
       type_: ~
       value:
         Identifier: "{\"name\":\"expr\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":14,\\\"col_stop\\\":18,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"let (x, y) = expr;\\\"}\"}"
@@ -664,6 +685,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y) = ();"
+      parened: true
       type_: ~
       value:
         TupleInit:
@@ -703,6 +725,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y) = x+y;"
+      parened: true
       type_: ~
       value:
         Binary:
@@ -746,6 +769,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y) = (x,y);"
+      parened: true
       type_: ~
       value:
         TupleInit:
@@ -787,6 +811,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y) = x();"
+      parened: true
       type_: ~
       value:
         Call:
@@ -828,6 +853,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y) = expr;"
+      parened: true
       type_: ~
       value:
         Identifier: "{\"name\":\"expr\",\"span\":\"{\\\"line_start\\\":1,\\\"line_stop\\\":1,\\\"col_start\\\":16,\\\"col_stop\\\":20,\\\"path\\\":\\\"\\\",\\\"content\\\":\\\"const (x, y) = expr;\\\"}\"}"
@@ -859,6 +885,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y) = ();"
+      parened: true
       type_: ~
       value:
         TupleInit:
@@ -898,6 +925,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y) = x+y;"
+      parened: true
       type_: ~
       value:
         Binary:
@@ -941,6 +969,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y) = (x,y);"
+      parened: true
       type_: ~
       value:
         TupleInit:
@@ -982,6 +1011,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y) = x();"
+      parened: true
       type_: ~
       value:
         Call:
@@ -1023,6 +1053,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y): u32 = expr;"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1055,6 +1086,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y): u32 = ();"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1095,6 +1127,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y): u32 = x+y;"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1139,6 +1172,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y): u32 = (x,y);"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1181,6 +1215,7 @@ outputs:
             col_stop: 10
             path: ""
             content: "let (x, y): u32 = x();"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1223,6 +1258,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y): u32 = expr;"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1255,6 +1291,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y): u32 = ();"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1295,6 +1332,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y): u32 = x+y;"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1339,6 +1377,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y): u32 = (x,y);"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1381,6 +1420,7 @@ outputs:
             col_stop: 12
             path: ""
             content: "const (x, y): u32 = x();"
+      parened: true
       type_:
         IntegerType: U32
       value:
@@ -1423,6 +1463,7 @@ outputs:
             col_stop: 9
             path: ""
             content: "let (x,y,) = ();"
+      parened: true
       type_: ~
       value:
         TupleInit:
@@ -1453,6 +1494,7 @@ outputs:
             col_stop: 7
             path: ""
             content: "let (x,) = ();"
+      parened: true
       type_: ~
       value:
         TupleInit:
@@ -1483,6 +1525,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: [char; _] = \"Hello, World!\";"
+      parened: false
       type_:
         Array:
           - Char
@@ -1529,6 +1572,7 @@ outputs:
             col_stop: 6
             path: ""
             content: "let x: [[u8; 2]; 2] = [[0,0], [0,0]];"
+      parened: false
       type_:
         Array:
           - Array:


### PR DESCRIPTION
I did some code clean-up around array zero element checking.
Also did a check for 1 element type tuples. They are now disallowed.
Also adds a field to Definition statements to know if they are parened.
Then during canonicalization, this is disallowed if there is only one variable name.

Closes #1405.