### PR TITLE
[ABNF] Add rule for numeric literals.

### DIFF
--- a/docs/grammar/README.md
+++ b/docs/grammar/README.md
@@ -378,18 +378,26 @@ integer-literal = unsigned-literal
 Go to: _[signed-literal](#user-content-signed-literal), [unsigned-literal](#user-content-unsigned-literal)_;
 
 
+<a name="numeric-literal"></a>
+```abnf
+numeric-literal = integer-literal
+                / field-literal
+                / product-group-literal
+```
+
+Go to: _[field-literal](#user-content-field-literal), [integer-literal](#user-content-integer-literal), [product-group-literal](#user-content-product-group-literal)_;
+
+
 <a name="atomic-literal"></a>
 ```abnf
-atomic-literal = integer-literal
-               / field-literal
-               / product-group-literal
+atomic-literal = numeric-literal
                / boolean-literal
                / address-literal
                / character-literal
                / string-literal
 ```
 
-Go to: _[address-literal](#user-content-address-literal), [boolean-literal](#user-content-boolean-literal), [character-literal](#user-content-character-literal), [field-literal](#user-content-field-literal), [integer-literal](#user-content-integer-literal), [product-group-literal](#user-content-product-group-literal), [string-literal](#user-content-string-literal)_;
+Go to: _[address-literal](#user-content-address-literal), [boolean-literal](#user-content-boolean-literal), [character-literal](#user-content-character-literal), [numeric-literal](#user-content-numeric-literal), [string-literal](#user-content-string-literal)_;
 
 
 <a name="symbol"></a>

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -163,9 +163,11 @@ string-literal-element = not-double-quote-or-backslash
 integer-literal = unsigned-literal
                 / signed-literal
 
-atomic-literal = integer-literal
-               / field-literal
-               / product-group-literal
+numeric-literal = integer-literal
+                / field-literal
+                / product-group-literal
+
+atomic-literal = numeric-literal
                / boolean-literal
                / address-literal
                / character-literal


### PR DESCRIPTION
This does not change the language. It just factors things better and introduces
more nomenclature in the grammar.

As mentioned at today's sync, this is also motivated by improving the exposition in the Leo Reference book.