### PR TITLE
[Fix] Fixes unwrapping panic when unwrapping `lookup_struct` in `ProgramVisitor::visit_function`

### DIFF
--- a/compiler/passes/src/type_checking/check_program.rs
+++ b/compiler/passes/src/type_checking/check_program.rs
@@ -243,13 +243,19 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
                 }
                 Output::Internal(function_output) => {
                     // Check that the type of output is defined.
-                    self.assert_type_is_defined(&function_output.type_, function_output.span);
-                    // If the function is not a transition function, then it cannot output a record.
-                    if let Type::Identifier(identifier) = function_output.type_ {
-                        if !matches!(function.variant, Variant::Transition)
-                            && self.symbol_table.borrow().lookup_struct(identifier.name).unwrap().is_record
-                        {
-                            self.emit_err(TypeCheckerError::function_cannot_output_record(function_output.span));
+                    if self.assert_type_is_defined(&function_output.type_, function_output.span) {
+                        // If the function is not a transition function, then it cannot output a record.
+                        if let Type::Identifier(identifier) = function_output.type_ {
+                            if !matches!(function.variant, Variant::Transition)
+                                && self
+                                    .symbol_table
+                                    .borrow()
+                                    .lookup_struct(identifier.name)
+                                    .unwrap()
+                                    .is_record
+                            {
+                                self.emit_err(TypeCheckerError::function_cannot_output_record(function_output.span));
+                            }
                         }
                     }
                     // Check that the type of the output is not a tuple. This is necessary to forbid nested tuples.

--- a/compiler/passes/src/type_checking/check_program.rs
+++ b/compiler/passes/src/type_checking/check_program.rs
@@ -247,12 +247,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
                         // If the function is not a transition function, then it cannot output a record.
                         if let Type::Identifier(identifier) = function_output.type_ {
                             if !matches!(function.variant, Variant::Transition)
-                                && self
-                                    .symbol_table
-                                    .borrow()
-                                    .lookup_struct(identifier.name)
-                                    .unwrap()
-                                    .is_record
+                                && self.symbol_table.borrow().lookup_struct(identifier.name).unwrap().is_record
                             {
                                 self.emit_err(TypeCheckerError::function_cannot_output_record(function_output.span));
                             }

--- a/compiler/passes/src/type_checking/check_statements.rs
+++ b/compiler/passes/src/type_checking/check_statements.rs
@@ -201,7 +201,9 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
                     }
                 }
             },
-            Type::Mapping(_) | Type::Err => unreachable!(),
+            Type::Mapping(_) | Type::Err => unreachable!(
+                "Parsing guarantees that `mapping` and `err` types are not present at this location in the AST."
+            ),
             // Otherwise, the type is valid.
             _ => (), // Do nothing
         }

--- a/tests/expectations/compiler/function/undefined_data_type_fail.out
+++ b/tests/expectations/compiler/function/undefined_data_type_fail.out
@@ -1,0 +1,5 @@
+---
+namespace: Compile
+expectation: Fail
+outputs:
+  - "Error [ETYC0372017]: The type `Board` is not found in the current scope.\n    --> compiler-test:4:35\n     |\n   4 |     function aria192check_for_win(b: Board, p: u8) -> u128bool {\n     |                                   ^\nError [ETYC0372017]: The type `u128bool` is not found in the current scope.\n    --> compiler-test:4:55\n     |\n   4 |     function aria192check_for_win(b: Board, p: u8) -> u128bool {\n     |                                                       ^^^^^^^^\nError [ETYC0372005]: Unknown variable `test`\n    --> compiler-test:5:16\n     |\n   5 |         return test;\n     |                ^^^^\n"

--- a/tests/tests/compiler/function/undefined_data_type_fail.leo
+++ b/tests/tests/compiler/function/undefined_data_type_fail.leo
@@ -1,0 +1,10 @@
+/*
+namespace: Compile
+expectation: Fail
+*/
+
+program test.aleo {
+    function aria192check_for_win(b: Board, p: u8) -> u128bool {
+        return test;
+    }
+}


### PR DESCRIPTION
Closes #2324.
