### PR TITLE
[ABNF] Relax input and output expressions.

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -357,7 +357,7 @@ format-string = *format-string-element
 
 input-type = type
 
-input-expression = literal
+input-expression = expression
 
 input-item = identifier ":" input-type "=" input-expression ";"
 
@@ -372,7 +372,7 @@ input-file = *input-section
 ; Output Grammar
 ; --------------
 
-output-expression = literal
+output-expression = expression
 
 output-item = output-expression ";"
 


### PR DESCRIPTION
In input and output files, literals are actually insufficient to represent the
most negative values of the signed integer types.

Given that we are likely to need richer forms of input and output expressions
anyways, at this point it seems best to allow any expression at the grammatical
level, and add static semantic requirements on the allowed expressions. As done
with all the other requirements, these will be stated in the Leo Reference,
formalized in ACL2, and enforced in the Leo compiler.
