### PR TITLE
[ABNF] remove Unicode codepoints that can not occur

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -21,10 +21,9 @@ along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 Lexical Grammar
 ---------------
 
-<a name="character"></a>
-```abnf
-character = %x0-10FFFF   ; any Unicode code point
-```
+This rule states the basic elements that form Leo code:
+the Unicode code points that can be decoded from UTF-8.
+character = %x0-D7FF / %xE000-10FFFF
 
 <a name="horizontal-tab"></a>
 ```abnf
@@ -58,29 +57,30 @@ single-quote = %x27   ; '
 
 <a name="not-star"></a>
 ```abnf
-not-star = %x0-29 / %x2B-10FFFF   ; anything but *
+not-star = %x0-29 / %x2B-D7FF / %xE000-10FFFF   ; anything but *
 ```
 
 <a name="not-star-or-slash"></a>
 ```abnf
-not-star-or-slash = %x0-29 / %x2B-2E / %x30-10FFFF   ; anything but * or /
+not-star-or-slash = %x0-29 / %x2B-2E / %x30-D7FF / %xE000-10FFFF
+                    ; anything but * or /
 ```
 
 <a name="not-line-feed-or-carriage-return"></a>
 ```abnf
-not-line-feed-or-carriage-return = %x0-9 / %xB-C / %xE-10FFFF
+not-line-feed-or-carriage-return = %x0-9 / %xB-C / %xE-D7FF / %xE000-10FFFF
                                    ; anything but <LF> or <CR>
 ```
 
 <a name="not-double-quote-or-backslash"></a>
 ```abnf
-not-double-quote-or-backslash = %x0-21 / %x23-5B / %x5D-10FFFF
+not-double-quote-or-backslash = %x0-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
                                 ; anything but " or \
 ```
 
 <a name="not-single-quote-or-backslash"></a>
 ```abnf
-not-single-quote-or-backslash = %x0-26 / %x28-5B / %x5D-10FFFF
+not-single-quote-or-backslash = %x0-26 / %x28-5B / %x5D-D7FF / %xE000-10FFFF
                                 ; anything but ' or \
 ```
 
@@ -823,7 +823,7 @@ Format String Grammar
 
 <a name="not-brace"></a>
 ```abnf
-not-brace = %x0-7A / %x7C / %x7E-10FFFF ; anything but { or }
+not-brace = %x0-7A / %x7C / %x7E-D7FF / %xE000-10FFFF ; anything but { or }
 ```
 
 <a name="format-string-container"></a>

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -19,7 +19,9 @@
 ; Lexical Grammar
 ; ---------------
 
-character = %x0-10FFFF   ; any Unicode code point
+; This rule states the basic elements that form Leo code:
+; the Unicode code points that can be decoded from UTF-8.
+character = %x0-D7FF / %xE000-10FFFF
 
 horizontal-tab = %x9   ; <HT>
 
@@ -33,17 +35,18 @@ double-quote = %x22   ; "
 
 single-quote = %x27   ; '
 
-not-star = %x0-29 / %x2B-10FFFF   ; anything but *
+not-star = %x0-29 / %x2B-D7FF / %xE000-10FFFF   ; anything but *
 
-not-star-or-slash = %x0-29 / %x2B-2E / %x30-10FFFF   ; anything but * or /
+not-star-or-slash = %x0-29 / %x2B-2E / %x30-D7FF / %xE000-10FFFF
+                    ; anything but * or /
 
-not-line-feed-or-carriage-return = %x0-9 / %xB-C / %xE-10FFFF
+not-line-feed-or-carriage-return = %x0-9 / %xB-C / %xE-D7FF / %xE000-10FFFF
                                    ; anything but <LF> or <CR>
 
-not-double-quote-or-backslash = %x0-21 / %x23-5B / %x5D-10FFFF
+not-double-quote-or-backslash = %x0-21 / %x23-5B / %x5D-D7FF / %xE000-10FFFF
                                 ; anything but " or \
 
-not-single-quote-or-backslash = %x0-26 / %x28-5B / %x5D-10FFFF
+not-single-quote-or-backslash = %x0-26 / %x28-5B / %x5D-D7FF / %xE000-10FFFF
                                 ; anything but ' or \
 
 line-terminator = line-feed / carriage-return / carriage-return line-feed
@@ -326,7 +329,7 @@ file = *declaration
 ; Format String Grammar
 ; ---------------------
 
-not-brace = %x0-7A / %x7C / %x7E-10FFFF ; anything but { or }
+not-brace = %x0-7A / %x7C / %x7E-D7FF / %xE000-10FFFF ; anything but { or }
 
 format-string-container = "{}"
 


### PR DESCRIPTION
In the range of Unicode code points, `%x0-10FFFF`, some of those
(the "Surrogates", `%xD800-DFFF`)
are not accessible by decoding UTF-8.  This PR removes the
code points that are inaccessible to make the grammar more
consistent with source code.

This is also done in other ABNF grammars that handle Unicode,
for example [in TOML](https://github.com/toml-lang/toml/blob/cbf3b13128fb717517afbd22f8fcb665a0b0b035/toml.abnf#L41).

Note that this PR does not change the syntax of Leo at all.
Additionally, this does not affect the set of characters that can occur 
in strings in parsed Leo programs.  Those can be any code point,
including surrogate code points, and can be created using escapes,
for example `"a surrogate code point: \u{D800}"`.