### PR TITLE
change abnf grammar link

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ If the issue still persists, please [open an issue](https://github.com/AleoHQ/le
 
 * [Hello World - Next Steps](https://developer.aleo.org/leo/hello)
 * [Leo Language Documentation](https://developer.aleo.org/leo/language)
-* [Leo ABNF Grammar](./docs/grammar/abnf-grammar.txt)
+* [Leo ABNF Grammar](https://github.com/AleoHQ/grammars/blob/master/leo.abnf)
 * [Homepage](https://developer.aleo.org/overview/)
 
 ## 6. Contributing 🤝


### PR DESCRIPTION
The abnf grammar is no longer stored in the leo repo. There is just a forwarding pointer to the grammars repo. This commit changes the link to go directly to the grammars repo.

<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

(Write your motivation here)

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

(Write your test plan here)

## Related PRs

<!--
    If this PR adds or changes functionality,
    please take some time to update the docs at https://github.com/AleoHQ/leo,
    and link to your PR here.
-->

(Link your related PRs here)
