### PR TITLE
[ABNF] Add (first draft of) input grammar.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -148,6 +148,7 @@ keyword = %s"address"
         / %s"char"
         / %s"console"
         / %s"const"
+        / %s"constant"
         / %s"else"
         / %s"field"
         / %s"for"
@@ -399,6 +400,7 @@ symbol = "!" / "&&" / "||"
        / "+" / "-" / "*" / "/" / "**"
        / "="
        / "(" / ")"
+       / "[" / "]"
        / "{" / "}"
        / "," / "." / ".." / ";" / ":" / "?"
        / "->" / "_"
@@ -805,7 +807,7 @@ Go to: _[function-parameter](#user-content-function-parameter)_;
 
 <a name="function-parameter"></a>
 ```abnf
-function-parameter = [ %s"public" / %s"const" ] identifier ":" type
+function-parameter = [ %s"public" / %s"constant" / %s"const" ] identifier ":" type
 ```
 
 Go to: _[identifier](#user-content-identifier), [type](#user-content-type)_;
@@ -866,4 +868,56 @@ Go to: _[format-string-close-brace](#user-content-format-string-close-brace), [f
 <a name="format-string"></a>
 ```abnf
 format-string = *format-string-element
+```
+
+
+--------
+
+
+Input Grammar
+-------------
+
+<a name="input-type"></a>
+```abnf
+input-type = type
+```
+
+Go to: _[type](#user-content-type)_;
+
+
+<a name="input-expression"></a>
+```abnf
+input-expression = literal
+```
+
+Go to: _[literal](#user-content-literal)_;
+
+
+<a name="input-item"></a>
+```abnf
+input-item = identifier ":" input-type "=" input-expression ";"
+```
+
+Go to: _[identifier](#user-content-identifier), [input-expression](#user-content-input-expression), [input-type](#user-content-input-type)_;
+
+
+<a name="input-title"></a>
+```abnf
+input-title = "[" identifier "]"
+```
+
+Go to: _[identifier](#user-content-identifier)_;
+
+
+<a name="input-section"></a>
+```abnf
+input-section = input-title *input-item
+```
+
+Go to: _[input-title](#user-content-input-title)_;
+
+
+<a name="input-file"></a>
+```abnf
+input-file = *input-section
 

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -177,6 +177,7 @@ symbol = "!" / "&&" / "||"
        / "+" / "-" / "*" / "/" / "**"
        / "="
        / "(" / ")"
+       / "[" / "]"
        / "{" / "}"
        / "," / "." / ".." / ";" / ":" / "?"
        / "->" / "_"
@@ -346,3 +347,20 @@ format-string-element = not-brace
                       / format-string-close-brace
 
 format-string = *format-string-element
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+; Input Grammar
+; -------------
+
+input-type = type
+
+input-expression = literal
+
+input-item = identifier ":" input-type "=" input-expression ";"
+
+input-title = "[" identifier "]"
+
+input-section = input-title *input-item
+
+input-file = *input-section


### PR DESCRIPTION
This is the (sub)grammar for input files. It is an initial draft, written based
on the Notion page 'Leo Input File Doc/Spec'. This should be compared with the
currently implemented parser of input (i.e. .in) files.

As the Leo Reference will describe (that part has not been written yet), the
input grammar is based on the lexical grammar, i.e. an input file consists of
tokens, comments, and whitespace. However, only some tokens (compared to the
syntactic grammar for Leo code files) are used, namely the ones reachable from
the `input-file` nonterminal.

Currently (i.e. im this initial version of Leo) `input-type` is (any) `type` and
`input-expression` is just a `literal`, but these may evolve as we extend the
language (e.g. we'll probably disallow circuit types and allow tuple and array
constructions). The intent is that `input-type` will be a subset of `type` and
that `input-expression` will be a subset of `expression`.

(Just look at the `.txt` file, as the `.md` file seems to include some previous updates.)

Note that reading input files is needed for having a complete vertical slice for this initial version of Leo.