### PR TITLE
[ABNF] Add numerals to tokens.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -401,10 +401,11 @@ symbol = "!" / "&&" / "||"
 token = keyword
       / identifier
       / atomic-literal
+      / numeral
       / symbol
 ```
 
-Go to: _[atomic-literal](#user-content-atomic-literal), [identifier](#user-content-identifier), [keyword](#user-content-keyword), [symbol](#user-content-symbol)_;
+Go to: _[atomic-literal](#user-content-atomic-literal), [identifier](#user-content-identifier), [keyword](#user-content-keyword), [numeral](#user-content-numeral), [symbol](#user-content-symbol)_;
 
 
 <a name="lexeme"></a>

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -181,6 +181,7 @@ symbol = "!" / "&&" / "||"
 token = keyword
       / identifier
       / atomic-literal
+      / numeral
       / symbol
 
 lexeme = token / comment / whitespace


### PR DESCRIPTION
In the currently restricted version of Leo, this is necessary for the numerals
in affine group literals to be tokens.

No change necessary to the lexer/parser, which already handle this properly.
