### PR TITLE
[ABNF] Add operator calls.

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -233,20 +233,22 @@ primary-expression = identifier
                    / literal
                    / "(" expression ")"
                    / function-call
-                   / operator-call
 
 function-call = identifier function-arguments
 
-operator-call = unary-operator-call / binary-operator-call
-
-unary-operator-call = primary-expression "." identifier "(" ")"
-
-binary-operator-call =
-    primary-expression "." identifier "(" expression [ "," ] ")"
-
 function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 
-unary-expression = primary-expression
+postfix-expression = primary-expression
+                   / operator-call
+
+operator-call = unary-operator-call / binary-operator-call
+
+unary-operator-call = postfix-expression "." identifier "(" ")"
+
+binary-operator-call =
+    postfix-expression "." identifier "(" expression [ "," ] ")"
+
+unary-expression = postfix-expression
                  / "!" unary-expression
                  / "-" unary-expression
 

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -233,8 +233,16 @@ primary-expression = identifier
                    / literal
                    / "(" expression ")"
                    / function-call
+                   / operator-call
 
 function-call = identifier function-arguments
+
+operator-call = unary-operator-call / binary-operator-call
+
+unary-operator-call = primary-expression "." identifier "(" ")"
+
+binary-operator-call =
+    primary-expression "." identifier "(" expression [ "," ] ")"
 
 function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 


### PR DESCRIPTION
Since these are a method-like syntax for unary and binary operators (as in fact
these are represented as operators in the AST), the nomenclature 'operator call'
seems appropriate, at least for now. There is no need yet to introduce notions
of associated functions (and constants).

The rules explicitly distinguish between unary and binary ones, corresponding to
unary and binary operators. This lets us exclude right away calls with too many
arguments, and gives us a way to distinguish the two kinds.

A trailing comma is allowed at the end of the one argument of binary operator
calls, if one is really inclined to use it, just for syntactic consistency with
other calls (namely, function calls).
