### PR TITLE
[feat/stubs] Fix ParseIntError InvalidInteger in ast related to array type.

### DIFF
--- a/compiler/ast/src/types/array.rs
+++ b/compiler/ast/src/types/array.rs
@@ -57,7 +57,7 @@ impl<N: Network> From<&ConsoleArrayType<N>> for ArrayType {
     fn from(array_type: &ConsoleArrayType<N>) -> Self {
         Self {
             element_type: Box::new(Type::from(array_type.next_element_type())),
-            length: NonNegativeNumber::from(array_type.length().to_string()),
+            length: NonNegativeNumber::from(array_type.length().to_string().replace("u32", "")),
         }
     }
 }


### PR DESCRIPTION
I resolved an issue parsing aleo code for generation of stubs from network-retrieval which was related to the array length property of `snarkvm_console_program::data_types::array_type::ArrayType<N>`. This type's length property is stored as `U32<N>`, not `PlaintextType<N>`.  `compiler > ast > src > types > array.rs` is attempting to utilize `NonNegativeNumber::from(array_type.length().to_string()),)`.  `NonNegativeNumber` expects pure numeric string values. 

 See from `let value = usize::from_str(&string).unwrap();` that value is a `usize`.  In this case, the snarkVM value is parsed through `to_string()` and the `U32<N>::to_string` implementation appends `"u32"` to its value, resulting in the `InvalidInteger` `ParseIntError` error observed.

snarkVM relevant line:
```
assert_eq!(array.to_string(), "[[field; 2u32]; 3u32]");
```

```zshrc
7: core::panicking::panic_fmt
8: core::result::unwrap_failed
9: <leo_ast::types::array::ArrayType as core::convert::From<&snarkvm_console_program::data_types::array_type::ArrayType<N>>>::from
10: <leo_ast::types::type_::Type as core::convert::From<&snarkvm_console_program::data_types::plaintext_type::PlaintextType<N>>>::from
```

snark VM ArrayType:
```rust
pub struct ArrayType<N: Network> {
    /// The element type.
    element_type: Box<PlaintextType<N>>,
    /// The length of the array.
    length: U32<N>,
}
```

## Motivation

Trying to test feature/stubs with a contract.

## Test Plan

After rebuilding with patch applied, leo compiles without a panic, and gives more generic caught errors by the compiler for different issues. (Stub not found in program.json, import `import array_testing_aleo.leo;` not recognizeing `.leo` as a valid identifier because it has been deprecated in favor of `.aleo`).

`arrays.aleo`:
```aleo
import array_testing_aleo.aleo;

// The 'arrays' program.
program arrays.aleo {
    transition main(public a: u32, b: u32) -> u32 {
        let c: u32 = a + b;
        return c;
    }
}
```

`leo run` without patch:
```zshrc
% leo run main
Retrieving array_testing_aleo.aleo from Testnet3.
Successfully retrieved array_testing_aleo.aleo from Testnet3!
thread `main` panicked at compiler/ast/src/common/positive_number.rs:48:46:
called `Result::unwrap()` on an `Err` value: ParseIntError { kind: InvalidDigit }
```

`leo run` with patch:
```zhsrc
Error [EPAR0370028]: Invalid network identifier. The only supported identifier is `.aleo`.
    --> /Users/arosboro/git/arrays/src/main.leo:1:27
     |
   1 | import array_testing_aleo.leo;
```

`leo run` after changing identifier:
```zshrc
Error [ECMP0376006]: `arrays` imports `array_testing_aleo.aleo`, but `array_testing_aleo.aleo` is not found in `program.json`.
    --> /Users/arosboro/git/arrays/src/main.leo:1:1
     |
   1 | import array_testing_aleo.aleo;
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = Run `leo add array_testing_aleo.aleo` to add `array_testing_aleo.aleo` to `program.json`. Consult `leo add --help` for more information.
```

`program.json`:
```json
{
  "program": "arrays.aleo",
  "version": "0.0.0",
  "description": "",
  "license": "MIT",
  "dependencies": [
    {
      "name": "array_testing_aleo.aleo",
      "location": "network",
      "network": "testnet3"
    }
  ]
}
```

`main.leo`:
```leo
import array_testing_aleo.leo;

// The 'arrays' program.
program arrays.aleo {
    transition main(public a: u32, b: u32) -> u32 {
        let c: u32 = a + b;
        return c;
    }
}
```

`main.leo` after changing the identifier:
```leo
import array_testing_aleo.aleo;

// The 'arrays' program.
program arrays.aleo {
    transition main(public a: u32, b: u32) -> u32 {
        let c: u32 = a + b;
        return c;
    }
}
```

