### PR TITLE
[ABNF] Add syntax for circuits and for associated constants and functions

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -260,9 +260,9 @@ static-function-call = named-type "::" identifier function-arguments
 
 function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 
-circuit-expression = identifier "{" [ circuit-component-initializer
-                                      *( "," circuit-component-initializer )
-                                      [ "," ] ] "}"
+circuit-expression = identifier "{" circuit-component-initializer
+                                    *( "," circuit-component-initializer )
+                                    [ "," ] "}"
 
 circuit-component-initializer = identifier
                               / identifier ":" expression
@@ -387,9 +387,9 @@ function-parameters = function-parameter *( "," function-parameter ) [ "," ]
 function-parameter = [ %s"public" / %s"constant" / %s"const" ]
                      identifier ":" type
 
-circuit-declaration = %s"circuit" "{" [ circuit-component-declaration
-                                        *( "," circuit-component-declaration )
-                                        [ "," ] ] "}"
+circuit-declaration = %s"circuit" "{" circuit-component-declaration
+                                      *( "," circuit-component-declaration )
+                                      [ "," ] "}"
 
 circuit-component-declaration = identifier ":" type
 

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -190,7 +190,7 @@ symbol = "!" / "&&" / "||"
        / "(" / ")"
        / "[" / "]"
        / "{" / "}"
-       / "," / "." / ".." / ";" / ":" / "?"
+       / "," / "." / ".." / ";" / ":" / "::" / "?"
        / "->" / "_"
        / %s")group"
 
@@ -229,7 +229,9 @@ string-type = %s"string"
 
 primitive-type =  boolean-type / arithmetic-type / address-type / string-type
 
-type = primitive-type / identifier
+named-type = primitive-type / identifier
+
+type = named-type
 
 group-coordinate = ( [ "-" ] numeral ) / "+" / "-" / "_"
 
@@ -242,9 +244,12 @@ group-literal = product-group-literal / affine-group-literal
 primary-expression = identifier
                    / literal
                    / "(" expression ")"
-                   / function-call
+                   / free-function-call
+                   / static-function-call
 
-function-call = identifier function-arguments
+free-function-call = identifier function-arguments
+
+static-function-call = named-type "::" identifier function-arguments
 
 function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 

--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -78,6 +78,7 @@ end-of-line-comment = "//" *not-line-feed-or-carriage-return
 
 keyword = %s"address"
         / %s"bool"
+        / %s"circuit"
         / %s"console"
         / %s"const"
         / %s"constant"
@@ -241,11 +242,17 @@ literal = atomic-literal / affine-group-literal
 
 group-literal = product-group-literal / affine-group-literal
 
-primary-expression = identifier
-                   / literal
+primary-expression = literal
+                   / variable-or-free-constant
+                   / associated-constant
                    / "(" expression ")"
                    / free-function-call
                    / static-function-call
+                   / circuit-expression
+
+variable-or-free-constant = identifier
+
+associated-constant = named-type "::" identifier
 
 free-function-call = identifier function-arguments
 
@@ -253,8 +260,18 @@ static-function-call = named-type "::" identifier function-arguments
 
 function-arguments = "(" [ expression *( "," expression ) [ "," ] ] ")"
 
+circuit-expression = identifier "{" [ circuit-component-initializer
+                                      *( "," circuit-component-initializer )
+                                      [ "," ] ] "}"
+
+circuit-component-initializer = identifier
+                              / identifier ":" expression
+
 postfix-expression = primary-expression
+                   / circuit-component-expression
                    / operator-call
+
+circuit-component-expression = postfix-expression "." identifier
 
 operator-call = unary-operator-call / binary-operator-call
 
@@ -370,7 +387,14 @@ function-parameters = function-parameter *( "," function-parameter ) [ "," ]
 function-parameter = [ %s"public" / %s"constant" / %s"const" ]
                      identifier ":" type
 
+circuit-declaration = %s"circuit" "{" [ circuit-component-declaration
+                                        *( "," circuit-component-declaration )
+                                        [ "," ] ] "}"
+
+circuit-component-declaration = identifier ":" type
+
 declaration = function-declaration
+            / circuit-declaration
 
 file = *declaration
 


### PR DESCRIPTION
Renames pre-existing (generic) function calls to 'free function calls', now that we are introducing a new kind of functions, namely (associated) static functions, distinguished from free (i.e. non-associated) functions.

Introduces notion of named type, as a type that has a name, which may be either a keyword (e.g. `u8`, `address`) or an identifier (e.g. `Pedersen64`).

Introduces nomenclature for identifiers used as expressions as being 'variables' or 'free constants'. The latter are distinguished from 'associated constants', which are a new kind of primary expression.

I went with 'component', rather than 'member', for the things that circuit types and values are made of. The reason is that 'member' seems to more generally refer to things tied to a type (cf. Java, or https://doc.rust-lang.org/reference/glossary.html#free-item), while 'component' has more the meaning of being a part/portion of a value. This provides a nice terminological symmetry:
- Circuits have (named) components.
- Tuples have (numbered) components. [future]
- Arrays have (numbered) components. [future]

(Aside: In the future, we could use the terms 'array element' vs. 'array components' as in Java, e.g. the array type `[u8; (3, 2)]` has component type `[u8; 2]` and element type `u8`.)

In earlier versions of Leo we used 'member variable', but it's two words instead of one for 'component'. Also, 'member variable' may cause confusion if we ever extend Leo with associated variables, which would be like associated constants but changeable, like static field in Java.

The grammar also exhibits a regular and symmetrical terminology for:
- Circuit component declarations, e.g. `a: u8`.
- Circuit component initializers, e.g. `a: 1u8`.
- Circuit component expressions, e.g. `e.a`.
