### PR TITLE
Fix leo install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ cd leo
 $ cargo install --path .
 ```
 
-Now to use aleo, in your terminal, run:
+Now to use leo, in your terminal, run:
 ```bash
 leo
 ```

--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ cd leo
 $ cargo install --path .
 ```
 
+Now to use aleo, in your terminal, run:
+```bash
+leo
+```
+
 ## 3. Quick Start
 
 Use the Leo CLI to create a new project

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Leo is a functional, statically-typed programming language built for writing pri
 * [1. Overview](#1-overview)
 * [2. Build Guide](#2-build-guide)
     * [2.1 Install Rust](#21-install-rust)
-    * [2.2a Build from Crates.io](#22a-build-from-cratesio)
-    * [2.2b Build from Source Code](#22b-build-from-source-code)
+    * [2.2 Build from Source Code](#22-build-from-source-code)
 * [3. Quick Start](#3-quick-start)
 * [4. Documentation](#4-documentation)
 * [5. Contributing](#5-contributing)
@@ -66,13 +65,8 @@ We recommend installing Leo by building from the source code as follows:
 git clone https://github.com/AleoHQ/leo
 cd leo
 
-# Build in release mode
-$ cargo build --release
-```
-
-This will generate an executable under the `./target/release` directory. To run Leo, run the following command:
-```bash
-./target/release/leo
+# Install 'leo'
+$ cargo install --path .
 ```
 
 ## 3. Quick Start


### PR DESCRIPTION
Fix leo install method from source directly by `cargo install --path .`