### PR TITLE
[ABNF] Allow trailing commas everywhere.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -993,7 +993,7 @@ A tuple type consists of zero, two, or more component types.
 
 <a name="tuple-type"></a>
 ```abnf
-tuple-type = "(" [ type 1*( "," type ) ] ")"
+tuple-type = "(" [ type 1*( "," type ) [ "," ] ] ")"
 ```
 
 Go to: _[type](#user-content-type)_;
@@ -1002,7 +1002,7 @@ Go to: _[type](#user-content-type)_;
 An array type consists of an element type
 and an indication of dimensions.
 There is either a single dimension,
-or a tuple of one or more dimensions.
+or a tuple of two or more dimensions.
 Each dimension is a numeral.
 
 <a name="array-type"></a>
@@ -1015,7 +1015,7 @@ Go to: _[array-dimensions](#user-content-array-dimensions), [type](#user-content
 
 <a name="array-dimensions"></a>
 ```abnf
-array-dimensions = numeral / "(" numeral *( "," numeral ) ")"
+array-dimensions = numeral / "(" numeral 1*( "," numeral ) [ "," ] ")"
 ```
 
 Go to: _[numeral](#user-content-numeral)_;
@@ -1152,7 +1152,7 @@ Each consists of zero, two, or more component expressions.
 
 <a name="tuple-construction"></a>
 ```abnf
-tuple-construction = "(" [ expression 1*( "," expression ) ] ")"
+tuple-construction = "(" [ expression 1*( "," expression ) [ "," ] ] ")"
 ```
 
 Go to: _[expression](#user-content-expression)_;
@@ -1178,6 +1178,7 @@ across one or more dimensions.
 array-inline-construction = "["
                             array-inline-element
                             *( "," array-inline-element )
+                            [ "," ]
                             "]"
 ```
 
@@ -1279,7 +1280,7 @@ as static constants are associated to named types.
 
 <a name="function-arguments"></a>
 ```abnf
-function-arguments = "(" [ expression *( "," expression ) ] ")"
+function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 ```
 
 Go to: _[expression](#user-content-expression)_;
@@ -1502,7 +1503,7 @@ Go to: _[expression](#user-content-expression), [identifier-or-identifiers](#use
 <a name="identifier-or-identifiers"></a>
 ```abnf
 identifier-or-identifiers = identifier
-                          / "(" identifier 1*( "," identifier ) ")"
+                          / "(" identifier 1*( "," identifier ) [ "," ] ")"
 ```
 
 Go to: _[identifier](#user-content-identifier)_;
@@ -1605,7 +1606,7 @@ print-function = %s"error" / %s"log"
 
 <a name="print-arguments"></a>
 ```abnf
-print-arguments = "(" string-literal  *( "," expression ) ")"
+print-arguments = "(" string-literal  *( "," expression ) [ "," ] ")"
 ```
 
 Go to: _[string-literal](#user-content-string-literal)_;
@@ -1625,7 +1626,7 @@ with optional annotation arguments, which are identifiers.
 <a name="annotation"></a>
 ```abnf
 annotation = annotation-name
-             [ "(" *( identifier "," ) [ identifier ] ")" ]
+             [ "(" [ identifier *( "," identifier ) [ "," ] ] ")" ]
 ```
 
 Go to: _[annotation-name](#user-content-annotation-name), [identifier](#user-content-identifier)_;
@@ -1650,7 +1651,7 @@ Go to: _[block](#user-content-block), [function-parameters](#user-content-functi
 
 <a name="function-parameters"></a>
 ```abnf
-function-parameters = self-parameter
+function-parameters = self-parameter [ "," ]
                     / self-parameter "," function-inputs
                     / function-inputs
 ```
@@ -1665,7 +1666,7 @@ self-parameter = [ %s"&" / %s"const" ] %s"self"
 
 <a name="function-inputs"></a>
 ```abnf
-function-inputs = function-input *( "," function-input )
+function-inputs = function-input *( "," function-input ) [ "," ]
 ```
 
 Go to: _[function-input](#user-content-function-input)_;
@@ -1706,8 +1707,9 @@ see the rule `circuit-declaration`.
 
 <a name="member-variable-declarations"></a>
 ```abnf
-member-variable-declarations = *( identifier ":" type ( "," / ";" ) )
-                               identifier ":" type ( [ "," ] / ";" )
+member-variable-declarations = identifier ":" type
+                               *( ( "," / ";" ) identifier ":" type )
+                               [ "," / ";" ]
 ```
 
 Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -640,17 +640,17 @@ scalar-type =  boolean-type / arithmetic-type / address-type / character-type
 
 ; A tuple type consists of zero, two, or more component types.
 
-tuple-type = "(" [ type 1*( "," type ) ] ")"
+tuple-type = "(" [ type 1*( "," type ) [ "," ] ] ")"
 
 ; An array type consists of an element type
 ; and an indication of dimensions.
 ; There is either a single dimension,
-; or a tuple of one or more dimensions.
+; or a tuple of two or more dimensions.
 ; Each dimension is a numeral.
 
 array-type = "[" type ";" array-dimensions "]"
 
-array-dimensions = numeral / "(" numeral *( "," numeral ) ")"
+array-dimensions = numeral / "(" numeral 1*( "," numeral ) [ "," ] ")"
 
 ; The keyword `Self` denotes the enclosing circuit type.
 ; It is only allowed inside a circuit type declaration.
@@ -730,7 +730,7 @@ primary-expression = identifier
 ; Tuple expressions construct tuples.
 ; Each consists of zero, two, or more component expressions.
 
-tuple-construction = "(" [ expression 1*( "," expression ) ] ")"
+tuple-construction = "(" [ expression 1*( "," expression ) [ "," ] ] ")"
 
 tuple-expression = tuple-construction
 
@@ -744,6 +744,7 @@ tuple-expression = tuple-construction
 array-inline-construction = "["
                             array-inline-element
                             *( "," array-inline-element )
+                            [ "," ]
                             "]"
 
 array-inline-element = expression / "..." expression
@@ -797,7 +798,7 @@ circuit-expression = circuit-construction
 ; They consist of a named type followed by the constant name,
 ; as static constants are associated to named types.
 
-function-arguments = "(" [ expression *( "," expression ) ] ")"
+function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 
 postfix-expression = primary-expression
                    / postfix-expression "." numeral
@@ -915,7 +916,7 @@ constant-declaration = %s"const" identifier-or-identifiers ":" type
                        "=" expression ";"
 
 identifier-or-identifiers = identifier
-                          / "(" identifier 1*( "," identifier ) ")"
+                          / "(" identifier 1*( "," identifier ) [ "," ] ")"
 
 ; A conditional statement always starts with a condition and a block
 ; (which together form a branch).
@@ -964,7 +965,7 @@ assert-call = %s"assert" "(" expression ")"
 
 print-function = %s"error" / %s"log"
 
-print-arguments = "(" string-literal  *( "," expression ) ")"
+print-arguments = "(" string-literal  *( "," expression ) [ "," ] ")"
 
 print-call = print-function print-arguments
 
@@ -972,7 +973,7 @@ print-call = print-function print-arguments
 ; with optional annotation arguments, which are identifiers.
 
 annotation = annotation-name
-             [ "(" *( identifier "," ) [ identifier ] ")" ]
+             [ "(" [ identifier *( "," identifier ) [ "," ] ] ")" ]
 
 ; A function declaration defines a function.
 ; The output type is optional, defaulting to the empty tuple type.
@@ -985,13 +986,13 @@ function-declaration = *annotation [ %s"const" ] %s"function" identifier
                        "(" [ function-parameters ] ")" [ "->" type ]
                        block
 
-function-parameters = self-parameter
+function-parameters = self-parameter [ "," ]
                     / self-parameter "," function-inputs
                     / function-inputs
 
 self-parameter = [ %s"&" / %s"const" ] %s"self"
 
-function-inputs = function-input *( "," function-input )
+function-inputs = function-input *( "," function-input ) [ "," ]
 
 function-input = [ %s"const" ] identifier ":" type
 
@@ -1014,8 +1015,9 @@ member-constant-declaration = %s"static" %s"const" identifier ":" type
 ; but instead one for a sequence of them;
 ; see the rule `circuit-declaration`.
 
-member-variable-declarations = *( identifier ":" type ( "," / ";" ) )
-                               identifier ":" type ( [ "," ] / ";" )
+member-variable-declarations = identifier ":" type
+                               *( ( "," / ";" ) identifier ":" type )
+                               [ "," / ";" ]
 
 ; A circuit member function declaration consists of a function declaration.
 


### PR DESCRIPTION
Also disallow 1-tuple array dimensions.

NOTES:
- The parser allow allows trailing commas everywhere, so it needs no change.
- Disallowing 1-tuple array dimensions is consistent with disallowing all the other kinds of 1-tuples, which was previously agreed. I think that the parser already disallows 1-tuple array dimensions (as of a relatively recent commit), but it would be good to double-check.
- There is a slight discrepancy regarding circuit member variables: the grammar allows commas and semicolons interchangeably, even mixing them in the same circuit declaration; while the parser accepts, in each single circuit declaration, either commas or semicolons (via two flags). Eventually we should pick one or the other, but the choice interacts with whether we want member function to be inside circuit declarations as they are now (class-like, in which case semicolons are more appropriate for member variables) or whether we want member functions to be outside (Rust-like, in which case commas are more appropriate for member variables). For the time being, we can either leave the discrepancy (since it's minor) or change the parser to be like the grammar (which should simplify the code because there would be no need for the flags).