### PR TITLE
fix: code refactor

### DIFF
--- a/compiler/ast/src/expressions/access.rs
+++ b/compiler/ast/src/expressions/access.rs
@@ -1,5 +1,7 @@
+// License Information:
 // Copyright (C) 2019-2023 Aleo Systems Inc.
 // This file is part of the Leo library.
+
 
 // The Leo library is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -81,12 +83,14 @@ impl Node for AccessExpression {
 
 impl fmt::Display for AccessExpression {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use Self::*;
         match self {
-            Self::Array(access) => access.fmt(f),
-            Self::AssociatedConstant(access) => access.fmt(f),
-            Self::AssociatedFunction(access) => access.fmt(f),
-            Self::Member(access) => access.fmt(f),
-            Self::Tuple(access) => access.fmt(f),
+            Array(access) => access.fmt(f),
+            AssociatedConstant(access) => access.fmt(f),
+            AssociatedFunction(access) => access.fmt(f),
+            Member(access) => access.fmt(f),
+            Tuple(access) => access.fmt(f),
         }
     }
 }
+

--- a/compiler/ast/src/expressions/access.rs
+++ b/compiler/ast/src/expressions/access.rs
@@ -83,14 +83,12 @@ impl Node for AccessExpression {
 
 impl fmt::Display for AccessExpression {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use Self::*;
         match self {
-            Array(access) => access.fmt(f),
-            AssociatedConstant(access) => access.fmt(f),
-            AssociatedFunction(access) => access.fmt(f),
-            Member(access) => access.fmt(f),
-            Tuple(access) => access.fmt(f),
+            Self::Array(access) => access.fmt(f),
+            Self::AssociatedConstant(access) => access.fmt(f),
+            Self::AssociatedFunction(access) => access.fmt(f),
+            Self::Member(access) => access.fmt(f),
+            Self::Tuple(access) => access.fmt(f),
         }
     }
 }
-

--- a/compiler/ast/src/expressions/access.rs
+++ b/compiler/ast/src/expressions/access.rs
@@ -32,7 +32,7 @@ pub enum AccessExpression {
     /// Access to an associated function of a struct e.g `Pedersen64::hash()`.
     AssociatedFunction(AssociatedFunction),
     /// An expression accessing a field in a structure, e.g., `struct_var.field`.
-    Member(MemberAccess),
+    Member(MemberAccess), 
     /// Access to a tuple field using its position, e.g., `tuple.1`.
     Tuple(TupleAccess),
 }
@@ -81,13 +81,12 @@ impl Node for AccessExpression {
 
 impl fmt::Display for AccessExpression {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use AccessExpression::*;
         match self {
-            Array(access) => access.fmt(f),
-            AssociatedConstant(access) => access.fmt(f),
-            AssociatedFunction(access) => access.fmt(f),
-            Member(access) => access.fmt(f),
-            Tuple(access) => access.fmt(f),
+            Self::Array(access) => access.fmt(f),
+            Self::AssociatedConstant(access) => access.fmt(f),
+            Self::AssociatedFunction(access) => access.fmt(f),
+            Self::Member(access) => access.fmt(f),
+            Self::Tuple(access) => access.fmt(f),
         }
     }
 }


### PR DESCRIPTION
fix: Instead of explicitly specifying the enum variant, you can use Self to refer to the current enum variant. This can make the code more maintainable if you decide to change the enum's name.



