### PR TITLE
[grammar] add missing record name identifier; factor circuit-componen…

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -400,15 +400,16 @@ function-parameter = [ %s"public" / %s"constant" / %s"const" ]
                      identifier ":" type
 
 circuit-declaration = %s"circuit" identifier
-                      "{" circuit-component-declaration
-                          *( "," circuit-component-declaration )
-                          [ "," ] "}"
+                      "{" circuit-component-declarations "}"
+
+circuit-component-declarations = circuit-component-declaration
+                                 *( "," circuit-component-declaration )
+                                 [ "," ]
 
 circuit-component-declaration = identifier ":" type
 
-record-declaration = %s"record" "{" circuit-component-declaration
-                                    *( "," circuit-component-declaration )
-                                    [ "," ] "}"
+record-declaration = %s"record" identifier
+                     "{" circuit-component-declarations "}"
 
 declaration = function-declaration
             / circuit-declaration


### PR DESCRIPTION
…t-declarations into separate grammar rule

## Description and Motivation

1. fixed the missing identifier for `record-declaration` rule
2. factored out the common list of circuit component declarations from `circuit-declaration` and `record-declaration` into a separate rule, `circuit-component-declarations`, to make it clear they had the same syntax and to reduce code duplication

