### PR TITLE
[Chore] Update to snarkVM-0.9.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,10 +32,10 @@ members = [
 ]
 
 [workspace.dependencies.snarkvm]
-version = "0.9.15"
+version = "0.9.16"
 
 [workspace.dependencies.snarkvm-console]
-version = "0.9.15"
+version = "0.9.16"
 
 [lib]
 path = "leo/lib.rs"
@@ -125,7 +125,8 @@ version = "1.0"
 
 [dependencies.snarkvm]
 workspace = true
-features = [ "aleo-cli", "circuit", "console", "parallel" ]
+default-features = false
+features = [ "circuit", "cli", "console"]
 
 [dependencies.sys-info]
 version = "0.9.1"

--- a/compiler/compiler/Cargo.toml
+++ b/compiler/compiler/Cargo.toml
@@ -52,7 +52,7 @@ default-features = false
 [dev-dependencies.snarkvm]
 workspace = true
 default-features = false
-features = [ "aleo-cli", "circuit", "console", "parallel" ]
+features = [ "circuit", "cli", "console" ]
 
 [dev-dependencies.regex]
 version = "1.7.3"


### PR DESCRIPTION
^.

TODO: Requires release with snarkVM-0.9.16 from Aleo SDK.
