### PR TITLE
[ABNF] Improve some rule names.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -1674,11 +1674,11 @@ Go to: _[block](#user-content-block), [function-parameters](#user-content-functi
 <a name="function-parameters"></a>
 ```abnf
 function-parameters = self-parameter [ "," ]
-                    / self-parameter "," function-inputs
-                    / function-inputs
+                    / self-parameter "," named-parameters
+                    / named-parameters
 ```
 
-Go to: _[function-inputs](#user-content-function-inputs), [self-parameter](#user-content-self-parameter)_;
+Go to: _[named-parameters](#user-content-named-parameters), [self-parameter](#user-content-self-parameter)_;
 
 
 <a name="self-parameter"></a>
@@ -1686,17 +1686,17 @@ Go to: _[function-inputs](#user-content-function-inputs), [self-parameter](#user
 self-parameter = [ %s"&" / %s"const" ] %s"self"
 ```
 
-<a name="function-inputs"></a>
+<a name="named-parameters"></a>
 ```abnf
-function-inputs = function-input *( "," function-input ) [ "," ]
+named-parameters = named-parameter *( "," named-parameter ) [ "," ]
 ```
 
-Go to: _[function-input](#user-content-function-input)_;
+Go to: _[named-parameter](#user-content-named-parameter)_;
 
 
-<a name="function-input"></a>
+<a name="named-parameter"></a>
 ```abnf
-function-input = [ %s"const" ] identifier ":" type
+named-parameter = [ %s"const" ] identifier ":" type
 ```
 
 Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -1009,14 +1009,14 @@ function-declaration = *annotation [ %s"const" ] %s"function" identifier
                        block
 
 function-parameters = self-parameter [ "," ]
-                    / self-parameter "," function-inputs
-                    / function-inputs
+                    / self-parameter "," named-parameters
+                    / named-parameters
 
 self-parameter = [ %s"&" / %s"const" ] %s"self"
 
-function-inputs = function-input *( "," function-input ) [ "," ]
+named-parameters = named-parameter *( "," named-parameter ) [ "," ]
 
-function-input = [ %s"const" ] identifier ":" type
+named-parameter = [ %s"const" ] identifier ":" type
 
 ; A circuit member constant declaration consists of
 ; the `static` and `const` keywords followed by


### PR DESCRIPTION
This does not change the language. It only renames two related rule names:

function-input => named-parameter
function-inputs => named-parameters

According to the new nomenclature, there are function parameters, which are self
parameters and named parameters: the nomenclature is clear and "symmetric".

The problem with the previous nomenclature is that both self and named
parameters are inputs, not just the named ones.
