### PR TITLE
[Fix] Codegen for futures.

### DIFF
--- a/compiler/passes/src/code_generation/visit_program.rs
+++ b/compiler/passes/src/code_generation/visit_program.rs
@@ -266,6 +266,9 @@ impl<'a> CodeGenerator<'a> {
                 writeln!(function_string, "    await {register};").expect("failed to write to string");
             }
 
+            // Clear the futures.
+            self.futures.clear();
+
             // Construct and append the finalize block body, if it exists.
             if let Some(finalize) = &function.finalize {
                 function_string.push_str(&self.visit_block(&finalize.block));

--- a/compiler/passes/src/code_generation/visit_program.rs
+++ b/compiler/passes/src/code_generation/visit_program.rs
@@ -225,7 +225,7 @@ impl<'a> CodeGenerator<'a> {
             // If the function contained calls that produced futures, then we need to add the futures to the finalize block as input.
             // Store the new future registers.
             let mut future_registers = Vec::new();
-            for (_, future_type) in &self.futures {
+            for (_, future_type) in self.futures.drain(..) {
                 let register_string = format!("r{}", self.next_register);
                 writeln!(function_string, "    input {register_string} as {future_type}.future;")
                     .expect("failed to write to string");
@@ -265,9 +265,6 @@ impl<'a> CodeGenerator<'a> {
             for register in future_registers {
                 writeln!(function_string, "    await {register};").expect("failed to write to string");
             }
-
-            // Clear the futures.
-            self.futures.clear();
 
             // Construct and append the finalize block body, if it exists.
             if let Some(finalize) = &function.finalize {


### PR DESCRIPTION
This PR fixes code generation to be compatible with `futures`.

Closes #3093.