### PR TITLE
[Feat] Better `leo add` and `leo build` UX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,6 +1972,7 @@ dependencies = [
  "toml 0.8.12",
  "tracing",
  "tracing-subscriber",
+ "ureq",
  "walkdir",
  "zip",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,7 +1879,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -1902,7 +1902,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "tempfile",
 ]
 
@@ -1913,7 +1913,7 @@ dependencies = [
  "leo-ast",
  "leo-errors",
  "leo-span",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -1966,7 +1966,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "snarkos-cli",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "sys-info",
  "test_dir",
  "toml 0.8.12",
@@ -1989,7 +1989,7 @@ dependencies = [
  "serde",
  "serial_test",
  "snarkos-cli",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "toml 0.8.12",
  "tracing",
 ]
@@ -2009,7 +2009,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smallvec",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "tracing",
 ]
 
@@ -2026,7 +2026,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -3921,12 +3921,12 @@ dependencies = [
  "rayon",
  "self_update 0.38.0",
  "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "thiserror",
  "ureq",
  "walkdir",
@@ -3985,10 +3985,10 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "thiserror",
 ]
 
@@ -4027,13 +4027,13 @@ name = "snarkvm-circuit"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4055,10 +4055,10 @@ name = "snarkvm-circuit-account"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4077,9 +4077,9 @@ name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4097,9 +4097,9 @@ name = "snarkvm-circuit-collections"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4122,12 +4122,12 @@ dependencies = [
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4163,10 +4163,10 @@ name = "snarkvm-circuit-network"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4186,13 +4186,13 @@ version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "paste",
- "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4215,14 +4215,14 @@ name = "snarkvm-circuit-types"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4245,12 +4245,12 @@ name = "snarkvm-circuit-types-address"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4271,8 +4271,8 @@ name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4289,9 +4289,9 @@ name = "snarkvm-circuit-types-field"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4309,11 +4309,11 @@ name = "snarkvm-circuit-types-group"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4333,11 +4333,11 @@ name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4357,10 +4357,10 @@ name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4379,11 +4379,11 @@ name = "snarkvm-circuit-types-string"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4403,12 +4403,12 @@ name = "snarkvm-console"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4430,8 +4430,8 @@ version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bs58",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "zeroize",
 ]
 
@@ -4453,9 +4453,9 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "tiny-keccak",
 ]
 
@@ -4479,8 +4479,8 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4506,15 +4506,15 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4552,9 +4552,9 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "zeroize",
 ]
 
@@ -4589,12 +4589,12 @@ dependencies = [
  "once_cell",
  "paste",
  "serde_json",
- "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4623,14 +4623,14 @@ name = "snarkvm-console-types"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4653,10 +4653,10 @@ name = "snarkvm-console-types-address"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4675,7 +4675,7 @@ name = "snarkvm-console-types-boolean"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4691,8 +4691,8 @@ name = "snarkvm-console-types-field"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "zeroize",
 ]
 
@@ -4711,10 +4711,10 @@ name = "snarkvm-console-types-group"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4733,10 +4733,10 @@ name = "snarkvm-console-types-integers"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4755,9 +4755,9 @@ name = "snarkvm-console-types-scalar"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "zeroize",
 ]
 
@@ -4777,10 +4777,10 @@ name = "snarkvm-console-types-string"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4803,8 +4803,8 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde",
- "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "thiserror",
 ]
 
@@ -4834,7 +4834,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "thiserror",
  "zeroize",
 ]
@@ -4867,15 +4867,15 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "time",
  "tracing",
 ]
@@ -4912,8 +4912,8 @@ dependencies = [
  "anyhow",
  "rand",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4936,15 +4936,15 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -4994,8 +4994,8 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5014,12 +5014,12 @@ name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-transmission 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-transmission 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5043,9 +5043,9 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5069,8 +5069,8 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5091,7 +5091,7 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "tokio",
 ]
 
@@ -5114,11 +5114,11 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5142,9 +5142,9 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
 ]
 
@@ -5166,7 +5166,7 @@ name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
 ]
 
@@ -5195,8 +5195,8 @@ dependencies = [
  "rand_chacha",
  "rayon",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5210,7 +5210,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
 ]
 
@@ -5221,9 +5221,9 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "ureq",
 ]
 
@@ -5253,14 +5253,14 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5317,8 +5317,8 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "thiserror",
 ]
 
@@ -5360,19 +5360,19 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-puzzle-epoch",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-process 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-process 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "tracing",
 ]
 
@@ -5415,14 +5415,14 @@ dependencies = [
  "rand",
  "rayon",
  "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5458,8 +5458,8 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde_json",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5484,9 +5484,9 @@ dependencies = [
  "bincode",
  "once_cell",
  "serde_json",
- "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
- "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=da3d78a)",
  "thiserror",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ default = [ ]
 ci_skip = [ "leo-compiler/ci_skip" ]
 noconfig = [ ]
 
+[dependencies]
+ureq = "2.9.7"
+
 [dependencies.leo-ast]
 path = "./compiler/ast"
 version = "=1.11.0"

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -383,4 +383,18 @@ create_messages!(
         msg: format!("The dependency program `{name}` was not found among the manifest's dependencies."),
         help: None,
     }
+
+    @backtraced
+    conflicting_on_chain_program_name {
+        args: (first: impl Display, second: impl Display),
+        msg: format!("Conflicting program names given to execute on chain: `{first}` and `{second}`."),
+        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    }
+
+    @backtraced
+    missing_on_chain_program_name {
+        args: (),
+        msg: "The name of the program to execute on-chain is missing.".to_string(),
+        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    }
 );

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -376,7 +376,7 @@ create_messages!(
         msg: format!("The dependency program name `{name}` is invalid."),
         help: Some("Aleo program names must only contain lower case letters, numbers and underscores.".to_string()),
     }
-    
+
     @backtraced
     dependency_not_found {
         args: (name: impl Display),

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -371,16 +371,9 @@ create_messages!(
     }
 
     @backtraced
-    missing_on_chain_program_name {
-        args: (),
-        msg: "The name of the program to execute on-chain is missing.".to_string(),
-        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
-    }
-
-    @backtraced
-    conflicting_on_chain_program_name {
-        args: (first: impl Display, second: impl Display),
-        msg: format!("Conflicting program names given to execute on chain: `{first}` and `{second}`."),
-        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    invalid_file_name_dependency {
+        args: (name: impl Display),
+        msg: format!("The dependency program name `{name}` is invalid."),
+        help: Some("Aleo program names must only contain lower case letters, numbers and underscores.".to_string()),
     }
 );

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -376,4 +376,11 @@ create_messages!(
         msg: format!("The dependency program name `{name}` is invalid."),
         help: Some("Aleo program names must only contain lower case letters, numbers and underscores.".to_string()),
     }
+    
+    @backtraced
+    dependency_not_found {
+        args: (name: impl Display),
+        msg: format!("The dependency program `{name}` was not found among the manifest's dependencies."),
+        help: None,
+    }
 );

--- a/errors/src/errors/utils/util_errors.rs
+++ b/errors/src/errors/utils/util_errors.rs
@@ -140,8 +140,8 @@ create_messages!(
 
     @formatted
     failed_to_retrieve_from_endpoint {
-        args: (endpoint: impl Display, error: impl ErrorArg),
-        msg: format!("Failed to retrieve from endpoint `{endpoint}`. Error: {error}"),
+        args: (error: impl ErrorArg),
+        msg: format!("{error}"),
         help: None,
     }
 
@@ -150,5 +150,47 @@ create_messages!(
         args: (path: impl Display),
         msg: format!("Compiled file at `{path}` does not exist, cannot compile parent."),
         help: Some("If you were using the `--non-recursive` flag, remove it and try again.".to_string()),
+    }
+
+    @backtraced
+    invalid_input_id_len {
+        args: (input: impl Display, expected_type: impl Display),
+        msg: format!("Invalid input: {input}."),
+        help: Some(format!("Type `{expected_type}` must contain exactly 61 lowercase characters or numbers.")),
+    }
+
+    @backtraced
+    invalid_input_id {
+        args: (input: impl Display, expected_type: impl Display, expected_preface: impl Display),
+        msg: format!("Invalid input: {input}."),
+        help: Some(format!("Type `{expected_type}` must start with \"{expected_preface}\".")),
+    }
+
+    @backtraced
+    invalid_numerical_input {
+        args: (input: impl Display),
+        msg: format!("Invalid numerical input: {input}."),
+        help: Some("Input must be a valid u32.".to_string()),
+    }
+
+    @backtraced
+    invalid_range {
+        args: (),
+        msg: "The range must be less than or equal to 50 blocks.".to_string(),
+        help: None,
+    }
+
+    @backtraced
+    invalid_height_or_hash {
+        args: (input: impl Display),
+        msg: format!("Invalid input: {input}."),
+        help: Some("Input must be a valid height or hash. Valid hashes are 61 characters long, composed of only numbers and lower case letters, and be prefaced with \"ab1\".".to_string()),
+    }
+
+    @backtraced
+    invalid_field {
+        args: (field: impl Display),
+        msg: format!("Invalid field: {field}."),
+        help: Some("Field element must be numerical string with optional \"field\" suffix.".to_string()),
     }
 );

--- a/leo/cli/cli.rs
+++ b/leo/cli/cli.rs
@@ -33,10 +33,10 @@ pub struct CLI {
     #[clap(subcommand)]
     command: Commands,
 
-    #[clap(long, global = true, help = "Optional path to Leo program root folder")]
+    #[clap(long, global = true, help = "Path to Leo program root folder")]
     path: Option<PathBuf>,
 
-    #[clap(long, global = true, help = "Optional path to aleo program registry.")]
+    #[clap(long, global = true, help = "Path to aleo program registry.")]
     pub home: Option<PathBuf>,
 }
 
@@ -401,6 +401,7 @@ function external_nested_function:
                     name: "nested_example_layer_0".to_string(),
                     local: None,
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(project_directory.clone()),
@@ -494,6 +495,7 @@ program child.aleo {
                     name: "parent".to_string(),
                     local: Some(parent_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(grandparent_directory.clone()),
@@ -508,6 +510,7 @@ program child.aleo {
                     name: "child".to_string(),
                     local: Some(child_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(grandparent_directory.clone()),
@@ -522,6 +525,7 @@ program child.aleo {
                     name: "child".to_string(),
                     local: Some(child_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(parent_directory.clone()),
@@ -645,6 +649,7 @@ program outer.aleo {
                     name: "inner_1".to_string(),
                     local: Some(inner_1_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(outer_directory.clone()),
@@ -659,6 +664,7 @@ program outer.aleo {
                     name: "inner_2".to_string(),
                     local: Some(inner_2_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(outer_directory.clone()),
@@ -812,6 +818,7 @@ program outer_2.aleo {
                     name: "inner_1".to_string(),
                     local: Some(inner_1_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(outer_directory.clone()),
@@ -826,6 +833,7 @@ program outer_2.aleo {
                     name: "inner_2".to_string(),
                     local: Some(inner_2_directory.clone()),
                     network: "testnet3".to_string(),
+                    clear: false,
                 },
             },
             path: Some(outer_directory.clone()),

--- a/leo/cli/cli.rs
+++ b/leo/cli/cli.rs
@@ -48,11 +48,6 @@ enum Commands {
         #[clap(subcommand)]
         command: Account,
     },
-    #[clap(about = "Add a new on-chain or local dependency to the current package.")]
-    Add {
-        #[clap(flatten)]
-        command: Add,
-    },
     #[clap(about = "Create a new Leo package in a new directory")]
     New {
         #[clap(flatten)]
@@ -78,11 +73,20 @@ enum Commands {
         #[clap(flatten)]
         command: Deploy,
     },
-
     #[clap(about = "Compile the current package as a program")]
     Build {
         #[clap(flatten)]
         command: Build,
+    },
+    #[clap(about = "Add a new on-chain or local dependency to the current package.")]
+    Add {
+        #[clap(flatten)]
+        command: Add,
+    },
+    #[clap(about = "Remove a dependency from the current package.")]
+    Remove {
+        #[clap(flatten)]
+        command: Remove,
     },
     #[clap(about = "Clean the output directory")]
     Clean {
@@ -145,6 +149,7 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
         Commands::Example { command } => command.try_execute(context),
         Commands::Run { command } => command.try_execute(context),
         Commands::Execute { command } => command.try_execute(context),
+        Commands::Remove { command } => command.try_execute(context),
         Commands::Update { command } => command.try_execute(context),
     }
 }

--- a/leo/cli/cli.rs
+++ b/leo/cli/cli.rs
@@ -36,7 +36,7 @@ pub struct CLI {
     #[clap(long, global = true, help = "Path to Leo program root folder")]
     path: Option<PathBuf>,
 
-    #[clap(long, global = true, help = "Path to aleo program registry.")]
+    #[clap(long, global = true, help = "Path to aleo program registry")]
     pub home: Option<PathBuf>,
 }
 
@@ -72,6 +72,11 @@ enum Commands {
     Deploy {
         #[clap(flatten)]
         command: Deploy,
+    },
+    #[clap(about = "Query live data from the Aleo network")]
+    Query {
+        #[clap(flatten)]
+        command: Query,
     },
     #[clap(about = "Compile the current package as a program")]
     Build {
@@ -144,6 +149,7 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
 
             command.try_execute(context)
         }
+        Commands::Query { command } => command.try_execute(context),
         Commands::Clean { command } => command.try_execute(context),
         Commands::Deploy { command } => command.try_execute(context),
         Commands::Example { command } => command.try_execute(context),

--- a/leo/cli/commands/add.rs
+++ b/leo/cli/commands/add.rs
@@ -59,8 +59,8 @@ impl Command for Add {
         // Make sure the program name is valid.
         // Allow both `credits.aleo` and `credits` syntax.
         let name: String = match &self.name {
-            name if name.ends_with(".aleo") && is_valid_program_name(&name[0..self.name.len() - 5]) => name.clone(),
-            name if is_valid_program_name(name) => format!("{name}.aleo"),
+            name if name.ends_with(".aleo") && Package::<CurrentNetwork>::is_program_name_valid(&name[0..self.name.len() - 5]) => name.clone(),
+            name if Package::<CurrentNetwork>::is_program_name_valid(name) => format!("{name}.aleo"),
             name => return Err(PackageError::invalid_file_name_dependency(name).into()),
         };
 
@@ -127,9 +127,4 @@ impl Command for Add {
 
         Ok(())
     }
-}
-
-/// Returns `true` if the String is a valid Aleo program name.
-pub fn is_valid_program_name(name: &str) -> bool {
-    name.chars().all(|c| matches!(c, '0'..='9' | 'a'..='z' | '_'))
 }

--- a/leo/cli/commands/add.rs
+++ b/leo/cli/commands/add.rs
@@ -60,11 +60,11 @@ impl Command for Add {
         // Allow both `credits.aleo` and `credits` syntax.
         let name: String = match &self.name {
             name if name.ends_with(".aleo")
-                && Package::<CurrentNetwork>::is_program_name_valid(&name[0..self.name.len() - 5]) =>
+                && Package::<CurrentNetwork>::is_aleo_name_valid(&name[0..self.name.len() - 5]) =>
             {
                 name.clone()
             }
-            name if Package::<CurrentNetwork>::is_program_name_valid(name) => format!("{name}.aleo"),
+            name if Package::<CurrentNetwork>::is_aleo_name_valid(name) => format!("{name}.aleo"),
             name => return Err(PackageError::invalid_file_name_dependency(name).into()),
         };
 

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -193,10 +193,6 @@ fn compile_leo_file(
     options: BuildOptions,
     stubs: IndexMap<Symbol, Stub>,
 ) -> Result<()> {
-    // Construct the Leo file name with extension `foo.leo`.
-    let file_name =
-        file_path.file_name().and_then(|name| name.to_str()).ok_or_else(PackageError::failed_to_get_file_name)?;
-
     // Construct program name from the program_id found in `package.json`.
     let program_name = program_id.name().to_string();
 

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -206,7 +206,7 @@ fn compile_leo_file(
 
     // Create a new instance of the Leo compiler.
     let mut compiler = Compiler::new(
-        program_name,
+        program_name.clone(),
         program_id.network().to_string(),
         handler,
         file_path.clone(),
@@ -224,6 +224,6 @@ fn compile_leo_file(
         .write_all(instructions.as_bytes())
         .map_err(CliError::failed_to_load_instructions)?;
 
-    tracing::info!("✅ Compiled '{}' into Aleo instructions", file_name);
+    tracing::info!("✅ Compiled '{program_name}.aleo' into Aleo instructions");
     Ok(())
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -41,6 +41,9 @@ pub use new::New;
 // pub mod node;
 // pub use node::Node;
 
+pub mod remove;
+pub use remove::Remove;
+
 pub mod run;
 pub use run::Run;
 

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -35,6 +35,9 @@ pub use example::Example;
 pub mod execute;
 pub use execute::Execute;
 
+pub mod query;
+pub use query::Query;
+
 pub mod new;
 pub use new::New;
 

--- a/leo/cli/commands/query/block.rs
+++ b/leo/cli/commands/query/block.rs
@@ -1,0 +1,93 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use crate::cli::context::Context;
+use clap::Parser;
+
+// Query on-chain information related to blocks.
+#[derive(Parser, Debug)]
+pub struct Block {
+    #[clap(help = "Fetch a block by specifying its height or hash", required_unless_present_any = &["latest", "latest_hash", "latest_height", "range"])]
+    pub(crate) id: Option<String>,
+    #[arg(short, long, help = "Get the latest block", default_value = "false", conflicts_with_all(["latest_hash", "latest_height", "range", "transactions", "to_height"]))]
+    pub(crate) latest: bool,
+    #[arg(short, long, help = "Get the latest block hash", default_value = "false", conflicts_with_all(["latest", "latest_height", "range", "transactions", "to_height"]))]
+    pub(crate) latest_hash: bool,
+    #[arg(short, long, help = "Get the latest block height", default_value = "false", conflicts_with_all(["latest", "latest_hash", "range", "transactions", "to_height"]))]
+    pub(crate) latest_height: bool,
+    #[arg(short, long, help = "Get up to 50 consecutive blocks", number_of_values = 2, value_names = &["START_HEIGHT", "END_HEIGHT"], conflicts_with_all(["latest", "latest_hash", "latest_height", "transactions", "to_height"]))]
+    pub(crate) range: Option<Vec<String>>,
+    #[arg(
+        short,
+        long,
+        help = "Get all transactions at the specified block height",
+        conflicts_with("to_height"),
+        default_value = "false"
+    )]
+    pub(crate) transactions: bool,
+    #[arg(short, long, help = "Lookup the block height corresponding to a hash value", default_value = "false")]
+    pub(crate) to_height: bool,
+}
+
+impl Command for Block {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _input: Self::Input) -> Result<Self::Output> {
+        // Build custom url to fetch from based on the flags and user's input.
+        let url = if self.latest_height {
+            "block/height/latest".to_string()
+        } else if self.latest_hash {
+            "block/hash/latest".to_string()
+        } else if self.latest {
+            "block/latest".to_string()
+        } else if let Some(range) = self.range {
+            // Make sure the range is composed of valid numbers.
+            is_valid_numerical_input(&range[0])?;
+            is_valid_numerical_input(&range[1])?;
+
+            // Make sure the range is not too large.
+            if range[1].parse::<u32>().unwrap() - range[0].parse::<u32>().unwrap() > 50 {
+                return Err(UtilError::invalid_range().into());
+            }
+            format!("blocks?start={}&end={}", range[0], range[1])
+        } else if self.transactions {
+            is_valid_numerical_input(&self.id.clone().unwrap())?;
+            format!("block/{}/transactions", self.id.unwrap()).to_string()
+        } else if self.to_height {
+            let id = self.id.unwrap();
+            is_valid_hash(&id)?;
+            format!("height/{}", id).to_string()
+        } else if let Some(id) = self.id {
+            is_valid_height_or_hash(&id)?;
+            format!("block/{}", id)
+        } else {
+            unreachable!("All cases are covered")
+        };
+
+        Ok(url)
+    }
+}

--- a/leo/cli/commands/query/committee.rs
+++ b/leo/cli/commands/query/committee.rs
@@ -1,0 +1,40 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use clap::Parser;
+
+/// Query the committee.
+#[derive(Parser, Debug)]
+pub struct Committee {}
+
+impl Command for Committee {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
+        Ok("/committee/latest".to_string())
+    }
+}

--- a/leo/cli/commands/query/mempool.rs
+++ b/leo/cli/commands/query/mempool.rs
@@ -1,0 +1,69 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use crate::cli::context::Context;
+use clap::Parser;
+
+// Query transactions and transmissions from the memory pool.
+#[derive(Parser, Debug)]
+pub struct Mempool {
+    #[arg(
+        short,
+        long,
+        help = "Get the memory pool transactions",
+        default_value = "false",
+        required_unless_present = "transmissions",
+        conflicts_with("transmissions")
+    )]
+    pub(crate) transactions: bool,
+    #[arg(
+        short,
+        long,
+        help = "Get the memory pool transmissions",
+        default_value = "false",
+        required_unless_present = "transactions",
+        conflicts_with("transactions")
+    )]
+    pub(crate) transmissions: bool,
+}
+
+impl Command for Mempool {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _input: Self::Input) -> Result<Self::Output> {
+        // Build custom url to fetch from based on the flags and user's input.
+        let url = if self.transactions {
+            "memoryPool/transactions".to_string()
+        } else if self.transmissions {
+            "memoryPool/transmissions".to_string()
+        } else {
+            unreachable!("All cases are covered")
+        };
+
+        Ok(url)
+    }
+}

--- a/leo/cli/commands/query/mod.rs
+++ b/leo/cli/commands/query/mod.rs
@@ -1,0 +1,153 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+mod block;
+use block::Block;
+
+mod program;
+use program::Program;
+
+mod state_root;
+use state_root::StateRoot;
+
+mod committee;
+use committee::Committee;
+
+mod mempool;
+use mempool::Mempool;
+
+mod peers;
+use peers::Peers;
+
+mod transaction;
+use transaction::Transaction;
+
+mod utils;
+use utils::*;
+
+use leo_errors::UtilError;
+
+///  Query live data from the Aleo network.
+#[derive(Parser, Debug)]
+pub struct Query {
+    #[clap(
+        short,
+        long,
+        global = true,
+        help = "Endpoint to retrieve network state from. Defaults to http://api.explorer.aleo.org/v1.",
+        default_value = "http://api.explorer.aleo.org/v1"
+    )]
+    pub endpoint: String,
+    #[clap(short, long, global = true, help = "Network to use. Defaults to testnet3.", default_value = "testnet3")]
+    pub(crate) network: String,
+    #[clap(subcommand)]
+    command: QueryCommands,
+}
+
+impl Command for Query {
+    type Input = ();
+    type Output = ();
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
+        let output = match self.command {
+            QueryCommands::Block { command } => command.apply(context, ())?,
+            QueryCommands::Transaction { command } => command.apply(context, ())?,
+            QueryCommands::Program { command } => command.apply(context, ())?,
+            QueryCommands::Stateroot { command } => command.apply(context, ())?,
+            QueryCommands::Committee { command } => command.apply(context, ())?,
+            QueryCommands::Mempool { command } => {
+                if self.endpoint == "http://api.explorer.aleo.org/v1" {
+                    tracing::warn!(
+                        "⚠️  `leo query mempool` is only valid when using a custom endpoint. Specify one using `--endpoint`."
+                    );
+                }
+                command.apply(context, ())?
+            }
+            QueryCommands::Peers { command } => {
+                if self.endpoint == "http://api.explorer.aleo.org/v1" {
+                    tracing::warn!(
+                        "⚠️  `leo query peers` is only valid when using a custom endpoint. Specify one using `--endpoint`."
+                    );
+                }
+                command.apply(context, ())?
+            }
+        };
+
+        // Make GET request to retrieve on-chain state.
+        let url = format!("{}/{}/{}", self.endpoint, self.network, output);
+        let response = ureq::get(&url.clone())
+            .set(&format!("X-Aleo-Leo-{}", env!("CARGO_PKG_VERSION")), "true")
+            .call()
+            .map_err(|err| UtilError::failed_to_retrieve_from_endpoint(err, Default::default()))?;
+        if response.status() == 200 {
+            tracing::info!("✅ Successfully retrieved data from '{url}'.\n");
+            // Unescape the newlines.
+            println!("{}\n", response.into_string().unwrap().replace("\\n", "\n"));
+            Ok(())
+        } else {
+            Err(UtilError::network_error(url, response.status(), Default::default()).into())
+        }
+    }
+}
+
+#[derive(Parser, Debug)]
+enum QueryCommands {
+    #[clap(about = "Query block information")]
+    Block {
+        #[clap(flatten)]
+        command: Block,
+    },
+    #[clap(about = "Query transaction information")]
+    Transaction {
+        #[clap(flatten)]
+        command: Transaction,
+    },
+    #[clap(about = "Query program source code and live mapping values")]
+    Program {
+        #[clap(flatten)]
+        command: Program,
+    },
+    #[clap(about = "Query the latest stateroot")]
+    Stateroot {
+        #[clap(flatten)]
+        command: StateRoot,
+    },
+    #[clap(about = "Query the current committee")]
+    Committee {
+        #[clap(flatten)]
+        command: Committee,
+    },
+    #[clap(about = "Query transactions and transmissions from the memory pool")]
+    Mempool {
+        #[clap(flatten)]
+        command: Mempool,
+    },
+    #[clap(about = "Query peer information")]
+    Peers {
+        #[clap(flatten)]
+        command: Peers,
+    },
+}

--- a/leo/cli/commands/query/peers.rs
+++ b/leo/cli/commands/query/peers.rs
@@ -1,0 +1,61 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use crate::cli::context::Context;
+use clap::Parser;
+
+// Query information about network peers.
+#[derive(Parser, Debug)]
+pub struct Peers {
+    #[arg(short, long, help = "Get all peer metrics", default_value = "false", conflicts_with("count"))]
+    pub(crate) metrics: bool,
+    #[arg(
+        short,
+        long,
+        help = "Get the count of all participating peers",
+        default_value = "false",
+        conflicts_with("metrics")
+    )]
+    pub(crate) count: bool,
+}
+
+impl Command for Peers {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _input: Self::Input) -> Result<Self::Output> {
+        // Build custom url to fetch from based on the flags and user's input.
+        let url = if self.metrics {
+            "peers/all/metrics".to_string()
+        } else if self.count {
+            "peers/count".to_string()
+        } else {
+            "peers/all".to_string()
+        };
+
+        Ok(url)
+    }
+}

--- a/leo/cli/commands/query/program.rs
+++ b/leo/cli/commands/query/program.rs
@@ -1,0 +1,67 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use clap::Parser;
+use leo_package::package::Package;
+
+/// Query program source code and live mapping values.
+#[derive(Parser, Debug)]
+pub struct Program {
+    #[clap(name = "NAME", help = "The name of the program to fetch")]
+    pub(crate) name: String,
+    #[arg(
+        short,
+        long,
+        help = "Get all mappings defined in the program",
+        default_value = "false",
+        conflicts_with = "mapping_value"
+    )]
+    pub(crate) mappings: bool,
+    #[arg(short, long, help = "Get the value corresponding to the specified mapping and key.", number_of_values = 2, value_names = &["MAPPING", "KEY"], conflicts_with = "mappings")]
+    pub(crate) mapping_value: Option<Vec<String>>,
+}
+
+impl Command for Program {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
+        // Check that the program name is valid.
+        let program = check_valid_program_name(self.name);
+        // Build custom url to fetch from based on the flags and user's input.
+        let url = if let Some(mapping_info) = self.mapping_value {
+            // Check that the mapping name is valid.
+            Package::<CurrentNetwork>::is_aleo_name_valid(&mapping_info[0]);
+            format!("program/{}/mapping/{}/{}", program, mapping_info[0], mapping_info[1])
+        } else if self.mappings {
+            format!("program/{}/mappings", program)
+        } else {
+            format!("program/{}", program)
+        };
+
+        Ok(url)
+    }
+}

--- a/leo/cli/commands/query/state_root.rs
+++ b/leo/cli/commands/query/state_root.rs
@@ -1,0 +1,40 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use clap::Parser;
+
+/// Query the latest stateroot.
+#[derive(Parser, Debug)]
+pub struct StateRoot {}
+
+impl Command for StateRoot {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
+        Ok("/stateRoot/latest".to_string())
+    }
+}

--- a/leo/cli/commands/query/transaction.rs
+++ b/leo/cli/commands/query/transaction.rs
@@ -1,0 +1,68 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use clap::Parser;
+
+/// Query transaction information.
+#[derive(Parser, Debug)]
+pub struct Transaction {
+    #[clap(name = "ID", help = "The id of the transaction to fetch", required_unless_present_any = &["from_program", "from_transition", "from_io", "range"])]
+    pub(crate) id: Option<String>,
+    #[arg(short, long, help = "Get the transaction only if it has been confirmed", default_value = "false", conflicts_with_all(["from_io", "from_transition", "from_program"]))]
+    pub(crate) confirmed: bool,
+    #[arg(value_name = "INPUT_OR_OUTPUT_ID", short, long, help = "Get the transition id that an input or output id occurred in", conflicts_with_all(["from_program", "from_transition", "confirmed", "id"]))]
+    pub(crate) from_io: Option<String>,
+    #[arg(value_name = "TRANSITION_ID", short, long, help = "Get the id of the transaction containing the specified transition", conflicts_with_all(["from_io", "from_program", "confirmed", "id"]))]
+    pub(crate) from_transition: Option<String>,
+    #[arg(value_name = "PROGRAM", short, long, help = "Get the id of the transaction id that the specified program was deployed in", conflicts_with_all(["from_io", "from_transition", "confirmed", "id"]))]
+    pub(crate) from_program: Option<String>,
+}
+
+impl Command for Transaction {
+    type Input = ();
+    type Output = String;
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _context: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
+        // Build custom url to fetch from based on the flags and user's input.
+        let url = if let Some(io_id) = self.from_io {
+            let field = is_valid_field(&io_id)?;
+            format!("find/transitionID/{field}")
+        } else if let Some(transition) = self.from_transition {
+            is_valid_transition_id(&transition)?;
+            format!("find/transactionID/{transition}")
+        } else if let Some(program) = self.from_program {
+            // Check that the program name is valid.
+            format!("find/transactionID/deployment/{}", check_valid_program_name(program))
+        } else if let Some(id) = self.id {
+            is_valid_transaction_id(&id)?;
+            if self.confirmed { format!("transaction/confirmed/{}", id) } else { format!("transaction/{}", id) }
+        } else {
+            unreachable!("All command paths covered.")
+        };
+
+        Ok(url)
+    }
+}

--- a/leo/cli/commands/query/utils.rs
+++ b/leo/cli/commands/query/utils.rs
@@ -1,0 +1,94 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use leo_errors::{LeoError, Result, UtilError};
+
+use leo_package::package::Package;
+
+// A valid hash is 61 characters long, with preface "ab1" and all characters lowercase or numbers.
+pub fn is_valid_hash(hash: &str) -> Result<(), LeoError> {
+    if hash.len() != 61 {
+        Err(UtilError::invalid_input_id_len(hash, "hash").into())
+    } else if !hash.starts_with("ab1") && hash.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit()) {
+        Err(UtilError::invalid_input_id(hash, "hash", "ab1").into())
+    } else {
+        Ok(())
+    }
+}
+
+// A valid transaction id is 61 characters long, with preface "at1" and all characters lowercase or numbers.
+pub fn is_valid_transaction_id(transaction: &str) -> Result<(), LeoError> {
+    if transaction.len() != 61 {
+        Err(UtilError::invalid_input_id_len(transaction, "transaction").into())
+    } else if !transaction.starts_with("at1")
+        && transaction.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        Err(UtilError::invalid_input_id(transaction, "transaction", "at1").into())
+    } else {
+        Ok(())
+    }
+}
+
+// A valid transition id is 61 characters long, with preface "au1" and all characters lowercase or numbers.
+pub fn is_valid_transition_id(transition: &str) -> Result<(), LeoError> {
+    if transition.len() != 61 {
+        Err(UtilError::invalid_input_id_len(transition, "transition").into())
+    } else if !transition.starts_with("au1") && transition.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+    {
+        Err(UtilError::invalid_input_id(transition, "transition", "au1").into())
+    } else {
+        Ok(())
+    }
+}
+
+// A valid numerical input is a u32.
+pub fn is_valid_numerical_input(num: &str) -> Result<(), LeoError> {
+    if num.parse::<u32>().is_err() { Err(UtilError::invalid_numerical_input(num).into()) } else { Ok(()) }
+}
+
+// A valid height or hash.
+pub fn is_valid_height_or_hash(input: &str) -> Result<(), LeoError> {
+    match (is_valid_hash(input), is_valid_numerical_input(input)) {
+        (Ok(_), _) | (_, Ok(_)) => Ok(()),
+        _ => Err(UtilError::invalid_height_or_hash(input).into()),
+    }
+}
+
+// Checks if the string is a valid field, allowing for optional `field` suffix.
+pub fn is_valid_field(field: &str) -> Result<String, LeoError> {
+    let split = field.split("field").collect::<Vec<&str>>();
+
+    if split.len() == 1 && split[0].chars().all(|c| c.is_numeric()) {
+        Ok(format!("{}field", field))
+    } else if split.len() == 2 && split[0].chars().all(|c| c.is_numeric()) && split[1].is_empty() {
+        Ok(field.to_string())
+    } else {
+        Err(UtilError::invalid_field(field).into())
+    }
+}
+
+// Checks if the string is a valid program name in Aleo.
+pub fn check_valid_program_name(name: String) -> String {
+    if name.ends_with(".aleo") {
+        Package::<CurrentNetwork>::is_aleo_name_valid(&name[0..name.len() - 5]);
+        name
+    } else {
+        Package::<CurrentNetwork>::is_aleo_name_valid(&name);
+        format!("{}.aleo", name)
+    }
+}

--- a/leo/cli/commands/remove.rs
+++ b/leo/cli/commands/remove.rs
@@ -1,0 +1,116 @@
+// Copyright (C) 2019-2023 Aleo Systems Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+use leo_retriever::{Dependency, Manifest};
+use std::path::PathBuf;
+
+/// Remove a dependency from the current package.
+#[derive(Parser, Debug)]
+#[clap(name = "leo", author = "The Aleo Team <hello@aleo.org>", version)]
+pub struct Remove {
+    #[clap(name = "NAME", help = "The dependency name. Ex: `credits.aleo` or `credits`.", required_unless_present = "all")]
+    pub(crate) name: Option<String>,
+
+    #[clap(short = 'l', long, help = "Path to local dependency")]
+    pub(crate) local: Option<PathBuf>,
+
+    #[clap(short = 'n', long, help = "Name of the network to use", default_value = "testnet3")]
+    pub(crate) network: String,
+
+    #[clap(long, help = "Clear all previous dependencies.", default_value = "false")]
+    pub(crate) all: bool,
+}
+
+impl Command for Remove {
+    type Input = ();
+    type Output = ();
+
+    fn log_span(&self) -> Span {
+        tracing::span!(tracing::Level::INFO, "Leo")
+    }
+
+    fn prelude(&self, _: Context) -> Result<Self::Input> {
+        Ok(())
+    }
+
+    fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
+        let path = context.dir()?;
+        
+        // TODO: Dedup with Add Command. Requires merging utils/retriever/program_context with leo/package as both involve modifying the manifest.
+        // Deserialize the manifest.
+        let program_data: String = std::fs::read_to_string(path.join("program.json"))
+            .map_err(|err| PackageError::failed_to_read_file(path.to_str().unwrap(), err))?;
+        let manifest: Manifest = serde_json::from_str(&program_data)
+            .map_err(|err| PackageError::failed_to_deserialize_manifest_file(path.to_str().unwrap(), err))?;
+        
+        let dependencies: Vec<Dependency> = if !self.all {
+            // Make sure the program name is valid.
+            // Allow both `credits.aleo` and `credits` syntax.
+            let name: String = match &self.name {
+                Some(name) if name.ends_with(".aleo") && Package::<CurrentNetwork>::is_program_name_valid(&name[0..name.len() - 5]) => name.clone(),
+                Some(name) if Package::<CurrentNetwork>::is_program_name_valid(name) => format!("{name}.aleo"),
+                name => return Err(PackageError::invalid_file_name_dependency(name.clone().unwrap()).into()),
+            };
+            
+            let mut found_match = false;
+            let dep = match manifest.dependencies() {
+                Some(ref dependencies) => dependencies
+                    .iter()
+                    .filter_map(|dependency| {
+                        if dependency.name() == &name {
+                            found_match = true;
+                            let msg = match (dependency.path(), dependency.network()) {
+                                (Some(local_path), _) => format!("local dependency to `{}` from path `{}`", name, local_path.to_str().unwrap().replace('\"', "")),
+                                (_, Some(network)) => format!("network dependency to `{}` from network `{}`", name, network),
+                                _ => format!("git dependency to `{name}`"),
+                            };
+                            tracing::warn!("✅ Successfully removed the {msg}.");
+                            None
+                        } else {
+                            Some(dependency.clone())
+                        }
+                    })
+                    .collect(),
+                _ => Vec::new(),
+            };
+            
+            // Throw error if no match is found.
+            if !found_match {
+                return Err(PackageError::dependency_not_found(name).into());
+            }
+            
+            dep
+        } else {
+            Vec::new()
+        };
+        
+        // Update the manifest file.
+        let new_manifest = Manifest::new(
+            manifest.program(),
+            manifest.version(),
+            manifest.description(),
+            manifest.license(),
+            Some(dependencies),
+        );
+        let new_manifest_data = serde_json::to_string_pretty(&new_manifest)
+            .map_err(|err| PackageError::failed_to_serialize_manifest_file(path.to_str().unwrap(), err))?;
+        std::fs::write(path.join("program.json"), new_manifest_data).map_err(PackageError::failed_to_write_manifest)?;
+
+        Ok(())
+    }
+}
+

--- a/leo/cli/commands/remove.rs
+++ b/leo/cli/commands/remove.rs
@@ -67,11 +67,11 @@ impl Command for Remove {
             let name: String = match &self.name {
                 Some(name)
                     if name.ends_with(".aleo")
-                        && Package::<CurrentNetwork>::is_program_name_valid(&name[0..name.len() - 5]) =>
+                        && Package::<CurrentNetwork>::is_aleo_name_valid(&name[0..name.len() - 5]) =>
                 {
                     name.clone()
                 }
-                Some(name) if Package::<CurrentNetwork>::is_program_name_valid(name) => format!("{name}.aleo"),
+                Some(name) if Package::<CurrentNetwork>::is_aleo_name_valid(name) => format!("{name}.aleo"),
                 name => return Err(PackageError::invalid_file_name_dependency(name.clone().unwrap()).into()),
             };
 

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -37,8 +37,8 @@ pub struct Package<N: Network> {
 
 impl<N: Network> Package<N> {
     pub fn new(package_name: &str) -> Result<Self> {
-        // Check that the package name is valid.
-        if !Self::is_package_name_valid(package_name) {
+        // Check that the package name is a valid Aleo program name.
+        if !Self::is_program_name_valid(package_name) {
             return Err(PackageError::invalid_package_name(package_name).into());
         }
 
@@ -51,35 +51,35 @@ impl<N: Network> Package<N> {
         })
     }
 
-    /// Returns `true` if the package name is valid.
+    /// Returns `true` if the program name is valid.
     ///
-    /// Package names can only contain ASCII alphanumeric characters and underscores.
-    pub fn is_package_name_valid(package_name: &str) -> bool {
-        // Check that the package name is nonempty.
-        if package_name.is_empty() {
-            tracing::error!("Project names must be nonempty");
+    /// Program names can only contain ASCII alphanumeric characters and underscores.
+    pub fn is_program_name_valid(program_name: &str) -> bool {
+        // Check that the program name is nonempty.
+        if program_name.is_empty() {
+            tracing::error!("Program names must be nonempty");
             return false;
         }
 
-        let first = package_name.chars().next().unwrap();
+        let first = program_name.chars().next().unwrap();
 
         // Check that the first character is not an underscore.
         if first == '_' {
-            tracing::error!("Project names cannot begin with an underscore");
+            tracing::error!("Program names cannot begin with an underscore");
             return false;
         }
 
         // Check that the first character is not a number.
         if first.is_numeric() {
-            tracing::error!("Project names cannot begin with a number");
+            tracing::error!("Program names cannot begin with a number");
             return false;
         }
 
-        // Iterate and check that the package name is valid.
-        for current in package_name.chars() {
-            // Check that the package name contains only ASCII alphanumeric or underscores.
+        // Iterate and check that the program name is valid.
+        for current in program_name.chars() {
+            // Check that the program name contains only ASCII alphanumeric or underscores.
             if !current.is_ascii_alphanumeric() && current != '_' {
-                tracing::error!("Project names must can only contain ASCII alphanumeric characters and underscores.");
+                tracing::error!("Program names must can only contain ASCII alphanumeric characters and underscores.");
                 return false;
             }
         }
@@ -89,8 +89,8 @@ impl<N: Network> Package<N> {
 
     /// Returns `true` if a package is can be initialized at a given path.
     pub fn can_initialize(package_name: &str, path: &Path) -> bool {
-        // Check that the package name is valid.
-        if !Self::is_package_name_valid(package_name) {
+        // Check that the package name is a valid Aleo program name.
+        if !Self::is_program_name_valid(package_name) {
             return false;
         }
 
@@ -112,8 +112,8 @@ impl<N: Network> Package<N> {
 
     /// Returns `true` if a package is initialized at the given path
     pub fn is_initialized(package_name: &str, path: &Path) -> bool {
-        // Check that the package name is valid.
-        if !Self::is_package_name_valid(package_name) {
+        // Check that the package name is a valid Aleo program name.
+        if !Self::is_program_name_valid(package_name) {
             return false;
         }
 
@@ -173,25 +173,25 @@ mod tests {
 
     #[test]
     fn test_is_package_name_valid() {
-        assert!(Package::<CurrentNetwork>::is_package_name_valid("foo"));
-        assert!(Package::<CurrentNetwork>::is_package_name_valid("foo_bar"));
-        assert!(Package::<CurrentNetwork>::is_package_name_valid("foo1"));
-        assert!(Package::<CurrentNetwork>::is_package_name_valid("foo_bar___baz_"));
+        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo"));
+        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo_bar"));
+        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo1"));
+        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo_bar___baz_"));
 
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo-bar"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo-bar-baz"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo-1"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid(""));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("-"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("-foo"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("-foo-"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("_foo"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo--bar"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo---bar"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo--bar--baz"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo---bar---baz"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo*bar"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("foo,bar"));
-        assert!(!Package::<CurrentNetwork>::is_package_name_valid("1-foo"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo-bar"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo-bar-baz"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo-1"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid(""));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("-"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("-foo"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("-foo-"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("_foo"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo--bar"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo---bar"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo--bar--baz"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo---bar---baz"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo*bar"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo,bar"));
+        assert!(!Package::<CurrentNetwork>::is_program_name_valid("1-foo"));
     }
 }

--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -38,7 +38,7 @@ pub struct Package<N: Network> {
 impl<N: Network> Package<N> {
     pub fn new(package_name: &str) -> Result<Self> {
         // Check that the package name is a valid Aleo program name.
-        if !Self::is_program_name_valid(package_name) {
+        if !Self::is_aleo_name_valid(package_name) {
             return Err(PackageError::invalid_package_name(package_name).into());
         }
 
@@ -51,35 +51,35 @@ impl<N: Network> Package<N> {
         })
     }
 
-    /// Returns `true` if the program name is valid.
+    /// Returns `true` if it is a valid Aleo name.
     ///
-    /// Program names can only contain ASCII alphanumeric characters and underscores.
-    pub fn is_program_name_valid(program_name: &str) -> bool {
-        // Check that the program name is nonempty.
-        if program_name.is_empty() {
-            tracing::error!("Program names must be nonempty");
+    /// Aleo names can only contain ASCII alphanumeric characters and underscores.
+    pub fn is_aleo_name_valid(name: &str) -> bool {
+        // Check that the name is nonempty.
+        if name.is_empty() {
+            tracing::error!("Aleo names must be nonempty");
             return false;
         }
 
-        let first = program_name.chars().next().unwrap();
+        let first = name.chars().next().unwrap();
 
         // Check that the first character is not an underscore.
         if first == '_' {
-            tracing::error!("Program names cannot begin with an underscore");
+            tracing::error!("Aleo names cannot begin with an underscore");
             return false;
         }
 
         // Check that the first character is not a number.
         if first.is_numeric() {
-            tracing::error!("Program names cannot begin with a number");
+            tracing::error!("Aleo names cannot begin with a number");
             return false;
         }
 
-        // Iterate and check that the program name is valid.
-        for current in program_name.chars() {
+        // Iterate and check that the name is valid.
+        for current in name.chars() {
             // Check that the program name contains only ASCII alphanumeric or underscores.
             if !current.is_ascii_alphanumeric() && current != '_' {
-                tracing::error!("Program names must can only contain ASCII alphanumeric characters and underscores.");
+                tracing::error!("Aleo names must can only contain ASCII alphanumeric characters and underscores.");
                 return false;
             }
         }
@@ -90,7 +90,7 @@ impl<N: Network> Package<N> {
     /// Returns `true` if a package is can be initialized at a given path.
     pub fn can_initialize(package_name: &str, path: &Path) -> bool {
         // Check that the package name is a valid Aleo program name.
-        if !Self::is_program_name_valid(package_name) {
+        if !Self::is_aleo_name_valid(package_name) {
             return false;
         }
 
@@ -113,7 +113,7 @@ impl<N: Network> Package<N> {
     /// Returns `true` if a package is initialized at the given path
     pub fn is_initialized(package_name: &str, path: &Path) -> bool {
         // Check that the package name is a valid Aleo program name.
-        if !Self::is_program_name_valid(package_name) {
+        if !Self::is_aleo_name_valid(package_name) {
             return false;
         }
 
@@ -173,25 +173,25 @@ mod tests {
 
     #[test]
     fn test_is_package_name_valid() {
-        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo"));
-        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo_bar"));
-        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo1"));
-        assert!(Package::<CurrentNetwork>::is_program_name_valid("foo_bar___baz_"));
+        assert!(Package::<CurrentNetwork>::is_aleo_name_valid("foo"));
+        assert!(Package::<CurrentNetwork>::is_aleo_name_valid("foo_bar"));
+        assert!(Package::<CurrentNetwork>::is_aleo_name_valid("foo1"));
+        assert!(Package::<CurrentNetwork>::is_aleo_name_valid("foo_bar___baz_"));
 
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo-bar"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo-bar-baz"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo-1"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid(""));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("-"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("-foo"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("-foo-"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("_foo"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo--bar"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo---bar"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo--bar--baz"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo---bar---baz"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo*bar"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("foo,bar"));
-        assert!(!Package::<CurrentNetwork>::is_program_name_valid("1-foo"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo-bar"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo-bar-baz"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo-1"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid(""));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("-"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("-foo"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("-foo-"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("_foo"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo--bar"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo---bar"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo--bar--baz"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo---bar---baz"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo*bar"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("foo,bar"));
+        assert!(!Package::<CurrentNetwork>::is_aleo_name_valid("1-foo"));
     }
 }

--- a/utils/retriever/src/retriever/mod.rs
+++ b/utils/retriever/src/retriever/mod.rs
@@ -508,7 +508,7 @@ fn fetch_from_network(endpoint: &String, program: &String, network: Network) -> 
     let url = format!("{}/{}/program/{}", endpoint, network.clone(), program);
     let response = ureq::get(&url.clone())
         .call()
-        .map_err(|err| UtilError::failed_to_retrieve_from_endpoint(url.clone(), err, Default::default()))?;
+        .map_err(|err| UtilError::failed_to_retrieve_from_endpoint(err, Default::default()))?;
     if response.status() == 200 {
         Ok(response.into_string().unwrap())
     } else {


### PR DESCRIPTION
Resolves #27914. Additionally:
- `-c` flag to remove all previous dependencies
- Prevent adding local dependencies that have duplicate paths. (Choose to overwrite old dependency in favor of new one)
- Write the program that gets built instead of the generic `main.leo`