### PR TITLE
[Feat] Deploy new programs and execute on-chain programs from the command line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,6 +55,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -110,7 +134,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f2a841f04c2eaeb5a95312e5201a9e4b7c95b64ca99870d6bd2e2376df540a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -121,7 +145,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6118baab6285accf088b31d5ea5029c37bbf9d98e62b4d8720a0a5a66bc2e427"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -133,9 +157,9 @@ checksum = "7e4f181fc1a372e8ceff89612e5c9b13f72bff5b066da9f8d6827ae65af492c4"
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anes"
@@ -202,9 +226,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 
 [[package]]
 name = "arrayref"
@@ -234,14 +258,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.79"
+name = "async-recursion"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -249,6 +284,85 @@ name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+
+[[package]]
+name = "axum"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.1",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper 0.1.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -272,6 +386,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +410,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.65.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote 1.0.36",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -349,15 +490,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.6",
  "serde",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.15.4"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -393,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,12 +547,22 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.90"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
+checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -413,6 +570,30 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
 
 [[package]]
 name = "ci_info"
@@ -458,6 +639,18 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -488,10 +681,10 @@ version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -690,7 +883,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core",
  "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -747,8 +950,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -758,7 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -766,9 +969,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -790,7 +993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.36",
  "syn 1.0.109",
 ]
 
@@ -891,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "encode_unicode"
@@ -903,9 +1106,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -963,21 +1166,21 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
+checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1011,6 +1214,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror",
 ]
 
 [[package]]
@@ -1059,6 +1272,7 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+ "num_cpus",
 ]
 
 [[package]]
@@ -1066,6 +1280,17 @@ name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "futures-sink"
@@ -1080,6 +1305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1319,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1126,13 +1358,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1142,10 +1386,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "h2"
-version = "0.3.25"
+name = "glob"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "governor"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1162,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
  "bytes",
  "fnv",
@@ -1181,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -1197,13 +1467,43 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1310,7 +1610,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1326,17 +1626,18 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.3",
+ "h2 0.4.4",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1365,7 +1666,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1384,7 +1685,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1421,7 +1722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "rayon",
  "serde",
 ]
@@ -1438,6 +1739,12 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "inout"
@@ -1509,9 +1816,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -1526,10 +1833,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+dependencies = [
+ "base64 0.21.7",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "leo-abnf"
@@ -1551,7 +1879,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "snarkvm",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
 ]
 
 [[package]]
@@ -1574,7 +1902,7 @@ dependencies = [
  "serde",
  "serde_yaml",
  "sha2",
- "snarkvm",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "tempfile",
 ]
 
@@ -1585,7 +1913,7 @@ dependencies = [
  "leo-ast",
  "leo-errors",
  "leo-span",
- "snarkvm",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
 ]
 
 [[package]]
@@ -1598,7 +1926,7 @@ dependencies = [
  "colored",
  "derivative",
  "leo-span",
- "reqwest 0.12.2",
+ "reqwest 0.12.4",
  "serde",
  "thiserror",
 ]
@@ -1630,14 +1958,15 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_core",
- "reqwest 0.12.2",
+ "reqwest 0.12.4",
  "rpassword",
  "rusty-hook",
  "self_update 0.39.0",
  "serde",
  "serde_json",
  "serial_test",
- "snarkvm",
+ "snarkos-cli",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "sys-info",
  "test_dir",
  "toml 0.8.12",
@@ -1659,7 +1988,8 @@ dependencies = [
  "rand",
  "serde",
  "serial_test",
- "snarkvm",
+ "snarkos-cli",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "toml 0.8.12",
  "tracing",
 ]
@@ -1679,7 +2009,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "smallvec",
- "snarkvm",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "tracing",
 ]
 
@@ -1696,7 +2026,7 @@ dependencies = [
  "num-traits",
  "serde",
  "serde_json",
- "snarkvm",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
 ]
 
 [[package]]
@@ -1749,9 +2079,19 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+
+[[package]]
+name = "libloading"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "libredox"
@@ -1761,6 +2101,21 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+]
+
+[[package]]
+name = "librocksdb-sys"
+version = "0.11.0+8.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "glob",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
 ]
 
 [[package]]
@@ -1789,9 +2144,9 @@ checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1809,14 +2164,92 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
 ]
+
+[[package]]
+name = "lz4-sys"
+version = "1.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf4e7146e30ad172c42c39b3246864bd2d3c6396780711a1baf749cfe423e21"
+dependencies = [
+ "base64 0.21.7",
+ "hyper 0.14.28",
+ "hyper-tls 0.5.0",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1886,6 +2319,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +2346,18 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1929,8 +2393,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -1991,12 +2455,21 @@ name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+dependencies = [
+ "parking_lot_core",
+]
 
 [[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -2020,8 +2493,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2056,9 +2529,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2066,15 +2539,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -2107,6 +2580,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,8 +2617,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2195,6 +2684,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2240,12 +2752,37 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.79"
+name = "prettyplease"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5ac2cf0f2e4f42b49f5ffd07dae8d746508ef7526c13940e5f524012ae6c6550"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2265,9 +2802,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2312,6 +2849,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+dependencies = [
+ "bitflags 2.5.0",
+ "cassowary",
+ "crossterm",
+ "indoc",
+ "itertools 0.12.1",
+ "lru",
+ "paste",
+ "stability",
+ "strum",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e29830cbb1290e404f24c73af91c5d8d631ce7e128691e9477556b540cd01ecd"
+dependencies = [
+ "bitflags 2.5.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2333,11 +2898,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.5.0",
 ]
 
 [[package]]
@@ -2359,8 +2924,17 @@ checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2371,8 +2945,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -2386,12 +2966,12 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -2404,11 +2984,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2417,26 +2997,26 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.50.0",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.3",
+ "h2 0.4.4",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.3.1",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -2448,11 +3028,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 2.1.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2461,7 +3041,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -2477,6 +3057,16 @@ dependencies = [
  "spin",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rocksdb"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
 ]
 
 [[package]]
@@ -2507,6 +3097,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,9 +3113,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -2530,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
@@ -2548,25 +3144,41 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
 
 [[package]]
 name = "rusty-hook"
@@ -2596,6 +3208,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96560eea317a9cc4e0bb1f6a2c93c09a19b8c4fc5cb3fcc0ec1c094cd783e2"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +3236,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "security-framework"
@@ -2698,33 +3325,43 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "indexmap 2.2.6",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2763,27 +3400,27 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
 dependencies = [
- "dashmap",
  "futures",
- "lazy_static",
  "log",
+ "once_cell",
  "parking_lot",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -2818,6 +3455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2840,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -2856,6 +3499,24 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -2885,6 +3546,364 @@ dependencies = [
 ]
 
 [[package]]
+name = "snarkos-account"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "colored",
+ "rand",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+]
+
+[[package]]
+name = "snarkos-cli"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anstyle",
+ "anyhow",
+ "bincode",
+ "clap",
+ "colored",
+ "crossterm",
+ "indexmap 2.2.6",
+ "nix",
+ "num_cpus",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rayon",
+ "self_update 0.39.0",
+ "serde",
+ "serde_json",
+ "snarkos-account",
+ "snarkos-display",
+ "snarkos-node",
+ "snarkos-node-cdn",
+ "snarkos-node-metrics",
+ "snarkos-node-rest",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "sys-info",
+ "thiserror",
+ "tokio",
+ "tracing-subscriber",
+ "ureq",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkos-display"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "crossterm",
+ "ratatui",
+ "snarkos-node",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "async-trait",
+ "colored",
+ "futures-util",
+ "indexmap 2.2.6",
+ "num_cpus",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde_json",
+ "snarkos-account",
+ "snarkos-node-bft",
+ "snarkos-node-cdn",
+ "snarkos-node-consensus",
+ "snarkos-node-metrics",
+ "snarkos-node-rest",
+ "snarkos-node-router",
+ "snarkos-node-sync",
+ "snarkos-node-tcp",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "async-recursion",
+ "async-trait",
+ "bytes",
+ "colored",
+ "futures",
+ "indexmap 2.2.6",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde",
+ "sha2",
+ "snarkos-account",
+ "snarkos-node-bft-events",
+ "snarkos-node-bft-ledger-service",
+ "snarkos-node-bft-storage-service",
+ "snarkos-node-metrics",
+ "snarkos-node-sync",
+ "snarkos-node-tcp",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snow",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft-events"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "indexmap 2.2.6",
+ "rayon",
+ "serde",
+ "snarkos-node-metrics",
+ "snarkos-node-sync-locators",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snow",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft-ledger-service"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "async-trait",
+ "indexmap 2.2.6",
+ "lru",
+ "parking_lot",
+ "rand",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-bft-storage-service"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "indexmap 2.2.6",
+ "parking_lot",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-cdn"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "colored",
+ "futures",
+ "parking_lot",
+ "rayon",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-consensus"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "colored",
+ "indexmap 2.2.6",
+ "lru",
+ "parking_lot",
+ "rand",
+ "snarkos-account",
+ "snarkos-node-bft",
+ "snarkos-node-bft-ledger-service",
+ "snarkos-node-bft-storage-service",
+ "snarkos-node-metrics",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-metrics"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "metrics-exporter-prometheus",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node-rest"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "axum",
+ "axum-extra",
+ "http 1.1.0",
+ "indexmap 2.2.6",
+ "jsonwebtoken",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde",
+ "serde_json",
+ "snarkos-node-consensus",
+ "snarkos-node-router",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "time",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower_governor",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-router"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bytes",
+ "colored",
+ "futures",
+ "indexmap 2.2.6",
+ "linked-hash-map",
+ "parking_lot",
+ "rand",
+ "reqwest 0.11.27",
+ "serde",
+ "snarkos-account",
+ "snarkos-node-metrics",
+ "snarkos-node-router-messages",
+ "snarkos-node-sync-locators",
+ "snarkos-node-tcp",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-router-messages"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "indexmap 2.2.6",
+ "rayon",
+ "serde",
+ "snarkos-node-bft-events",
+ "snarkos-node-sync-locators",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snow",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-sync"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "itertools 0.12.1",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "serde",
+ "snarkos-node-bft-ledger-service",
+ "snarkos-node-sync-communication-service",
+ "snarkos-node-sync-locators",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-sync-communication-service"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "async-trait",
+ "tokio",
+]
+
+[[package]]
+name = "snarkos-node-sync-locators"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "snarkvm 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkos-node-tcp"
+version = "2.2.7"
+source = "git+https://github.com/AleoHQ/snarkos?rev=d69e417#d69e417325ff20da660db355db9d8cf025dfb9dd"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "once_cell",
+ "parking_lot",
+ "snarkos-node-metrics",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "snarkvm"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
@@ -2902,12 +3921,42 @@ dependencies = [
  "rayon",
  "self_update 0.38.0",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-ledger",
- "snarkvm-parameters",
- "snarkvm-synthesizer",
- "snarkvm-utilities",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "thiserror",
+ "ureq",
+ "walkdir",
+]
+
+[[package]]
+name = "snarkvm"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anstyle",
+ "anyhow",
+ "clap",
+ "colored",
+ "dotenvy",
+ "indexmap 2.2.6",
+ "num-format",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "self_update 0.38.0",
+ "serde_json",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-metrics",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
  "ureq",
  "walkdir",
@@ -2923,7 +3972,7 @@ dependencies = [
  "blake2",
  "cfg-if",
  "fxhash",
- "hashbrown 0.14.3",
+ "hashbrown 0.14.5",
  "hex",
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -2936,10 +3985,40 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-algorithms"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "blake2",
+ "cfg-if",
+ "fxhash",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "num-traits",
+ "parking_lot",
+ "rand",
+ "rand_chacha",
+ "rand_core",
+ "rayon",
+ "serde",
+ "sha2",
+ "smallvec",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
 ]
 
@@ -2948,13 +4027,27 @@ name = "snarkvm-circuit"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-account",
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-environment",
- "snarkvm-circuit-network",
- "snarkvm-circuit-program",
- "snarkvm-circuit-types",
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -2962,10 +4055,21 @@ name = "snarkvm-circuit-account"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-network",
- "snarkvm-circuit-types",
- "snarkvm-console-account",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-account"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -2973,9 +4077,19 @@ name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-types",
- "snarkvm-console-algorithms",
- "snarkvm-fields",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-algorithms"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -2983,9 +4097,19 @@ name = "snarkvm-circuit-collections"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-types",
- "snarkvm-console-collections",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-collections"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -2998,12 +4122,30 @@ dependencies = [
  "nom",
  "num-traits",
  "once_cell",
- "snarkvm-algorithms",
- "snarkvm-circuit-environment-witness",
- "snarkvm-console-network",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-environment"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "once_cell",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-environment-witness 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3012,14 +4154,30 @@ version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 
 [[package]]
+name = "snarkvm-circuit-environment-witness"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+
+[[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-types",
- "snarkvm-console-network",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-network"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3028,13 +4186,28 @@ version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
  "paste",
- "snarkvm-circuit-account",
- "snarkvm-circuit-algorithms",
- "snarkvm-circuit-collections",
- "snarkvm-circuit-network",
- "snarkvm-circuit-types",
- "snarkvm-console-program",
- "snarkvm-utilities",
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-program"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "paste",
+ "snarkvm-circuit-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3042,14 +4215,29 @@ name = "snarkvm-circuit-types"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-address",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-group",
- "snarkvm-circuit-types-integers",
- "snarkvm-circuit-types-scalar",
- "snarkvm-circuit-types-string",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3057,12 +4245,25 @@ name = "snarkvm-circuit-types-address"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-group",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-address",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-address"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3070,8 +4271,17 @@ name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-boolean"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3079,9 +4289,19 @@ name = "snarkvm-circuit-types-field"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-field"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3089,11 +4309,23 @@ name = "snarkvm-circuit-types-group"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-group",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-group"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3101,11 +4333,23 @@ name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-scalar",
- "snarkvm-console-types-integers",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-integers"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3113,10 +4357,21 @@ name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-scalar"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3124,11 +4379,23 @@ name = "snarkvm-circuit-types-string"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-circuit-environment",
- "snarkvm-circuit-types-boolean",
- "snarkvm-circuit-types-field",
- "snarkvm-circuit-types-integers",
- "snarkvm-console-types-string",
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-circuit-types-string"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-circuit-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3136,12 +4403,25 @@ name = "snarkvm-console"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-account",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network",
- "snarkvm-console-program",
- "snarkvm-console-types",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3150,8 +4430,19 @@ version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
  "bs58",
- "snarkvm-console-network",
- "snarkvm-console-types",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-account"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bs58",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3162,9 +4453,22 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277c
 dependencies = [
  "blake2s_simd",
  "smallvec",
- "snarkvm-console-types",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "snarkvm-console-algorithms"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "blake2s_simd",
+ "smallvec",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "tiny-keccak",
 ]
 
@@ -3175,8 +4479,19 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277c
 dependencies = [
  "aleo-std",
  "rayon",
- "snarkvm-console-algorithms",
- "snarkvm-console-types",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-collections"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "rayon",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3191,15 +4506,38 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
- "snarkvm-algorithms",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network-environment",
- "snarkvm-console-types",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-parameters",
- "snarkvm-utilities",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-network"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "lazy_static",
+ "once_cell",
+ "paste",
+ "serde",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-parameters 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3214,9 +4552,27 @@ dependencies = [
  "num-traits",
  "rand",
  "serde",
- "snarkvm-curves",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-network-environment"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anyhow",
+ "bech32",
+ "itertools 0.11.0",
+ "nom",
+ "num-traits",
+ "rand",
+ "serde",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3233,12 +4589,33 @@ dependencies = [
  "once_cell",
  "paste",
  "serde_json",
- "snarkvm-console-account",
- "snarkvm-console-algorithms",
- "snarkvm-console-collections",
- "snarkvm-console-network",
- "snarkvm-console-types",
- "snarkvm-utilities",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-program"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "enum_index",
+ "enum_index_derive",
+ "indexmap 2.2.6",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "serde_json",
+ "snarkvm-console-account 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-collections 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-network 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3246,14 +4623,29 @@ name = "snarkvm-console-types"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-address",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
- "snarkvm-console-types-integers",
- "snarkvm-console-types-scalar",
- "snarkvm-console-types-string",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-types"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-address 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-string 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3261,10 +4653,21 @@ name = "snarkvm-console-types-address"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-group",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-types-address"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-group 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3272,7 +4675,15 @@ name = "snarkvm-console-types-boolean"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-types-boolean"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3280,8 +4691,18 @@ name = "snarkvm-console-types-field"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-field"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3290,10 +4711,21 @@ name = "snarkvm-console-types-group"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-types-group"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3301,10 +4733,21 @@ name = "snarkvm-console-types-integers"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-scalar",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-types-integers"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-scalar 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3312,9 +4755,20 @@ name = "snarkvm-console-types-scalar"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-console-types-scalar"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "zeroize",
 ]
 
@@ -3323,10 +4777,21 @@ name = "snarkvm-console-types-string"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console-network-environment",
- "snarkvm-console-types-boolean",
- "snarkvm-console-types-field",
- "snarkvm-console-types-integers",
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-console-types-string"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console-network-environment 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-boolean 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-field 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console-types-integers 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3338,8 +4803,22 @@ dependencies = [
  "rayon",
  "rustc_version",
  "serde",
- "snarkvm-fields",
- "snarkvm-utilities",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-curves"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "rand",
+ "rayon",
+ "rustc_version",
+ "serde",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
 ]
 
@@ -3355,7 +4834,24 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "snarkvm-utilities",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-fields"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "itertools 0.11.0",
+ "num-traits",
+ "rand",
+ "rayon",
+ "serde",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
  "zeroize",
 ]
@@ -3371,15 +4867,39 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-console",
- "snarkvm-ledger-authority",
- "snarkvm-ledger-block",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
- "snarkvm-ledger-query",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-ledger"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap 2.2.6",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "time",
  "tracing",
 ]
@@ -3392,8 +4912,20 @@ dependencies = [
  "anyhow",
  "rand",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-subdag",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-authority"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "anyhow",
+ "rand",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3404,15 +4936,54 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-authority",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-subdag",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-block"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+]
+
+[[package]]
+name = "snarkvm-ledger-coinbase"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "blake2",
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-fields 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3423,8 +4994,19 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-batch-header",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-committee"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-metrics",
 ]
 
 [[package]]
@@ -3432,12 +5014,25 @@ name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-ledger-narwhal-batch-certificate",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-data",
- "snarkvm-ledger-narwhal-subdag",
- "snarkvm-ledger-narwhal-transmission",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-transmission 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-subdag 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3448,9 +5043,22 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-certificate"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3461,8 +5069,19 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-batch-header"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3472,7 +5091,18 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277c
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "tokio",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-data"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bytes",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "tokio",
 ]
 
@@ -3484,11 +5114,25 @@ dependencies = [
  "indexmap 2.2.6",
  "rayon",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal-batch-certificate",
- "snarkvm-ledger-narwhal-batch-header",
- "snarkvm-ledger-narwhal-transmission-id",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-subdag"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "rayon",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-header 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-transmission-id 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3498,10 +5142,23 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277c
 dependencies = [
  "bytes",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-block",
- "snarkvm-ledger-narwhal-data",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bytes",
+ "serde_json",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-ledger-narwhal-data 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3509,8 +5166,17 @@ name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
- "snarkvm-console",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
+]
+
+[[package]]
+name = "snarkvm-ledger-narwhal-transmission-id"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase",
 ]
 
 [[package]]
@@ -3529,8 +5195,8 @@ dependencies = [
  "rand_chacha",
  "rayon",
  "serde_json",
- "snarkvm-algorithms",
- "snarkvm-console",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
 ]
 
 [[package]]
@@ -3544,7 +5210,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rayon",
- "snarkvm-console",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
 ]
 
@@ -3555,9 +5221,22 @@ source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277c
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
- "snarkvm-console",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer-program",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "ureq",
+]
+
+[[package]]
+name = "snarkvm-ledger-query"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "async-trait",
+ "reqwest 0.11.27",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "ureq",
 ]
 
@@ -3574,14 +5253,48 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "snarkvm-console",
- "snarkvm-ledger-authority",
- "snarkvm-ledger-block",
- "snarkvm-ledger-committee",
- "snarkvm-ledger-narwhal-batch-certificate",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-ledger-store"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std-storage",
+ "anyhow",
+ "bincode",
+ "indexmap 2.2.6",
+ "once_cell",
+ "parking_lot",
+ "rayon",
+ "rocksdb",
+ "serde",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-authority 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-narwhal-batch-certificate 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-metrics"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "metrics",
+ "metrics-exporter-prometheus",
 ]
 
 [[package]]
@@ -3604,8 +5317,33 @@ dependencies = [
  "rand",
  "serde_json",
  "sha2",
- "snarkvm-curves",
- "snarkvm-utilities",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "thiserror",
+]
+
+[[package]]
+name = "snarkvm-parameters"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "cfg-if",
+ "colored",
+ "curl",
+ "hex",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "lazy_static",
+ "parking_lot",
+ "paste",
+ "rand",
+ "serde_json",
+ "sha2",
+ "snarkvm-curves 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
 ]
 
@@ -3622,19 +5360,45 @@ dependencies = [
  "parking_lot",
  "rand",
  "rayon",
- "snarkvm-algorithms",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-ledger-block",
- "snarkvm-ledger-committee",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
  "snarkvm-ledger-puzzle",
  "snarkvm-ledger-puzzle-epoch",
- "snarkvm-ledger-query",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer-process",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
- "snarkvm-utilities",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-process 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "tracing",
+]
+
+[[package]]
+name = "snarkvm-synthesizer"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "indexmap 2.2.6",
+ "lru",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-coinbase",
+ "snarkvm-ledger-committee 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-process 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "tracing",
 ]
 
@@ -3651,14 +5415,37 @@ dependencies = [
  "rand",
  "rayon",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-console",
- "snarkvm-ledger-block",
- "snarkvm-ledger-query",
- "snarkvm-ledger-store",
- "snarkvm-synthesizer-program",
- "snarkvm-synthesizer-snark",
- "snarkvm-utilities",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-process"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "colored",
+ "indexmap 2.2.6",
+ "once_cell",
+ "parking_lot",
+ "rand",
+ "rayon",
+ "serde_json",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-block 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-query 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-ledger-store 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-program 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-synthesizer-snark 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-utilities 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3671,8 +5458,22 @@ dependencies = [
  "rand",
  "rand_chacha",
  "serde_json",
- "snarkvm-circuit",
- "snarkvm-console",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-program"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "indexmap 2.2.6",
+ "paste",
+ "rand",
+ "rand_chacha",
+ "serde_json",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3683,9 +5484,22 @@ dependencies = [
  "bincode",
  "once_cell",
  "serde_json",
- "snarkvm-algorithms",
- "snarkvm-circuit",
- "snarkvm-console",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+]
+
+[[package]]
+name = "snarkvm-synthesizer-snark"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "bincode",
+ "once_cell",
+ "serde_json",
+ "snarkvm-algorithms 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-circuit 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
+ "snarkvm-console 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
 ]
 
 [[package]]
@@ -3704,7 +5518,28 @@ dependencies = [
  "serde",
  "serde_json",
  "smol_str",
- "snarkvm-utilities-derives",
+ "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a)",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "snarkvm-utilities"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "aleo-std",
+ "anyhow",
+ "bincode",
+ "num-bigint",
+ "num_cpus",
+ "rand",
+ "rand_xorshift",
+ "rayon",
+ "serde",
+ "serde_json",
+ "smol_str",
+ "snarkvm-utilities-derives 0.16.19 (git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e)",
  "thiserror",
  "zeroize",
 ]
@@ -3715,15 +5550,41 @@ version = "0.16.19"
 source = "git+https://github.com/AleoHQ/snarkVM?rev=2cbf34a#2cbf34a1010bf781277cdc6ff1ae966230cf97c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "snarkvm-utilities-derives"
+version = "0.16.19"
+source = "git+https://github.com/AleoHQ/snarkVM.git?rev=f761d1e#f761d1e53eca2505c0b6a089e84636cbc21f0ad7"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core",
+ "rustc_version",
+ "sha2",
+ "subtle",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -3736,6 +5597,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,10 +5616,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.11.0"
+name = "stability"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "ebd1b177894da2a2d9120208c3386066af06a488255caabc5de8ddca22dbc3ce"
+dependencies = [
+ "quote 1.0.36",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote 1.0.36",
+ "rustversion",
+ "syn 2.0.60",
+]
 
 [[package]]
 name = "subtle"
@@ -3775,18 +5677,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.36",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.57"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a6ae1e52eb25aab8f3fb9fca13be982a373b8f1157ca14b897a825ba4a2d35"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
+ "quote 1.0.36",
  "unicode-ident",
 ]
 
@@ -3795,6 +5697,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synom"
@@ -3843,7 +5751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.2",
+ "fastrand 2.1.0",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -3874,22 +5782,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3904,15 +5812,17 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -3920,6 +5830,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -3966,9 +5886,23 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -3978,6 +5912,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -4027,9 +5972,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.9"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e40bb779c5187258fd7aad0eb68cb8706a0a81fa712fbea808ab43c4b8374c4"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -4055,6 +6000,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.5.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4065,6 +6027,22 @@ name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tower_governor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3790eac6ad3fb8d9d96c2b040ae06e2517aa24b067545d1078b96ae72f7bb9a7"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http 1.1.0",
+ "pin-project",
+ "thiserror",
+ "tower",
+ "tracing",
+]
 
 [[package]]
 name = "tracing"
@@ -4085,8 +6063,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4116,10 +6094,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -4167,16 +6149,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.11"
+name = "unicode-segmentation"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -4186,11 +6184,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.9.6"
+version = "2.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f214ce18d8b2cbe84ed3aa6486ed3f5b285cf8d8fbdbce9f3f767a724adc35"
+checksum = "d11a831e3c0b56e438a28308e7c810799e3c118417f342d30ecec080105395cd"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -4298,8 +6296,8 @@ dependencies = [
  "log",
  "once_cell",
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
  "wasm-bindgen-shared",
 ]
 
@@ -4321,7 +6319,7 @@ version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
- "quote 1.0.35",
+ "quote 1.0.36",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4332,8 +6330,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4381,11 +6379,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4409,7 +6407,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.5",
 ]
 
 [[package]]
@@ -4429,17 +6427,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
 
 [[package]]
@@ -4450,9 +6449,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -4462,9 +6461,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4474,9 +6473,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4486,9 +6491,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4498,9 +6503,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4510,9 +6515,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4522,15 +6527,15 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "14b9415ee827af173ebb3f15f9083df5a122eb93572ec28741fb153356ea2578"
 dependencies = [
  "memchr",
 ]
@@ -4540,6 +6545,16 @@ name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -4570,8 +6585,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -4590,8 +6605,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.35",
- "syn 2.0.57",
+ "quote 1.0.36",
+ "syn 2.0.60",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,10 @@ members = [
   "utils/retriever"
 ]
 
+[workspace.dependencies.snarkos-cli]
+git = "https://github.com/AleoHQ/snarkos"
+rev = "d69e417"
+
 [workspace.dependencies.snarkvm]
 #version = "0.16.19"
 git = "https://github.com/AleoHQ/snarkVM"
@@ -148,6 +152,9 @@ version = "1.0"
 
 [dependencies.serial_test]
 version = "3.0.0"
+
+[dependencies.snarkos-cli]
+workspace = true
 
 [dependencies.snarkvm]
 workspace = true

--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -215,4 +215,11 @@ create_messages!(
         msg: format!("Failed to read private key from environment.\nIO Error: {error}"),
         help: Some("Pass in private key using `--private-key <PRIVATE-KEY>` or create a .env file with your private key information. See examples for formatting information.".to_string()),
     }
+
+    @backtraced
+    recursive_deploy_with_record {
+        args: (),
+        msg: "Cannot combine recursive deploy with private fee.".to_string(),
+        help: None,
+    }
 );

--- a/errors/src/errors/package/package_errors.rs
+++ b/errors/src/errors/package/package_errors.rs
@@ -370,4 +370,17 @@ create_messages!(
         help: None,
     }
 
+    @backtraced
+    missing_on_chain_program_name {
+        args: (),
+        msg: "The name of the program to execute on-chain is missing.".to_string(),
+        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    }
+
+    @backtraced
+    conflicting_on_chain_program_name {
+        args: (first: impl Display, second: impl Display),
+        msg: format!("Conflicting program names given to execute on chain: `{first}` and `{second}`."),
+        help: Some("Either set `--local` to execute the local program on chain, or set `--program <PROGRAM>`.".to_string()),
+    }
 );

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -14,19 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use std::path::PathBuf;
 use super::*;
 use snarkos_cli::commands::{Deploy as SnarkOSDeploy, Developer};
 use snarkvm::cli::helpers::dotenv_private_key;
+use std::path::PathBuf;
 
 /// Deploys an Aleo program.
 #[derive(Parser, Debug)]
 pub struct Deploy {
-    #[clap(
-    long,
-    help = "Endpoint to retrieve network state from.",
-    default_value = "http://api.explorer.aleo.org/v1"
-    )]
+    #[clap(long, help = "Endpoint to retrieve network state from.", default_value = "http://api.explorer.aleo.org/v1")]
     pub endpoint: String,
     #[clap(flatten)]
     pub(crate) fee_options: FeeOptions,
@@ -34,7 +30,11 @@ pub struct Deploy {
     pub(crate) no_build: bool,
     #[clap(long, help = "Disables recursive deployment of dependencies", default_value = "false")]
     pub(crate) non_recursive: bool,
-    #[clap(long, help = "Custom wait gap between consecutive deployments. This is to help prevent a program from trying to be included in an earlier block than its dependency program.", default_value = "12")]
+    #[clap(
+        long,
+        help = "Custom wait gap between consecutive deployments. This is to help prevent a program from trying to be included in an earlier block than its dependency program.",
+        default_value = "12"
+    )]
     pub(crate) wait_gap: u64,
 }
 
@@ -56,43 +56,44 @@ impl Command for Deploy {
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
         // Get the program name.
         let project_name = context.open_manifest()?.program_id().to_string();
-        
+
         // Get the private key.
         let mut private_key = self.fee_options.private_key;
         if private_key.is_none() {
             private_key =
                 Some(dotenv_private_key().map_err(CliError::failed_to_read_environment_private_key)?.to_string());
         }
-        
+
         let mut all_paths: Vec<(String, PathBuf)> = Vec::new();
-        
+
         // Extract post-ordered list of local dependencies' paths from `leo.lock`.
         if !self.non_recursive {
             all_paths = context.local_dependency_paths()?;
         }
-        
+
         // Add the parent program to be deployed last.
         all_paths.push((project_name, context.dir()?.join("build")));
-        
+
         for (index, (name, path)) in all_paths.iter().enumerate() {
             // Set the deploy arguments.
-            let mut deploy_args = vec!["snarkos".to_string(),
-                                       "--private-key".to_string(),
-                                       private_key.as_ref().unwrap().clone(),
-                                       "--query".to_string(),
-                                       self.endpoint.clone(),
-                                       "--priority-fee".to_string(),
-                                       self.fee_options.priority_fee.to_string(),
-                                       "--path".to_string(),
-                                       path.to_str().unwrap().parse().unwrap(),
-                                       "--broadcast".to_string(),
-                                       format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
-                                       name.clone(),
+            let mut deploy_args = vec![
+                "snarkos".to_string(),
+                "--private-key".to_string(),
+                private_key.as_ref().unwrap().clone(),
+                "--query".to_string(),
+                self.endpoint.clone(),
+                "--priority-fee".to_string(),
+                self.fee_options.priority_fee.to_string(),
+                "--path".to_string(),
+                path.to_str().unwrap().parse().unwrap(),
+                "--broadcast".to_string(),
+                format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
+                name.clone(),
             ];
 
             // Use record as payment option if it is provided.
             if let Some(record) = self.fee_options.record.clone() {
-               deploy_args.push("--record".to_string());
+                deploy_args.push("--record".to_string());
                 deploy_args.push(record);
             };
 
@@ -100,14 +101,14 @@ impl Command for Deploy {
 
             // Deploy program.
             Developer::Deploy(deploy).parse().map_err(CliError::failed_to_execute_deploy)?;
-        
+
             // Sleep for `wait_gap` seconds.
             // This helps avoid parents from being serialized before children.
             if index < all_paths.len() - 1 {
                 std::thread::sleep(std::time::Duration::from_secs(self.wait_gap));
             }
         }
-        
+
         Ok(())
     }
 }

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -14,25 +14,27 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use std::path::PathBuf;
 use super::*;
-//use snarkos_cli::commands::{Deploy as SnarkOSDeploy, Developer};
+use snarkos_cli::commands::{Deploy as SnarkOSDeploy, Developer};
+use snarkvm::cli::helpers::dotenv_private_key;
 
 /// Deploys an Aleo program.
 #[derive(Parser, Debug)]
 pub struct Deploy {
-    #[clap(long, help = "Custom priority fee in microcredits", default_value = "1000000")]
-    pub(crate) priority_fee: String,
-    #[clap(long, help = "Custom query endpoint", default_value = "http://api.explorer.aleo.org/v1")]
-    pub(crate) endpoint: String,
-    #[clap(long, help = "Custom network", default_value = "testnet3")]
-    pub(crate) network: String,
-    #[clap(long, help = "Custom private key")]
-    pub(crate) private_key: Option<String>,
+    #[clap(
+    long,
+    help = "Endpoint to retrieve network state from.",
+    default_value = "http://api.explorer.aleo.org/v1"
+    )]
+    pub endpoint: String,
+    #[clap(flatten)]
+    pub(crate) fee_options: FeeOptions,
     #[clap(long, help = "Disables building of the project before deployment", default_value = "false")]
     pub(crate) no_build: bool,
     #[clap(long, help = "Disables recursive deployment of dependencies", default_value = "false")]
     pub(crate) non_recursive: bool,
-    #[clap(long, help = "Custom wait gap between consecutive deployments", default_value = "12")]
+    #[clap(long, help = "Custom wait gap between consecutive deployments. This is to help prevent a program from trying to be included in an earlier block than its dependency program.", default_value = "12")]
     pub(crate) wait_gap: u64,
 }
 
@@ -51,55 +53,61 @@ impl Command for Deploy {
         Ok(())
     }
 
-    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
-        // // Get the program name
-        // let project_name = context.open_manifest()?.program_id().to_string();
-        //
-        // // Get the private key
-        // let mut private_key = self.private_key;
-        // if private_key.is_none() {
-        //     private_key =
-        //         Some(dotenv_private_key().map_err(CliError::failed_to_read_environment_private_key)?.to_string());
-        // }
-        //
-        // let mut all_paths: Vec<(String, PathBuf)> = Vec::new();
-        //
-        // // Extract post-ordered list of local dependencies' paths from `leo.lock`
-        // if !self.non_recursive {
-        //     all_paths = context.local_dependency_paths()?;
-        // }
-        //
-        // // Add the parent program to be deployed last
-        // all_paths.push((project_name, context.dir()?.join("build")));
-        //
-        // for (index, (name, path)) in all_paths.iter().enumerate() {
-        //     // Set deploy arguments
-        //     let deploy = SnarkOSDeploy::try_parse_from([
-        //         "snarkos",
-        //         "--private-key",
-        //         private_key.as_ref().unwrap(),
-        //         "--query",
-        //         self.endpoint.as_str(),
-        //         "--priority-fee",
-        //         self.priority_fee.as_str(),
-        //         "--path",
-        //         path.to_str().unwrap(),
-        //         "--broadcast",
-        //         format!("{}/{}/transaction/broadcast", self.endpoint, self.network).as_str(),
-        //         &name,
-        //     ])
-        //     .unwrap();
-        //
-        //     // Deploy program
-        //     Developer::Deploy(deploy).parse().map_err(CliError::failed_to_execute_deploy)?;
-        //
-        //     // Sleep for `wait_gap` seconds.
-        //     // This helps avoid parents from being serialized before children.
-        //     if index < all_paths.len() - 1 {
-        //         std::thread::sleep(std::time::Duration::from_secs(self.wait_gap));
-        //     }
-        // }
+    fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
+        // Get the program name.
+        let project_name = context.open_manifest()?.program_id().to_string();
+        
+        // Get the private key.
+        let mut private_key = self.fee_options.private_key;
+        if private_key.is_none() {
+            private_key =
+                Some(dotenv_private_key().map_err(CliError::failed_to_read_environment_private_key)?.to_string());
+        }
+        
+        let mut all_paths: Vec<(String, PathBuf)> = Vec::new();
+        
+        // Extract post-ordered list of local dependencies' paths from `leo.lock`.
+        if !self.non_recursive {
+            all_paths = context.local_dependency_paths()?;
+        }
+        
+        // Add the parent program to be deployed last.
+        all_paths.push((project_name, context.dir()?.join("build")));
+        
+        for (index, (name, path)) in all_paths.iter().enumerate() {
+            // Set the deploy arguments.
+            let mut deploy_args = vec!["snarkos".to_string(),
+                                       "--private-key".to_string(),
+                                       private_key.as_ref().unwrap().clone(),
+                                       "--query".to_string(),
+                                       self.endpoint.clone(),
+                                       "--priority-fee".to_string(),
+                                       self.fee_options.priority_fee.to_string(),
+                                       "--path".to_string(),
+                                       path.to_str().unwrap().parse().unwrap(),
+                                       "--broadcast".to_string(),
+                                       format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
+                                       name.clone(),
+            ];
 
-        Err(PackageError::unimplemented_command("leo deploy").into())
+            // Use record as payment option if it is provided.
+            if let Some(record) = self.fee_options.record.clone() {
+               deploy_args.push("--record".to_string());
+                deploy_args.push(record);
+            };
+
+            let deploy = SnarkOSDeploy::try_parse_from(deploy_args).unwrap();
+
+            // Deploy program.
+            Developer::Deploy(deploy).parse().map_err(CliError::failed_to_execute_deploy)?;
+        
+            // Sleep for `wait_gap` seconds.
+            // This helps avoid parents from being serialized before children.
+            if index < all_paths.len() - 1 {
+                std::thread::sleep(std::time::Duration::from_secs(self.wait_gap));
+            }
+        }
+        
+        Ok(())
     }
 }

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -17,8 +17,10 @@
 use super::*;
 use clap::Parser;
 use snarkos_cli::commands::{Developer, Execute as SnarkOSExecute};
-use snarkvm::{cli::Execute as SnarkVMExecute, prelude::Parser as SnarkVMParser};
-use snarkvm::cli::helpers::dotenv_private_key;
+use snarkvm::{
+    cli::{helpers::dotenv_private_key, Execute as SnarkVMExecute},
+    prelude::Parser as SnarkVMParser,
+};
 
 /// Build, Prove and Run Leo program with inputs
 #[derive(Parser, Debug)]
@@ -71,15 +73,17 @@ impl Command for Execute {
             };
 
             // Set deploy arguments.
-            let mut fee_args = vec!["snarkos".to_string(),
-               "--private-key".to_string(),
-               private_key.clone(),
-               "--query".to_string(),
-               self.compiler_options.endpoint.clone(),
-               "--priority-fee".to_string(),
-               self.fee_options.priority_fee.to_string(),
-               "--broadcast".to_string(),
-               format!("{}/{}/transaction/broadcast", self.compiler_options.endpoint, self.fee_options.network).to_string(),
+            let mut fee_args = vec![
+                "snarkos".to_string(),
+                "--private-key".to_string(),
+                private_key.clone(),
+                "--query".to_string(),
+                self.compiler_options.endpoint.clone(),
+                "--priority-fee".to_string(),
+                self.fee_options.priority_fee.to_string(),
+                "--broadcast".to_string(),
+                format!("{}/{}/transaction/broadcast", self.compiler_options.endpoint, self.fee_options.network)
+                    .to_string(),
             ];
 
             // Use record as payment option if it is provided.
@@ -87,7 +91,7 @@ impl Command for Execute {
                 fee_args.push("--record".to_string());
                 fee_args.push(record);
             };
-            
+
             // Execute program.
             Developer::Execute(
                 SnarkOSExecute::try_parse_from(

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -122,11 +122,7 @@ pub trait Command {
 /// require Build command output as their input.
 #[derive(Parser, Clone, Debug, Default)]
 pub struct BuildOptions {
-    #[clap(
-        long,
-        help = "Endpoint to retrieve network state from.",
-        default_value = "http://api.explorer.aleo.org/v1"
-    )]
+    #[clap(long, help = "Endpoint to retrieve network state from.", default_value = "http://api.explorer.aleo.org/v1")]
     pub endpoint: String,
     #[clap(long, help = "Does not recursively compile dependencies.")]
     pub non_recursive: bool,
@@ -176,6 +172,10 @@ pub struct FeeOptions {
     pub(crate) network: String,
     #[clap(long, help = "Private key to authorize fee expenditure.")]
     pub(crate) private_key: Option<String>,
-    #[clap(short, help = "Record to pay for fee privately. If one is not specified, a public fee will be taken.", long)]
+    #[clap(
+        short,
+        help = "Record to pay for fee privately. If one is not specified, a public fee will be taken.",
+        long
+    )]
     record: Option<String>,
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -124,7 +124,7 @@ pub trait Command {
 pub struct BuildOptions {
     #[clap(
         long,
-        help = "Endpoint to retrieve on-chain dependencies from.",
+        help = "Endpoint to retrieve network state from.",
         default_value = "http://api.explorer.aleo.org/v1"
     )]
     pub endpoint: String,
@@ -164,4 +164,18 @@ pub struct BuildOptions {
     pub conditional_block_max_depth: usize,
     #[clap(long, help = "Disable type checking of nested conditional branches in finalize scope.")]
     pub disable_conditional_branch_type_checking: bool,
+}
+
+/// On Chain Execution Options to set preferences for keys, fees and networks.
+/// Used by Execute and Deploy commands.
+#[derive(Parser, Clone, Debug, Default)]
+pub struct FeeOptions {
+    #[clap(long, help = "Priority fee in microcredits. Defaults to 1000000.", default_value = "1000000")]
+    pub(crate) priority_fee: String,
+    #[clap(long, help = "Network to broadcast to. Defaults to testnet3.", default_value = "testnet3")]
+    pub(crate) network: String,
+    #[clap(long, help = "Private key to authorize fee expenditure.")]
+    pub(crate) private_key: Option<String>,
+    #[clap(short, help = "Record to pay for fee privately. If one is not specified, a public fee will be taken.", long)]
+    record: Option<String>,
 }

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -166,7 +166,7 @@ pub struct BuildOptions {
 /// Used by Execute and Deploy commands.
 #[derive(Parser, Clone, Debug, Default)]
 pub struct FeeOptions {
-    #[clap(long, help = "Priority fee in microcredits. Defaults to 1000000.", default_value = "1000000")]
+    #[clap(long, help = "Priority fee in microcredits. Defaults to 0.", default_value = "0")]
     pub(crate) priority_fee: String,
     #[clap(long, help = "Network to broadcast to. Defaults to testnet3.", default_value = "testnet3")]
     pub(crate) network: String,

--- a/leo/package/Cargo.toml
+++ b/leo/package/Cargo.toml
@@ -26,6 +26,9 @@ version = "=1.11.0"
 path = "../../utils/retriever"
 version = "1.11.0"
 
+[dependencies.snarkos-cli]
+workspace = true
+
 [dependencies.snarkvm]
 workspace = true
 


### PR DESCRIPTION
- `leo deploy`:
	- Can now easily deploy programs to custom networks, with custom broadcast endpoints, all while using private or public fees.
	- Now supports easy deployment of projects that contain any depth of dependencies by specifying `--recursive`. Customizable parameter `--wait <SECONDS>` to specify how long to wait between nested program deployments to help avoid a parent program from reaching a snarkOS node before its child. 
- `leo execute`:
	- Can now easily execute existing on-chain programs, even if they don't match the current directory you are in.
- Examples:
	- `leo deploy --endpoint "http://0.0.0.0:3030" --private-key "<INSERT PRIVATE_KEY>"`
	- `leo execute --program football_players_v001.aleo add_player "{player_id: 1000field,team_id: 1field,position: 1field,attack: 1u128,defense: 1u128,speed: 1u128,power: 1u128,stamina: 1u128,technique: 1u128,goalkeeping: 1u128}" --endpoint "http://0.0.0.0:3030" --private-key "<INSERT PRIVATE KEY>" --broadcast --record "<INSERT RECORD>"`
	- `leo execute --program credits.aleo --endpoint "http://0.0.0.0:3030" --private-key "<INSERT PRIVATE_KEY 1>" --broadcast transfer_public_to_private <INSERT RECIPIENT ADDRESS> 5000000u64`