### PR TITLE
[ABNF] Add new operators.

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -278,11 +278,12 @@ bitwise-exclusive-or-expression =
       bitwise-inclusive-or-expression
     / bitwise-exclusive-or-expression "^" bitwise-inclusive-or-expression
 
-ordering-expression = bitwise-exclusive-or-expression
-                    / bitwise-exclusive-or-expression "<" additive-expression
-                    / bitwise-exclusive-or-expression ">" additive-expression
-                    / bitwise-exclusive-or-expression "<=" additive-expression
-                    / bitwise-exclusive-or-expression ">=" additive-expression
+ordering-expression =
+      bitwise-exclusive-or-expression
+    / bitwise-exclusive-or-expression "<" bitwise-exclusive-or-expression
+    / bitwise-exclusive-or-expression ">" bitwise-exclusive-or-expression
+    / bitwise-exclusive-or-expression "<=" bitwise-exclusive-or-expression
+    / bitwise-exclusive-or-expression ">=" bitwise-exclusive-or-expression
 
 equality-expression = ordering-expression
                     / ordering-expression "==" ordering-expression

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -263,23 +263,38 @@ additive-expression = multiplicative-expression
                     / additive-expression "+" multiplicative-expression
                     / additive-expression "-" multiplicative-expression
 
-ordering-expression = additive-expression
-                    / additive-expression "<" additive-expression
-                    / additive-expression ">" additive-expression
-                    / additive-expression "<=" additive-expression
-                    / additive-expression ">=" additive-expression
+shift-expression = additive-expression
+                 / shift-expression "<<" additive-expression
+                 / shift-expression ">>" additive-expression
+
+bitwise-and-expression = shift-expression
+                       / bitwise-and-expression "&" shift-expression
+
+bitwise-inclusive-or-expression =
+      bitwise-and-expression
+    / bitwise-inclusive-or-expression "|" bitwise-and-expression
+
+bitwise-exclusive-or-expression =
+      bitwise-inclusive-or-expression
+    / bitwise-exclusive-or-expression "^" bitwise-inclusive-or-expression
+
+ordering-expression = bitwise-exclusive-or-expression
+                    / bitwise-exclusive-or-expression "<" additive-expression
+                    / bitwise-exclusive-or-expression ">" additive-expression
+                    / bitwise-exclusive-or-expression "<=" additive-expression
+                    / bitwise-exclusive-or-expression ">=" additive-expression
 
 equality-expression = ordering-expression
                     / ordering-expression "==" ordering-expression
                     / ordering-expression "!=" ordering-expression
 
-conjunctive-expression = equality-expression
-                       / conjunctive-expression "&&" equality-expression
+boolean-and-expression = equality-expression
+                       / boolean-and-expression "&&" equality-expression
 
-disjunctive-expression = conjunctive-expression
-                       / disjunctive-expression "||" conjunctive-expression
+boolean-or-expression = boolean-and-expression
+                      / boolean-or-expression "||" boolean-and-expression
 
-binary-expression = disjunctive-expression
+binary-expression = boolean-or-expression
 
 conditional-expression = binary-expression
                        / binary-expression "?" expression ":" expression


### PR DESCRIPTION
This adds shift (`<<` `>>`) and bitwise logical (`&` `|` `^`) operators.

Their precedence is between the additive and ordering operations, in this order
(higher to lower):
- ... others, to additive
- `<<` and `>>`
- `&`
- `|`
- `^`
- ... others, from ordering

This is consistent with Rust, but not with C and Java, both of which make the
bitwise logical operators lower-precedence than equalities.

Shift operations are left-associative, so `a >> b >> c` is like `(a >> b) >> c`, which makes sense.

Bitwise logical operators are left-associative, just to pick an order (they satisfy associativity).

The previous ABNF rule names for `conjunctive-expression` and
`disjunctive-expression` have been renamed to be more consistent with the newly
added ones. Also, the rule names "abbreviate" 'conjunctive' and 'disjunctive'
with 'and' and 'or', otherwise the names were a bit too long.
