### PR TITLE
Abnf natural to numeral

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -635,56 +635,56 @@ annotation-name = "@" identifier
 Go to: _[identifier](#user-content-identifier)_;
 
 
-A natural (number) is a sequence of one or more decimal digits.
+A numeral is a sequence of one or more decimal digits.
 We allow leading zeros, e.g. `007`.
 
-<a name="natural"></a>
+<a name="numeral"></a>
 ```abnf
-natural = 1*decimal-digit
+numeral = 1*decimal-digit
 ```
 
-Unsigned literals are naturals followed by unsigned types.
+Unsigned literals are numerals followed by unsigned types.
 
 <a name="unsigned-literal"></a>
 ```abnf
-unsigned-literal = natural ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
+unsigned-literal = numeral ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
 ```
 
-Go to: _[natural](#user-content-natural)_;
+Go to: _[numeral](#user-content-numeral)_;
 
 
-Signed literals are naturals followed by signed types.
+Signed literals are numerals followed by signed types.
 
 <a name="signed-literal"></a>
 ```abnf
-signed-literal = natural ( %s"i8" / %s"i16" / %s"i32" / %s"i64" / %s"i128" )
+signed-literal = numeral ( %s"i8" / %s"i16" / %s"i32" / %s"i64" / %s"i128" )
 ```
 
-Go to: _[natural](#user-content-natural)_;
+Go to: _[numeral](#user-content-numeral)_;
 
 
-Field literals are naturals followed by the type of field elements.
+Field literals are numerals followed by the type of field elements.
 
 <a name="field-literal"></a>
 ```abnf
-field-literal = natural %s"field"
+field-literal = numeral %s"field"
 ```
 
-Go to: _[natural](#user-content-natural)_;
+Go to: _[numeral](#user-content-numeral)_;
 
 
 There are two kinds of group literals.
-One is a single natural followed by the type of group elements,
-which denotes the scalar product of the generator point by the natural.
+One is a single numeral followed by the type of group elements,
+which denotes the scalar product of the generator point by the numeral.
 The other kind is not a token because it allows some whitespace inside;
 therefore, it is defined in the syntactic grammar.
 
 <a name="product-group-literal"></a>
 ```abnf
-product-group-literal = natural %s"group"
+product-group-literal = numeral %s"group"
 ```
 
-Go to: _[natural](#user-content-natural)_;
+Go to: _[numeral](#user-content-numeral)_;
 
 
 Boolean literals are the usual two.
@@ -991,7 +991,7 @@ An array type consists of an element type
 and an indication of dimensions.
 There is either a single dimension,
 or a tuple of one or more dimensions.
-Each dimension is a natural.
+Each dimension is a numeral.
 
 <a name="array-type"></a>
 ```abnf
@@ -1003,10 +1003,10 @@ Go to: _[array-dimensions](#user-content-array-dimensions), [type](#user-content
 
 <a name="array-dimensions"></a>
 ```abnf
-array-dimensions = natural / "(" natural *( "," natural ) ")"
+array-dimensions = numeral / "(" numeral *( "," numeral ) ")"
 ```
 
-Go to: _[natural](#user-content-natural)_;
+Go to: _[numeral](#user-content-numeral)_;
 
 
 The keyword `Self` denotes the enclosing circuit type.
@@ -1069,10 +1069,10 @@ because it consists of affine point coordinates.
 
 <a name="group-coordinate"></a>
 ```abnf
-group-coordinate = [ "-" ] natural / "+" / "-" / "_"
+group-coordinate = [ "-" ] numeral / "+" / "-" / "_"
 ```
 
-Go to: _[natural](#user-content-natural)_;
+Go to: _[numeral](#user-content-numeral)_;
 
 
 <a name="affine-group-literal"></a>
@@ -1275,7 +1275,7 @@ Go to: _[expression](#user-content-expression)_;
 <a name="postfix-expression"></a>
 ```abnf
 postfix-expression = primary-expression
-                   / postfix-expression "." natural
+                   / postfix-expression "." numeral
                    / postfix-expression "." identifier
                    / identifier function-arguments
                    / postfix-expression "." identifier function-arguments
@@ -1285,7 +1285,7 @@ postfix-expression = primary-expression
                    / postfix-expression "[" [expression] ".." [expression] "]"
 ```
 
-Go to: _[expression](#user-content-expression), [function-arguments](#user-content-function-arguments), [identifier](#user-content-identifier), [named-type](#user-content-named-type), [natural](#user-content-natural), [postfix-expression](#user-content-postfix-expression), [primary-expression](#user-content-primary-expression)_;
+Go to: _[expression](#user-content-expression), [function-arguments](#user-content-function-arguments), [identifier](#user-content-identifier), [named-type](#user-content-named-type), [numeral](#user-content-numeral), [postfix-expression](#user-content-postfix-expression), [primary-expression](#user-content-primary-expression)_;
 
 
 Unary operators have the highest operator precedence.

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -59,7 +59,7 @@
 ; usable as last resort in the definiens of a nonterminal.
 
 ; While BNF allows arbitrary terminals,
-; ABNF uses only natural numbers as terminals,
+; ABNF uses only natural numbers (i.e. non-negative integers) as terminals,
 ; and denotes them via:
 ; (i) binary, decimal, or hexadecimal sequences,
 ; e.g. `%b1.11.1010`, `%d1.3.10`, and `%x.1.3.A`

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -451,30 +451,30 @@ identifier = letter *( letter / decimal-digit / "_" )
 
 annotation-name = "@" identifier
 
-; A natural (number) is a sequence of one or more decimal digits.
+; A numeral is a sequence of one or more decimal digits.
 ; We allow leading zeros, e.g. `007`.
 
-natural = 1*decimal-digit
+numeral = 1*decimal-digit
 
-; Unsigned literals are naturals followed by unsigned types.
+; Unsigned literals are numerals followed by unsigned types.
 
-unsigned-literal = natural ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
+unsigned-literal = numeral ( %s"u8" / %s"u16" / %s"u32" / %s"u64" / %s"u128" )
 
-; Signed literals are naturals followed by signed types.
+; Signed literals are numerals followed by signed types.
 
-signed-literal = natural ( %s"i8" / %s"i16" / %s"i32" / %s"i64" / %s"i128" )
+signed-literal = numeral ( %s"i8" / %s"i16" / %s"i32" / %s"i64" / %s"i128" )
 
-; Field literals are naturals followed by the type of field elements.
+; Field literals are numerals followed by the type of field elements.
 
-field-literal = natural %s"field"
+field-literal = numeral %s"field"
 
 ; There are two kinds of group literals.
-; One is a single natural followed by the type of group elements,
-; which denotes the scalar product of the generator point by the natural.
+; One is a single numeral followed by the type of group elements,
+; which denotes the scalar product of the generator point by the numeral.
 ; The other kind is not a token because it allows some whitespace inside;
 ; therefore, it is defined in the syntactic grammar.
 
-product-group-literal = natural %s"group"
+product-group-literal = numeral %s"group"
 
 ; Boolean literals are the usual two.
 
@@ -640,11 +640,11 @@ tuple-type = "(" [ type 1*( "," type ) ] ")"
 ; and an indication of dimensions.
 ; There is either a single dimension,
 ; or a tuple of one or more dimensions.
-; Each dimension is a natural.
+; Each dimension is a numeral.
 
 array-type = "[" type ";" array-dimensions "]"
 
-array-dimensions = natural / "(" natural *( "," natural ) ")"
+array-dimensions = numeral / "(" numeral *( "," numeral ) ")"
 
 ; The keyword `Self` denotes the enclosing circuit type.
 ; It is only allowed inside a circuit type declaration.
@@ -683,7 +683,7 @@ named-type = identifier / self-type / scalar-type
 ; This is an affine group literal,
 ; because it consists of affine point coordinates.
 
-group-coordinate = [ "-" ] natural / "+" / "-" / "_"
+group-coordinate = [ "-" ] numeral / "+" / "-" / "_"
 
 affine-group-literal = "(" group-coordinate "," group-coordinate %s")group"
 
@@ -793,7 +793,7 @@ circuit-expression = circuit-construction
 function-arguments = "(" [ expression *( "," expression ) ] ")"
 
 postfix-expression = primary-expression
-                   / postfix-expression "." natural
+                   / postfix-expression "." numeral
                    / postfix-expression "." identifier
                    / identifier function-arguments
                    / postfix-expression "." identifier function-arguments


### PR DESCRIPTION
This applies both to the rule name and to the terminology used for that, namely
for a non-empty sequence of decimal digits.

While 'natural' was meant to describe a natural number (i.e. a non-negative
integer: 0, 1, 2, ...), it is perhaps not a familiar term to many users.

On the other hand, 'integer', while often used in programming languages for this
kind of thing, is not ideal as integers may be negative.

Also, assuming type inference, a lone numeral like `17` may actually not denote
an integer number at all, because it may actually denote a group element if type
inference turns it into `17group`, and group elements are not integers.

All in all, 'numeral' seems like a good term, also according to its dictionary
definition. It is used in the Java grammar to denote this kind of thing, for
instance.

If, in the future, we want to allow hexadecimal, octal, or binary notation, we
could rename this to `decimal-numeral`, introduce `hexadecimal-numeral`,
`octal-numeral`, and `binary-numeral`, and `numeral` as the union of these.