### PR TITLE
Preserve struct member order when reordering `owner` and `gates`

### DIFF
--- a/compiler/passes/src/static_single_assignment/rename_program.rs
+++ b/compiler/passes/src/static_single_assignment/rename_program.rs
@@ -41,11 +41,11 @@ impl StructConsumer for StaticSingleAssigner<'_> {
 
                 // Add the owner field to the beginning of the members list.
                 // Note that type checking ensures that the owner field exists.
-                members.push(member_map.remove(&sym::owner).unwrap());
+                members.push(member_map.shift_remove(&sym::owner).unwrap());
 
                 // Add the gates field to the beginning of the members list.
                 // Note that type checking ensures that the gates field exists.
-                members.push(member_map.remove(&sym::gates).unwrap());
+                members.push(member_map.shift_remove(&sym::gates).unwrap());
 
                 // Add the remaining fields to the members list.
                 members.extend(member_map.into_iter().map(|(_, member)| member));


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

`IndexMap::remove()` doesn't preserve the insertion order ([doc](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#method.remove)). As a result, the order of struct members and struct initialize expressions will mismatch in aleo instructions. Although a little slower, `shift_remove()` preserves the order of the keys in the map.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

`battleship` example was not working before this.

