### PR TITLE
Print panic hook in stderr

### DIFF
--- a/leo/main.rs
+++ b/leo/main.rs
@@ -180,27 +180,27 @@ fn set_panic_hook() {
     #[cfg(not(debug_assertions))]
     std::panic::set_hook({
         Box::new(move |e| {
-            println!(
+            eprintln!(
                 "thread `{}` {}",
                 std::thread::current().name().unwrap_or("<unnamed>"),
                 e
             );
-            println!("stack backtrace: \n{:?}", backtrace::Backtrace::new());
-            println!("error: internal compiler error: unexpected panic\n");
-            println!("note: the compiler unexpectedly panicked. this is a bug.\n");
-            println!("note: we would appreciate a bug report: https://github.com/AleoHQ/leo/issues/new?labels=bug,panic&template=bug.md&title=[Bug]\n");
-            println!(
+            eprintln!("stack backtrace: \n{:?}", backtrace::Backtrace::new());
+            eprintln!("error: internal compiler error: unexpected panic\n");
+            eprintln!("note: the compiler unexpectedly panicked. this is a bug.\n");
+            eprintln!("note: we would appreciate a bug report: https://github.com/AleoHQ/leo/issues/new?labels=bug,panic&template=bug.md&title=[Bug]\n");
+            eprintln!(
                 "note: {} {} running on {} {}\n",
                 env!("CARGO_PKG_NAME"),
                 env!("CARGO_PKG_VERSION"),
                 sys_info::os_type().unwrap_or_else(|e| e.to_string()),
                 sys_info::os_release().unwrap_or_else(|e| e.to_string()),
             );
-            println!(
+            eprintln!(
                 "note: compiler args: {}\n",
                 std::env::args().collect::<Vec<_>>().join(" ")
             );
-            println!("note: compiler flags: {:?}\n", Opt::from_args());
+            eprintln!("note: compiler flags: {:?}\n", Opt::from_args());
         })
     });
 }


### PR DESCRIPTION
while working on #1811 i realized that our panic hook prints to `stdout` instead of `stderr`. this is a super trivial change to fix that. just changes the hook's `println!` to `eprintln!`