### PR TITLE
[ABNF] Improve some rule names.

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -302,40 +302,41 @@ shift-expression = additive-expression
                  / shift-expression "<<" additive-expression
                  / shift-expression ">>" additive-expression
 
-bitwise-and-expression = shift-expression
-                       / bitwise-and-expression "&" shift-expression
+conjunctive-expression = shift-expression
+                       / conjunctive-expression "&" shift-expression
 
-bitwise-inclusive-or-expression =
-      bitwise-and-expression
-    / bitwise-inclusive-or-expression "|" bitwise-and-expression
+disjunctive-expression = conjunctive-expression
+                       / disjunctive-expression "|" conjunctive-expression
 
-bitwise-exclusive-or-expression =
-      bitwise-inclusive-or-expression
-    / bitwise-exclusive-or-expression "^" bitwise-inclusive-or-expression
+exclusive-disjunctive-expression =
+      disjunctive-expression
+    / exclusive-disjunctive-expression "^" disjunctive-expression
 
 ordering-expression =
-      bitwise-exclusive-or-expression
-    / bitwise-exclusive-or-expression "<" bitwise-exclusive-or-expression
-    / bitwise-exclusive-or-expression ">" bitwise-exclusive-or-expression
-    / bitwise-exclusive-or-expression "<=" bitwise-exclusive-or-expression
-    / bitwise-exclusive-or-expression ">=" bitwise-exclusive-or-expression
+      exclusive-disjunctive-expression
+    / exclusive-disjunctive-expression "<" exclusive-disjunctive-expression
+    / exclusive-disjunctive-expression ">" exclusive-disjunctive-expression
+    / exclusive-disjunctive-expression "<=" exclusive-disjunctive-expression
+    / exclusive-disjunctive-expression ">=" exclusive-disjunctive-expression
 
 equality-expression = ordering-expression
                     / ordering-expression "==" ordering-expression
                     / ordering-expression "!=" ordering-expression
 
-boolean-and-expression = equality-expression
-                       / boolean-and-expression "&&" equality-expression
+conditional-conjunctive-expression =
+      equality-expression
+    / conditional-conjunctive-expression "&&" equality-expression
 
-boolean-or-expression = boolean-and-expression
-                      / boolean-or-expression "||" boolean-and-expression
+conditional-disjunctive-expression =
+      conditional-conjunctive-expression
+    / conditional-disjunctive-expression "||" conditional-conjunctive-expression
 
-binary-expression = boolean-or-expression
+binary-expression = conditional-disjunctive-expression
 
-conditional-expression = binary-expression
-                       / binary-expression "?" expression ":" expression
+conditional-ternary-expression = binary-expression
+                               / binary-expression "?" expression ":" expression
 
-expression = conditional-expression
+expression = conditional-ternary-expression
 
 statement = return-statement
           / variable-declaration


### PR DESCRIPTION
Based on a recent discussion on Slack, and on some related slight terminological
changes in the documentation of the Aleo instructions, this commit similarly
improves the Leo nomenclature for expressions involving the logical operators.

The attribute 'bitwise' for `&` and `|` and `^` has been dropped, since the
operations also operate on booleans besides integers.

Given that the operation and method names `or` and `xor` for inclusive and
exclusive disjunctions (as opposed to `ior` and `xor`), the unqualified
'disjunction' now refers to the inclusive one.

The non-strict `&&` and `||` are now called 'conditional' (as done in other
languages), and thus the ternary one has been expanded to 'conditional ternary'.

This does not change the Leo language; it just improves the nomenclature derived
from the grammar.
