### PR TITLE
Custom panic hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1262,6 +1262,7 @@ version = "1.5.3"
 dependencies = [
  "ansi_term",
  "assert_cmd",
+ "backtrace",
  "clap 3.1.9",
  "color-backtrace",
  "colored",
@@ -1282,6 +1283,7 @@ dependencies = [
  "serde_json",
  "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=51633e2)",
  "structopt",
+ "sys-info",
  "test_dir",
  "toml",
  "tracing",
@@ -2587,6 +2589,16 @@ dependencies = [
  "proc-macro2 1.0.37",
  "quote 1.0.18",
  "unicode-xid 0.2.2",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,12 @@ version = "0.5.1"
 [dependencies.colored]
 version = "2.0"
 
+[dependencies.backtrace]
+version = "0.3.65"
+
+[dependencies.sys-info]
+version = "0.9.1"
+
 [dependencies.dirs]
 version = "4.0.0"
 


### PR DESCRIPTION
closes #1205 

This is a small PR that adds a custom panic hook to the leo compiler. This allows us to control the output in the event that a user encounters a critical bug while using leo. This is pretty standard practice in most compilers.

The function `set_panic_hook` now gets called at the beginning of `main` before anything in the compiler is run. If the binary was built in debug mode then this call does nothing and panics still operate exactly like normal, but if it was built in release mode then it registers a custom panic hook with some info about the environment and a link to [our bug template](https://github.com/AleoHQ/leo/issues/new?labels=bug,panic&template=bug.md&title=[Bug]) on github. I tried to model the panic message after the [rust internal panic message](https://github.com/AleoHQ/leo/issues/1205#issuecomment-1061299410), but feel free to change it however you see fit (or we can just wait to merge and discuss it in a meeting).

debug build (no panic hook registered, so the same as normal):
```
E:\Work\Aleo\leo_repos\leo>cargo run -- build
   Compiling leo-lang v1.5.3 (E:\Work\Aleo\leo_repos\leo)
    Finished dev [unoptimized + debuginfo] target(s) in 1.23s
     Running `target\debug\leo.exe build`
thread 'main' panicked at 'explicit panic', leo/main.rs:209:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
error: process didn't exit successfully: `target\debug\leo.exe build` (exit code: 101)
```

release build (custom panic hook registered):
```
E:\Work\Aleo\leo_repos\leo>cargo run --release -- build
    Finished release [optimized] target(s) in 0.35s
     Running `target\release\leo.exe build`
thread `main` panicked at 'explicit panic', leo/main.rs:209:5
stack backtrace: 
   0: backtrace::backtrace::trace
   1: backtrace::capture::Backtrace::new
   2: core::ptr::drop_in_place<<leo::Opt as structopt::StructOptInternal>::augment_clap::{{closure}}>
   3: std::panicking::rust_panic_with_hook
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:702
   4: std::panicking::begin_panic_handler::closure$0
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:586
   5: std::sys_common::backtrace::__rust_end_short_backtrace<std::panicking::begin_panic_handler::closure_env$0,never$>
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\sys_common\backtrace.rs:138
   6: std::panicking::begin_panic_handler
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:584
   7: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\core\src\panicking.rs:143
   8: core::panicking::panic
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\core\src\panicking.rs:48
   9: core::ptr::drop_in_place<<leo::Opt as structopt::StructOptInternal>::augment_clap::{{closure}}>
  10: std::sys_common::backtrace::__rust_begin_short_backtrace
  11: std::rt::lang_start::{{closure}}
  12: core::ops::function::impls::impl$2::call_once
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\library\core\src\ops\function.rs:259
  13: std::panicking::try::do_call
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:492
  14: std::panicking::try
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:456
  15: std::panic::catch_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panic.rs:137
  16: std::rt::lang_start_internal::closure$2
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\rt.rs:128
  17: std::panicking::try::do_call
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:492
  18: std::panicking::try
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panicking.rs:456
  19: std::panic::catch_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\panic.rs:137
  20: std::rt::lang_start_internal
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c\/library\std\src\rt.rs:128
  21: main
  22: invoke_main
             at D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:78
  23: __scrt_common_main_seh
             at D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288
  24: BaseThreadInitThunk
  25: RtlUserThreadStart

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/AleoHQ/leo/issues/new?labels=bug,panic&template=bug.md&title=[Bug]

note: leo-lang 1.5.3 running on Windows 6.2.9200

note: compiler args: target\release\leo.exe build

note: compiler flags: Opt { debug: false, quiet: false, command: Build { command: Build { compiler_options: BuildOptions { disable_constant_folding: false, disable_code_elimination: false, disable_all_optimizations: false, enable_spans: false, enable_all_ast_snapshots: false, enable_initial_ast_snapshot: false, enable_imports_resolved_ast_snapshot: false, enable_canonicalized_ast_snapshot: false, enable_type_inferenced_ast_snapshot: false } } }, api: None, path: None }

error: process didn't exit successfully: `target\release\leo.exe build` (exit code: 101)
```
