### PR TITLE
[Feat] Add `network.id` and `self.address` opcodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2887,7 +2887,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2916,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -2960,7 +2960,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -2981,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -3009,12 +3009,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3025,7 +3025,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -3040,7 +3040,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3055,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3068,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3087,7 +3087,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3099,7 +3099,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3111,7 +3111,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3122,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3134,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3147,7 +3147,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3158,7 +3158,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3171,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3182,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3223,7 +3223,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -3244,7 +3244,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3259,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3270,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -3278,7 +3278,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3299,7 +3299,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3310,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3332,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "rand",
  "rayon",
@@ -3346,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "rand",
@@ -3399,7 +3399,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3418,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3430,7 +3430,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3443,7 +3443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3456,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3479,7 +3479,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -3494,7 +3494,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3507,7 +3507,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3516,7 +3516,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3536,7 +3536,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "anyhow",
  "colored",
@@ -3551,7 +3551,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3587,7 +3587,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3612,7 +3612,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3641,7 +3641,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "colored",
@@ -3664,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -3678,7 +3678,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "bincode",
  "once_cell",
@@ -3691,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3712,7 +3712,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
+source = "git+https://github.com/AleoHQ/snarkVM?rev=da3d78a#da3d78a5726ce5b07581203a9aaff3fe39fc3057"
 dependencies = [
  "proc-macro2",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ members = [
 [workspace.dependencies.snarkvm]
 #version = "0.16.19"
 git = "https://github.com/AleoHQ/snarkVM"
-rev = "2cbf34a"
+rev = "da3d78a"
 
 [lib]
 path = "leo/lib.rs"

--- a/compiler/ast/src/expressions/literal.rs
+++ b/compiler/ast/src/expressions/literal.rs
@@ -22,7 +22,7 @@ use super::*;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Literal {
     // todo: deserialize values here
-    /// An address literal, e.g., `aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8s7pyjh9`.
+    /// An address literal, e.g., `aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8s7pyjh9` or `hello.aleo`.
     Address(String, #[serde(with = "leo_span::span_json")] Span, NodeID),
     /// A boolean literal, either `true` or `false`.
     Boolean(bool, #[serde(with = "leo_span::span_json")] Span, NodeID),

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -443,7 +443,7 @@ impl ParserContext<'_> {
     fn parse_external_resource(&mut self, expr: Expression, network_span: Span) -> Result<Expression> {
         // Parse `/`.
         self.expect(&Token::Div)?;
-        
+
         // Parse name.
         let name = self.expect_identifier()?;
 

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -526,7 +526,7 @@ impl ParserContext<'_> {
                     if let Expression::Identifier(id) = expr {
                         if id.name == sym::SelfLower && self.token.token == Token::Address {
                             let span = self.expect(&Token::Address)?;
-                            // Convert `self.address` to the current program name.
+                            // Convert `self.address` to the current program name. TODO: Move this conversion to canonicalization pass when the new pass is added.
                             // Note that the unwrap is safe as in order to get to this stage of parsing a program name must have already been parsed.
                             return Ok(Expression::Literal(Literal::Address(
                                 format!("{}.aleo", self.program_name.unwrap()),

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -510,7 +510,7 @@ impl ParserContext<'_> {
                     if self.token.token == Token::Div {
                         expr = self.parse_external_resource(expr, self.prev_token.span)?;
                     } else {
-                        // Parse as address literal, e.g. `let next: address = hello.aleo;`.
+                        // Parse as address literal, e.g. `hello.aleo`.
                         if !matches!(expr, Expression::Identifier(_)) {
                             self.emit_err(ParserError::unexpected(expr.to_string(), "an identifier", expr.span()))
                         }

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -514,18 +514,26 @@ impl ParserContext<'_> {
                         if !matches!(expr, Expression::Identifier(_)) {
                             self.emit_err(ParserError::unexpected(expr.to_string(), "an identifier", expr.span()))
                         }
-                        
-                        expr = Expression::Literal(Literal::Address(format!("{}.aleo", expr.to_string()), expr.span(), self.node_builder.next_id()))
+
+                        expr = Expression::Literal(Literal::Address(
+                            format!("{}.aleo", expr),
+                            expr.span(),
+                            self.node_builder.next_id(),
+                        ))
                     }
                 } else {
                     // Parse instances of `self.address`.
                     if let Expression::Identifier(id) = expr {
-                        if id.name == sym::SelfLower && self.token.token == Token::Address  {
+                        if id.name == sym::SelfLower && self.token.token == Token::Address {
                             let span = self.expect(&Token::Address)?;
                             // Convert `self.address` to the current program name.
-                            // Note that the unwrap is safe as in order to get to this stage of parsing a program name must have already been parsed. 
-                            return Ok(Expression::Literal(Literal::Address(format!("{}.aleo", self.program_name.unwrap()), expr.span() + span, self.node_builder.next_id())));
-                        } 
+                            // Note that the unwrap is safe as in order to get to this stage of parsing a program name must have already been parsed.
+                            return Ok(Expression::Literal(Literal::Address(
+                                format!("{}.aleo", self.program_name.unwrap()),
+                                expr.span() + span,
+                                self.node_builder.next_id(),
+                            )));
+                        }
                     }
 
                     // Parse identifier name.

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -788,6 +788,9 @@ impl ParserContext<'_> {
             Token::Future => {
                 Expression::Identifier(Identifier { name: sym::Future, span, id: self.node_builder.next_id() })
             }
+            Token::Network => {
+                Expression::Identifier(Identifier { name: sym::network, span, id: self.node_builder.next_id() })
+            }
             t if crate::type_::TYPE_TOKENS.contains(&t) => Expression::Identifier(Identifier {
                 name: t.keyword_to_symbol().unwrap(),
                 span,

--- a/compiler/parser/src/parser/expression.rs
+++ b/compiler/parser/src/parser/expression.rs
@@ -441,9 +441,6 @@ impl ParserContext<'_> {
 
     // Parses an external function call `credits.aleo/transfer()` or locator `token.aleo/accounts`.
     fn parse_external_resource(&mut self, expr: Expression, network_span: Span) -> Result<Expression> {
-        // Eat an external function call.
-        self.eat(&Token::Div); // todo: Make `/` a more general token.
-
         // Parse name.
         let name = self.expect_identifier()?;
 

--- a/compiler/parser/src/tokenizer/token.rs
+++ b/compiler/parser/src/tokenizer/token.rs
@@ -143,6 +143,7 @@ pub enum Token {
     Block,
     Eof,
     Leo,
+    Network,
 }
 
 /// Represents all valid Leo keyword tokens.
@@ -237,6 +238,7 @@ impl Token {
             Token::Let => sym::Let,
             Token::Leo => sym::leo,
             Token::Mapping => sym::mapping,
+            Token::Network => sym::network,
             Token::Private => sym::private,
             Token::Program => sym::program,
             Token::Public => sym::public,
@@ -374,6 +376,7 @@ impl fmt::Display for Token {
             Block => write!(f, "block"),
             Leo => write!(f, "leo"),
             Eof => write!(f, "<eof>"),
+            Network => write!(f, "network"),
         }
     }
 }

--- a/compiler/parser/src/tokenizer/token.rs
+++ b/compiler/parser/src/tokenizer/token.rs
@@ -181,6 +181,7 @@ pub const KEYWORD_TOKENS: &[Token] = &[
     Token::Inline,
     Token::Let,
     Token::Mapping,
+    Token::Network,
     Token::Private,
     Token::Program,
     Token::Public,

--- a/compiler/passes/src/code_generation/visit_program.rs
+++ b/compiler/passes/src/code_generation/visit_program.rs
@@ -182,6 +182,7 @@ impl<'a> CodeGenerator<'a> {
         // TODO: Figure out a better way to initialize.
         self.variable_mapping.insert(&sym::SelfLower, "self".to_string());
         self.variable_mapping.insert(&sym::block, "block".to_string());
+        self.variable_mapping.insert(&sym::network, "network".to_string());
         self.current_function = Some(function);
 
         // Construct the header of the function.

--- a/compiler/passes/src/flattening/flatten_statement.rs
+++ b/compiler/passes/src/flattening/flatten_statement.rs
@@ -273,7 +273,9 @@ impl StatementReconstructor for Flattener<'_> {
         let guard = self.construct_guard();
 
         match input.expression {
-            Expression::Unit(_) | Expression::Identifier(_) | Expression::Access(_) => self.returns.push((guard, input)),
+            Expression::Unit(_) | Expression::Identifier(_) | Expression::Access(_) => {
+                self.returns.push((guard, input))
+            }
             _ => unreachable!("SSA guarantees that the expression is always an identifier or unit expression."),
         };
 

--- a/compiler/passes/src/flattening/flatten_statement.rs
+++ b/compiler/passes/src/flattening/flatten_statement.rs
@@ -273,7 +273,7 @@ impl StatementReconstructor for Flattener<'_> {
         let guard = self.construct_guard();
 
         match input.expression {
-            Expression::Unit(_) | Expression::Identifier(_) => self.returns.push((guard, input)),
+            Expression::Unit(_) | Expression::Identifier(_) | Expression::Access(_) => self.returns.push((guard, input)),
             _ => unreachable!("SSA guarantees that the expression is always an identifier or unit expression."),
         };
 

--- a/compiler/passes/src/type_checking/check_expressions.rs
+++ b/compiler/passes/src/type_checking/check_expressions.rs
@@ -202,22 +202,12 @@ impl<'a> ExpressionVisitor<'a> for TypeChecker<'a> {
                     Expression::Identifier(identifier) if identifier.name == sym::SelfLower => match access.name.name {
                         sym::caller => {
                             // Check that the operation is not invoked in a `finalize` block.
-                            if self.scope_state.variant == Some(Variant::AsyncFunction) {
-                                self.handler.emit_err(TypeCheckerError::invalid_operation_inside_finalize(
-                                    "self.caller",
-                                    access.name.span(),
-                                ))
-                            }
+                            self.check_access_allowed("self.caller", false, access.name.span());
                             return Some(Type::Address);
                         }
                         sym::signer => {
                             // Check that operation is not invoked in a `finalize` block.
-                            if self.scope_state.variant == Some(Variant::AsyncFunction) {
-                                self.handler.emit_err(TypeCheckerError::invalid_operation_inside_finalize(
-                                    "self.signer",
-                                    access.name.span(),
-                                ))
-                            }
+                            self.check_access_allowed("self.signer", false, access.name.span());
                             return Some(Type::Address);
                         }
                         _ => {
@@ -228,12 +218,7 @@ impl<'a> ExpressionVisitor<'a> for TypeChecker<'a> {
                     Expression::Identifier(identifier) if identifier.name == sym::block => match access.name.name {
                         sym::height => {
                             // Check that the operation is invoked in a `finalize` block.
-                            if self.scope_state.variant != Some(Variant::AsyncFunction) {
-                                self.handler.emit_err(TypeCheckerError::invalid_operation_outside_finalize(
-                                    "block.height",
-                                    access.name.span(),
-                                ))
-                            }
+                            self.check_access_allowed("block.height", true, access.name.span());
                             return Some(Type::Integer(IntegerType::U32));
                         }
                         _ => {
@@ -244,12 +229,7 @@ impl<'a> ExpressionVisitor<'a> for TypeChecker<'a> {
                     Expression::Identifier(identifier) if identifier.name == sym::network => match access.name.name {
                         sym::id => {
                             // Check that the operation is not invoked outside a `finalize` block.
-                            if self.scope_state.variant != Some(Variant::AsyncFunction) {
-                                self.handler.emit_err(TypeCheckerError::invalid_operation_outside_finalize(
-                                    "network.id",
-                                    access.name.span(),
-                                ))
-                            }
+                            self.check_access_allowed("network.id", true, access.name.span());
                             return Some(Type::Integer(IntegerType::U16));
                         }
                         _ => {

--- a/compiler/passes/src/type_checking/check_expressions.rs
+++ b/compiler/passes/src/type_checking/check_expressions.rs
@@ -243,14 +243,14 @@ impl<'a> ExpressionVisitor<'a> for TypeChecker<'a> {
                     // If the access expression is of the form `network.<name>`, then check that the <name> is valid.
                     Expression::Identifier(identifier) if identifier.name == sym::network => match access.name.name {
                         sym::id => {
-                            // Check that the operation is not invoked in a `finalize` block.
-                            if self.scope_state.variant == Some(Variant::AsyncFunction) {
+                            // Check that the operation is not invoked outside a `finalize` block.
+                            if self.scope_state.variant != Some(Variant::AsyncFunction) {
                                 self.handler.emit_err(TypeCheckerError::invalid_operation_outside_finalize(
                                     "network.id",
                                     access.name.span(),
                                 ))
                             }
-                            return Some(Type::Integer(IntegerType::U32));
+                            return Some(Type::Integer(IntegerType::U16));
                         }
                         _ => {
                             self.emit_err(TypeCheckerError::invalid_block_access(access.name.span()));

--- a/compiler/span/src/symbol.rs
+++ b/compiler/span/src/symbol.rs
@@ -272,6 +272,8 @@ symbols! {
     stub,
     block,
     height,
+    network,
+    id,
 }
 
 /// An interned string.

--- a/tests/expectations/compiler/address/special_address.out
+++ b/tests/expectations/compiler/address/special_address.out
@@ -1,0 +1,18 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - - compile:
+        - initial_symbol_table: f159adcd5ea24c580a6b8535b217667a40173809e5802a0b03db3dc5b9bec9aa
+          type_checked_symbol_table: 9fd0ee7288d5151305f4cd3820594bd9db7accb589bc936e186709af1df6de21
+          unrolled_symbol_table: 9fd0ee7288d5151305f4cd3820594bd9db7accb589bc936e186709af1df6de21
+          initial_ast: 21db64864f84959ad71dace62a2487285c3b6bb74818536b83a54b63a2bd8d82
+          unrolled_ast: 21db64864f84959ad71dace62a2487285c3b6bb74818536b83a54b63a2bd8d82
+          ssa_ast: d4e2a516deaa30f8663bb3cd1501c52e3cc781b330dbb149ee3bad0692a8cb59
+          flattened_ast: 175fbd23f91421e3d47440c8a7e00fb9e3a2bef1147e061cd8a3f2bd0c978098
+          destructured_ast: a23caa23b3ac10d6c2a1b119af502a9ec4380cf521eb65da2c9e2a5f19d44172
+          inlined_ast: a23caa23b3ac10d6c2a1b119af502a9ec4380cf521eb65da2c9e2a5f19d44172
+          dce_ast: a23caa23b3ac10d6c2a1b119af502a9ec4380cf521eb65da2c9e2a5f19d44172
+          bytecode: d9e6c28f9e5527abe9cdb07b9d35375901446415f5d645b0363597200ee45be7
+          errors: ""
+          warnings: ""

--- a/tests/expectations/compiler/expression/network_id.out
+++ b/tests/expectations/compiler/expression/network_id.out
@@ -1,0 +1,18 @@
+---
+namespace: Compile
+expectation: Pass
+outputs:
+  - - compile:
+        - initial_symbol_table: 02b83350abcecb36109bf268cf52b9fc867ab1893c49badf31ff527156528943
+          type_checked_symbol_table: 1ace971bd20adb9ce07f802070f05c51733af791ef32c7b1130d4a4b2182768d
+          unrolled_symbol_table: 1ace971bd20adb9ce07f802070f05c51733af791ef32c7b1130d4a4b2182768d
+          initial_ast: 6dc0a710ab752f571f4dae9fdb172a7fa1c43e3af3858cbc8cf96c5d510a0c3a
+          unrolled_ast: 6dc0a710ab752f571f4dae9fdb172a7fa1c43e3af3858cbc8cf96c5d510a0c3a
+          ssa_ast: e09d30595377e81788433b702f76f1338ff4bb720f8564e2560e5f78ebd18bc0
+          flattened_ast: 16df732ae63243e249201817b30ae02b8a190072d39894648607970eb2b09192
+          destructured_ast: b2f615fbb0825b50c961b4014e2e2d60117b543cab0d2e1acd4f3237c878e95e
+          inlined_ast: d3f7291df3faf6f8a4893b91133fe183d44c35f3d9c4b9d270d71f943482f965
+          dce_ast: d3f7291df3faf6f8a4893b91133fe183d44c35f3d9c4b9d270d71f943482f965
+          bytecode: ae04a04e7ffb01dfdd0ae0249f31649302bc120ea928c5ace16bc0879140e1f9
+          errors: ""
+          warnings: ""

--- a/tests/expectations/execution/metadata.out
+++ b/tests/expectations/execution/metadata.out
@@ -1,0 +1,195 @@
+---
+namespace: Execute
+expectation: Pass
+outputs:
+  - - compile:
+        - initial_symbol_table: 1bf49c8a2227ea1452454eac5931b6dd9e9313c0a87175db31aa8fcf221dfe6d
+          type_checked_symbol_table: 6b15865777d5453848ba8e2a089d31f97befb0a88b27935b2eb9ae6745723bdc
+          unrolled_symbol_table: 6b15865777d5453848ba8e2a089d31f97befb0a88b27935b2eb9ae6745723bdc
+          initial_ast: 3355314cbc25644717fb83bdbd5075649847683e4bfe58c2547e5a0169e273f3
+          unrolled_ast: 3355314cbc25644717fb83bdbd5075649847683e4bfe58c2547e5a0169e273f3
+          ssa_ast: f7673dee5dae150c895fd00cc07e24db99cb4cca42dfe2f54d311f1bd7c460c2
+          flattened_ast: 5ad3b910db260531c64908c42dbe56aafb11cfac3c2afbdcdb58b8d4a7d86a8f
+          destructured_ast: 73fc708dc67e1f01255aa8bfbaa0a040db7658e8db6360240dbff3b6005904b5
+          inlined_ast: 0174db986b989193bda3984dc0e13aa533fa8a465fd7b986af55f1346ac20e30
+          dce_ast: 0174db986b989193bda3984dc0e13aa533fa8a465fd7b986af55f1346ac20e30
+          bytecode: c5fbc61b3a7b1400dda65dc947a495d14f1b43986550cd889efd4cc653912355
+          errors: ""
+          warnings: ""
+      execute:
+        - execution:
+            transitions:
+              - id: au196vk6tpj7cgyp0dvfm2c8009z89q8ch5376t0qavp87msv39wcqsucuvus
+                program: metadata.aleo
+                function: is_block_height
+                inputs:
+                  - type: private
+                    id: 1828886139934070702847867954511879816884750762363092521533208865235753727566field
+                    value: ciphertext1qyqg8xn27x3ukujrthuh67jazc3h5v96hhc7zacwef08y7a9lpu92pqpf7jp8
+                outputs:
+                  - type: future
+                    id: 5457953770891457596513693104617313278374925684406320053944467986971462340947field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    0u32\n  ]\n}"
+                tpk: 4174266389141840694112770464623549736508472115786023137592436699114609405528group
+                tcm: 8338099097402671626408038034858578087638496090147697571937791628404909729345field
+                scm: 1980270338266624580494901677581519840423416572710948745278059423752506827747field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqtxu2hrjlkjsvwn6de72q34lqmtstr69ahhjy0mlc5jujj4zxhkzncpd8tl6y2nrx5fuxnmpd9ej5qqylhezq3dmrqm3cm4tawnuznt5gc2fv8psgvswzavf79my3t8ahzhj9x5epa9k6s9vznyh8mp4qsnqgz2jsuc23szktw2ckx5jn4sqde76qaxp5ngwxssv407kqa659cg4mxc7f8yhzexrkc6mzwslrjj6qeza4qy2hrdrtp2884x55jq3j8tfcllhcne2k55dq2wyckw7zyd23c9uv8a4gdtvczsy76ef4vf2sq5eat9urj0u52f2zgeqrl7kcq3vj6wvzgrl7xv4fdffy3tmvu547uj766lkfm4my98wa4dg8tdtagpcsrzxy8fuktmgsxu8jztldkcm05enzvyhg5n6qfnc3v97hdzdkaruhdm4gy99rhcy8q6alfzwk5srqzylx6l6a7lpsjpmkkfj6pg0j479shgcl469r7tglt4dkr3mc4hhdw7rya8cr4wekr8raftqweqq948a5nw9x8krz7hfux8y52p6jq56r87dcc2a2n8dxnunpeeg7rlem45ft9v7cvdsx2r79c2uvq3sq66kh0z9xaa6yf7l40vzeqkrjhpwau0jms575gw7z8r0y5572rflkdu0p6zwshn7c5fhexjyxg60gp44fp0zwc6x8pjan4hgxsw28l3ev9raz02ljcehpkefwtnvs6sqz8qykyeneq9kk5kxydlng76qjjy5zk6tgkmgtr0ua76e5hpxrevz3uyml43y3w4p6vez9xpne8cvq25mnqu6tyg9v3h6g95xhq2p9zz2ekpxk2xk7hh5zkk8anuar8m5ph08vdzkg2290uw8l8a05hn57p9xcj4kmpn2hp0ckfsysugukry3hlul49j5xlr4s4z3kzykn6mzqvz3lg8fnlrx69yeywp47mk7xm8z4wuasxkjatseeut4lkdsda0yy5vsuqpyalet83e70xhmpfpzejlqq93fftq3jdgrp2pl46myhyxpmjwvna56km2486cx4npl9fthutud6adgud60azx067hu7rfd36p7esvlz2sw609dhmprjhgxxfa9jk78wuf67vnq46zsu092unjnpppyvqlu8qg2euhj2ccgqyt4xz7wnem2j8supprfeuhst3zt5le3qdqvqqqqqqqqqqqhds93teyttdchawkeg3er480yf2gmgwmps5n4sepqvyvc7jz6ujhla7h6tw9ucnyk0p5c9gjggssyq2h0zlh5sqgwkutfehr4usqqlrjax6j2xh28e2zc9rjx8tvzc97ve2tzw0sq78zdvlx6ck3akpqxvpqywtdg5mncgw5ulhc06y3pmnfnqyl7v2qs9eve80m5n3rt4yc7qqy5culrh39czv8yujx9xfyvq0wh3pl7f5sq2fca38mqxdt5qmk475xvsthnundq3vultnrh7wcjygqyqq0hrrhd
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au1r352lhvujpnjs6dsv7zxjlesddm6mdzwl2579vglc9d0jf5zd5rq5ceuj5
+                program: metadata.aleo
+                function: is_block_height
+                inputs:
+                  - type: private
+                    id: 4286956730291478172967552406966020510655589486973029992023461375203373137580field
+                    value: ciphertext1qyqf8p8u0l6w5w7nmsquncjs36gjxeaxpkkuvl4h6jfqntenutrykrglqqg0t
+                outputs:
+                  - type: future
+                    id: 2385412319407656831158957518021928306540861142632415702983135495782059153176field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    1u32\n  ]\n}"
+                tpk: 6826075503536703408877015806866676888464978285285642759889480649615825407885group
+                tcm: 2184261592989300536746165496548115475812152687244578178115561569274734999038field
+                scm: 407281751932047584685189018244827210538163428192377398266270897182443379767field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq94afhc7cpuy4kjcl8j5cndyxajsp37895s58fsx8qyh7yr7qtnz0mca7um7n8scq7hhurkxe976upq9na6qs3klshmquwdhuja5z67tvxswtmytsceyqtsd3vqk227suywajtjjef694w8c6df4my4mjjqqrwjvf90ea6e3veg27rhme0n49hlfjxnd607y2p8jm2zj20mr3yndf5n0yunz7mh5tk3tf8syxescqvx7s5cnzky2leuqcg7ytmdl60uchgx3l96kelcr3gznjsql9mv8w4aez7vv0d2e982xun3agnwaup3dleeqaacr9p0m5vac0xly4wqrm73hfsgfsjcq5dph49v66mw2s0kptpvcl4en27sgcnpmc48e3sqmjaevd4g02h67vsx79yn85nm5h8h3mlhegal2xz0x5984qg3qaqpjweckp98naxnj8j0mwm9ty7qy7vt2qr9nuazvhlx9qwss5y3spsmafcq3c28gva5ls0h93r7zt6nv5zf7gtv9ekqrjt95cnh67m0qx0mmt033dr286st0cpp6exmff4cn77w04q8dc29cyhrzppgd3xspy7007mnpac8ywgh3nvq7r6csq9x7rdl74vevz7fg70fn2dxq563vfwq0uewrn09xlwu5h5ehjjn7paszqnvngkuyxfdwl8ypgpzp5p6lfws7m482q65y2wn2u40vatf9f5scnak7aecd6eqwhurzyusyrykxtdswtvyxacvpn5hspww5vw8uptpgy9w248hedgevm02se4ypur94w4ed3ap6xudtvekyyca39fnctsnh2fq7d85quv4yj34m09q0afddnt3nq4vcn3f0j5pq36s9dp90he9r3za4n0nymlppwtgpfqd2qy0d7xud83g058t3c3de0taqfxs7s3pvfxx793jfrkessskmqwlfelj0j2h820wxcjc2y93jj7dfyg2hng6tfwsg4pc2yld9dldgxzc5myqcjltls94lpf7zz40ztq80xj8w2ftc4sp5vs8le375efqpj627jm6qpz83dfmu8z030lwez6jek3mp3qvvc3drpwke6dsm9cp7a9gzrqrc5yqhsqa9v8f7tf3rlgxk03rvn5m5rhgwnf8tp7kj7qcmr0w6ffru7q36qtyg9lqk4amw3khapt7xmfw6m29kckjnww0kg9qvqqqqqqqqqqpek7f7tm8j3x7knxqath3pjg7gcdgmhxk2vhnqgfs3mdmm0dx5d2fx0u9n4z6gqgf5crhwn69g98syq806fm00fg3nwdyeuhlkm8ee49jf5ehmwjxp4wlp3yd4h6hnldgvkpl990923xjuwqd6dwdmryyaypq90y0td3upv5rx3r6u4xsvelryf5nfetp6mnn6qva36d62ucafaszj3729t8lck995c3g6fhqw3rwvu3vdnmzdg8wpthglcc9cae2lt93pjndujzvq33kvj7ezerdpprqyqqnru28k
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au13zslsaxttpvsgtmcmrw73x03k2lmuq4p2fvhjak42qwdm02jrs9qxssdm7
+                program: metadata.aleo
+                function: is_block_height
+                inputs:
+                  - type: private
+                    id: 8211778640811586469327625094750393673294867466010064667391066202117864355889field
+                    value: ciphertext1qyqrkdwenqpgp7vqqv5tvnt7nvumr5w553pq5lwjntjeuavh3re7cqq0u2w79
+                outputs:
+                  - type: future
+                    id: 2644113075717811263567925485017682536194868718759129046632116666842982336474field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    2u32\n  ]\n}"
+                tpk: 5961719084867262658611365638360766420582791439974047595680459060088949753734group
+                tcm: 6626624319880809262391967868024871859050942736550513386256577389697770634318field
+                scm: 1709184858721614245415770013947709782814544370016004415745981136924726103130field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqvy8y0kv6jtl5hvetkc3vudc0nlnk85vjf9u3sw69d0n7n8urttcef2z97nyeutwrvrhajftc5ewqqq880k0f7kg9mhl9f3nqerjwsv28v57anx2qcvxqsndd0wuhldwwh5cj0cj2rm24vk40u5le0gkz8qqx026a4utrczjdshfhapv9uxjwm7rf5yfcjcs97rhqg6n0fdvl63yza57kv6n08wnyyqe73gaxs0xq3h3mnefw43gn59uzcz2kctjjgwlvfw2a853kds7ut0q34pyjlfj7rqwf5gct8ggtkvjcm5uyckwspz5vy4fqclmehcqfycgzt52ha5evv6sdjcvwcytk830k3jkqptuf9fjqqyp96wrat360dcut23pmcqwqg0kwxz6n98dww8zavmj6uyde4mfn0tz920zaqdcyx8veatxfgsku6gm2qh7qwyx0zlyp5mzzws9jmhkk8hj2stnyj5x50ypg7hvcl7lml7dzrdut26vjvpc86c555hhj4mat4s07dn8m4a3lerxs99qplm0zqwdzv0yff2uaqqjg3fvqg5wpzdxeskm052g20qxm98jzqkhqghu427hc5r4z6263d9m39n6qh477zemljmur7ad0jqrqcx8rvwyhthhrzgxmsavs6wkyxupv392u6u0w3lr8craa9zmrxy04p6esqp5v0z0a849g3yzgwkf439rqfuu3ytme7026wlyaq23zpfzvg559mjr7hym0l333xuwvynkgy3smg60p5v6aumttxe7cku8skja5gzr6q2jtl9t9e5gp6k928zp9pprmehjllv57mzmal7p8n385kt5s7qwy6tkwtgpcxlkm6zxtkqmc584h7dhxt6hrg9ahq3nwzu5u5d3tsl2xgjzs6wsm5d6jaf8xj5wlhcxdja0au06gt25fgn54r5u4d9ugvhktpstu4vhw9kwxf7u284df8ethqwwckjedvkzm83hdvwacjn5q4ye2fcdru97tq0vz3g2tcjuljgdvtlkdqj4zjn72d3tptyclzuydxdc6vdrq436pfn5mhskqerm20w02c8n5yqqhjxep62sqk4x9fzfxcd2k3pd9e3txfz8jh0xhnmzyajxwyvvhkmvd6ffhu943evk7q4neae0r3pgj0l6xfrsygxgpuu0w2m386qn6ptd9mdswnchvqe4gyqvqqqqqqqqqqpts0qkdkj8akq5zvd8ue852qg6z2agmctk7q9ptevs5k72hr7xt3g5n97sxa6w289lu45mzdm4atqyq8jtxcyd23u4n850ne3nt7k27szqwelnt93w8qwkmcr3kzsgmeqlkutm0c9n3zmdgcc59eyu4nytgpq8yntau9uvct50r3e9mjwknc0ladxmdyhhrrp3g6j3tt85h6z5xqaw2523mchx35lmfcgvarfhcc0lc4n48z8n2fg69244npddgqnhrluudxfl2lekecevc2qeaa4nn4qyqq3eqlel
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au1d4gcxz8n54cx906ta3pdkh0rfceqaehtlnazlkulhwsfeqw855zsr45csn
+                program: metadata.aleo
+                function: is_block_height
+                inputs:
+                  - type: private
+                    id: 3135069345152341838952663532563340664522465142511255226861901318078991996664field
+                    value: ciphertext1qyqy0udrrk2za49wpc2p3cdu5gnx7wrgxgdazmkxev7w52kk50m4crqz9jjkl
+                outputs:
+                  - type: future
+                    id: 6212337145581851034051086140353914628088463539878723696070597953853228640387field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    3u32\n  ]\n}"
+                tpk: 1444729407522809558323470265213923228766243452572825861150604562994526846724group
+                tcm: 6605683873534110561518205917497290187071187934421726209194585939237041100572field
+                scm: 6386290422692476953856701959340582555742652888613812253698770682334976467968field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq98gssxjzs9urgj4efycpqmxx7nwkyc6tq00fj5ra6v0jakcdega0gq5yccvpftprxzda5hcydl2gqq8vawxkgvfuqnppmz6zjmjfjjtyvlqjl3uks5x3fprdmc8vzy6ueea4ndqkxv22fq5p9flh590zvvqyk862z7mnr4uuh6a9chh7m6mqvzvpdzepv7gthyahefc0hfy75226casj9qwhfu72k5yd9tzacz5q4es8qkpn0xxxx48ek6fmsk8e382672agtuqez0vsgnf922ukvdwnxd5hautgwhr6frjj3zka4esgqmv4ddujq5q7ehqueultty8hnyvs3y0umxjxzycz8jvm5z3rxnst7392xpczrjz3a8ecgqpwtklfspz4u27wrjj4zze3t3meg8c9g3qd5r0a2r6zh0hpnpraqhcwd7mk25y5qdresvzuzz7zczt0hvl5ksz9pv422e407r5n0vlnlnmmpwj596s4n90vyrgcguhr7ult0rjgl4xnq25p245nhhxrpc0khu3uvyqrals462j4ku452uje2d550ppzuth3gsw4xr39ntyplnfuaqqhak62f6x24zxsrrkhs8zs3ky3k25qys24sswxmkkhvhp86q75ufc9r2h45ugu2q98mmwpup90e4tmuw0zlkllkj52ru5nz6qjtwg3mk9uqsa9cjx6krhmhj9swrquxua82yrpwzuce9tts6xat9m07dh979ygre37dlud4lk56h39yugznaxfaylucrm8yn7pwhmqnyj76x0smwztzqrh2f5hcgy5cqklhzl93twqe5uzqq9yst7s3p87ywh6cn9z7qrvpwsyemehgugxynn4t753t0kucz38dmkdx72yuexc8rm5yk0lpp0wetmnprz0yd4z48e0jqwep3c4aedmnm6x9g7gucaskn73gv2cv4pz7h55zq52wynp3zlj8yah0xay4kgggda3kqyupugwk6qem7vxjr5dtwhd9gv4hl5enqms0zsaxu3wzyehqzdtke0x4v6chvsqrqz3ljfps33e7fqfq9ffl4pxzvkvnzq7uf47430at6cw7jrvu3yz0pkt5wr0434z7ygga78rf0awt4e5a8tpgwv5msgm2ljqe3tchnxhsakay7jd7gpfzajj7ulun7cyyyutwdrw7ve09wkcx557vdtekxzczqvqqqqqqqqqqq5t2cgrt52r88rg6jjyyf2tsav7nesesujn0jff9ds39ga4a2q9u3chr9ve2sv5tqr758ma48nwrqqqq7398ng724p5aas3l5jdg4v7srjaushyzjt9tu82tfhkl53ll8xrlzxynjc9ludr6tdre74h688sqqymzju3cvzc453m8cgfq7ex43p2nrp6py6vpsfca2zue2fr6gknpyv5m0zlk5x6vlmlyzlw4qxgcp39wpr7uw5hxc3m794zgmel5cheesujku7v8u25tnty8z7z7czshqqqqausnkv
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au1a2leejxweztp26wle5ppu4d38g7cy834qyjg68nde5sztyvkwy9sn3s0zp
+                program: metadata.aleo
+                function: is_network_id
+                inputs:
+                  - type: private
+                    id: 1668253572722249004754550111746806543734709237973262206564980341309666489114field
+                    value: ciphertext1qyqrya4v7lv7j5gpldaneyaj3hpl79n9nawlt085kunwlqm2s2a2kqsg9c3l3
+                outputs:
+                  - type: future
+                    id: 1539677279749963537807733780953347200083489102040081905411697663081843666141field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_network_id,\n  arguments: [\n    0u16\n  ]\n}"
+                tpk: 1340232995313789889707870100633828614952994697713322419253213356280424596637group
+                tcm: 8217955983468310915175130532526952797051163869431616512626964240444177287740field
+                scm: 5286852775688099827771180960665525889691546224120923411174520720536024854359field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq09e76wddnurkycfduqt5jj7hafhxxdsl8k3dsgz5s99859gwg0tkvxg56hdy0puu48hxvkfzgxagqqyxwv9q32sm0hdewcfr5qvdfawq7cdld64haa8k4mh4nhl3wv99g9jrnar265pw0zvmza2sj4dzedq8dzke0lexr5xaypug5dg9qt2ptc9s63dcfl42vq33ncwjaeudetyfwxdvpyq6fwv3lchath3lgd5qunj6zpxtmf6jpjt5yzl9l606eycun3madcsah50zamp94a6ykvnyt4pavlwtazkyp75u72pzy2tsqk2wxv2cwa8rxjpsvnts5dsl2a93l9ejmxxmvqgsdmm92h44hyaqw2uw9xh9c7qcf98pvp2tqck3cpdrmd3puahfpn4vv4e4hpnnj5yzv2wg4jes9cpttx3gpatme3tzdttp0mdjsqtye2tz3lkmcwhufs9ffg7nne7wnh8e2tr5gujevpr0g4gyxp4jejt89k0rry0ah9p3suu0guekf8q2zrjhz99hr6j946qrqyh4w4xe97p0ac0635q6q5m6xutdz3t53harjr5tukqgvt9r0n36y0ek2eg0cfq4sdzm8q4452vqxkmmc23v8x47jxn7ky2hx0gdsnrqc9pwuhap8rtr0dqjskwl2nata0we62lkue6z84akr9v8d8svqjusjyxcevyte989pafx23m0jt2hg94pl28k4uj4fnwnqgq4j4580a99ndkyrhym3kh3uwdufymy8879kxfqtm43v84jlnaqm6qhk6q7p4frl3t22zgrt6sfkf5hlvcypljdhfxczx5h9vggk0pwxjgatpdc4f5yav85sxwy9fyfjq0z77zkxzruhetyk80d3v72efr3ycscqsvzfy4p0mh64wz2mhtzcj9wr83tevaag5t0975zs0hfupxnqylqflpgdg6cfu6ylxhp7w4xvwwnwac24n2cfnvk5pnsmyeut8n4fwq9cj36wsu7faag77epqcw6dkzsvc0cv9lvkj5xnc0u53v3kjsm65pjd557l0pyudch4646fkz45vsqy8xz7dcg86aqdgcv6q3mv6etpzrs0dxtcnz7uapehary54unwk8p9f57pz2ywvx8wjf7qs2rjtpzsca98hjwu9uuyhyw45zzy59vn7xn385ml7q2k9yuw27kqpeznm7q9qvqqqqqqqqqqpucfrq24alwu3lv7k8srg7ht00vus65afdl4dqxeqgsw45epn2tnjv7slu828djrs0hzfhge4xpkqqq275wp5guxrxjc7rpfu8mkk9wz0k7qsy7fz2nglfkjv83u6clxq73v5z6782er0zvd2ektcj844fgqq9tg36fyg8ypra2xq9an4gafntkq048le295xwaksepvlhgahypqtdrtu0mxrxhpmmvlzuy5d477k3ddncn42yk64wyl66nxd3ps8vv5teylrzsrf7gkgfx8h957g4m7syqqhlhwmj
+          verified: true
+          status: accepted
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au1p6dnfh03zklzzs9geuav7wv7setuzqdutchu5y3v2mextejcquzqkqwrsm
+                program: metadata.aleo
+                function: is_network_id
+                inputs:
+                  - type: private
+                    id: 2502240154805122913754950482164060205713010124319839564435072682062878840162field
+                    value: ciphertext1qyqxt75s26szy43jyfepy39w4d73djcs3m5zy32d3x97pzq4tz6yvrc6krhwf
+                outputs:
+                  - type: future
+                    id: 3510883460457420092377029532012709622763897279943796296090819877739355135729field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_network_id,\n  arguments: [\n    1u16\n  ]\n}"
+                tpk: 1241422812750809040633541710935659167182171861372164882434451533657783900235group
+                tcm: 5101387774266692927046996997659568586960496233365914098412457384845133261795field
+                scm: 2058887597321544003446839824871525583138282285522439768552503536778673854175field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqw2mpt4vp2kdrt6z0lryx0e32t9ngsldqzumnu08u7wak3csj55e7qnnfa4sv5wh2a2w9g6x0xttgqq9wlv87swn8kyk4durjwzdxlmtuj8tdu5nvmvxm26ddv6f3v77dqxhkqma5pa2z993zl5k4m4mlgaqvaadfpuceedmfclvru99al2wma6dtqrq8hll8x2fepflwght6h3a893exxs2kcvuqd9yv7exxpf2qlu90ssgywlpl3yaqdqj92a2n7dhwmt6mugs2vvc0g82x4lvv53yfcpnjpu6h6096hxvcwx6uenlcqnccvpkjlphettnkp4kl0m2zhnwsd29d2vv9lmrs7q3xwph4auz5ndxm4u7jk24kcum7f36lykrhsp7d0ezu2550s5spm4ngxq0alhyea9rj02apntqszclhq2mdnddm8pjg7mdzxfd90ypswy82tz456qx8esjhvf7mczznfagsdhmm4w3ks3jv86qunvdp2evtsn7zzfw54jxsnv7h40jvqlqdt2y6cg4gemq0ack7zd4cswrg825s6ekuh03pj0nnue0zexfkd5q6mrqfwwgc6vsv6z0dqwcm0k7p23fp92sekwvq60xcf6f4ukhazzpq65kxj2ydk790td9ea03xpdu287gxmax376ranc08vmy6sm2g5m9x5j45y59vpm7u0y0gxnnhw75mzq5cwqq3uyg5ah3j9ma6f7gxl9nc0rmnxwcqey0uz5hcksuj0vye0hua3yylnpf452syphap27d988a3f2r2gkqqs69pj7vp4pf364v4rjn54f3hu9lyg2e895ka28m7fp6cm0zmeq86svehealsspweg6vtl9dvr4d6cpp0fvfr3pllx4hrfdnr7jh5sfdy6rwemk9y990nfn5uu9mlyvlzs3thd8aywmwzpezkzdnvkx3gxt5m0940ffg3wfsll2akg2dxv90ct335nk47ucvenmlmzudq77ypq82f3yr9x92tmt5mfh5xpg55c099ujm0ycqtz3r8q58ynakdnkyvxgf8s43ce54qr955q44n2rsvnlhd7cs3r728agmxc0sencdldpyx36hypekceg8p0qwhh2yjcfyd5e92v50lgh46lpna7gemkhwsqpsga7dyuaxduf4ze57dqk582clp88m8sud60mz8wckck6uqj56cwqvqqqqqqqqqqpmqg85894svzenmckslpej8fe0q8taszeh37cvs6fswnguypddfew4wuwdfz7hucesl4czp7ckfzsyq88kaun7e2r9hff74tmj84jjaxv385s57nw2hddeekanq653k6xu37w93y50mqhn02y0eaq5sc9qspq8mjtdrx7cskcwpwvulfw96yhds3smrgjh3qz0w0h0xk5qead6xqequ37nnunjglfpwauyg52xy0f7a85sc970mwg53aa7a0r3uhkh4ts672peqc07ykj52h86zn9dmesyqqfd8ktz
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au1jll9jpzf2280nvn3kzt8y6637n5ez8pa0fyg0v8qpz4dn42sdsgszgyfd8
+                program: metadata.aleo
+                function: is_network_id
+                inputs:
+                  - type: private
+                    id: 3818594322984197536201841623343353965535635040024778735947422566750518631238field
+                    value: ciphertext1qyqdhlds6hmnj75076e8rp439d2w0kkhlehqwpxyna4ermue25k77pc7vd0t8
+                outputs:
+                  - type: future
+                    id: 7537178816451179749955293921141073144829691758346850600262417117569051950256field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_network_id,\n  arguments: [\n    2u16\n  ]\n}"
+                tpk: 3020628155079738676029341956864028183556220726126818119892843813515945814634group
+                tcm: 5092678026348501787479712092206654928057371516556014317181185415850075250455field
+                scm: 6698525472848186851972463463758579475375335023496196068921682192475550867475field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqdw66a0r389tve06r3hfuadzhcerz9maumqm53zyyvly9vh8n89l76syecwfvft3jpzepnj9znn0gqq9rjtyudv2826svlgz7wg2q98z80jg6utafa8a826munh5k772hdtmq57e7p5gc57n8q6m0j5ghy7qrmpr2sqhgfydnxw3esncpryz6d4l68y6kjdjr887gmma28s4253wllq796avhhthnv962h2jejtyqderr37zt3pkzexdmxhnjtpgeymn86s0mr87jfn0jfr3dxepc8yr8l27tws4dl65aema34mnxdrzspx3adzxl6vzffaceuhe574u9aptx86e9xkkay2qdg46vf7qykwehaqfkx7ync5dw0rg3gp53fxu7sqgdf8ntq2lehfj0w890n7hmqtda79xjhw5mgrqx6p82ff9f8v6xwrthu0rsgycxzz9nkzwuseez0sqmjqkenlm93cmqnnzp388kkh5rne27prhj2zmshe2xmtn3mvz7c4mu2x5yp9z3k7ksmtvj2ekcfzqfs5jy6z4pvk7p9h6q0lx59ry3m3dfv0hwvfdw6r5g37n8aau687f9ex4tv3787v92zatsl3sg8nqq7y6ullw7eg45ygg6cx3cc7unqp3jdgswp7yepjr3r8nhdgxskuvv8ewkcng0aq98aqf40z0w93fsqzh343luxdrlwd3ugz0xpyf26m4yx38h60pvrawp6gst0zuvkzcq2dscf42dg3t5qxuskvjncd6e6uzlt2nfu06s6tyhq8c2yr578kqmmqpnfj3kt6q5rhctdpgf0h32fwckzhv3y45fxw38p4envheptq2elwgjewcgjevcr8svwtd6zrmzemjrwl8g7l64a39yz6e22kn3sjqa7wfk4md4jeh0fp5wyyl5n0537qttvuzpaqqc07dtw00cj0kq32xxcuxwagrhq054kd9q0kfn4atgw05cn750yg0y5mdtlfk2ufgqw9epe4a877mm3wnezctnxvzwz00vsjlrktlevefyqxuyzl7hw2pzvh8nxc727haul228ll2h379trd6778lpfl28q0dfv8r3dudt4qmpdnse7vtc9cre96k8vkp2wk6mkzgsp2paruf0sfzxn3tn3gqrsxu3q5e6ttfa3z36t7xz76fq4v79d0t78euu775eyn20sd7mwzyc8qvqqqqqqqqqqqp6q072lqns9g6fve53lfc7tqvmly2wp7rvzyefvsy9zn9t2f8espt3ucaud8d88w454ht2vfrg0qqqylkclqswxj0wn830heygjy3qdl5qvjycddttke3gh9y2wlvvsv0trngx8wmmh6fjzac7dgusa5vgqqxgdada0y88jjhzgh5wr3prhqr72jrwd7t8ll5f7ne765m65y6nq3ufguxmap9javwg33yfl7vdhfcx0y295rfjm90tujr2klhysh5lh63069er00h3t8wksdnpq0ze5qqqqqc3q64
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""
+        - execution:
+            transitions:
+              - id: au1v7d5emm5qv92eulwzug07zef3jtulz0wtx327sgneuxwwq2n3ygqff5xtv
+                program: metadata.aleo
+                function: is_network_id
+                inputs:
+                  - type: private
+                    id: 427388127841120656445243905080318759102213861603935015273048542880171276770field
+                    value: ciphertext1qyqvszj42vuw5mrh26jse5x6x9nr4shv4t7spvjy93586dyksftaczsj2mmc5
+                outputs:
+                  - type: future
+                    id: 2214372592663363501000356836064875093257329610279266518247128855554701148078field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_network_id,\n  arguments: [\n    3u16\n  ]\n}"
+                tpk: 5166995774473884857353890834507697003252798886819763885458919875879302699010group
+                tcm: 2857269466509252429260393571916264430248634027864154552164266119325455448664field
+                scm: 5015898762287590171698086886227097532893513313055100890056714442595417776693field
+            global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqxjnzalspm3ge54g3u64k46ajew68hfgjrvw4rwpq5uv8yvlzn092gzfpw9d4zww8cq85uteu2cpsqqy8qrgcldyw90hrcgefx0hf5wzrrl0z4e3la75xlmrvykh9nxzqu7jpwv3p5mqwjegz0mhphx4eynqxpl02fsw9ttvfnrdgeylj8tnezkpj62wyks49q0dmzkxld8l2h8x6ycxx4cd0aedlhgj7t2pa6g5qwldagqet4gdrtm4jrj8alfutly5kklcs8c57dnc3n8v0p5e942maln69mv9qzyh5cypkkpvhw3zvqmp6u7qvehd6m5hqa6kzynyvr03x597ydckuex89plhtcj60fxypkdcegpgsd4kh5pknhvyjtqpusqv5z9jx20yaae740gnjhwad78ujmsjz3qrt2mf82kg4qh8s57pzff20ekcv5qy7vlmq4qt40el8aqqtgkjvlcdwhzhs8md3d8wz5jw2w0fkmdwa2qu5rz6penct0hfjucyq4626hlvhtrhpfsg53lc483qr09t69t5gk2t3k46z3dzsul85vkc77fturpr3rjd9lwlg5dr8h7m808uucvm9xvhkfugdd3vpul7q9eeug3cqz3g39y445vvrssn3nrdsl6xm6t660wxe368ne60nwsf93z6ydynjjkz0qr56d36xq5pgqz895z3aep3u06exfc3m2d24yewfmvzzcnlf8mcekge0q3fd49qq4czy6drge0fggv58hcyhdk8l2c77sxk4qt9k2klfukepnrjg76zttljvan85k87e2utgn6t7p20y6zs8r6x3v85p72q954agcdhuxp8cpgyt3ahunyluulat3qxeggcsjy87mda4uzf3ffs8n4w5usszq6mjf4qpsgjf5g8cum9vv4zl5pz8jwzzqpqczgdh9fwnvrtnlnhgv65xpekee7djetwtcevxxmm97pgtjtk0yuesjnr2swg4890k6rgptu20jkc0wuw8a3kfvl9anlngf3krmctjlwyw5k93aq9amum3rczet800tch2ngx0ay29hdrnkfdpa6hj0xegx35fa4np69ug800j2qp6t87r59zmfhnst7qdsf0ej46dcupnt7jcfazjyvxwnwype6p7qrs0p0fj38zkamm5y4fl8uvejl2pmh6nqjnkqf72vlepx3uans8s9qvqqqqqqqqqqp28js6ex4tk2ds9txma659n6rexsj7acgh6k8z95jgc6r3lc839ufjmf6ftk8h6p6xddnuf5h5r3syq9az5k7yml7wvuu2ukrmgwfz4qym075nz2pdqn3wwl4ukyhyuk7qy3e2su75wyfg26t7vwxtuzwtgqq86crh5xvpt730q448vpc9fwjwmauzu80fx44nmrrq992pjh479q8xmdral0gm45xdfej7sh65eqtuen2pvdnqwxhvxzurcuq5jznlt5fx06v43a0tp2wwlek3xycmdlqqqq2kj9ar
+          verified: true
+          status: rejected
+          errors: ""
+          warnings: ""

--- a/tests/expectations/execution/metadata.out
+++ b/tests/expectations/execution/metadata.out
@@ -19,88 +19,88 @@ outputs:
       execute:
         - execution:
             transitions:
-              - id: au196vk6tpj7cgyp0dvfm2c8009z89q8ch5376t0qavp87msv39wcqsucuvus
+              - id: au1mdg84h5sf70jd3jcz5ly6v7d2d65jthy2c9mp00ftsd7d7wasq9sywmyl4
                 program: metadata.aleo
                 function: is_block_height
                 inputs:
                   - type: private
-                    id: 1828886139934070702847867954511879816884750762363092521533208865235753727566field
-                    value: ciphertext1qyqg8xn27x3ukujrthuh67jazc3h5v96hhc7zacwef08y7a9lpu92pqpf7jp8
+                    id: 6254483773873152836214079053344956162296914127394184523955489854019104782235field
+                    value: ciphertext1qyqg8xn2lx3ukujrthuh67jazc3h5v96hhc7zacwef08y7a9lpu92pq3dsj78
                 outputs:
                   - type: future
-                    id: 5457953770891457596513693104617313278374925684406320053944467986971462340947field
-                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    0u32\n  ]\n}"
+                    id: 3584812567307540139221803946418691936915110293757497103263084678323624798088field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    2u32\n  ]\n}"
                 tpk: 4174266389141840694112770464623549736508472115786023137592436699114609405528group
                 tcm: 8338099097402671626408038034858578087638496090147697571937791628404909729345field
                 scm: 1980270338266624580494901677581519840423416572710948745278059423752506827747field
             global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
-            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqtxu2hrjlkjsvwn6de72q34lqmtstr69ahhjy0mlc5jujj4zxhkzncpd8tl6y2nrx5fuxnmpd9ej5qqylhezq3dmrqm3cm4tawnuznt5gc2fv8psgvswzavf79my3t8ahzhj9x5epa9k6s9vznyh8mp4qsnqgz2jsuc23szktw2ckx5jn4sqde76qaxp5ngwxssv407kqa659cg4mxc7f8yhzexrkc6mzwslrjj6qeza4qy2hrdrtp2884x55jq3j8tfcllhcne2k55dq2wyckw7zyd23c9uv8a4gdtvczsy76ef4vf2sq5eat9urj0u52f2zgeqrl7kcq3vj6wvzgrl7xv4fdffy3tmvu547uj766lkfm4my98wa4dg8tdtagpcsrzxy8fuktmgsxu8jztldkcm05enzvyhg5n6qfnc3v97hdzdkaruhdm4gy99rhcy8q6alfzwk5srqzylx6l6a7lpsjpmkkfj6pg0j479shgcl469r7tglt4dkr3mc4hhdw7rya8cr4wekr8raftqweqq948a5nw9x8krz7hfux8y52p6jq56r87dcc2a2n8dxnunpeeg7rlem45ft9v7cvdsx2r79c2uvq3sq66kh0z9xaa6yf7l40vzeqkrjhpwau0jms575gw7z8r0y5572rflkdu0p6zwshn7c5fhexjyxg60gp44fp0zwc6x8pjan4hgxsw28l3ev9raz02ljcehpkefwtnvs6sqz8qykyeneq9kk5kxydlng76qjjy5zk6tgkmgtr0ua76e5hpxrevz3uyml43y3w4p6vez9xpne8cvq25mnqu6tyg9v3h6g95xhq2p9zz2ekpxk2xk7hh5zkk8anuar8m5ph08vdzkg2290uw8l8a05hn57p9xcj4kmpn2hp0ckfsysugukry3hlul49j5xlr4s4z3kzykn6mzqvz3lg8fnlrx69yeywp47mk7xm8z4wuasxkjatseeut4lkdsda0yy5vsuqpyalet83e70xhmpfpzejlqq93fftq3jdgrp2pl46myhyxpmjwvna56km2486cx4npl9fthutud6adgud60azx067hu7rfd36p7esvlz2sw609dhmprjhgxxfa9jk78wuf67vnq46zsu092unjnpppyvqlu8qg2euhj2ccgqyt4xz7wnem2j8supprfeuhst3zt5le3qdqvqqqqqqqqqqqhds93teyttdchawkeg3er480yf2gmgwmps5n4sepqvyvc7jz6ujhla7h6tw9ucnyk0p5c9gjggssyq2h0zlh5sqgwkutfehr4usqqlrjax6j2xh28e2zc9rjx8tvzc97ve2tzw0sq78zdvlx6ck3akpqxvpqywtdg5mncgw5ulhc06y3pmnfnqyl7v2qs9eve80m5n3rt4yc7qqy5culrh39czv8yujx9xfyvq0wh3pl7f5sq2fca38mqxdt5qmk475xvsthnundq3vultnrh7wcjygqyqq0hrrhd
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqwnt9kc7w5mlsy92749ly00s3d8aje529f6qrun8ra8utk7dse49ezfwj8erxuclwetdthkz20z9uqqylhezq3dmrqm3cm4tawnuznt5gc2fv8psgvswzavf79my3t8ahzhj9x5epa9k6s9vznyh8mp4qsnqg8n8aza9sfw3kryelnz8k0p7sx375kzu754wlhy3k5rdq3vz0gnxs0dh0pcz5nchj72ug77suxnxqe20ln5arx2lrvykq6ela5tfzajjew2jmr2e2nfjzafrt3alsplf2llm62deuq02xa4406r5heqhvpp30p46fjt7u7xc3mhv6j65l5cdnmuxzu9d9ngewapqs3d4ad9jpq42ltsmdt9gtv8utv9hqywe4gp9jw4dsapm4nlmeu02hhn6tj44065j5k6l3lrjksmhfletr6kvu92usrlgqdwvhnv87g36afl7hcsrwepsc8nlepqngw2q4r3kpyq20avfgrnft528axwr7e9jjr66dmt63ylatjvh65rc69uqz3nkvemqtqlzescl08dx3xjy36a5u7x89vh5vjkvkpfz5edep3av8f2p37f7d9vjnq3zfrn3p85zx7gjyqg7qyqrqh5hg70a7klgy5eq0vrth7pz7e7g8t57pkju5k9z6xwexvg4uz2svry0mk7latuz3z6ynyc9cprfmcjkjwmezs4vl7w3kk4hlhumkzm2v3jvzqahx2m9e86p557c8pjtudkgd499geem5jf5u9qxuz5mcpdvegqm43x4dn6uyrdzjmzz6mgcadv0y0gced4dh20t757kgms6u45ma5kezmc6ghf9n538arp076gjrkp9y7lggntqr2v8aqvpuyw7szd0f9d8hrlsyff6re23xpp288aeadrh8lwqdjkpgwhdv95vn8araf5t8tgrtm22w8r7turzcqtyllzl8s9cfeczzst6ec4narg7da76fcq5neycd6slgx68g63yyv6g63ae9m7ztepxvxw4852aadryfy49zemrzhqquypkaehrf66qwwjhf3gwnm5aamtv79v4zeps0xf5urc5cw8xlaltapg0pm54kjplc3udlz587zkd82qzj7vlzljeup57t4hggmafzf303yx8l3ypvq25cvm4jfympct84an2f7q53pqymcgzgxwln29ga909uhv2c6nss0qvqqqqqqqqqqq4ydt9dssx08jcecc7lpc8x4npzm45nzx4gjeepzltl42xqtu6ljaegs3vmkyp9gmcxejarwucjysyq9gjdqfq9ugcxqc2dlwxzhgw6ltxctn0gva6m6hz9a5lm8la0fm2nctmj3kksdal53ktu3wffgmfypq9sp749hfxy8wvdnsagqs4w3hxr83qkpdacm92er3htljzqz4yzss8valjgymcql5xm5uqxwuar3549jrkl577ww5mxvxarkcs97jpulpht09q6w4axjxj254ezzahy4sqqq7sy9wf
           verified: true
-          status: rejected
+          status: accepted
           errors: ""
           warnings: ""
         - execution:
             transitions:
-              - id: au1r352lhvujpnjs6dsv7zxjlesddm6mdzwl2579vglc9d0jf5zd5rq5ceuj5
+              - id: au1kajlhp3am5km6qs3w8turpajy92jll8h5du8xahl38lrju42ryqscpf7qs
                 program: metadata.aleo
                 function: is_block_height
                 inputs:
                   - type: private
-                    id: 4286956730291478172967552406966020510655589486973029992023461375203373137580field
-                    value: ciphertext1qyqf8p8u0l6w5w7nmsquncjs36gjxeaxpkkuvl4h6jfqntenutrykrglqqg0t
+                    id: 7722322839839951421026301806812591976215758329272280293651204384239373811149field
+                    value: ciphertext1qyqf8p8usl6w5w7nmsquncjs36gjxeaxpkkuvl4h6jfqntenutrykrgr87gjt
                 outputs:
                   - type: future
-                    id: 2385412319407656831158957518021928306540861142632415702983135495782059153176field
-                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    1u32\n  ]\n}"
+                    id: 3909450722149817926760252005945160002086204331713328859672090569802582231538field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    3u32\n  ]\n}"
                 tpk: 6826075503536703408877015806866676888464978285285642759889480649615825407885group
                 tcm: 2184261592989300536746165496548115475812152687244578178115561569274734999038field
                 scm: 407281751932047584685189018244827210538163428192377398266270897182443379767field
             global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
-            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq94afhc7cpuy4kjcl8j5cndyxajsp37895s58fsx8qyh7yr7qtnz0mca7um7n8scq7hhurkxe976upq9na6qs3klshmquwdhuja5z67tvxswtmytsceyqtsd3vqk227suywajtjjef694w8c6df4my4mjjqqrwjvf90ea6e3veg27rhme0n49hlfjxnd607y2p8jm2zj20mr3yndf5n0yunz7mh5tk3tf8syxescqvx7s5cnzky2leuqcg7ytmdl60uchgx3l96kelcr3gznjsql9mv8w4aez7vv0d2e982xun3agnwaup3dleeqaacr9p0m5vac0xly4wqrm73hfsgfsjcq5dph49v66mw2s0kptpvcl4en27sgcnpmc48e3sqmjaevd4g02h67vsx79yn85nm5h8h3mlhegal2xz0x5984qg3qaqpjweckp98naxnj8j0mwm9ty7qy7vt2qr9nuazvhlx9qwss5y3spsmafcq3c28gva5ls0h93r7zt6nv5zf7gtv9ekqrjt95cnh67m0qx0mmt033dr286st0cpp6exmff4cn77w04q8dc29cyhrzppgd3xspy7007mnpac8ywgh3nvq7r6csq9x7rdl74vevz7fg70fn2dxq563vfwq0uewrn09xlwu5h5ehjjn7paszqnvngkuyxfdwl8ypgpzp5p6lfws7m482q65y2wn2u40vatf9f5scnak7aecd6eqwhurzyusyrykxtdswtvyxacvpn5hspww5vw8uptpgy9w248hedgevm02se4ypur94w4ed3ap6xudtvekyyca39fnctsnh2fq7d85quv4yj34m09q0afddnt3nq4vcn3f0j5pq36s9dp90he9r3za4n0nymlppwtgpfqd2qy0d7xud83g058t3c3de0taqfxs7s3pvfxx793jfrkessskmqwlfelj0j2h820wxcjc2y93jj7dfyg2hng6tfwsg4pc2yld9dldgxzc5myqcjltls94lpf7zz40ztq80xj8w2ftc4sp5vs8le375efqpj627jm6qpz83dfmu8z030lwez6jek3mp3qvvc3drpwke6dsm9cp7a9gzrqrc5yqhsqa9v8f7tf3rlgxk03rvn5m5rhgwnf8tp7kj7qcmr0w6ffru7q36qtyg9lqk4amw3khapt7xmfw6m29kckjnww0kg9qvqqqqqqqqqqpek7f7tm8j3x7knxqath3pjg7gcdgmhxk2vhnqgfs3mdmm0dx5d2fx0u9n4z6gqgf5crhwn69g98syq806fm00fg3nwdyeuhlkm8ee49jf5ehmwjxp4wlp3yd4h6hnldgvkpl990923xjuwqd6dwdmryyaypq90y0td3upv5rx3r6u4xsvelryf5nfetp6mnn6qva36d62ucafaszj3729t8lck995c3g6fhqw3rwvu3vdnmzdg8wpthglcc9cae2lt93pjndujzvq33kvj7ezerdpprqyqqnru28k
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqx7vnw2caxnpn2mxquhz760v6g2ncehepcdlg7y8hsdp9f8thtz6e7xs4yfddcy7w8969xlhufx7spq9na6qs3klshmquwdhuja5z67tvxswtmytsceyqtsd3vqk227suywajtjjef694w8c6df4my4mjjqqrwvyaz8vxtqekmn2uvdw59l6eqfa95s45fnfkgllz73xv4armyrweal4g6ctfqphecew3g5evzauqy0epstlxvstdukgynsr9c80202ywk22aztjncctlljzv6dp9k4kjjafsswjnhp0x3pw38md5dr9vqkucck0925lwlf930jd0963d368wuh43qtwvstzu45lnpx7ltsq42dr42nteu7le72xyhtfyryt3sqlpnn2n5gz9ke4extnay75kytrq6e0qfysllv9qpd5grq9pq2wppdxs438g6zjysmj4zkwp58wmrsqn3de3ge33m9yduj5cu3j8qazthdkfy7uqppxpym43wnsk2536q6fer0tghyutavchmmatm94jfaqvqvcr06hcy70zcfz0kgjvxs6rt9ncs4c887uhgnwxdmvxspz2vyzvnxzxn5jn3e3medrutlwfpyzq2a2qxs2f0e020auqsp7gujuzk8cl56rvqqytq56pxyec90nwqkk3vfhafuz4wlqx583fuwsxyh75qfl8q4cchgedng7gd8ju6u8a9s8xstd2gjznxc5rcaeule3qeeyr05rtyj8zhxwvgh08r2wfnkpjerwpl33lj7mvehm2vjhqf7akaqrse392u0v9hfrrp9954hwzhqe35e7z44exkexr5zlth7wf7a5nkqdqcq5e4q5a2u8894j0fnfjrk80g864fgrv3ttu4zleplw89575qzp8s8jkflf7ncjqzy806tef5sxavkfdrl385tza80cjegd6609gjdrf9mjyhvj5hxm2rhgsslsavmpxtt0f34q32nk9lln3t7ljmayrltqz8etsxfzsslyre8usx2emndkxtxpdpfrms0y5x9fsf69kg5zyu54r2vezw949pyzdyfzaqh8v2t0rpxltgd2unttd80k26kacdqc6zvf36pqztqx9w3df2964uq976ar9jfyjrdke0e73mzfvwezuqvvul6v0nk9cpln9nxdxadvpdre4ct9cdm2wqvytzm5ny3xv2hdcrqvqqqqqqqqqqpejt6mlphm76wza29mm0pys6uxwf82mqcatm3yu9zkraqujm0yymgpxcuttq3f8680jrdznavlfvqqqwj9g9hx3qyfevvu3y3xjmn6vtpek0sfwyaqdjre4lgu833k40aeqq07xrecaj6a2whft3rc97y3qpqy25r7zgfr0kq2jmk73vxsumypw09rg4qqdaxftyfn3hlpm6fuasmtkmtfq87ewhy0ggvjvgq6fjjeszsmchmuqqy7rz3w9rnjeepzj5w96wk9g2ffpktzwcvgn6pqgvqyqqxp7l8u
           verified: true
-          status: rejected
+          status: accepted
           errors: ""
           warnings: ""
         - execution:
             transitions:
-              - id: au13zslsaxttpvsgtmcmrw73x03k2lmuq4p2fvhjak42qwdm02jrs9qxssdm7
+              - id: au1f247mhakw2ac486n8shjpe9cczyevyyy6yfahku5rfehjh99uv9sh642wk
                 program: metadata.aleo
                 function: is_block_height
                 inputs:
                   - type: private
-                    id: 8211778640811586469327625094750393673294867466010064667391066202117864355889field
-                    value: ciphertext1qyqrkdwenqpgp7vqqv5tvnt7nvumr5w553pq5lwjntjeuavh3re7cqq0u2w79
+                    id: 3045860458496390867694070088198301599250184717892350776505560963236032378259field
+                    value: ciphertext1qyqrkdwe5qpgp7vqqv5tvnt7nvumr5w553pq5lwjntjeuavh3re7cqqyqfw39
                 outputs:
                   - type: future
-                    id: 2644113075717811263567925485017682536194868718759129046632116666842982336474field
-                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    2u32\n  ]\n}"
+                    id: 3385728006652327570493585525511743343760587719990357436071125793263092737280field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    4u32\n  ]\n}"
                 tpk: 5961719084867262658611365638360766420582791439974047595680459060088949753734group
                 tcm: 6626624319880809262391967868024871859050942736550513386256577389697770634318field
                 scm: 1709184858721614245415770013947709782814544370016004415745981136924726103130field
             global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
-            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqvy8y0kv6jtl5hvetkc3vudc0nlnk85vjf9u3sw69d0n7n8urttcef2z97nyeutwrvrhajftc5ewqqq880k0f7kg9mhl9f3nqerjwsv28v57anx2qcvxqsndd0wuhldwwh5cj0cj2rm24vk40u5le0gkz8qqx026a4utrczjdshfhapv9uxjwm7rf5yfcjcs97rhqg6n0fdvl63yza57kv6n08wnyyqe73gaxs0xq3h3mnefw43gn59uzcz2kctjjgwlvfw2a853kds7ut0q34pyjlfj7rqwf5gct8ggtkvjcm5uyckwspz5vy4fqclmehcqfycgzt52ha5evv6sdjcvwcytk830k3jkqptuf9fjqqyp96wrat360dcut23pmcqwqg0kwxz6n98dww8zavmj6uyde4mfn0tz920zaqdcyx8veatxfgsku6gm2qh7qwyx0zlyp5mzzws9jmhkk8hj2stnyj5x50ypg7hvcl7lml7dzrdut26vjvpc86c555hhj4mat4s07dn8m4a3lerxs99qplm0zqwdzv0yff2uaqqjg3fvqg5wpzdxeskm052g20qxm98jzqkhqghu427hc5r4z6263d9m39n6qh477zemljmur7ad0jqrqcx8rvwyhthhrzgxmsavs6wkyxupv392u6u0w3lr8craa9zmrxy04p6esqp5v0z0a849g3yzgwkf439rqfuu3ytme7026wlyaq23zpfzvg559mjr7hym0l333xuwvynkgy3smg60p5v6aumttxe7cku8skja5gzr6q2jtl9t9e5gp6k928zp9pprmehjllv57mzmal7p8n385kt5s7qwy6tkwtgpcxlkm6zxtkqmc584h7dhxt6hrg9ahq3nwzu5u5d3tsl2xgjzs6wsm5d6jaf8xj5wlhcxdja0au06gt25fgn54r5u4d9ugvhktpstu4vhw9kwxf7u284df8ethqwwckjedvkzm83hdvwacjn5q4ye2fcdru97tq0vz3g2tcjuljgdvtlkdqj4zjn72d3tptyclzuydxdc6vdrq436pfn5mhskqerm20w02c8n5yqqhjxep62sqk4x9fzfxcd2k3pd9e3txfz8jh0xhnmzyajxwyvvhkmvd6ffhu943evk7q4neae0r3pgj0l6xfrsygxgpuu0w2m386qn6ptd9mdswnchvqe4gyqvqqqqqqqqqqpts0qkdkj8akq5zvd8ue852qg6z2agmctk7q9ptevs5k72hr7xt3g5n97sxa6w289lu45mzdm4atqyq8jtxcyd23u4n850ne3nt7k27szqwelnt93w8qwkmcr3kzsgmeqlkutm0c9n3zmdgcc59eyu4nytgpq8yntau9uvct50r3e9mjwknc0ladxmdyhhrrp3g6j3tt85h6z5xqaw2523mchx35lmfcgvarfhcc0lc4n48z8n2fg69244npddgqnhrluudxfl2lekecevc2qeaa4nn4qyqq3eqlel
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqqqevkrn0qlq2nquvu6xc43jqgdpl8rfpk4hnzugwch6qraag292tzkar3vlp0q5wl088t25txgrdqqq880k0f7kg9mhl9f3nqerjwsv28v57anx2qcvxqsndd0wuhldwwh5cj0cj2rm24vk40u5le0gkz8qqqc3339959e6xz768zwvu9mcp4ruv8mhd3twdxzyqur768fwmngazy33dqadrc2un9v3z206fmtf2qj6jd6txax9pe75jasd0xf49u32r9ran9n2q7lyachszqnm2uf6dvyrwgvg4xshtv2jjsnv4v6cqvp2u0k8hwv4n5df6rhz9p6ehjfkuggfvthfuukr2ex95wfyf4gasfky576q284q9jgl7naf3253t2qpnwfj0jeme7xhegaw9r3lywgpa5fp9qsx9m96n5865l90v9sumwquk9t6stse5dw845rtknud0skq89qgza5mkn0fdgzhrprrxjz0f62vstvq25kfy2e7lgzs9pk2ujkkathgv024g7vezmzvczggmwc0qdjpg4ddmzwx2k5fe353lhmcjpupfuazj6w80hj37pt64wjswz0f8cug8n8rfux76xtc5lkxw4cjjqazwsrafxyfp7pxjj42l4rn6uauujkx8qk79y0dp4830j9893kz8thz250jsag662869k83g8p06uqx9f5tlpfcwg8pat5y98dqvmm4lqu3htzhxd0y0gzzk902nc49vqyyl669c37zp7umpquj08vu7z0sesrv0cwmy3c7fytp23zh47pcrl4nsn6kxv9qe92hujj3vz8k548zdkkk4d8z5k5p0qtp69p4mq2zg2qeq52j6a6l9nu2qnmj78zhk85k7r6nl9lgearrqv9y9nvf96qcj3lsq7er983rvlsw2ykjclhj6dsxc3dg8j3k0vs584rjn9986cdd7t6rr4jalzfrfwf8r8v9leq3ct4m49v8tj9qed0ay9jq5kklqz9nxa9uchyl7zxq0d05cqk7m0p9mcqzpgk24wrfy7ucx34n3wuyp4y7qz2hgt823d2p6mdvu3jkz5wu7auds884d3drsgdell4z3kgqn5hy7y7q38zwxznha2w3qezkhtxutkv8pgg3my353xgenpa4ttqqtk3af9qn6dwvcdv2vnylchnxk7mzumcys26a0lqelrm9lc3ztsfqvqqqqqqqqqqqjhnc7wfnqwkzul45rtxd04y9md9j8qfger8d3juve9syvk23tz40eahw3k3kp7nz49ex0hts9q6syqrq22xng0ecwpycpvp6zqf90l7asfnrqzyznskqsqftgrc36cnx0cxxkwkekp8kkmvtd8hnzv8qmgqqyp3rea3knhscdjh39yardx2u2e5lz508jh8trugnqfqc4ct5mlswf4j7uu7tkgsl6tkd0jttd4zqnp3xdwlx2t9r6m8mgvqsdz7c4gkxkwkjnt2s7jyul2mzglsktvxqqqq8jtpwc
           verified: true
-          status: rejected
+          status: accepted
           errors: ""
           warnings: ""
         - execution:
             transitions:
-              - id: au1d4gcxz8n54cx906ta3pdkh0rfceqaehtlnazlkulhwsfeqw855zsr45csn
+              - id: au14wkt0uwdeqr3rtyanm34w05erz09e5pz3vefsras92gw7mg9ruyq2cjhs0
                 program: metadata.aleo
                 function: is_block_height
                 inputs:
                   - type: private
-                    id: 3135069345152341838952663532563340664522465142511255226861901318078991996664field
-                    value: ciphertext1qyqy0udrrk2za49wpc2p3cdu5gnx7wrgxgdazmkxev7w52kk50m4crqz9jjkl
+                    id: 995875758905348650887838336071398965006340013590388127329542388661760814042field
+                    value: ciphertext1qyqy0udrzx2za49wpc2p3cdu5gnx7wrgxgdazmkxev7w52kk50m4crqjmwyfr
                 outputs:
                   - type: future
-                    id: 6212337145581851034051086140353914628088463539878723696070597953853228640387field
-                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    3u32\n  ]\n}"
+                    id: 7062753008479587970728813912297002098956298483699113034949808175760398051196field
+                    value: "{\n  program_id: metadata.aleo,\n  function_name: is_block_height,\n  arguments: [\n    0u32\n  ]\n}"
                 tpk: 1444729407522809558323470265213923228766243452572825861150604562994526846724group
                 tcm: 6605683873534110561518205917497290187071187934421726209194585939237041100572field
                 scm: 6386290422692476953856701959340582555742652888613812253698770682334976467968field
             global_state_root: sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu
-            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq98gssxjzs9urgj4efycpqmxx7nwkyc6tq00fj5ra6v0jakcdega0gq5yccvpftprxzda5hcydl2gqq8vawxkgvfuqnppmz6zjmjfjjtyvlqjl3uks5x3fprdmc8vzy6ueea4ndqkxv22fq5p9flh590zvvqyk862z7mnr4uuh6a9chh7m6mqvzvpdzepv7gthyahefc0hfy75226casj9qwhfu72k5yd9tzacz5q4es8qkpn0xxxx48ek6fmsk8e382672agtuqez0vsgnf922ukvdwnxd5hautgwhr6frjj3zka4esgqmv4ddujq5q7ehqueultty8hnyvs3y0umxjxzycz8jvm5z3rxnst7392xpczrjz3a8ecgqpwtklfspz4u27wrjj4zze3t3meg8c9g3qd5r0a2r6zh0hpnpraqhcwd7mk25y5qdresvzuzz7zczt0hvl5ksz9pv422e407r5n0vlnlnmmpwj596s4n90vyrgcguhr7ult0rjgl4xnq25p245nhhxrpc0khu3uvyqrals462j4ku452uje2d550ppzuth3gsw4xr39ntyplnfuaqqhak62f6x24zxsrrkhs8zs3ky3k25qys24sswxmkkhvhp86q75ufc9r2h45ugu2q98mmwpup90e4tmuw0zlkllkj52ru5nz6qjtwg3mk9uqsa9cjx6krhmhj9swrquxua82yrpwzuce9tts6xat9m07dh979ygre37dlud4lk56h39yugznaxfaylucrm8yn7pwhmqnyj76x0smwztzqrh2f5hcgy5cqklhzl93twqe5uzqq9yst7s3p87ywh6cn9z7qrvpwsyemehgugxynn4t753t0kucz38dmkdx72yuexc8rm5yk0lpp0wetmnprz0yd4z48e0jqwep3c4aedmnm6x9g7gucaskn73gv2cv4pz7h55zq52wynp3zlj8yah0xay4kgggda3kqyupugwk6qem7vxjr5dtwhd9gv4hl5enqms0zsaxu3wzyehqzdtke0x4v6chvsqrqz3ljfps33e7fqfq9ffl4pxzvkvnzq7uf47430at6cw7jrvu3yz0pkt5wr0434z7ygga78rf0awt4e5a8tpgwv5msgm2ljqe3tchnxhsakay7jd7gpfzajj7ulun7cyyyutwdrw7ve09wkcx557vdtekxzczqvqqqqqqqqqqq5t2cgrt52r88rg6jjyyf2tsav7nesesujn0jff9ds39ga4a2q9u3chr9ve2sv5tqr758ma48nwrqqqq7398ng724p5aas3l5jdg4v7srjaushyzjt9tu82tfhkl53ll8xrlzxynjc9ludr6tdre74h688sqqymzju3cvzc453m8cgfq7ex43p2nrp6py6vpsfca2zue2fr6gknpyv5m0zlk5x6vlmlyzlw4qxgcp39wpr7uw5hxc3m794zgmel5cheesujku7v8u25tnty8z7z7czshqqqqausnkv
+            proof: proof1qyqsqqqqqqqqqqqpqqqqqqqqqqq97zr4fk2uw9lljltrjq8xdrxgzrwx365yywak3key90jepew79znyxpupzmqwjm8pwesa42knzd5pq8vawxkgvfuqnppmz6zjmjfjjtyvlqjl3uks5x3fprdmc8vzy6ueea4ndqkxv22fq5p9flh590zvvqzkys72k46wn8hn089nlpu5a9qxypm6m4m5a98p07vq38ye6n7vvce8sqcu935z9k6kk8ljm95v32qkfflma302wclmclz07y5r4skts6vlqcsxjwd2cxygyrn77y29w04283av6266s228vhv0hz6gm05qzrcf0ravlp382uegjg8z85fypgykgqst9dsde435nv3jx82xsg3608nxjl299vvuu4xdlmk6jyrqrf83tvpx9w3ezfunw4umtudmrugz5ms2d42a055jl2fv5v75q3p5lsdvvlhe66c38su7w2k82jeas94e3sgjsrsyh42ac75pksrhcqnya6hqh9l3cv28ggrty88mwhgrphc7s5ugnpnzuvztnprcv45cfqrs8l2798l30pej8d4xkme2hxmdyjrkch47al54xyawdps5ql07ghj38wrsazgyaek2dckhgev7xvqxhc6ulvdrzvps7jues4sh70eamp7stt3ugk5tmtvpd4f3l5py4r2f773938gsxgd200ux8r8k9kgqxeectjylau580wghtwkyq8usgyjwpmvummmqws04cgjt5zec0v8kzycn6xk3w0qxxshak8saly0287ttklsmcjzj9kqsec03fjswvrk2jkqtfwwej48z7apv29jmkt2rvjas9y4unhzcpv9z9ns2fgqfpj3jp3yqasm4srywrjs5jzcskvez6vxkh7ndaey6p4gdvwdvkptprh03rg5kscuhawl4v74axkq8fc50f5tfd92dprt6l6td2p5h6fs8jwcsjgjvucrtwgw6ejhup3jd7j5rq6xqtavzh0mv0zg36tmh0u95435c4cux7t007yz3jeeugv4nzvrsmp7u8wj07wjtzcp6h44jkp4wxcrp9zgvy3jnz75pj9tzzqqvckttk2ggpngle9xrv6ufswalq9t7xp4ykwvq0qe4wrfvefvqfqnmwen4m92f07r8vtzc5ahgamnsxxzz3l7yz0er7smk6eqae22ve8m8vkt34g0wwywr4qtggnh5j2cvqvqqqqqqqqqqpj9lr2ngqgqxl9r6ga9wscx2a20szgfdta4ssq2namc6e06nguc4h9shcusug9r4jr408npszjuksyqwdd2d53vjrv4ajjkmyeu8kvd9dav08ulzcfdlclyjupau83udcga8xdg43djuqkfyvljf56wghngqqxzam6r7zh3klkp0jdda60zx9hkzeepzsetvzezhdk7qtcpncl2qt6el68lz56q22qzvlfrx83yj92hqukc9hnxhwpa734jk0adaed4pxe8l737hzh8t9f2r6d4d4x0fsqqqfe3ct3
           verified: true
           status: rejected
           errors: ""

--- a/tests/expectations/parser/expression/literal/address_parse.out
+++ b/tests/expectations/parser/expression/literal/address_parse.out
@@ -11,21 +11,21 @@ outputs:
         - 0
   - Literal:
       Address:
-        - hello
+        - hello.aleo
         - span:
             lo: 0
             hi: 5
         - 1
   - Literal:
       Address:
-        - fooooo
+        - fooooo.aleo
         - span:
             lo: 0
             hi: 6
         - 1
   - Literal:
       Address:
-        - bar
+        - bar.aleo
         - span:
             lo: 0
             hi: 3

--- a/tests/expectations/parser/expression/literal/address_parse.out
+++ b/tests/expectations/parser/expression/literal/address_parse.out
@@ -9,3 +9,24 @@ outputs:
             lo: 0
             hi: 63
         - 0
+  - Literal:
+      Address:
+        - hello
+        - span:
+            lo: 0
+            hi: 5
+        - 1
+  - Literal:
+      Address:
+        - fooooo
+        - span:
+            lo: 0
+            hi: 6
+        - 1
+  - Literal:
+      Address:
+        - bar
+        - span:
+            lo: 0
+            hi: 3
+        - 1

--- a/tests/expectations/parser/program/address_literal.out
+++ b/tests/expectations/parser/program/address_literal.out
@@ -1,0 +1,110 @@
+---
+namespace: Parse
+expectation: Pass
+outputs:
+  - imports: {}
+    stubs: {}
+    program_scopes:
+      test:
+        program_id: "{\"name\":\"test\",\"network\":\"\\\"{\\\\\\\"id\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"name\\\\\\\":\\\\\\\"aleo\\\\\\\",\\\\\\\"span\\\\\\\":\\\\\\\"{\\\\\\\\\\\\\\\"lo\\\\\\\\\\\\\\\":0,\\\\\\\\\\\\\\\"hi\\\\\\\\\\\\\\\":0}\\\\\\\"}\\\"\"}"
+        consts: []
+        structs: []
+        mappings:
+          - - Yo
+            - identifier: "{\"id\":\"2\",\"name\":\"Yo\",\"span\":\"{\\\"lo\\\":34,\\\"hi\\\":36}\"}"
+              key_type: Address
+              value_type:
+                Integer: U32
+              span:
+                lo: 26
+                hi: 53
+              id: 3
+        functions:
+          - - main
+            - annotations: []
+              variant: Transition
+              identifier: "{\"id\":\"4\",\"name\":\"main\",\"span\":\"{\\\"lo\\\":70,\\\"hi\\\":74}\"}"
+              input:
+                - Internal:
+                    identifier: "{\"id\":\"5\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":75,\\\"hi\\\":76}\"}"
+                    mode: None
+                    type_: Address
+                    span:
+                      lo: 75
+                      hi: 76
+                    id: 6
+              output: []
+              output_type: Unit
+              block:
+                statements:
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Identifier: "{\"id\":\"7\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":107,\\\"hi\\\":108}\"}"
+                          - Access:
+                              Member:
+                                inner:
+                                  Identifier: "{\"id\":\"8\",\"name\":\"self\",\"span\":\"{\\\"lo\\\":110,\\\"hi\\\":114}\"}"
+                                name: "{\"id\":\"9\",\"name\":\"caller\",\"span\":\"{\\\"lo\\\":115,\\\"hi\\\":121}\"}"
+                                span:
+                                  lo: 110
+                                  hi: 121
+                                id: 10
+                      span:
+                        lo: 97
+                        hi: 106
+                      id: 11
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Identifier: "{\"id\":\"12\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":142,\\\"hi\\\":143}\"}"
+                          - Literal:
+                              Address:
+                                - test.aleo
+                                - span:
+                                    lo: 145
+                                    hi: 157
+                                - 14
+                      span:
+                        lo: 132
+                        hi: 141
+                      id: 15
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Identifier: "{\"id\":\"16\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":178,\\\"hi\\\":179}\"}"
+                          - Literal:
+                              Address:
+                                - hello
+                                - span:
+                                    lo: 181
+                                    hi: 186
+                                - 18
+                      span:
+                        lo: 168
+                        hi: 177
+                      id: 19
+                  - Return:
+                      expression:
+                        Literal:
+                          Address:
+                            - foo
+                            - span:
+                                lo: 209
+                                hi: 212
+                            - 21
+                      span:
+                        lo: 202
+                        hi: 218
+                      id: 22
+                span:
+                  lo: 87
+                  hi: 224
+                id: 23
+              span:
+                lo: 59
+                hi: 224
+              id: 24
+        span:
+          lo: 2
+          hi: 226

--- a/tests/expectations/parser/program/network_id.out
+++ b/tests/expectations/parser/program/network_id.out
@@ -1,0 +1,72 @@
+---
+namespace: Parse
+expectation: Pass
+outputs:
+  - imports: {}
+    stubs: {}
+    program_scopes:
+      test:
+        program_id: "{\"name\":\"test\",\"network\":\"\\\"{\\\\\\\"id\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"name\\\\\\\":\\\\\\\"aleo\\\\\\\",\\\\\\\"span\\\\\\\":\\\\\\\"{\\\\\\\\\\\\\\\"lo\\\\\\\\\\\\\\\":0,\\\\\\\\\\\\\\\"hi\\\\\\\\\\\\\\\":0}\\\\\\\"}\\\"\"}"
+        consts: []
+        structs: []
+        mappings: []
+        functions:
+          - - main
+            - annotations: []
+              variant: Function
+              identifier: "{\"id\":\"2\",\"name\":\"main\",\"span\":\"{\\\"lo\\\":34,\\\"hi\\\":38}\"}"
+              input:
+                - Internal:
+                    identifier: "{\"id\":\"3\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":39,\\\"hi\\\":40}\"}"
+                    mode: None
+                    type_: Address
+                    span:
+                      lo: 39
+                      hi: 40
+                    id: 4
+              output: []
+              output_type: Unit
+              block:
+                statements:
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Access:
+                              Member:
+                                inner:
+                                  Identifier: "{\"id\":\"5\",\"name\":\"network\",\"span\":\"{\\\"lo\\\":71,\\\"hi\\\":78}\"}"
+                                name: "{\"id\":\"6\",\"name\":\"id\",\"span\":\"{\\\"lo\\\":79,\\\"hi\\\":81}\"}"
+                                span:
+                                  lo: 71
+                                  hi: 81
+                                id: 7
+                          - Literal:
+                              Integer:
+                                - U32
+                                - "1"
+                                - span:
+                                    lo: 83
+                                    hi: 87
+                                - 8
+                      span:
+                        lo: 61
+                        hi: 70
+                      id: 9
+                  - Return:
+                      expression:
+                        Identifier: "{\"id\":\"10\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":105,\\\"hi\\\":106}\"}"
+                      span:
+                        lo: 98
+                        hi: 107
+                      id: 11
+                span:
+                  lo: 51
+                  hi: 113
+                id: 12
+              span:
+                lo: 25
+                hi: 113
+              id: 13
+        span:
+          lo: 1
+          hi: 115

--- a/tests/expectations/parser/program/special_address.out
+++ b/tests/expectations/parser/program/special_address.out
@@ -1,0 +1,110 @@
+---
+namespace: Parse
+expectation: Pass
+outputs:
+  - imports: {}
+    stubs: {}
+    program_scopes:
+      test:
+        program_id: "{\"name\":\"test\",\"network\":\"\\\"{\\\\\\\"id\\\\\\\":\\\\\\\"1\\\\\\\",\\\\\\\"name\\\\\\\":\\\\\\\"aleo\\\\\\\",\\\\\\\"span\\\\\\\":\\\\\\\"{\\\\\\\\\\\\\\\"lo\\\\\\\\\\\\\\\":0,\\\\\\\\\\\\\\\"hi\\\\\\\\\\\\\\\":0}\\\\\\\"}\\\"\"}"
+        consts: []
+        structs: []
+        mappings:
+          - - Yo
+            - identifier: "{\"id\":\"2\",\"name\":\"Yo\",\"span\":\"{\\\"lo\\\":34,\\\"hi\\\":36}\"}"
+              key_type: Address
+              value_type:
+                Integer: U32
+              span:
+                lo: 26
+                hi: 53
+              id: 3
+        functions:
+          - - main
+            - annotations: []
+              variant: Transition
+              identifier: "{\"id\":\"4\",\"name\":\"main\",\"span\":\"{\\\"lo\\\":70,\\\"hi\\\":74}\"}"
+              input:
+                - Internal:
+                    identifier: "{\"id\":\"5\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":75,\\\"hi\\\":76}\"}"
+                    mode: None
+                    type_: Address
+                    span:
+                      lo: 75
+                      hi: 76
+                    id: 6
+              output: []
+              output_type: Unit
+              block:
+                statements:
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Identifier: "{\"id\":\"7\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":107,\\\"hi\\\":108}\"}"
+                          - Access:
+                              Member:
+                                inner:
+                                  Identifier: "{\"id\":\"8\",\"name\":\"self\",\"span\":\"{\\\"lo\\\":110,\\\"hi\\\":114}\"}"
+                                name: "{\"id\":\"9\",\"name\":\"caller\",\"span\":\"{\\\"lo\\\":115,\\\"hi\\\":121}\"}"
+                                span:
+                                  lo: 110
+                                  hi: 121
+                                id: 10
+                      span:
+                        lo: 97
+                        hi: 106
+                      id: 11
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Identifier: "{\"id\":\"12\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":142,\\\"hi\\\":143}\"}"
+                          - Literal:
+                              Address:
+                                - test.aleo
+                                - span:
+                                    lo: 145
+                                    hi: 157
+                                - 14
+                      span:
+                        lo: 132
+                        hi: 141
+                      id: 15
+                  - Assert:
+                      variant:
+                        AssertEq:
+                          - Identifier: "{\"id\":\"16\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":178,\\\"hi\\\":179}\"}"
+                          - Literal:
+                              Address:
+                                - hello
+                                - span:
+                                    lo: 181
+                                    hi: 186
+                                - 18
+                      span:
+                        lo: 168
+                        hi: 177
+                      id: 19
+                  - Return:
+                      expression:
+                        Literal:
+                          Address:
+                            - foo
+                            - span:
+                                lo: 209
+                                hi: 212
+                            - 21
+                      span:
+                        lo: 202
+                        hi: 218
+                      id: 22
+                span:
+                  lo: 87
+                  hi: 224
+                id: 23
+              span:
+                lo: 59
+                hi: 224
+              id: 24
+        span:
+          lo: 2
+          hi: 226

--- a/tests/expectations/parser/program/special_address.out
+++ b/tests/expectations/parser/program/special_address.out
@@ -75,7 +75,7 @@ outputs:
                           - Identifier: "{\"id\":\"16\",\"name\":\"a\",\"span\":\"{\\\"lo\\\":178,\\\"hi\\\":179}\"}"
                           - Literal:
                               Address:
-                                - hello
+                                - hello.aleo
                                 - span:
                                     lo: 181
                                     hi: 186
@@ -88,7 +88,7 @@ outputs:
                       expression:
                         Literal:
                           Address:
-                            - foo
+                            - foo.aleo
                             - span:
                                 lo: 209
                                 hi: 212

--- a/tests/tests/compiler/address/special_address.leo
+++ b/tests/tests/compiler/address/special_address.leo
@@ -1,0 +1,15 @@
+/*
+namespace: Compile
+expectation: Pass
+*/
+
+program test.aleo {
+    mapping Yo: address => u32;
+
+    transition main(a: address) -> address {
+        assert_eq(a, self.caller);
+        assert_eq(a, self.address);
+        assert_eq(a, hello.aleo);
+        return foo.aleo;
+    }
+}

--- a/tests/tests/compiler/expression/network_id.leo
+++ b/tests/tests/compiler/expression/network_id.leo
@@ -1,0 +1,10 @@
+/*
+namespace: Compile
+expectation: Pass
+*/
+program test.aleo {
+    transition main(a: address) -> address {
+        assert_eq(network.id, network.id);
+        return a;
+    }
+}

--- a/tests/tests/compiler/expression/network_id.leo
+++ b/tests/tests/compiler/expression/network_id.leo
@@ -3,8 +3,13 @@ namespace: Compile
 expectation: Pass
 */
 program test.aleo {
-    transition main(a: address) -> address {
+    async transition main(a: u16) -> Future {
+        return finalize_main(a);
+    }
+
+    async function finalize_main(a: u16) {
+        assert_eq(1u16, network.id);
+        assert_eq(a, network.id);
         assert_eq(network.id, network.id);
-        return a;
     }
 }

--- a/tests/tests/execution/metadata.leo
+++ b/tests/tests/execution/metadata.leo
@@ -4,16 +4,16 @@ expectation: Pass
 cases:
     - program: metadata.aleo
       function: is_block_height
-      input: ["0u32"]
-    - program: metadata.aleo
-      function: is_block_height
-      input: ["1u32"]
-    - program: metadata.aleo
-      function: is_block_height
       input: ["2u32"]
     - program: metadata.aleo
       function: is_block_height
       input: ["3u32"]
+    - program: metadata.aleo
+      function: is_block_height
+      input: ["4u32"]
+    - program: metadata.aleo
+      function: is_block_height
+      input: ["0u32"]
     - program: metadata.aleo
       function: is_network_id
       input: ["0u16"]

--- a/tests/tests/execution/metadata.leo
+++ b/tests/tests/execution/metadata.leo
@@ -1,0 +1,49 @@
+/*
+namespace: Execute
+expectation: Pass
+cases:
+    - program: metadata.aleo
+      function: is_block_height
+      input: ["0u32"]
+    - program: metadata.aleo
+      function: is_block_height
+      input: ["1u32"]
+    - program: metadata.aleo
+      function: is_block_height
+      input: ["2u32"]
+    - program: metadata.aleo
+      function: is_block_height
+      input: ["3u32"]
+    - program: metadata.aleo
+      function: is_network_id
+      input: ["0u16"]
+    - program: metadata.aleo
+      function: is_network_id
+      input: ["1u16"]
+    - program: metadata.aleo
+      function: is_network_id
+      input: ["2u16"]
+    - program: metadata.aleo
+      function: is_network_id
+      input: ["3u16"]
+*/
+
+
+program metadata.aleo {
+
+    async transition is_block_height(block_height: u32) -> Future {
+        return finalize_is_block_height(block_height);
+    }
+
+    async function finalize_is_block_height(block_height: u32) {
+        assert_eq(block_height, block.height);
+    }
+
+    async transition is_network_id(network_id: u16) -> Future {
+        return finalize_is_network_id(network_id);
+    }
+
+    async function finalize_is_network_id(network_id: u16) {
+        assert_eq(network_id, network.id);
+    }
+}

--- a/tests/tests/parser/expression/literal/address_parse.leo
+++ b/tests/tests/parser/expression/literal/address_parse.leo
@@ -4,3 +4,9 @@ expectation: Pass
 */
 
 aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8s7pyjh9
+
+hello.aleo
+
+fooooo.aleo
+
+bar.aleo

--- a/tests/tests/parser/program/network_id.leo
+++ b/tests/tests/parser/program/network_id.leo
@@ -1,0 +1,10 @@
+/*
+namespace: Parse
+expectation: Pass
+*/
+program test.aleo {
+    function main(a: address) {
+        assert_eq(network.id, 1u32);
+        return a;
+    }
+}

--- a/tests/tests/parser/program/special_address.leo
+++ b/tests/tests/parser/program/special_address.leo
@@ -1,0 +1,15 @@
+/*
+namespace: Parse
+expectation: Pass
+*/
+
+program test.aleo {
+    mapping Yo: address => u32;
+
+    transition main(a: address) {
+        assert_eq(a, self.caller);
+        assert_eq(a, self.address);
+        assert_eq(a, hello.aleo);
+        return foo.aleo;
+    }
+}


### PR DESCRIPTION
Resolves #27912. Additionally, program name references are valid addresses. Example `let a: address = hello.aleo`.