### PR TITLE
[ABNF] Adapt ABNF to removal of unsized arrays.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -1013,32 +1013,22 @@ An array type consists of an element type
 and an indication of dimensions.
 There is either a single dimension,
 or a tuple of one or more dimensions.
-Each dimension is natural.
+Each dimension is a natural.
 
 <a name="array-type"></a>
 ```abnf
-array-type = "[" type ";" array-type-dimensions "]"
+array-type = "[" type ";" array-dimensions "]"
 ```
 
-Go to: _[array-type-dimensions](#user-content-array-type-dimensions), [type](#user-content-type)_;
+Go to: _[array-dimensions](#user-content-array-dimensions), [type](#user-content-type)_;
 
 
-<a name="array-type-dimension"></a>
+<a name="array-dimensions"></a>
 ```abnf
-array-type-dimension = natural / "_"
+array-dimensions = natural / "(" natural *( "," natural ) ")"
 ```
 
 Go to: _[natural](#user-content-natural)_;
-
-
-<a name="array-type-dimensions"></a>
-```abnf
-array-type-dimensions = array-type-dimension
-                      / "(" array-type-dimension
-                            *( "," array-type-dimension ) [","] ")"
-```
-
-Go to: _[array-type-dimension](#user-content-array-type-dimension)_;
 
 
 The keyword `Self` denotes the enclosing circuit type.
@@ -1214,19 +1204,10 @@ Go to: _[expression](#user-content-expression)_;
 
 <a name="array-repeat-construction"></a>
 ```abnf
-array-repeat-construction = "[" expression ";" array-expression-dimensions "]"
+array-repeat-construction = "[" expression ";" array-dimensions "]"
 ```
 
-Go to: _[array-expression-dimensions](#user-content-array-expression-dimensions), [expression](#user-content-expression)_;
-
-
-<a name="array-expression-dimensions"></a>
-```abnf
-array-expression-dimensions = natural
-                            / "(" natural *( "," natural ) ")"
-```
-
-Go to: _[natural](#user-content-natural)_;
+Go to: _[array-dimensions](#user-content-array-dimensions), [expression](#user-content-expression)_;
 
 
 <a name="array-construction"></a>

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -650,15 +650,11 @@ tuple-type = "(" [ type 1*( "," type ) ] ")"
 ; and an indication of dimensions.
 ; There is either a single dimension,
 ; or a tuple of one or more dimensions.
-; Each dimension is natural.
+; Each dimension is a natural.
 
-array-type = "[" type ";" array-type-dimensions "]"
+array-type = "[" type ";" array-dimensions "]"
 
-array-type-dimension = natural / "_"
-
-array-type-dimensions = array-type-dimension
-                      / "(" array-type-dimension
-                            *( "," array-type-dimension ) [","] ")"
+array-dimensions = natural / "(" natural *( "," natural ) ")"
 
 ; The keyword `Self` denotes the enclosing circuit type.
 ; It is only allowed inside a circuit type declaration.
@@ -756,10 +752,7 @@ array-inline-construction = "["
 
 array-inline-element = expression / "..." expression
 
-array-repeat-construction = "[" expression ";" array-expression-dimensions "]"
-
-array-expression-dimensions = natural
-                            / "(" natural *( "," natural ) ")"
+array-repeat-construction = "[" expression ";" array-dimensions "]"
 
 array-construction = array-inline-construction / array-repeat-construction
 


### PR DESCRIPTION
This "merges" the two previous slightly different notions of array type
dimensions and array expression dimension(s) into one notion of array
dimensions, in which the dimensions have to be natural numbers. (Previously,
array type dimensions were allowed to be unspecified (via underscores), while
array expression dimensions had to be specified.)

[Note that this PR is being made against the remove/unsized-array branch.]
