### PR TITLE
replaced structopt with clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,13 +380,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -397,11 +393,26 @@ checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "indexmap",
- "strsim 0.10.0",
+ "lazy_static",
+ "strsim",
  "termcolor",
  "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -958,12 +969,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1285,7 +1293,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkvm-utilities 0.7.5 (git+https://github.com/AleoHQ/snarkVM.git?rev=51633e2)",
- "structopt",
  "sys-info",
  "test_dir",
  "toml",
@@ -1312,6 +1319,7 @@ dependencies = [
 name = "leo-parser"
 version = "1.5.3"
 dependencies = [
+ "clap 3.1.18",
  "criterion",
  "indexmap",
  "lazy_static",
@@ -1324,7 +1332,6 @@ dependencies = [
  "serde_yaml",
  "smallvec",
  "snarkvm-dpc",
- "structopt",
  "tracing",
 ]
 
@@ -1354,12 +1361,12 @@ dependencies = [
 name = "leo-test-framework"
 version = "1.5.3"
 dependencies = [
+ "clap 3.1.18",
  "leo-errors",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
- "structopt",
 ]
 
 [[package]]
@@ -2517,39 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2 1.0.37",
- "quote 1.0.18",
- "syn 1.0.91",
-]
 
 [[package]]
 name = "subtle"
@@ -2874,12 +2851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,12 +2891,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,8 @@ rev = "51633e2"
 version = "0.3.65"
 
 [dependencies.clap]
-version = "3.1"
+version = "3.1.18"
+features = ["derive", "env"]
 
 [dependencies.color-backtrace]
 version = "0.5.1"
@@ -102,9 +103,6 @@ features = [ "derive" ]
 
 [dependencies.serde_json]
 version = "1.0"
-
-[dependencies.structopt]
-version = "0.3"
 
 [dependencies.sys-info]
 version = "0.9.1"

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -69,8 +69,9 @@ features = [ "preserve_order" ]
 [dev-dependencies.serde_yaml]
 version = "0.8"
 
-[dev-dependencies.structopt]
-version = "0.3"
+[dependencies.clap]
+version = "3.1.18"
+features = ["derive"]
 
 [features]
 default = [ ]

--- a/compiler/parser/examples/input_parser.rs
+++ b/compiler/parser/examples/input_parser.rs
@@ -17,11 +17,11 @@
 use leo_errors::{emitter::Handler, Result};
 use leo_span::symbol::create_session_if_not_set_then;
 
+use clap::StructOpt;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(
@@ -43,7 +43,7 @@ struct Opt {
 }
 
 fn main() -> Result<(), String> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     let input_tree = create_session_if_not_set_then(|s| {
         let input_string = s
             .source_map

--- a/compiler/parser/examples/parser.rs
+++ b/compiler/parser/examples/parser.rs
@@ -18,11 +18,11 @@ use leo_ast::Ast;
 use leo_errors::emitter::Handler;
 use leo_span::symbol::create_session_if_not_set_then;
 
+use clap::StructOpt;
 use std::{
     fs,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 #[structopt(name = "leo parser", about = "Parse Leo AST and store it as a JSON")]
@@ -41,7 +41,7 @@ struct Opt {
 }
 
 fn main() -> Result<(), String> {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
     // Parses the Leo file constructing an ast which is then serialized.
     let serialized_leo_tree = create_session_if_not_set_then(|s| {
         let code = s.source_map.load_file(&opt.input_path).expect("failed to open file");

--- a/leo/commands/build.rs
+++ b/leo/commands/build.rs
@@ -25,7 +25,7 @@ use leo_package::{
     source::{MainFile, MAIN_FILENAME, SOURCE_DIRECTORY_NAME},
 };
 
-use structopt::StructOpt;
+use clap::StructOpt;
 use tracing::span::Span;
 
 /// Compiler Options wrapper for Build command. Also used by other commands which
@@ -92,7 +92,6 @@ pub struct BuildOptions {
 
 /// Compile and build program command.
 #[derive(StructOpt, Debug)]
-#[structopt(setting = structopt::clap::AppSettings::ColoredHelp)]
 pub struct Build {
     #[allow(dead_code)]
     #[structopt(flatten)]

--- a/leo/main.rs
+++ b/leo/main.rs
@@ -32,12 +32,12 @@ use leo_errors::Result;
 use leo_span::symbol::create_session_if_not_set_then;
 // use snarkvm_utilities::Write;
 
+use clap::StructOpt;
 use std::{path::PathBuf, process::exit};
-use structopt::{clap::AppSettings, StructOpt};
 
 /// CLI Arguments entry point - includes global parameters and subcommands
 #[derive(StructOpt, Debug)]
-#[structopt(name = "leo", author = "The Aleo Team <hello@aleo.org>", setting = AppSettings::ColoredHelp)]
+#[structopt(name = "leo", author = "The Aleo Team <hello@aleo.org>")]
 struct Opt {
     #[structopt(short, global = true, help = "Print additional information for debugging")]
     debug: bool,
@@ -62,7 +62,6 @@ struct Opt {
 
 ///Leo compiler and package manager
 #[derive(StructOpt, Debug)]
-#[structopt(setting = AppSettings::ColoredHelp)]
 enum CommandOpts {
     // #[structopt(about = "Create a new Leo package in an existing directory")]
     // Init {
@@ -200,14 +199,14 @@ fn set_panic_hook() {
                 "note: compiler args: {}\n",
                 std::env::args().collect::<Vec<_>>().join(" ")
             );
-            eprintln!("note: compiler flags: {:?}\n", Opt::from_args());
+            eprintln!("note: compiler flags: {:?}\n", Opt::parse());
         })
     });
 }
 
 fn main() {
     set_panic_hook();
-    create_session_if_not_set_then(|_| handle_error(run_with_args(Opt::from_args())));
+    create_session_if_not_set_then(|_| handle_error(run_with_args(Opt::parse())));
 }
 
 /// Run command with custom build arguments.

--- a/tests/test-framework/Cargo.toml
+++ b/tests/test-framework/Cargo.toml
@@ -54,8 +54,12 @@ version = "0.8"
 # path = "../compiler"
 # version = "1.5.2"
 
-[dependencies.structopt]
-version = "0.3"
+# [dependencies.structopt]
+# version = "0.3"
+
+[dependencies.clap]
+version = "3.1.18"
+features = ["derive"]
 
 # List of dependencies for errcov
 

--- a/tests/test-framework/src/bin/errcov.rs
+++ b/tests/test-framework/src/bin/errcov.rs
@@ -21,14 +21,14 @@ use leo_test_framework::{
     test::{extract_test_config, TestExpectationMode as Expectation},
 };
 
+use clap::StructOpt;
 use regex::Regex;
 use serde_yaml::Value;
 use std::collections::{BTreeMap, HashSet};
 use std::{error::Error, fs, io, path::PathBuf};
-use structopt::{clap::AppSettings, StructOpt};
 
 #[derive(StructOpt)]
-#[structopt(name = "error-coverage", author = "The Aleo Team <hello@aleo.org>", setting = AppSettings::ColoredHelp)]
+#[structopt(name = "error-coverage", author = "The Aleo Team <hello@aleo.org>")]
 struct Opt {
     #[structopt(
         short,
@@ -40,7 +40,7 @@ struct Opt {
 }
 
 fn main() {
-    handle_error(run_with_args(Opt::from_args()));
+    handle_error(run_with_args(Opt::parse()));
 }
 
 fn run_with_args(opt: Opt) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
simple pr that switches leo over to `clap` instead of `structopt` since `structopt` is now deprecated. the only real change to the code is that `AppSettings::ColoredHelp` is now set by default