### PR TITLE
Add a simple license checker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: daily
       time: "10:00"
-    target-branch: "staging"
+    target-branch: "testnet3"
     open-pull-requests-limit: 20
     ignore:
       - dependency-name: snarkvm-curves

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -9,7 +9,6 @@ use_try_shorthand = true
 
 # Nightly configurations
 # imports_layout = "HorizontalVertical"
-# license_template_path = ".resources/license_header"
 # imports_granularity = "Crate"
 # overflow_delimited_expr = true
 # reorder_impl_items = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,15 +1567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2259,9 +2250,6 @@ name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
 
 [[package]]
 name = "regex-syntax"
@@ -3091,35 +3079,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
-version = "0.2.19"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab69019741fca4d98be3c62d2b75254528b5432233fd8a4d2739fec20278de48"
+checksum = "80a4ddde70311d8da398062ecf6fc2c309337de6b0f77d6c27aff8d53f6fca52"
 dependencies = [
  "ansi_term 0.12.1",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61f2b7f93d2c7d2b08263acaa4a363b3e276806c68af6134c44f523bf1aacd"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
 dependencies = [
  "gimli",
 ]
@@ -119,9 +119,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "backtrace"
-version = "0.3.62"
+version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091bcdf2da9950f96aa522681ce805e6857f6ca8df73833d35736ab2dc78e152"
+checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
@@ -921,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.25.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0a01e0497841a3b2db4f8afa483cce65f7e96a3498bd6c541734792aeac8fe7"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "glob"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1399,6 +1399,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "walkdir",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ version = "0.5"
 version = "0.1"
 
 [dependencies.tracing-subscriber]
-version = "0.2.19"
+version = "0.3.1"
 features = [ "fmt" ]
 
 [dependencies.zip]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,6 +180,9 @@ version = "2.0.2"
 [dev-dependencies.test_dir]
 version = "0.1.0"
 
+[build-dependencies.walkdir]
+version = "2"
+
 [features]
 default = [ ]
 ci_skip = [ "leo-compiler/ci_skip" ]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,75 @@
+// Copyright (C) 2019-2021 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::{fs::File, io::Read, path::Path};
+
+use walkdir::WalkDir;
+
+// The following license text that should be present at the beginning of every source file.
+const EXPECTED_LICENSE_TEXT: &[u8] = include_bytes!(".resources/license_header");
+
+// The following directories will be excluded from the license scan.
+const DIRS_TO_SKIP: [&str; 8] = [
+    ".cargo",
+    ".circleci",
+    ".git",
+    ".github",
+    ".resources",
+    "docs",
+    "examples",
+    "target",
+];
+
+fn check_file_licenses<P: AsRef<Path>>(path: P) {
+    let path = path.as_ref();
+
+    let mut iter = WalkDir::new(path).into_iter();
+    while let Some(entry) = iter.next() {
+        let entry = entry.unwrap();
+        let entry_type = entry.file_type();
+
+        // Skip the specified directories.
+        if entry_type.is_dir() && DIRS_TO_SKIP.contains(&entry.file_name().to_str().unwrap_or("")) {
+            iter.skip_current_dir();
+
+            continue;
+        }
+
+        // Check all files with the ".rs" extension.
+        if entry_type.is_file() && entry.file_name().to_str().unwrap_or("").ends_with(".rs") {
+            let file = File::open(entry.path()).unwrap();
+            let mut contents = Vec::with_capacity(EXPECTED_LICENSE_TEXT.len());
+            file.take(EXPECTED_LICENSE_TEXT.len() as u64)
+                .read_to_end(&mut contents)
+                .unwrap();
+
+            assert!(
+                contents == EXPECTED_LICENSE_TEXT,
+                "The license in \"{}\" is either missing or it doesn't match the expected string!",
+                entry.path().display()
+            );
+        }
+    }
+
+    // Re-run upon any changes to the workspace.
+    println!("cargo:rerun-if-changed=.");
+}
+
+// The build script; it currently only checks the licenses.
+fn main() {
+    // Check licenses in the current folder.
+    check_file_licenses(".");
+}

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -35,7 +35,7 @@ version = "0.6.5"
 default-features = false
 
 [dependencies.backtrace]
-version = "0.3.62"
+version = "0.3.63"
 
 [dependencies.pest]
 version = "2.0"

--- a/leo/logger.rs
+++ b/leo/logger.rs
@@ -162,12 +162,7 @@ where
     N: for<'a> FormatFields<'a> + 'static,
     T: FormatTime,
 {
-    fn format_event(
-        &self,
-        context: &FmtContext<'_, S, N>,
-        writer: &mut dyn fmt::Write,
-        event: &Event<'_>,
-    ) -> fmt::Result {
+    fn format_event(&self, context: &FmtContext<'_, S, N>, mut writer: Writer, event: &Event<'_>) -> fmt::Result {
         let meta = event.metadata();
 
         if self.display_level {
@@ -202,11 +197,11 @@ where
                 None => return Err(std::fmt::Error),
             }
 
-            write!(writer, "{:>10} ", colored_string(meta.level(), &message)).expect("Error writing event");
+            write!(&mut writer, "{:>10} ", colored_string(meta.level(), &message)).expect("Error writing event");
         }
 
-        context.format_fields(writer, event)?;
-        writeln!(writer)
+        context.format_fields(writer.by_ref(), event)?;
+        writeln!(&mut writer)
     }
 }
 


### PR DESCRIPTION
Due to https://github.com/rust-lang/rustfmt/issues/5103, rustfmt no longer supports this functionality, but it's simple enough to implement manually within a build script.