### PR TITLE
Fixes flattening for `console` statements.

### DIFF
--- a/compiler/passes/src/flattening/flatten_statement.rs
+++ b/compiler/passes/src/flattening/flatten_statement.rs
@@ -126,7 +126,7 @@ impl StatementReconstructor for Flattener<'_> {
     /// ```leo
     /// console.assert(!(condition1 && condition2) || foo);
     /// ```
-    /// which is equivalent to the logical formula `(condition1 ^ condition2) ==> foo`.
+    /// which is equivalent to the logical formula `(condition1 /\ condition2) ==> foo`.
     fn reconstruct_console(&mut self, input: ConsoleStatement) -> (Statement, Self::AdditionalOutput) {
         let mut statements = Vec::new();
 

--- a/compiler/passes/src/flattening/flatten_statement.rs
+++ b/compiler/passes/src/flattening/flatten_statement.rs
@@ -17,9 +17,9 @@
 use crate::Flattener;
 
 use leo_ast::{
-    AssignStatement, BinaryExpression, BinaryOperation, Block, ConditionalStatement, DefinitionStatement, Expression,
-    ExpressionReconstructor, FinalizeStatement, IterationStatement, Node, ReturnStatement, Statement,
-    StatementReconstructor, UnaryExpression, UnaryOperation,
+    AssignStatement, Block, ConditionalStatement, ConsoleStatement,
+    DefinitionStatement, Expression, ExpressionReconstructor, FinalizeStatement, IterationStatement, Node,
+    ReturnStatement, Statement, StatementReconstructor, UnaryExpression, UnaryOperation,
 };
 
 impl StatementReconstructor for Flattener<'_> {
@@ -110,6 +110,11 @@ impl StatementReconstructor for Flattener<'_> {
         (Statement::dummy(Default::default()), statements)
     }
 
+    /// Rewrites a console statement into a flattened form.
+    fn reconstruct_console(&mut self, input: ConsoleStatement) -> (Statement, Self::AdditionalOutput) {
+        todo!()
+    }
+
     /// Static single assignment converts definition statements into assignment statements.
     fn reconstruct_definition(&mut self, _definition: DefinitionStatement) -> (Statement, Self::AdditionalOutput) {
         unreachable!("`DefinitionStatement`s should not exist in the AST at this phase of compilation.")
@@ -119,20 +124,7 @@ impl StatementReconstructor for Flattener<'_> {
     /// Stores the arguments to the finalize statement, which are later folded into a single finalize statement at the end of the function.
     fn reconstruct_finalize(&mut self, input: FinalizeStatement) -> (Statement, Self::AdditionalOutput) {
         // Construct the associated guard.
-        let guard = match self.condition_stack.is_empty() {
-            true => None,
-            false => {
-                let (first, rest) = self.condition_stack.split_first().unwrap();
-                Some(rest.iter().cloned().fold(first.clone(), |acc, condition| {
-                    Expression::Binary(BinaryExpression {
-                        op: BinaryOperation::And,
-                        left: Box::new(acc),
-                        right: Box::new(condition),
-                        span: Default::default(),
-                    })
-                }))
-            }
-        };
+        let guard = self.construct_guard();
 
         // For each finalize argument, add it and its associated guard to the appropriate list of finalize arguments.
         // Note that type checking guarantees that the number of arguments in a finalize statement is equal to the number of arguments in to the finalize block.
@@ -153,20 +145,7 @@ impl StatementReconstructor for Flattener<'_> {
     /// Stores the arguments to the return statement, which are later folded into a single return statement at the end of the function.
     fn reconstruct_return(&mut self, input: ReturnStatement) -> (Statement, Self::AdditionalOutput) {
         // Construct the associated guard.
-        let guard = match self.condition_stack.is_empty() {
-            true => None,
-            false => {
-                let (first, rest) = self.condition_stack.split_first().unwrap();
-                Some(rest.iter().cloned().fold(first.clone(), |acc, condition| {
-                    Expression::Binary(BinaryExpression {
-                        op: BinaryOperation::And,
-                        left: Box::new(acc),
-                        right: Box::new(condition),
-                        span: Default::default(),
-                    })
-                }))
-            }
-        };
+        let guard = self.construct_guard();
 
         // Add it to the list of return statements.
         self.returns.push((guard, input.expression));

--- a/tests/compiler/console/conditional_assert.leo
+++ b/tests/compiler/console/conditional_assert.leo
@@ -1,0 +1,17 @@
+/*
+namespace: Compile
+expectation: Pass
+*/
+
+program test.aleo {
+    transition main(id_type: u8) -> bool {
+        if (id_type == 1u8) {
+            return true;
+        }
+        if (id_type == 2u8) {
+            console.assert(0u8 > id_type);
+            return false;
+        }
+        return false;
+    }
+}

--- a/tests/expectations/compiler/console/conditional_assert.out
+++ b/tests/expectations/compiler/console/conditional_assert.out
@@ -1,0 +1,10 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - output:
+      - initial_input_ast: no input
+    initial_ast: aa1777f90d189c4127edc7419efa3134969a6db3e138bcde36095377d22452a3
+    unrolled_ast: aa1777f90d189c4127edc7419efa3134969a6db3e138bcde36095377d22452a3
+    ssa_ast: 672c4dd4f4eca31c458b8a55d2af1cd46fda4261578993f353b6cdf1818256de
+    flattened_ast: 5eacb46ae48246907ab7d5cda2b33d5e49504cccc22b04c9b3c48a4b939679b3


### PR DESCRIPTION
This PR,
- Fixes flattening for `console` statements such that it accounts for conditional statements. (See documentation in code for a detailed explanation).
- Minor refactor.
