### PR TITLE
Fix/tyc for loop bounds

### DIFF
--- a/compiler/passes/src/type_checking/check_statements.rs
+++ b/compiler/passes/src/type_checking/check_statements.rs
@@ -322,6 +322,8 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         // If `input.start` is a literal, instantiate it as a value.
         if let Expression::Literal(literal) = &input.start {
             input.start_value.replace(Some(Value::from(literal)));
+        } else {
+            self.emit_err(TypeCheckerError::loop_bound_must_be_a_literal(input.start.span()));
         }
 
         self.visit_expression(&input.stop, iter_type);
@@ -329,6 +331,8 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         // If `input.stop` is a literal, instantiate it as a value.
         if let Expression::Literal(literal) = &input.stop {
             input.stop_value.replace(Some(Value::from(literal)));
+        } else {
+            self.emit_err(TypeCheckerError::loop_bound_must_be_a_literal(input.stop.span()));
         }
     }
 

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -423,4 +423,11 @@ create_messages!(
         msg: format!("Cannot call a local transition function from a transition function."),
         help: None,
     }
+
+    @formatted
+    loop_bound_must_be_a_literal {
+        args: (),
+        msg: format!("Loop bound must be a literal."),
+        help: None,
+    }
 );

--- a/tests/compiler/statements/loop_non_literal_bound_fail.leo
+++ b/tests/compiler/statements/loop_non_literal_bound_fail.leo
@@ -1,0 +1,24 @@
+/*
+namespace: Compile
+expectation: Fail
+*/
+
+program test.aleo {
+    record Token {
+        owner: address,
+        gates: u64,
+        amount: u64,
+    }
+
+    transition main(owner: address, amount: u64) -> Token {
+        let max: u64 = 0u64;
+        for i:u64 in 0u64..amount {
+            max = i;
+        }
+        return Token {
+            owner: owner,
+            gates: 0u64,
+            amount: amount,
+        };
+    }
+}

--- a/tests/expectations/compiler/statements/loop_non_literal_bound_fail.out
+++ b/tests/expectations/compiler/statements/loop_non_literal_bound_fail.out
@@ -1,0 +1,5 @@
+---
+namespace: Compile
+expectation: Fail
+outputs:
+  - "Error [ETYC0372049]: Loop bound must be a literal.\n    --> compiler-test:12:28\n     |\n  12 |         for i:u64 in 0u64..amount {\n     |                            ^^^^^^\n"


### PR DESCRIPTION
This PR implements type checking for loop bounds.
The compiler errors if the loop bounds are not literals. 

Closes #2145.