### PR TITLE
[Fix] Function calls must lead with an `Identifier.

### DIFF
--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -15,9 +15,11 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
+
 use leo_errors::{ParserError, Result};
 
 use leo_span::{sym, Symbol};
+
 use snarkvm_console::{account::Address, network::Testnet3};
 
 const INT_TYPES: &[Token] = &[
@@ -444,7 +446,10 @@ impl ParserContext<'_> {
                 // Eat a core struct constant or core struct function call.
                 expr = self.parse_associated_access_expression(expr)?;
             } else if self.check(&Token::LeftParen) {
-                // TODO (@d0cd) Check that the xpression is an identifier
+                // Check that the expression is an identifier.
+                if !matches!(expr, Expression::Identifier(_)) {
+                    self.emit_err(ParserError::unexpected(expr.to_string(), "an identifier", expr.span()))
+                }
                 // Parse a function call that's by itself.
                 let (arguments, _, span) = self.parse_paren_comma_list(|p| p.parse_expression().map(Some))?;
                 expr = Expression::Call(CallExpression {

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -444,6 +444,7 @@ impl ParserContext<'_> {
                 // Eat a core struct constant or core struct function call.
                 expr = self.parse_associated_access_expression(expr)?;
             } else if self.check(&Token::LeftParen) {
+                // TODO (@d0cd) Check that the xpression is an identifier
                 // Parse a function call that's by itself.
                 let (arguments, _, span) = self.parse_paren_comma_list(|p| p.parse_expression().map(Some))?;
                 expr = Expression::Call(CallExpression {

--- a/compiler/passes/src/code_generation/visit_expressions.rs
+++ b/compiler/passes/src/code_generation/visit_expressions.rs
@@ -456,7 +456,7 @@ impl<'a> CodeGenerator<'a> {
         // Lookup the function return type.
         let function_name = match input.function.borrow() {
             Expression::Identifier(identifier) => identifier.name,
-            _ => unreachable!("Parsing guarantees that all `input.function` is always an identifier."),
+            _ => unreachable!("Parsing guarantees that a function name is always an identifier."),
         };
         let return_type = &self.symbol_table.borrow().lookup_fn_symbol(function_name).unwrap().output_type;
         match return_type {

--- a/compiler/passes/src/type_checking/check_expressions.rs
+++ b/compiler/passes/src/type_checking/check_expressions.rs
@@ -453,6 +453,8 @@ impl<'a> ExpressionVisitor<'a> for TypeChecker<'a> {
     }
 
     fn visit_call(&mut self, input: &'a CallExpression, expected: &Self::AdditionalInput) -> Self::Output {
+        println!("call_expression: {}", input);
+        println!("input function: {:?}", input.function);
         match &*input.function {
             // Note that the parser guarantees that `input.function` is always an identifier.
             Expression::Identifier(ident) => {
@@ -514,7 +516,7 @@ impl<'a> ExpressionVisitor<'a> for TypeChecker<'a> {
                     None
                 }
             }
-            _ => unreachable!("Parser guarantees that `input.function` is always an identifier."),
+            _ => unreachable!("Parsing guarantees that a function name is always an identifier."),
         }
     }
 

--- a/tests/expectations/parser/functions/function_name_is_not_identifier.out
+++ b/tests/expectations/parser/functions/function_name_is_not_identifier.out
@@ -1,0 +1,5 @@
+---
+namespace: Parse
+expectation: Fail
+outputs:
+  - "Error [EPAR0370005]: expected an identifier -- found '100u8'\n    --> test:5:16\n     |\n   5 |         return 100u8(0u8);\n     |                ^^^^^"

--- a/tests/tests/parser/functions/function_name_is_not_identifier.leo
+++ b/tests/tests/parser/functions/function_name_is_not_identifier.leo
@@ -1,0 +1,10 @@
+/*
+namespace: Parse
+expectation: Fail
+*/
+
+program test.aleo {
+    function x(x: u32, constant y: i32) -> u8 {
+        return 100u8(0u8);
+    }
+}


### PR DESCRIPTION
This PR fixes #2521 by checking that function calls must lead with an identifier.
In the code linked in the above issue, the offending code is [here](https://gist.github.com/akalmykov/2a4d086f11142ed0083f74f7f32fdddf#file-main-aleo-L80)
```
        assert(amount <= 1000u128 (10u128 ** token_info.decimals));
```
