### PR TITLE
Prepend program name to AST output file.

### DIFF
--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -139,11 +139,14 @@ impl<'a> Compiler<'a> {
             if self.output_options.initial_ast {
                 // Write the input AST snapshot post parsing.
                 if self.output_options.spans_enabled {
-                    input_ast.to_json_file(self.output_directory.clone(), "initial_input_ast.json")?;
+                    input_ast.to_json_file(
+                        self.output_directory.clone(),
+                        &format!("{}.initial_input_ast.json", self.program_name),
+                    )?;
                 } else {
                     input_ast.to_json_file_without_keys(
                         self.output_directory.clone(),
-                        "initial_input_ast.json",
+                        &format!("{}.initial_input_ast.json", self.program_name),
                         &["span"],
                     )?;
                 }
@@ -233,13 +236,19 @@ impl<'a> Compiler<'a> {
     }
 
     /// Writes the AST to a JSON file.
-    fn write_ast_to_json(&self, file_name: &str) -> Result<()> {
+    fn write_ast_to_json(&self, file_suffix: &str) -> Result<()> {
         // Remove `Span`s if they are not enabled.
         if self.output_options.spans_enabled {
-            self.ast.to_json_file(self.output_directory.clone(), file_name)?;
+            self.ast.to_json_file(
+                self.output_directory.clone(),
+                &format!("{}.{file_suffix}", self.program_name),
+            )?;
         } else {
-            self.ast
-                .to_json_file_without_keys(self.output_directory.clone(), file_name, &["span"])?;
+            self.ast.to_json_file_without_keys(
+                self.output_directory.clone(),
+                &format!("{}.{file_suffix}", self.program_name),
+                &["span"],
+            )?;
         }
         Ok(())
     }

--- a/compiler/compiler/src/test.rs
+++ b/compiler/compiler/src/test.rs
@@ -233,7 +233,7 @@ fn run_test(test: Test, handler: &Handler, err_buf: &BufferEmitter) -> Result<Va
         for input in inputs {
             let mut parsed = parsed.clone();
             handler.extend_if_error(parsed.parse_input(input))?;
-            let initial_input_ast = hash_file("/tmp/output/initial_input_ast.json");
+            let initial_input_ast = hash_file("/tmp/output/test.initial_input_ast.json");
 
             output_items.push(OutputItem { initial_input_ast });
         }
@@ -271,10 +271,10 @@ fn run_test(test: Test, handler: &Handler, err_buf: &BufferEmitter) -> Result<Va
         // handler.extend_if_error(package.get_process().map_err(LeoError::Anyhow))?;
     }
 
-    let initial_ast = hash_file("/tmp/output/initial_ast.json");
-    let unrolled_ast = hash_file("/tmp/output/unrolled_ast.json");
-    let ssa_ast = hash_file("/tmp/output/ssa_ast.json");
-    let flattened_ast = hash_file("/tmp/output/flattened_ast.json");
+    let initial_ast = hash_file("/tmp/output/test.initial_ast.json");
+    let unrolled_ast = hash_file("/tmp/output/test.unrolled_ast.json");
+    let ssa_ast = hash_file("/tmp/output/test.ssa_ast.json");
+    let flattened_ast = hash_file("/tmp/output/test.flattened_ast.json");
 
     if fs::read_dir("/tmp/output").is_ok() {
         fs::remove_dir_all(Path::new("/tmp/output")).expect("Error failed to clean up output dir.");


### PR DESCRIPTION
This PR fixes in issue with output AST snapshots for programs with imports.
