### PR TITLE
[ABNF] Allow any expression to initialize member constants.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -1710,15 +1710,15 @@ Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;
 A circuit member constant declaration consists of
 the `static` and `const` keywords followed by
 an identifier and a type, then an initializer
-with a literal terminated by semicolon.
+with an expression (which must be constant) terminated by semicolon.
 
 <a name="member-constant-declaration"></a>
 ```abnf
 member-constant-declaration = %s"static" %s"const" identifier ":" type
-                              "=" literal ";"
+                              "=" expression ";"
 ```
 
-Go to: _[identifier](#user-content-identifier), [literal](#user-content-literal), [type](#user-content-type)_;
+Go to: _[expression](#user-content-expression), [identifier](#user-content-identifier), [type](#user-content-type)_;
 
 
 A circuit member variable declaration consists of

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -1026,10 +1026,10 @@ named-parameter = [ %s"const" ] identifier ":" type
 ; A circuit member constant declaration consists of
 ; the `static` and `const` keywords followed by
 ; an identifier and a type, then an initializer
-; with a literal terminated by semicolon.
+; with an expression (which must be constant) terminated by semicolon.
 
 member-constant-declaration = %s"static" %s"const" identifier ":" type
-                              "=" literal ";"
+                              "=" expression ";"
 
 ; A circuit member variable declaration consists of
 ; an identifier and a type, terminated by semicolon.


### PR DESCRIPTION
The grammar allows any expression at parse time. The static semantics (type
checking) will enforce that it is a constant expression. This is no different
than in global and local constant declarations.

This addresses the grammar part of Issue #1635.
