### PR TITLE
[tests] Change category of the `0x` tests

### DIFF
--- a/tests/parser/expression/literal/int_fail.leo
+++ b/tests/parser/expression/literal/int_fail.leo
@@ -1,5 +1,5 @@
 /*
-namespace: Token
+namespace: ParseExpression
 expectation: Fail
 */
 


### PR DESCRIPTION
This change, suggested by @bendyarm, is perhaps a simpler solution to #1829.

By changing the category of these tests to 'expression', we get a failure both in the Rust parser of Leo (with or without the special handling of `0x`), and in the ACL2 parser of Leo.

Closes #1829.