### PR TITLE
Leo run {program_name}

### DIFF
--- a/compiler/ast/src/input/input_ast.rs
+++ b/compiler/ast/src/input/input_ast.rs
@@ -44,7 +44,7 @@ impl InputAst {
     pub fn program_inputs(&self, program_name: &str) -> Vec<String> {
         self.sections
             .iter()
-            .filter(|section| &section.name() == program_name)
+            .filter(|section| section.name() == program_name)
             .flat_map(|section| {
                 section
                     .definitions

--- a/compiler/ast/src/input/input_ast.rs
+++ b/compiler/ast/src/input/input_ast.rs
@@ -41,9 +41,10 @@ pub struct InputAst {
 
 impl InputAst {
     /// Returns all values of the input AST for execution with `leo run`.
-    pub fn values(&self) -> Vec<String> {
+    pub fn program_inputs(&self, program_name: &str) -> Vec<String> {
         self.sections
             .iter()
+            .filter(|section| &section.name() == program_name)
             .flat_map(|section| {
                 section
                     .definitions

--- a/compiler/ast/src/input/section.rs
+++ b/compiler/ast/src/input/section.rs
@@ -24,3 +24,9 @@ pub struct Section {
     pub definitions: Vec<Definition>,
     pub span: Span,
 }
+
+impl Section {
+    pub fn name(&self) -> String {
+        self.name.to_string()
+    }
+}

--- a/examples/helloworld/imports/other.leo
+++ b/examples/helloworld/imports/other.leo
@@ -1,3 +1,0 @@
-circuit Other {
-    a: u64,
-}

--- a/examples/helloworld/inputs/helloworld.in
+++ b/examples/helloworld/inputs/helloworld.in
@@ -3,3 +3,5 @@
 public a: u32 = 1u32;
 b: u32 = 2u32; // Input variable `b` is private by default.
 
+[foo]
+x: u64 = 5u64;

--- a/examples/helloworld/src/main.leo
+++ b/examples/helloworld/src/main.leo
@@ -1,8 +1,8 @@
-import other.leo;
-
 // The 'helloworld' main function.
 function main(public a: u32, b: u32) -> u32 {
-    let o: Other = Other { a: 1u64 };
-
     return a + b;
+}
+
+function foo(x: u64) -> u64 {
+    return x - x;
 }

--- a/leo/commands/run.rs
+++ b/leo/commands/run.rs
@@ -31,6 +31,9 @@ use tracing::span::Span;
 /// Build, Prove and Run Leo program with inputs
 #[derive(StructOpt, Debug)]
 pub struct Run {
+    #[structopt(name = "NAME", help = "The name of the program to run.", default_value = "main")]
+    name: String,
+
     #[structopt(long = "skip-key-check", help = "Skip key verification on Setup stage")]
     pub(crate) skip_key_check: bool,
 
@@ -54,17 +57,15 @@ impl Command for Run {
     }
 
     fn apply(self, context: Context, input: Self::Input) -> Result<Self::Output> {
-        // Compose the `aleo run` command.
-        let mut arguments = vec![ALEO_CLI_COMMAND.to_string(), "main".to_string()];
-
         // Get the input values.
-        let mut values = match input {
-            Some(input_ast) => input_ast.values(),
+        let mut inputs = match input {
+            Some(input_ast) => input_ast.program_inputs(&self.name),
             None => Vec::new(),
         };
-        arguments.append(&mut values);
 
-        tracing::info!("Starting...");
+        // Compose the `aleo run` command.
+        let mut arguments = vec![ALEO_CLI_COMMAND.to_string(), self.name];
+        arguments.append(&mut inputs);
 
         // Open the Leo build/ directory
         let path = context.dir()?;

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -173,7 +173,7 @@ impl Package {
         InputsDirectory::create(path)?;
 
         // Create the Leo build/ directory
-        BuildDirectory::create(&path)?;
+        BuildDirectory::create(path)?;
 
         // Create the input file in the inputs directory.
         InputFile::new(package_name).write_to(path)?;


### PR DESCRIPTION
## Overview
Adds support for executing specific programs in a Leo package.

main.leo
```ts
function main(a: u8) -> u8 {
    return a + a;
}

function triple(b: u8) -> u8 {
    return b + b + b;
}
```


foo.in
```toml
[main]
a: u8 = 2u8;

[triple]
b: u8 = 3u8;
```


Running
```bash
leo run main 

output = 4
```


```bash
leo run foo

output = 9
```
