### PR TITLE
[Feat] Deploy new programs and execute on-chain programs from the command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +55,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -243,6 +267,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c5ef0ede93efbf733c1a727f3b6b5a1060bbedd5600183e66f6e4be4af0ec5"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +293,85 @@ name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -305,6 +419,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote 1.0.35",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -364,7 +499,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.6",
  "serde",
 ]
 
@@ -408,6 +543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,10 +565,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "ci_info"
@@ -473,6 +647,18 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -503,7 +689,7 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote 1.0.35",
  "syn 2.0.55",
@@ -723,7 +909,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -782,6 +978,19 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.35",
  "syn 2.0.55",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.3",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1052,6 +1261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
+]
+
+[[package]]
 name = "fsio"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1316,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1104,6 +1324,17 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1118,6 +1349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1363,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1169,8 +1407,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1178,6 +1428,32 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
 
 [[package]]
 name = "h2"
@@ -1242,6 +1518,36 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1375,6 +1681,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1478,6 +1785,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,10 +1877,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leo-abnf"
@@ -1589,7 +1923,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "snarkvm",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1612,7 +1946,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
- "snarkvm",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile",
 ]
 
@@ -1623,7 +1957,7 @@ dependencies = [
  "leo-ast",
  "leo-errors",
  "leo-span",
- "snarkvm",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1675,7 +2009,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "snarkvm",
+ "snarkos-cli",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "sys-info",
  "test_dir",
  "toml 0.8.12",
@@ -1697,7 +2032,8 @@ dependencies = [
  "rand",
  "serde",
  "serial_test",
- "snarkvm",
+ "snarkos-cli",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.8.12",
  "tracing",
 ]
@@ -1717,7 +2053,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smallvec",
- "snarkvm",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
 ]
 
@@ -1734,7 +2070,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "snarkvm",
+ "snarkvm 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1792,6 +2128,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "libredox"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1800,6 +2146,21 @@ dependencies = [
  "bitflags 2.5.0",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
 ]
 
 [[package]]
@@ -1853,6 +2214,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "lru"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "lzma-rs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1863,10 +2243,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1936,6 +2384,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +2411,18 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2041,12 +2520,21 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -2144,6 +2632,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.0",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2232,6 +2736,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,12 +2804,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2349,6 +2901,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+dependencies = [
+ "bitflags 2.5.0",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,8 +2976,17 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2408,8 +2997,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2445,7 +3040,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2489,7 +3084,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2514,6 +3109,16 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -2542,6 +3147,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -2614,6 +3225,12 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "rusty-hook"
@@ -2791,6 +3408,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2880,6 +3507,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2926,6 +3559,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,6 +3604,364 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkos-account"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "colored",
+ "rand",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+]
+
+[[package]]
+name = "snarkos-cli"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anstyle",
+ "anyhow",
+ "bincode",
+ "clap",
+ "colored",
+ "crossterm",
+ "indexmap 2.2.6",
+ "nix",
+ "num_cpus",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "self_update 0.39.0",
+ "serde",
+ "serde_json",
+ "snarkos-account",
+ "snarkos-display",
+ "snarkos-node",
+ "snarkos-node-cdn",
+ "snarkos-node-metrics",
+ "snarkos-node-rest",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "sys-info",
+ "thiserror",
+ "tokio",
+ "tracing-subscriber",
+ "ureq",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkos-display"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "crossterm",
+ "ratatui",
+ "snarkos-node",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "async-trait",
+ "colored",
+ "futures-util",
+ "indexmap 2.2.6",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde_json",
+ "snarkos-account",
+ "snarkos-node-bft",
+ "snarkos-node-cdn",
+ "snarkos-node-consensus",
+ "snarkos-node-metrics",
+ "snarkos-node-rest",
+ "snarkos-node-router",
+ "snarkos-node-sync",
+ "snarkos-node-tcp",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "bytes",
+ "colored",
+ "futures",
+ "indexmap 2.2.6",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde",
+ "sha2",
+ "snarkos-account",
+ "snarkos-node-bft-events",
+ "snarkos-node-bft-ledger-service",
+ "snarkos-node-bft-storage-service",
+ "snarkos-node-metrics",
+ "snarkos-node-sync",
+ "snarkos-node-tcp",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snow",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft-events"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "indexmap 2.2.6",
+ "rayon",
+ "serde",
+ "snarkos-node-metrics",
+ "snarkos-node-sync-locators",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snow",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft-ledger-service"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "async-trait",
+ "indexmap 2.2.6",
+ "lru",
+ "parking_lot",
+ "rand",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft-storage-service"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "indexmap 2.2.6",
+ "parking_lot",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-cdn"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "colored",
+ "futures",
+ "parking_lot",
+ "rayon",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-consensus"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "colored",
+ "indexmap 2.2.6",
+ "lru",
+ "parking_lot",
+ "rand",
+ "snarkos-account",
+ "snarkos-node-bft",
+ "snarkos-node-bft-ledger-service",
+ "snarkos-node-bft-storage-service",
+ "snarkos-node-metrics",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-metrics"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "metrics-exporter-prometheus",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node-rest"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-extra",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "jsonwebtoken",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+ "snarkos-node-consensus",
+ "snarkos-node-router",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "time",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower_governor",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-router"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bytes",
+ "colored",
+ "futures",
+ "indexmap 2.2.6",
+ "linked-hash-map",
+ "parking_lot",
+ "rand",
+ "reqwest 0.11.27",
+ "serde",
+ "snarkos-account",
+ "snarkos-node-metrics",
+ "snarkos-node-router-messages",
+ "snarkos-node-sync-locators",
+ "snarkos-node-tcp",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-router-messages"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "indexmap 2.2.6",
+ "rayon",
+ "serde",
+ "snarkos-node-bft-events",
+ "snarkos-node-sync-locators",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snow",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-sync"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "itertools 0.12.1",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "serde",
+ "snarkos-node-bft-ledger-service",
+ "snarkos-node-sync-communication-service",
+ "snarkos-node-sync-locators",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-sync-communication-service"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "async-trait",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node-sync-locators"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-tcp"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "once_cell",
+ "parking_lot",
+ "snarkos-node-metrics",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "snarkvm"
 version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2971,12 +3980,42 @@ dependencies = [
  "rayon",
  "self_update 0.38.0",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-ledger",
- "snarkvm-parameters",
- "snarkvm-synthesizer",
- "snarkvm-utilities",
+ "snarkvm-circuit 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-parameters 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "ureq",
+ "walkdir",
+]
+
+[[package]]
+name = "snarkvm"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anstyle",
+ "anyhow",
+ "clap",
+ "colored",
+ "dotenvy",
+ "indexmap 2.2.6",
+ "num-format",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "self_update 0.38.0",
+ "serde_json",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-metrics",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
  "ureq",
  "walkdir",
@@ -3006,10 +4045,40 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-curves 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-parameters 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "blake2",
+ "cfg-if",
+ "fxhash",
+ "hashbrown 0.14.3",
+ "hex",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "num-traits",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rayon",
+ "serde",
+ "sha2",
+ "smallvec",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
 ]
 
@@ -3019,13 +4088,27 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1e787dc7c7e67ea78bde7ba06746556e928251cdd6113a15d1967981926e750"
 dependencies = [
- "snarkvm-circuit-account",
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-environment",
- "snarkvm-circuit-network",
- "snarkvm-circuit-program",
- "snarkvm-circuit-types",
+ "snarkvm-circuit-account 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3034,10 +4117,21 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1453584c7bc7c6c85a11d21dc935220843584f107895482e9b3867b8529d167"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-network",
- "snarkvm-circuit-types",
- "snarkvm-console-account",
+ "snarkvm-circuit-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-account 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-account"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3046,9 +4140,19 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a921c30d7d02ebd423041893d486a010e1de0b3807cd6c64ae65a363aa1891"
 dependencies = [
- "snarkvm-circuit-types",
- "snarkvm-console-algorithms",
- "snarkvm-fields",
+ "snarkvm-circuit-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-algorithms"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3057,9 +4161,19 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed9cf845dfe8003c69b53a798293a3fcdcba96ed31b4e97ef8ee0eda13fbc35"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-types",
- "snarkvm-console-collections",
+ "snarkvm-circuit-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-collections"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3073,12 +4187,30 @@ dependencies = [
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-algorithms",
- "snarkvm-circuit-environment-witness",
- "snarkvm-console-network",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-environment-witness 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-curves 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-environment"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "once_cell",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3088,15 +4220,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f01b785db079d0eeb5c16bbb7f9c2685d54576fe3894d2c9cb5301812ee5d1e"
 
 [[package]]
+name = "snarkvm-circuit-environment-witness"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+
+[[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43718a07753a3b4e286caee5528273c978aa3431f3b9c3600f46683631be1b03"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-types",
- "snarkvm-console-network",
+ "snarkvm-circuit-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-network"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3106,13 +4254,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b998a18bd3d1a657da8bcba7dd185b64180b6978643ec56b79b10410c5a55d1"
 dependencies = [
  "paste",
- "snarkvm-circuit-account",
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-network",
- "snarkvm-circuit-types",
- "snarkvm-console-program",
- "snarkvm-utilities",
+ "snarkvm-circuit-account 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-program"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "paste",
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3121,14 +4284,29 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25555a9b65b6988d2eede1349fe4d3189333a80d6d0803dc8b74520a55d7e7"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-address",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-group",
- "snarkvm-circuit-types-integers",
- "snarkvm-circuit-types-scalar",
- "snarkvm-circuit-types-string",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-address 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-group 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-integers 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-string 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3137,12 +4315,25 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24031889f13a3434eb2348145ec15c97a81609b27242dd3d0bfa3a2b88ead9aa"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-group",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-address",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-group 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-address 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-address"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3151,8 +4342,17 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a34688c02c9c2521ba7d43e69b0809ef3aa179f89fc1e0794ff821cbc519bd57"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-boolean"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3161,9 +4361,19 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f1047b019405bbd3d38262e92d816b6561990b09a0f87c18c72dc34623eb149"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-field"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3172,11 +4382,23 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb2931b46a1402ece70d59b754eea329d93b659cb4c261b7d19db1cb34c04969"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-group",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-group 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-group"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3185,11 +4407,23 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc9214bbd8c2b0160a07a115f25706af950127539db3afe9769dd805e9dc1351"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-integers",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-integers 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-integers"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3198,10 +4432,21 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "226693cfe70f027a971ff8c5832b370d61b3895e10f947b8a05c549af58d98b1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-scalar"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3210,11 +4455,23 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0948eebb2b99aa51cc2fb17fd81267592d80d3238736fd558772fb71b59e6a3"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-integers",
- "snarkvm-console-types-string",
+ "snarkvm-circuit-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit-types-integers 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-string 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-string"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3223,12 +4480,25 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b7a007ffc355a2b71185b177917ac2a28a6129ef1a3a64713b24c56bd4ca2b5"
 dependencies = [
- "snarkvm-console-account",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network",
- "snarkvm-console-program",
- "snarkvm-console-types",
+ "snarkvm-console-account 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3238,8 +4508,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61868a92ba3dc6afcef854eeeaa07236797ed63dcb9eca3f7d246e2581febb02"
 dependencies = [
  "bs58",
- "snarkvm-console-network",
- "snarkvm-console-types",
+ "snarkvm-console-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bs58",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3251,9 +4532,22 @@ checksum = "d954faa7c6bdac0a9e2bb99c3e172555a2ac1f6aed972271121267adec6b0bba"
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-console-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "tiny-keccak",
 ]
 
@@ -3265,8 +4559,19 @@ checksum = "d3097e2239e8d41c1046680806e7e3222da56d32601f88cc03993abba5ee68a0"
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms",
- "snarkvm-console-types",
+ "snarkvm-console-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3282,15 +4587,38 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "snarkvm-algorithms",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network-environment",
- "snarkvm-console-types",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-curves 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-parameters 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "lazy_static",
+ "once_cell",
+ "paste",
+ "serde",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3306,9 +4634,27 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "rand",
+ "serde",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3326,12 +4672,33 @@ dependencies = [
  "once_cell",
  "paste",
  "serde_json",
- "snarkvm-console-account",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network",
- "snarkvm-console-types",
- "snarkvm-utilities",
+ "snarkvm-console-account 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-collections 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-network 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "enum_index",
+ "enum_index_derive",
+ "indexmap 2.2.6",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "serde_json",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3340,14 +4707,29 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59ad372274d3c21415f3a7f760730461d97c6b5ce6d374f6ac130262976cbb1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-address",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
- "snarkvm-console-types-integers",
- "snarkvm-console-types-scalar",
- "snarkvm-console-types-string",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-address 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-group 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-integers 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-string 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3356,10 +4738,21 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b826f09a1709ac72e2d39b5a9fb76958a6adef1964928b86893a9a9d505483a0"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-group 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3368,7 +4761,15 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a14553a54f378b99a95b4e6282d2150b90b5490f3325222d80bcc447193681d3"
 dependencies = [
- "snarkvm-console-network-environment",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3377,8 +4778,18 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5556a6588d787bc84a909e490726bcdcf88b905cbf488b750233951e010bb35"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3388,10 +4799,21 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "242b1019a6200edc6deb7041c04d48066936ce6dd30f8ea942d4c551fae2eefe"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3400,10 +4822,21 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9c3a02cf7d9c338c871052b4640f6e89ec71b6015821a7166651f3f5400d697"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-scalar 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3412,9 +4845,20 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e8b59d4520db15335c6f9885a81342bf66d23ed91db102249ea9357058d1c14"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3424,10 +4868,21 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ab7a19c040b5b2a5361efb8460d4a0af604629adf9b577b71619869e85f1a7"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-integers",
+ "snarkvm-console-network-environment 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-boolean 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-field 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console-types-integers 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3440,8 +4895,22 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "rand",
+ "rayon",
+ "rustc_version",
+ "serde",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
 ]
 
@@ -3458,7 +4927,24 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "itertools 0.11.0",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
  "zeroize",
 ]
@@ -3475,15 +4961,39 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-console",
- "snarkvm-ledger-authority",
- "snarkvm-ledger-block",
- "snarkvm-ledger-coinbase",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal",
- "snarkvm-ledger-query",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-authority 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-block 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-coinbase 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-committee 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-query 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-store 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-ledger"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap 2.2.6",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "time",
  "tracing",
 ]
@@ -3497,8 +5007,20 @@ dependencies = [
  "anyhow",
  "rand",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-authority"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anyhow",
+ "rand",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3510,15 +5032,34 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-authority",
- "snarkvm-ledger-coinbase",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-subdag",
- "snarkvm-ledger-narwhal-transmission-id",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-authority 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-coinbase 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-committee 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-snark 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-block"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3534,12 +5075,32 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-algorithms",
- "snarkvm-console",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-synthesizer-snark",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-curves 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-fields 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-snark 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-coinbase"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "blake2",
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3550,7 +5111,18 @@ checksum = "b6c56ea2d261cc6424f11c7153508fafae0634888fa90ea9706c4c2e34ae5f28"
 dependencies = [
  "indexmap 2.2.6",
  "serde_json",
- "snarkvm-console",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-committee"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-metrics",
 ]
 
 [[package]]
@@ -3559,12 +5131,25 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a0e8a20c2195fd7814613aa43ae5c8a2a618bf9329ff673f6309dd3213efa5e"
 dependencies = [
- "snarkvm-ledger-narwhal-batch-certificate",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-data",
- "snarkvm-ledger-narwhal-subdag",
- "snarkvm-ledger-narwhal-transmission",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-transmission 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3576,9 +5161,22 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-certificate"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3589,8 +5187,19 @@ checksum = "03e7554e85b9c7ce8daf35f722eb00fa35e92161803dc621cf0d7bcac06c7489"
 dependencies = [
  "indexmap 2.2.6",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-header"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3601,7 +5210,18 @@ checksum = "f7f1162e2233a5c767d462221b04641b90e1d80fd1bb1cd85f2bce234baea5f0"
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-data"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bytes",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "tokio",
 ]
 
@@ -3614,10 +5234,24 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-batch-certificate",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-subdag"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3628,10 +5262,23 @@ checksum = "c261002cba256d1cfb4761d79da704ac2637ba375034ee969e0e5c3314bd60c0"
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-block",
- "snarkvm-ledger-coinbase",
- "snarkvm-ledger-narwhal-data",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-block 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-coinbase 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bytes",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3640,8 +5287,17 @@ version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f1132b2b56e549df0447f4d0c8c2b908525187d54c620235d141b164a9e14a3"
 dependencies = [
- "snarkvm-console",
- "snarkvm-ledger-coinbase",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-coinbase 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission-id"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3652,9 +5308,22 @@ checksum = "295b07816920fbf3465cfeb10ad565eff8acacf78b047c69c0e1fe2bc1b47e2f"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
- "snarkvm-console",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer-program",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-store 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ureq",
+]
+
+[[package]]
+name = "snarkvm-ledger-query"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "async-trait",
+ "reqwest 0.11.27",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "ureq",
 ]
 
@@ -3671,14 +5340,48 @@ dependencies = [
  "parking_lot",
  "rayon",
  "serde",
- "snarkvm-console",
- "snarkvm-ledger-authority",
- "snarkvm-ledger-block",
- "snarkvm-ledger-coinbase",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal-batch-certificate",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-authority 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-block 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-coinbase 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-committee 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-snark 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-ledger-store"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std-storage",
+ "anyhow",
+ "bincode",
+ "indexmap 2.2.6",
+ "once_cell",
+ "parking_lot",
+ "rayon",
+ "rocksdb",
+ "serde",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-metrics"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "metrics",
+ "metrics-exporter-prometheus",
 ]
 
 [[package]]
@@ -3702,8 +5405,33 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves",
- "snarkvm-utilities",
+ "snarkvm-curves 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "colored",
+ "curl",
+ "hex",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "lazy_static",
+ "parking_lot",
+ "paste",
+ "rand",
+ "serde_json",
+ "sha2",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
 ]
 
@@ -3719,17 +5447,43 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-algorithms",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-ledger-block",
- "snarkvm-ledger-coinbase",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-query",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
+ "snarkvm-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-block 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-coinbase 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-committee 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-query 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-store 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-process 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-snark 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-synthesizer"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap 2.2.6",
+ "lru",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-process 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "tracing",
 ]
 
@@ -3747,14 +5501,37 @@ dependencies = [
  "rand",
  "rayon",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-ledger-block",
- "snarkvm-ledger-query",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
- "snarkvm-utilities",
+ "snarkvm-circuit 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-block 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-query 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-ledger-store 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-program 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-synthesizer-snark 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-utilities 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-process"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "colored",
+ "indexmap 2.2.6",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde_json",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3768,8 +5545,22 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-console",
+ "snarkvm-circuit 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-program"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "paste",
+ "rand",
+ "rand_chacha",
+ "serde_json",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3781,9 +5572,22 @@ dependencies = [
  "bincode",
  "once_cell",
  "serde_json",
- "snarkvm-algorithms",
- "snarkvm-circuit",
- "snarkvm-console",
+ "snarkvm-algorithms 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-circuit 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "snarkvm-console 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-snark"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bincode",
+ "once_cell",
+ "serde_json",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3803,7 +5607,28 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "snarkvm-utilities-derives",
+ "snarkvm-utilities-derives 0.16.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "num-bigint",
+ "num_cpus",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
  "zeroize",
 ]
@@ -3817,6 +5642,32 @@ dependencies = [
  "proc-macro2",
  "quote 1.0.35",
  "syn 2.0.55",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core",
+ "rustc_version",
+ "sha2",
+ "subtle",
 ]
 
 [[package]]
@@ -3836,6 +5687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3846,10 +5706,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "stability"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote 1.0.35",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote 1.0.35",
+ "rustversion",
+ "syn 2.0.55",
+]
 
 [[package]]
 name = "subtle"
@@ -3895,6 +5787,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synom"
@@ -4009,10 +5907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -4020,6 +5920,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -4066,9 +5976,23 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.35",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4078,6 +6002,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -4155,6 +6090,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,6 +6117,22 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tower_governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3790eac6ad3fb8d9d96c2b040ae06e2517aa24b067545d1078b96ae72f7bb9a7"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.1.0",
+ "pin-project",
+ "thiserror",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -4216,10 +6184,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -4273,6 +6245,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +6261,16 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ members = [
   "utils/retriever"
 ]
 
+[workspace.dependencies.snarkos-cli]
+git = "https://github.com/AleoHQ/snarkos"
+rev = "d69e417"
+
 [workspace.dependencies.snarkvm]
 version = "0.16.19"
 
@@ -146,6 +150,9 @@ version = "1.0"
 
 [dependencies.serial_test]
 version = "3.1.0"
+
+[dependencies.snarkos-cli]
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -215,4 +215,11 @@ create_messages!(
         msg: format!("Failed to read private key from environment.\nIO Error: {error}"),
         help: Some("Pass in private key using `--private-key <PRIVATE-KEY>` or create a .env file with your private key information. See examples for formatting information.".to_string()),
     }
+
+    @backtraced
+    recursive_deploy_with_record {
+        args: (),
+        msg: "Cannot combine recursive deploy with private fee.".to_string(),
+        help: None,
+    }
 );

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -370,4 +370,17 @@ create_messages!(
         help: None,
     }
 
+    @backtraced
+    missing_on_chain_program_name {
+        args: (),
+        msg: "The name of the program to execute on-chain is missing.".to_string(),
+        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    }
+
+    @backtraced
+    conflicting_on_chain_program_name {
+        args: (first: impl Display, second: impl Display),
+        msg: format!("Conflicting program names given to execute on chain: `{first}` and `{second}`."),
+        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    }
 );

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -14,19 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
 use super::*;
 use snarkos_cli::commands::{Deploy as SnarkOSDeploy, Developer};
 use snarkvm::cli::helpers::dotenv_private_key;
+use std::path::PathBuf;
 
 /// Deploys an Aleo program.
 #[derive(Parser, Debug)]
 pub struct Deploy {
-    #[clap(
-    long,
-    help = "Endpoint to retrieve network state from.",
-    default_value = "http://api.explorer.aleo.org/v1"
-    )]
+    #[clap(long, help = "Endpoint to retrieve network state from.", default_value = "http://api.explorer.aleo.org/v1")]
     pub endpoint: String,
     #[clap(flatten)]
     pub(crate) fee_options: FeeOptions,
@@ -34,7 +30,11 @@ pub struct Deploy {
     pub(crate) no_build: bool,
     #[clap(long, help = "Disables recursive deployment of dependencies", default_value = "false")]
     pub(crate) non_recursive: bool,
-    #[clap(long, help = "Custom wait gap between consecutive deployments. This is to help prevent a program from trying to be included in an earlier block than its dependency program.", default_value = "12")]
+    #[clap(
+        long,
+        help = "Custom wait gap between consecutive deployments. This is to help prevent a program from trying to be included in an earlier block than its dependency program.",
+        default_value = "12"
+    )]
     pub(crate) wait_gap: u64,
 }
 
@@ -56,43 +56,44 @@ impl Command for Deploy {
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Get the program name.
         let project_name = context.open_manifest()?.program_id().to_string();
-        
+
         // Get the private key.
         let mut private_key = self.fee_options.private_key;
         if private_key.is_none() {
             private_key =
                 Some(dotenv_private_key().map_err(CliError::failed_to_read_environment_private_key)?.to_string());
         }
-        
+
         let mut all_paths: Vec<(String, PathBuf)> = Vec::new();
-        
+
         // Extract post-ordered list of local dependencies' paths from `leo.lock`.
         if !self.non_recursive {
             all_paths = context.local_dependency_paths()?;
         }
-        
+
         // Add the parent program to be deployed last.
         all_paths.push((project_name, context.dir()?.join("build")));
-        
+
         for (index, (name, path)) in all_paths.iter().enumerate() {
             // Set the deploy arguments.
-            let mut deploy_args = vec!["snarkos".to_string(),
-                                       "--private-key".to_string(),
-                                       private_key.as_ref().unwrap().clone(),
-                                       "--query".to_string(),
-                                       self.endpoint.clone(),
-                                       "--priority-fee".to_string(),
-                                       self.fee_options.priority_fee.to_string(),
-                                       "--path".to_string(),
-                                       path.to_str().unwrap().parse().unwrap(),
-                                       "--broadcast".to_string(),
-                                       format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
-                                       name.clone(),
+            let mut deploy_args = vec![
+                "snarkos".to_string(),
+                "--private-key".to_string(),
+                private_key.as_ref().unwrap().clone(),
+                "--query".to_string(),
+                self.endpoint.clone(),
+                "--priority-fee".to_string(),
+                self.fee_options.priority_fee.to_string(),
+                "--path".to_string(),
+                path.to_str().unwrap().parse().unwrap(),
+                "--broadcast".to_string(),
+                format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
+                name.clone(),
             ];
 
             // Use record as payment option if it is provided.
             if let Some(record) = self.fee_options.record.clone() {
-               deploy_args.push("--record".to_string());
+                deploy_args.push("--record".to_string());
                 deploy_args.push(record);
             };
 
@@ -100,14 +101,14 @@ impl Command for Deploy {
 
             // Deploy program.
             Developer::Deploy(deploy).parse().map_err(CliError::failed_to_execute_deploy)?;
-        
+
             // Sleep for `wait_gap` seconds.
             // This helps avoid parents from being serialized before children.
             if index < all_paths.len() - 1 {
                 std::thread::sleep(std::time::Duration::from_secs(self.wait_gap));
             }
         }
-        
+
         Ok(())
     }
 }

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -14,25 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::PathBuf;
 use super::*;
-//use snarkos_cli::commands::{Deploy as SnarkOSDeploy, Developer};
+use snarkos_cli::commands::{Deploy as SnarkOSDeploy, Developer};
+use snarkvm::cli::helpers::dotenv_private_key;
 
 /// Deploys an Aleo program.
 #[derive(Parser, Debug)]
 pub struct Deploy {
-    #[clap(long, help = "Custom priority fee in microcredits", default_value = "1000000")]
-    pub(crate) priority_fee: String,
-    #[clap(long, help = "Custom query endpoint", default_value = "http://api.explorer.aleo.org/v1")]
-    pub(crate) endpoint: String,
-    #[clap(long, help = "Custom network", default_value = "testnet3")]
-    pub(crate) network: String,
-    #[clap(long, help = "Custom private key")]
-    pub(crate) private_key: Option<String>,
+    #[clap(
+    long,
+    help = "Endpoint to retrieve network state from.",
+    default_value = "http://api.explorer.aleo.org/v1"
+    )]
+    pub endpoint: String,
+    #[clap(flatten)]
+    pub(crate) fee_options: FeeOptions,
     #[clap(long, help = "Disables building of the project before deployment", default_value = "false")]
     pub(crate) no_build: bool,
     #[clap(long, help = "Disables recursive deployment of dependencies", default_value = "false")]
     pub(crate) non_recursive: bool,
-    #[clap(long, help = "Custom wait gap between consecutive deployments", default_value = "12")]
+    #[clap(long, help = "Custom wait gap between consecutive deployments. This is to help prevent a program from trying to be included in an earlier block than its dependency program.", default_value = "12")]
     pub(crate) wait_gap: u64,
 }
 
@@ -51,55 +53,61 @@ impl Command for Deploy {
         Ok(())
     }
 
-    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
-        // // Get the program name
-        // let project_name = context.open_manifest()?.program_id().to_string();
-        //
-        // // Get the private key
-        // let mut private_key = self.private_key;
-        // if private_key.is_none() {
-        //     private_key =
-        //         Some(dotenv_private_key().map_err(CliError::failed_to_read_environment_private_key)?.to_string());
-        // }
-        //
-        // let mut all_paths: Vec<(String, PathBuf)> = Vec::new();
-        //
-        // // Extract post-ordered list of local dependencies' paths from `leo.lock`
-        // if !self.non_recursive {
-        //     all_paths = context.local_dependency_paths()?;
-        // }
-        //
-        // // Add the parent program to be deployed last
-        // all_paths.push((project_name, context.dir()?.join("build")));
-        //
-        // for (index, (name, path)) in all_paths.iter().enumerate() {
-        //     // Set deploy arguments
-        //     let deploy = SnarkOSDeploy::try_parse_from([
-        //         "snarkos",
-        //         "--private-key",
-        //         private_key.as_ref().unwrap(),
-        //         "--query",
-        //         self.endpoint.as_str(),
-        //         "--priority-fee",
-        //         self.priority_fee.as_str(),
-        //         "--path",
-        //         path.to_str().unwrap(),
-        //         "--broadcast",
-        //         format!("{}/{}/transaction/broadcast", self.endpoint, self.network).as_str(),
-        //         &name,
-        //     ])
-        //     .unwrap();
-        //
-        //     // Deploy program
-        //     Developer::Deploy(deploy).parse().map_err(CliError::failed_to_execute_deploy)?;
-        //
-        //     // Sleep for `wait_gap` seconds.
-        //     // This helps avoid parents from being serialized before children.
-        //     if index < all_paths.len() - 1 {
-        //         std::thread::sleep(std::time::Duration::from_secs(self.wait_gap));
-        //     }
-        // }
+    fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
+        // Get the program name.
+        let project_name = context.open_manifest()?.program_id().to_string();
+        
+        // Get the private key.
+        let mut private_key = self.fee_options.private_key;
+        if private_key.is_none() {
+            private_key =
+                Some(dotenv_private_key().map_err(CliError::failed_to_read_environment_private_key)?.to_string());
+        }
+        
+        let mut all_paths: Vec<(String, PathBuf)> = Vec::new();
+        
+        // Extract post-ordered list of local dependencies' paths from `leo.lock`.
+        if !self.non_recursive {
+            all_paths = context.local_dependency_paths()?;
+        }
+        
+        // Add the parent program to be deployed last.
+        all_paths.push((project_name, context.dir()?.join("build")));
+        
+        for (index, (name, path)) in all_paths.iter().enumerate() {
+            // Set the deploy arguments.
+            let mut deploy_args = vec!["snarkos".to_string(),
+                                       "--private-key".to_string(),
+                                       private_key.as_ref().unwrap().clone(),
+                                       "--query".to_string(),
+                                       self.endpoint.clone(),
+                                       "--priority-fee".to_string(),
+                                       self.fee_options.priority_fee.to_string(),
+                                       "--path".to_string(),
+                                       path.to_str().unwrap().parse().unwrap(),
+                                       "--broadcast".to_string(),
+                                       format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
+                                       name.clone(),
+            ];
 
-        Err(PackageError::unimplemented_command("leo deploy").into())
+            // Use record as payment option if it is provided.
+            if let Some(record) = self.fee_options.record.clone() {
+               deploy_args.push("--record".to_string());
+                deploy_args.push(record);
+            };
+
+            let deploy = SnarkOSDeploy::try_parse_from(deploy_args).unwrap();
+
+            // Deploy program.
+            Developer::Deploy(deploy).parse().map_err(CliError::failed_to_execute_deploy)?;
+        
+            // Sleep for `wait_gap` seconds.
+            // This helps avoid parents from being serialized before children.
+            if index < all_paths.len() - 1 {
+                std::thread::sleep(std::time::Duration::from_secs(self.wait_gap));
+            }
+        }
+        
+        Ok(())
     }
 }

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -17,8 +17,10 @@
 use super::*;
 use clap::Parser;
 use snarkos_cli::commands::{Developer, Execute as SnarkOSExecute};
-use snarkvm::{cli::Execute as SnarkVMExecute, prelude::Parser as SnarkVMParser};
-use snarkvm::cli::helpers::dotenv_private_key;
+use snarkvm::{
+    cli::{helpers::dotenv_private_key, Execute as SnarkVMExecute},
+    prelude::Parser as SnarkVMParser,
+};
 
 /// Build, Prove and Run Leo program with inputs
 #[derive(Parser, Debug)]
@@ -71,15 +73,17 @@ impl Command for Execute {
             };
 
             // Set deploy arguments.
-            let mut fee_args = vec!["snarkos".to_string(),
-               "--private-key".to_string(),
-               private_key.clone(),
-               "--query".to_string(),
-               self.compiler_options.endpoint.clone(),
-               "--priority-fee".to_string(),
-               self.fee_options.priority_fee.to_string(),
-               "--broadcast".to_string(),
-               format!("{}/{}/transaction/broadcast", self.compiler_options.endpoint, self.fee_options.network).to_string(),
+            let mut fee_args = vec![
+                "snarkos".to_string(),
+                "--private-key".to_string(),
+                private_key.clone(),
+                "--query".to_string(),
+                self.compiler_options.endpoint.clone(),
+                "--priority-fee".to_string(),
+                self.fee_options.priority_fee.to_string(),
+                "--broadcast".to_string(),
+                format!("{}/{}/transaction/broadcast", self.compiler_options.endpoint, self.fee_options.network)
+                    .to_string(),
             ];
 
             // Use record as payment option if it is provided.
@@ -87,7 +91,7 @@ impl Command for Execute {
                 fee_args.push("--record".to_string());
                 fee_args.push(record);
             };
-            
+
             // Execute program.
             Developer::Execute(
                 SnarkOSExecute::try_parse_from(

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -124,7 +124,7 @@ pub trait Command {
 pub struct BuildOptions {
     #[clap(
         long,
-        help = "Endpoint to retrieve on-chain dependencies from.",
+        help = "Endpoint to retrieve network state from.",
         default_value = "http://api.explorer.aleo.org/v1"
     )]
     pub endpoint: String,
@@ -160,4 +160,18 @@ pub struct BuildOptions {
     pub enable_inlined_ast_snapshot: bool,
     #[clap(long, help = "Writes AST snapshot of the dead code eliminated (DCE) AST.")]
     pub enable_dce_ast_snapshot: bool,
+}
+
+/// On Chain Execution Options to set preferences for keys, fees and networks.
+/// Used by Execute and Deploy commands.
+#[derive(Parser, Clone, Debug, Default)]
+pub struct FeeOptions {
+    #[clap(long, help = "Priority fee in microcredits. Defaults to 1000000.", default_value = "1000000")]
+    pub(crate) priority_fee: String,
+    #[clap(long, help = "Network to broadcast to. Defaults to testnet3.", default_value = "testnet3")]
+    pub(crate) network: String,
+    #[clap(long, help = "Private key to authorize fee expenditure.")]
+    pub(crate) private_key: Option<String>,
+    #[clap(short, help = "Record to pay for fee privately. If one is not specified, a public fee will be taken.", long)]
+    record: Option<String>,
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -122,11 +122,7 @@ pub trait Command {
 /// require Build command output as their input.
 #[derive(Parser, Clone, Debug, Default)]
 pub struct BuildOptions {
-    #[clap(
-        long,
-        help = "Endpoint to retrieve network state from.",
-        default_value = "http://api.explorer.aleo.org/v1"
-    )]
+    #[clap(long, help = "Endpoint to retrieve network state from.", default_value = "http://api.explorer.aleo.org/v1")]
     pub endpoint: String,
     #[clap(long, help = "Does not recursively compile dependencies.")]
     pub non_recursive: bool,
@@ -172,6 +168,10 @@ pub struct FeeOptions {
     pub(crate) network: String,
     #[clap(long, help = "Private key to authorize fee expenditure.")]
     pub(crate) private_key: Option<String>,
-    #[clap(short, help = "Record to pay for fee privately. If one is not specified, a public fee will be taken.", long)]
+    #[clap(
+        short,
+        help = "Record to pay for fee privately. If one is not specified, a public fee will be taken.",
+        long
+    )]
     record: Option<String>,
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -162,7 +162,7 @@ pub struct BuildOptions {
 /// Used by Execute and Deploy commands.
 #[derive(Parser, Clone, Debug, Default)]
 pub struct FeeOptions {
-    #[clap(long, help = "Priority fee in microcredits. Defaults to 1000000.", default_value = "1000000")]
+    #[clap(long, help = "Priority fee in microcredits. Defaults to 0.", default_value = "0")]
     pub(crate) priority_fee: String,
     #[clap(long, help = "Network to broadcast to. Defaults to testnet3.", default_value = "testnet3")]
     pub(crate) network: String,

--- a/leo/package/Cargo.toml
+++ b/leo/package/Cargo.toml
@@ -26,6 +26,9 @@ version = "=1.11.0"
 path = "../../utils/retriever"
 version = "1.11.0"
 
+[dependencies.snarkos-cli]
+workspace = true
+
 [dependencies.snarkvm]
 workspace = true
 


### PR DESCRIPTION
- `leo deploy`:
	- Can now easily deploy programs to custom networks, with custom broadcast endpoints, all while using private or public fees.
	- Now supports easy deployment of projects that contain any depth of dependencies. Customizable parameter `--wait-gap <SECONDS>` to specify how long to wait between nested program deployments to help avoid a parent program from reaching a snarkOS node before its child. 
- `leo execute`:
	- Can now easily execute existing on-chain programs, even if they don't match the current directory you are in.
- Examples:
	- `leo deploy --endpoint "http://0.0.0.0:3030" --private-key "<INSERT PRIVATE_KEY>"`
	- `leo execute --external football_players_v001.aleo add_player "{player_id: 1000field,team_id: 1field,position: 1field,attack: 1u128,defense: 1u128,speed: 1u128,power: 1u128,stamina: 1u128,technique: 1u128,goalkeeping: 1u128}" --endpoint "http://0.0.0.0:3030" --private-key "<INSERT PRIVATE KEY>" --broadcast --record "<INSERT RECORD>"`
	- `leo execute --external credits.aleo --endpoint "http://0.0.0.0:3030" --private-key "<INSERT PRIVATE_KEY 1>" --broadcast transfer_public_to_private <INSERT RECIPIENT ADDRESS> 5000000u64`