### PR TITLE
[tests] Consistently use block comments.

### DIFF
--- a/tests/compiler/integers/i16/pow.leo
+++ b/tests/compiler/integers/i16/pow.leo
@@ -1,14 +1,16 @@
-// namespace: Compile
-// expectation: Pass
-// inputs:
-//  - i16.in: |
-//     [main]
-//     a: i16 = 2;
-//     b: i16 = 2;
-//     c: i16 = 4;
-    
-//     [registers]
-//     r0: bool = true;
+/*
+namespace: Compile
+expectation: Pass
+inputs:
+ - i16.in: |
+    [main]
+    a: i16 = 2;
+    b: i16 = 2;
+    c: i16 = 4;
+
+    [registers]
+    r0: bool = true;
+*/
 
 function main(a: i16, b: i16, c: i16) -> bool {
     return a ** b == c;

--- a/tests/compiler/integers/i8/pow.leo
+++ b/tests/compiler/integers/i8/pow.leo
@@ -1,14 +1,16 @@
-// namespace: Compile
-// expectation: Pass
-// inputs:
-//  - i8.in: |
-//     [main]
-//     a: i8 = 2;
-//     b: i8 = 2;
-//     c: i8 = 4;
-    
-//     [registers]
-//     r0: bool = true;
+/*
+namespace: Compile
+expectation: Pass
+inputs:
+ - i8.in: |
+    [main]
+    a: i8 = 2;
+    b: i8 = 2;
+    c: i8 = 4;
+
+    [registers]
+    r0: bool = true;
+*/
 
 function main(a: i8, b: i8, c: i8) -> bool {
     return a ** b == c;

--- a/tests/compiler/integers/u16/pow.leo
+++ b/tests/compiler/integers/u16/pow.leo
@@ -1,14 +1,16 @@
-// namespace: Compile
-// expectation: Pass
-// inputs:
-//  - u16_f.in: |
-//     [main]
-//     a: u16 = 2;
-//     b: u16 = 2;
-//     c: u16 = 4;
+/*
+namespace: Compile
+expectation: Pass
+inputs:
+ - u16_f.in: |
+    [main]
+    a: u16 = 2;
+    b: u16 = 2;
+    c: u16 = 4;
 
-//     [registers]
-//     r0: bool = true;
+    [registers]
+    r0: bool = true;
+*/
 
 function main(a: u16, b: u16, c: u16) -> bool {
     return a ** b == c;

--- a/tests/compiler/integers/u8/pow.leo
+++ b/tests/compiler/integers/u8/pow.leo
@@ -1,14 +1,16 @@
-// namespace: Compile
-// expectation: Pass
-// inputs:
-//  - u8_f.in: |
-//     [main]
-//     a: u8 = 2;
-//     b: u8 = 2;
-//     c: u8 = 4;
+/*
+namespace: Compile
+expectation: Pass
+inputs:
+ - u8_f.in: |
+    [main]
+    a: u8 = 2;
+    b: u8 = 2;
+    c: u8 = 4;
 
-//     [registers]
-//     r0: bool = true;
+    [registers]
+    r0: bool = true;
+*/
 
 function main(a: u8, b: u8, c: u8) -> bool {
     return a ** b == c;


### PR DESCRIPTION
(Note: I successfully ran `cargo test --all` on this PR, which I believe is all that's required right now.)

There were four test files, found by @bendyarm, that use end-of-line comments
instead of block comments as prescribed by the README.md.

This commit changes them to block comments, for consistency with the README.md,
and uniformity across the files.

There is clearly nothing wrong with supporting block comments (which apparently
the Rust implementation of the Leo test framework already does). However, just
supporting block comments slightly simplifies the processing of the Leo test
files on the ACL2 side, as we are building that processing right now.

We could support end-of-line comments on the ACL2 side as well if desired. But
it seems unnecessary and unimportant at least for now. This is a quick PR, so
it's okay if it gets rejected and instead we want to support end-of-line
comments right away.
