### PR TITLE
remove brew update command from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,6 @@ jobs:
       - name: Install sccache Macos
         if: matrix.os == 'macos-latest'
         run: |
-          brew update
           brew install sccache
 
       - name: Install Rust Stable
@@ -110,7 +109,6 @@ jobs:
 
       - name: Install sccache
         run: |
-          brew update
           brew install sccache
         
       - name: Install Rust


### PR DESCRIPTION
# Issue
```bash
Run brew update
error: Could not read 050b5490e7bb098f70f3de925431a24622f2d64c
fatal: revision walk setup failed
error: https://github.com/Homebrew/homebrew-cask did not send all necessary objects
```
GitHub actions CI failing due to broken `brew update` command on macos m1 platforms

Breaking in all current PRs. 
Example https://github.com/AleoHQ/leo/actions/runs/5463254559/jobs/9943707212?pr=2443

# Fix
Removing `brew update` from CI as referenced in https://github.com/orgs/Homebrew/discussions/4612#discussioncomment-6356325