### PR TITLE
[tests] move comment from body to yaml header

### DIFF
--- a/tests/expectations/parser/parser/unreachable/postfix_pass.leo.out
+++ b/tests/expectations/parser/parser/unreachable/postfix_pass.leo.out
@@ -2,17 +2,6 @@
 namespace: ParseStatement
 expectation: Pass
 outputs:
-  - Expression:
-      expression:
-        Value:
-          String:
-            - []
-            - span:
-                lo: 0
-                hi: 0
-      span:
-        lo: 0
-        hi: 0
   - Definition:
       declaration_type: Let
       variable_names:

--- a/tests/parser/unreachable/postfix_pass.leo
+++ b/tests/parser/unreachable/postfix_pass.leo
@@ -1,8 +1,9 @@
 /*
 namespace: ParseStatement
 expectation: Pass
+
+# These ones do not hit the unreachable as they are treated as valid idents rather than postfix.
 */
-// These ones do not hit the unreachable as they are treated as valid idents rather than postfix.
 
 let x: u8 = aimport;
 


### PR DESCRIPTION

## Motivation

Since this test file is `namespace: ParseStatement`, it is easier to reuse if it just has statements in it, and not comments.  Moved the comment line into the YAML header and updated the expectation file.


