### PR TITLE
[ABNF] Add rule for binary expressions.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -148,6 +148,7 @@ keyword = %s"address"
         / %s"char"
         / %s"console"
         / %s"const"
+        / %s"constant"
         / %s"else"
         / %s"field"
         / %s"for"
@@ -637,13 +638,21 @@ disjunctive-expression = conjunctive-expression
 Go to: _[conjunctive-expression](#user-content-conjunctive-expression), [disjunctive-expression](#user-content-disjunctive-expression)_;
 
 
-<a name="conditional-expression"></a>
+<a name="binary-expression"></a>
 ```abnf
-conditional-expression = disjunctive-expression
-                       / disjunctive-expression "?" expression ":" expression
+binary-expression = disjunctive-expression
 ```
 
-Go to: _[disjunctive-expression](#user-content-disjunctive-expression), [expression](#user-content-expression)_;
+Go to: _[disjunctive-expression](#user-content-disjunctive-expression)_;
+
+
+<a name="conditional-expression"></a>
+```abnf
+conditional-expression = binary-expression
+                       / binary-expression "?" expression ":" expression
+```
+
+Go to: _[binary-expression](#user-content-binary-expression), [expression](#user-content-expression)_;
 
 
 <a name="expression"></a>
@@ -805,7 +814,7 @@ Go to: _[function-parameter](#user-content-function-parameter)_;
 
 <a name="function-parameter"></a>
 ```abnf
-function-parameter = [ %s"public" / %s"const" ] identifier ":" type
+function-parameter = [ %s"public" / %s"constant" / %s"const" ] identifier ":" type
 ```
 
 Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -265,8 +265,10 @@ conjunctive-expression = equality-expression
 disjunctive-expression = conjunctive-expression
                        / disjunctive-expression "||" conjunctive-expression
 
-conditional-expression = disjunctive-expression
-                       / disjunctive-expression "?" expression ":" expression
+binary-expression = disjunctive-expression
+
+conditional-expression = binary-expression
+                       / binary-expression "?" expression ":" expression
 
 expression = conditional-expression
 


### PR DESCRIPTION
This does not change the language. It just adds a rule to name binary
expressions explicitly. This makes the relation with ternary expressions
clearer, and as usual it explicates more terminology.

Just see `abnf-grammar.txt` diff. The `README.md` diff appears to include also a previous update.