### PR TITLE
[tests] make integer pow tests consistent

### DIFF
--- a/tests/compiler/integers/i128/inputs/pow.in
+++ b/tests/compiler/integers/i128/inputs/pow.in
@@ -1,0 +1,7 @@
+[main]
+a: i128 = 2i128;
+b: i128 = 2i128;
+c: i128 = 4i128;
+
+[registers]
+r0: bool = true;

--- a/tests/compiler/integers/i128/pow_fail.leo
+++ b/tests/compiler/integers/i128/pow_fail.leo
@@ -1,3 +1,9 @@
+/*
+namespace: Compile
+expectation: Fail
+input_file: inputs/pow.in
+*/
+
 function main(a: i128, b: i128, c: i128) -> bool {
     return a ** b == c;
 }

--- a/tests/compiler/integers/i32/inputs/pow.in
+++ b/tests/compiler/integers/i32/inputs/pow.in
@@ -1,0 +1,7 @@
+[main]
+a: i32 = 2i32;
+b: i32 = 2i32;
+c: i32 = 4i32;
+
+[registers]
+r0: bool = true;

--- a/tests/compiler/integers/i32/pow_fail.leo
+++ b/tests/compiler/integers/i32/pow_fail.leo
@@ -1,3 +1,9 @@
+/*
+namespace: Compile
+expectation: Fail
+input_file: inputs/pow.in
+*/
+
 function main(a: i32, b: i32, c: i32) -> bool {
     return a ** b == c;
 }

--- a/tests/compiler/integers/i64/inputs/pow.in
+++ b/tests/compiler/integers/i64/inputs/pow.in
@@ -1,0 +1,7 @@
+[main]
+a: i64 = 2i64;
+b: i64 = 2i64;
+c: i64 = 4i64;
+
+[registers]
+r0: bool = true;

--- a/tests/compiler/integers/i64/pow.leo
+++ b/tests/compiler/integers/i64/pow.leo
@@ -1,3 +1,0 @@
-function main(a: i64, b: i64) -> bool {
-    return a ** 4 == b;
-}

--- a/tests/compiler/integers/i64/pow_fail.leo
+++ b/tests/compiler/integers/i64/pow_fail.leo
@@ -1,0 +1,9 @@
+/*
+namespace: Compile
+expectation: Fail
+input_file: inputs/pow.in
+*/
+
+function main(a: i64, b: i64, c: i64) -> bool {
+    return a ** b == c;
+}

--- a/tests/compiler/integers/u128/inputs/pow.in
+++ b/tests/compiler/integers/u128/inputs/pow.in
@@ -1,0 +1,7 @@
+[main]
+a: u128 = 2u128;
+b: u128 = 2u128;
+c: u128 = 4u128;
+
+[registers]
+r0: bool = true;

--- a/tests/compiler/integers/u128/pow.leo
+++ b/tests/compiler/integers/u128/pow.leo
@@ -1,3 +1,12 @@
+/*
+namespace: Compile
+expectation: Pass
+input_file: inputs/pow.in
+
+# This test might take to long to fully compile.
+# If necessary we could move it to disabled_tests.
+*/
+
 function main(a: u128, b: u128, c: u128) -> bool {
     return a ** b == c;
 }

--- a/tests/compiler/integers/u32/inputs/pow.in
+++ b/tests/compiler/integers/u32/inputs/pow.in
@@ -1,0 +1,7 @@
+[main]
+a: u32 = 2u32;
+b: u32 = 2u32;
+c: u32 = 4u32;
+
+[registers]
+r0: bool = true;

--- a/tests/compiler/integers/u32/pow.leo
+++ b/tests/compiler/integers/u32/pow.leo
@@ -1,3 +1,12 @@
+/*
+namespace: Compile
+expectation: Pass
+input_file: inputs/pow.in
+
+# This test might take to long to fully compile.
+# If necessary we could move it to disabled_tests.
+*/
+
 function main(a: u32, b: u32, c: u32) -> bool {
     return a ** b == c;
 }

--- a/tests/compiler/integers/u64/inputs/pow.in
+++ b/tests/compiler/integers/u64/inputs/pow.in
@@ -1,0 +1,7 @@
+[main]
+a: u64 = 2u64;
+b: u64 = 2u64;
+c: u64 = 4u64;
+
+[registers]
+r0: bool = true;

--- a/tests/compiler/integers/u64/pow.leo
+++ b/tests/compiler/integers/u64/pow.leo
@@ -1,3 +1,12 @@
+/*
+namespace: Compile
+expectation: Pass
+input_file: inputs/pow.in
+
+# This test might take to long to fully compile.
+# If necessary we could move it to disabled_tests.
+*/
+
 function main(a: u64, b: u64, c: u64) -> bool {
     return a ** b == c;
 }

--- a/tests/expectations/compiler/compiler/integers/i128/pow_fail.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i128/pow_fail.leo.out
@@ -1,0 +1,5 @@
+---
+namespace: Compile
+expectation: Fail
+outputs:
+  - "Error [ETYC0372009]: The second operand must be a unsigned int but got type `i128`\n    --> compiler-test:4:17\n     |\n   4 |     return a ** b == c;\n     |                 ^\nError [ETYC0372009]: The second operand must be a unsigned int but got type `i128`\n    --> compiler-test:4:17\n     |\n   4 |     return a ** b == c;\n     |                 ^"

--- a/tests/expectations/compiler/compiler/integers/i32/pow_fail.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i32/pow_fail.leo.out
@@ -1,0 +1,5 @@
+---
+namespace: Compile
+expectation: Fail
+outputs:
+  - "Error [ETYC0372009]: The second operand must be a unsigned int but got type `i32`\n    --> compiler-test:4:17\n     |\n   4 |     return a ** b == c;\n     |                 ^\nError [ETYC0372009]: The second operand must be a unsigned int but got type `i32`\n    --> compiler-test:4:17\n     |\n   4 |     return a ** b == c;\n     |                 ^"

--- a/tests/expectations/compiler/compiler/integers/i64/pow_fail.leo.out
+++ b/tests/expectations/compiler/compiler/integers/i64/pow_fail.leo.out
@@ -1,0 +1,5 @@
+---
+namespace: Compile
+expectation: Fail
+outputs:
+  - "Error [ETYC0372009]: The second operand must be a unsigned int but got type `i64`\n    --> compiler-test:4:17\n     |\n   4 |     return a ** b == c;\n     |                 ^\nError [ETYC0372009]: The second operand must be a unsigned int but got type `i64`\n    --> compiler-test:4:17\n     |\n   4 |     return a ** b == c;\n     |                 ^"

--- a/tests/expectations/compiler/compiler/integers/u128/pow.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u128/pow.leo.out
@@ -1,0 +1,8 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - output:
+      - initial_input_ast: f7022770406b07fcb59e741b04516838beabbaf118f1cf2c72501cf477a695ef
+    initial_ast: 5c54a5764d818cb3c119b4a11838429264a322b6b5e0f3704023d0c3b574fca1
+    symbol_table: 1a86ec5eeebf868096a4c47fad1543b602498f25d83a5644d9df7f25080b7ba5

--- a/tests/expectations/compiler/compiler/integers/u32/pow.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u32/pow.leo.out
@@ -1,0 +1,8 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - output:
+      - initial_input_ast: f9febc6a7e8f4c36c6878e06f30eb30808f02ab434ea7dc520407bb15eb8c37b
+    initial_ast: f219aee9d632f2fa97353572c3d6837d7b73bdce07e7b4607e66cee074e52694
+    symbol_table: 677671ae8d98952b07ca76432359d4fd3ae39d6d68493aa94856ef1525cbe18f

--- a/tests/expectations/compiler/compiler/integers/u64/pow.leo.out
+++ b/tests/expectations/compiler/compiler/integers/u64/pow.leo.out
@@ -1,0 +1,8 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - output:
+      - initial_input_ast: dc741dca85c7ced073969a884df08515f767765ad7dcc43f285b77a87cb97de7
+    initial_ast: 1f704360566c3d8bfc9b0ac406fa21fdb19e03c5cf35371b7cfa40568d23dc65
+    symbol_table: 451fdce6bd78e62017970c8309ad463b1aa18b153657f53fb57efdd6cd06f14e


### PR DESCRIPTION
## Motivation

Some of the larger integer `pow` compiler tests had no block comment header.  This PR adds those, and renames some files to be consistent, and adds some expectations files.

Although the test files are always supposed to have the header (according to `tests/README.md`), if the header is taken out, the test is just not run.  

It is possible that the `u32`, `u64`, and `u128` `pow.leo` files had their headers omitted for performance reasons.  For `testnet3` we are only compiling up to type checking now, and when we compile to the next IR the performance might not be as bad.  When I added the headers, I also added a comment about the possibility of future performance problems.

For the signed integer `pow` test cases, since all (except `i64`) were doing `a ** b` for `a` and `b` the same type, and since signed int exponents are not allowed, they should all be `expectation: Fail` tests.  That was already correct for `i8` and `i16`.  I made the others consistent with that.  Type checking should catch these cases so there should be no performance issue.

It would be good if some other mixed-type `pow` tests could be added in the future, with the variables being constant/var/expr,  base-type, and exponent-type, with the appropriate expectation: Pass/Fail in the header.

