### PR TITLE
fix typo in program name

### DIFF
--- a/examples/hackers-delight/ntzdebruijn/src/main.leo
+++ b/examples/hackers-delight/ntzdebruijn/src/main.leo
@@ -1,4 +1,4 @@
-program ntzdebrujin.aleo {
+program ntzdebruijn.aleo {
     // The 'ntzdebruijn' main function.
     // From Hacker's Delight 2nd ed. figure 5-26
     transition main(public x: u32) -> u8 {


### PR DESCRIPTION
Fix typo so program can compile.  The other hackers-delight examples all compile and run fine.