### PR TITLE
[ABNF] Add annotations.

### DIFF
--- a/docs/grammar/abnf-grammar.txt
+++ b/docs/grammar/abnf-grammar.txt
@@ -184,6 +184,8 @@ atomic-literal = numeric-literal
                / address-literal
                / string-literal
 
+annotation = "@" identifier
+
 symbol = "!"
        / "&&" / "||"
        / "==" / "!="
@@ -207,6 +209,7 @@ token = keyword
       / identifier
       / atomic-literal
       / numeral
+      / annotation
       / symbol
 
 lexeme = token / comment / whitespace
@@ -409,7 +412,7 @@ print-arguments = "(" string-literal  *( "," expression ) [ "," ] ")"
 
 print-call = print-function print-arguments
 
-function-declaration = %s"function" identifier
+function-declaration = *annotation %s"function" identifier
                        "(" [ function-parameters ] ")" "->" type
                        block
 


### PR DESCRIPTION
This is to match the recent introduction of the `@program` annotation for
external functions (i.e. functions that may be called externally, passing to
them inputs through the input files).

This PR adds not just that annotation, but a more general notion of annotation
as a new kind of token of the form `@<identifier>`, and with the ability to
precede each function declaration with zero or more such annotations.

The fact that it has been added as a token to the lexical grammar, means that
there cannot be any whitespace or comments between the `@` and the identifier.
If that is undesired, we can add it to the syntactic grammar instead, defining
an annotation as consisting of the (new) symbol token `@` followed by an
identifier token.

We can of course extend annotations with arguments at some point, if needed.
