### PR TITLE
feat: support display private key discreetly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,6 +1448,7 @@ dependencies = [
  "serde_json",
  "snarkvm",
  "sys-info",
+ "termion",
  "test_dir",
  "toml 0.8.8",
  "tracing",
@@ -1543,6 +1544,17 @@ name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
  "bitflags 2.4.1",
  "libc",
@@ -1756,6 +1768,12 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -2102,13 +2120,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_termios"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
+
+[[package]]
 name = "redox_users"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "libredox",
+ "libredox 0.0.1",
  "thiserror",
 ]
 
@@ -3520,6 +3544,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "termion"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
+dependencies = [
+ "libc",
+ "libredox 0.0.2",
+ "numtoa",
+ "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.1",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1428,6 +1453,7 @@ dependencies = [
  "color-backtrace",
  "colored",
  "console",
+ "crossterm",
  "dirs 5.0.1",
  "dotenvy",
  "indexmap 1.9.3",
@@ -1448,7 +1474,6 @@ dependencies = [
  "serde_json",
  "snarkvm",
  "sys-info",
- "termion",
  "test_dir",
  "toml 0.8.8",
  "tracing",
@@ -1551,17 +1576,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libredox"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
-dependencies = [
- "bitflags 2.4.1",
- "libc",
- "redox_syscall",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1654,6 +1668,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -1768,12 +1783,6 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "numtoa"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 
 [[package]]
 name = "object"
@@ -2120,19 +2129,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_termios"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20145670ba436b55d91fc92d25e71160fbfbdd57831631c8d7d36377a476f1cb"
-
-[[package]]
 name = "redox_users"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
  "getrandom",
- "libredox 0.0.1",
+ "libredox",
  "thiserror",
 ]
 
@@ -2500,6 +2503,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3544,18 +3577,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "termion"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4648c7def6f2043b2568617b9f9b75eae88ca185dbc1f1fda30e95a85d49d7d"
-dependencies = [
- "libc",
- "libredox 0.0.2",
- "numtoa",
- "redox_termios",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,8 +157,8 @@ features = [ "fmt" ]
 [dependencies.zip]
 version = "^0.6"
 
-[dependencies.termion]
-version = "2.0.3"
+[dependencies.crossterm]
+version = "0.27.0"
 
 [target."cfg(windows)".dependencies.ansi_term]
 version = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,9 @@ features = [ "fmt" ]
 [dependencies.zip]
 version = "^0.6"
 
+[dependencies.termion]
+version = "2.0.3"
+
 [target."cfg(windows)".dependencies.ansi_term]
 version = "0.12.1"
 

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -15,10 +15,10 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use crossterm::ExecutableCommand;
 use leo_package::root::Env;
 use snarkvm::prelude::{Address, PrivateKey, ViewKey};
 
+use crossterm::ExecutableCommand;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
 use std::io::{self, Read, Write};

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -45,7 +45,7 @@ pub enum Account {
         /// Write the private key to the .env file.
         #[clap(short = 'w', long)]
         write: bool,
-        /// Print sensitive information(such as private key) discreetly to an alternate screen
+        /// Print sensitive information (such as private key) discreetly to an alternate screen
         #[clap(long)]
         discreet: bool,
     },

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -34,7 +34,7 @@ pub enum Account {
         /// Write the private key to the .env file.
         #[clap(short = 'w', long)]
         write: bool,
-        /// Print sensitive information(such as private key) discreetly to an alternate screen
+        /// Print sensitive information (such as private key) discreetly to an alternate screen
         #[clap(long)]
         discreet: bool,
     },

--- a/leo/cli/commands/account.rs
+++ b/leo/cli/commands/account.rs
@@ -100,14 +100,10 @@ fn print_keys(private_key: PrivateKey<CurrentNetwork>) -> Result<()> {
     let address = Address::<CurrentNetwork>::try_from(&view_key)?;
 
     display_string_discreetly(
-        &private_key.to_string(), 
+        &private_key.to_string(),
         "### Do not share or lose this private key! Press any key to complete. ###",
     )?;
-    println!(
-        "\n {:>12}  {view_key}\n {:>12}  {address}\n",
-        "View Key".cyan().bold(),
-        "Address".cyan().bold(),
-    );
+    println!("\n {:>12}  {view_key}\n {:>12}  {address}\n", "View Key".cyan().bold(), "Address".cyan().bold(),);
     Ok(())
 }
 
@@ -121,10 +117,7 @@ fn write_to_env_file(private_key: PrivateKey<CurrentNetwork>, ctx: &Context) -> 
 }
 
 /// Print the string to an alternate screen, so that the string won't been printed to the terminal.
-fn display_string_discreetly(
-    discreet_string: &str,
-    continue_message: &str,
-) -> Result<()> {
+fn display_string_discreetly(discreet_string: &str, continue_message: &str) -> Result<()> {
     use termion::screen::IntoAlternateScreen;
     let mut screen = std::io::stdout().into_alternate_screen().unwrap();
     writeln!(screen, "{discreet_string}").unwrap();


### PR DESCRIPTION
## Motivation

close #10016 

When we run `leo account new` or `leo account import`, will display private key discreently on an alternate screen. See following pics

![2023-11-28_16-50-53](https://github.com/AleoHQ/leo/assets/25278203/e6c8ba91-488a-464a-ab36-fb0a7b381b0e)

![image](https://github.com/AleoHQ/leo/assets/25278203/28fb2736-e3c9-43e4-984e-950dc9d68a60)

