### PR TITLE
[Fix] `leo deploy` build panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "snarkos-account"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "colored",
@@ -3558,7 +3558,7 @@ dependencies = [
 [[package]]
 name = "snarkos-cli"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "aleo-std",
  "anstyle",
@@ -3597,7 +3597,7 @@ dependencies = [
 [[package]]
 name = "snarkos-display"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -3610,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-bft"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3676,7 +3676,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-bft-events"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3693,7 +3693,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-bft-ledger-service"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "async-trait",
  "indexmap 2.2.6",
@@ -3709,7 +3709,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-bft-storage-service"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "aleo-std",
  "indexmap 2.2.6",
@@ -3721,7 +3721,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-cdn"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3740,7 +3740,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-consensus"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3762,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-metrics"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "metrics-exporter-prometheus",
  "parking_lot",
@@ -3775,7 +3775,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-rest"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-router"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-router-messages"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-sync"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-sync-communication-service"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "async-trait",
  "tokio",
@@ -3881,7 +3881,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-sync-locators"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "snarkos-node-tcp"
 version = "2.2.7"
-source = "git+https://github.com/AleoHQ/snarkos?rev=6ac2fe5#6ac2fe5fc2b85960c2fec11a9caba3819ef59b21"
+source = "git+https://github.com/AleoNet/snarkOS.git?rev=01ea476#01ea4768ed62d3f1933745568f023fadcf15cdf1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3909,7 +3909,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3939,7 +3939,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3969,7 +3969,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3983,7 +3983,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-network",
@@ -3994,7 +3994,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4004,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "itertools 0.11.0",
@@ -4032,12 +4032,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4048,7 +4048,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "paste",
  "snarkvm-circuit-account",
@@ -4063,7 +4063,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4091,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4100,7 +4100,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4110,7 +4110,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4122,7 +4122,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4134,7 +4134,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4157,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4170,7 +4170,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4181,7 +4181,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -4194,7 +4194,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4205,7 +4205,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "anyhow",
  "indexmap 2.2.6",
@@ -4228,7 +4228,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4246,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "enum_index",
  "enum_index_derive",
@@ -4267,7 +4267,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4282,7 +4282,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4293,7 +4293,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4301,7 +4301,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4311,7 +4311,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4322,7 +4322,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4333,7 +4333,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4344,7 +4344,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4355,7 +4355,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "rand",
  "rayon",
@@ -4369,7 +4369,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4386,7 +4386,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4410,7 +4410,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "anyhow",
  "rand",
@@ -4422,7 +4422,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4441,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4467,7 +4467,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4480,7 +4480,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4492,7 +4492,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4503,7 +4503,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "rayon",
@@ -4518,7 +4518,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4531,7 +4531,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4540,7 +4540,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "anyhow",
  "colored",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "async-trait",
  "reqwest 0.11.27",
@@ -4588,7 +4588,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4615,7 +4615,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-metrics"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
@@ -4624,7 +4624,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4649,7 +4649,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4678,7 +4678,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4701,7 +4701,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "indexmap 2.2.6",
  "paste",
@@ -4715,7 +4715,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "bincode",
  "once_cell",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4749,7 +4749,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "0.16.19"
-source = "git+https://github.com/AleoHQ/snarkVM?rev=3ebe60c#3ebe60c499285a140ec2171fe8dd06662c325531"
+source = "git+https://github.com/AleoNet/snarkVM.git?rev=140ff26#140ff26f87697c2e9d18212cce2cc831fc4b146a"
 dependencies = [
  "proc-macro2",
  "quote 1.0.36",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,13 @@ members = [
 ]
 
 [workspace.dependencies.snarkos-cli]
-git = "https://github.com/AleoHQ/snarkos"
-rev = "6ac2fe5"
+git = "https://github.com/AleoNet/snarkOS.git"
+rev = "01ea476"
 
 [workspace.dependencies.snarkvm]
 #version = "0.16.19"
-git = "https://github.com/AleoHQ/snarkVM"
-rev = "3ebe60c"
+git = "https://github.com/AleoNet/snarkVM.git"
+rev = "140ff26"
 
 [lib]
 path = "leo/lib.rs"

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -22,8 +22,6 @@ use std::path::PathBuf;
 /// Deploys an Aleo program.
 #[derive(Parser, Debug)]
 pub struct Deploy {
-    #[clap(long, help = "Endpoint to retrieve network state from.", default_value = "http://api.explorer.aleo.org/v1")]
-    pub endpoint: String,
     #[clap(flatten)]
     pub(crate) fee_options: FeeOptions,
     #[clap(long, help = "Disables building of the project before deployment.", default_value = "false")]
@@ -36,6 +34,8 @@ pub struct Deploy {
         default_value = "12"
     )]
     pub(crate) wait: u64,
+    #[clap(flatten)]
+    pub(crate) compiler_options: BuildOptions,
 }
 
 impl Command for Deploy {
@@ -48,7 +48,7 @@ impl Command for Deploy {
 
     fn prelude(&self, context: Context) -> Result<Self::Input> {
         if !self.no_build {
-            (Build { options: BuildOptions::default() }).execute(context)?;
+            (Build { options: self.compiler_options.clone() }).execute(context)?;
         }
         Ok(())
     }
@@ -85,13 +85,14 @@ impl Command for Deploy {
                 "--private-key".to_string(),
                 private_key.as_ref().unwrap().clone(),
                 "--query".to_string(),
-                self.endpoint.clone(),
+                self.compiler_options.endpoint.clone(),
                 "--priority-fee".to_string(),
                 self.fee_options.priority_fee.to_string(),
                 "--path".to_string(),
                 path.to_str().unwrap().parse().unwrap(),
                 "--broadcast".to_string(),
-                format!("{}/{}/transaction/broadcast", self.endpoint, self.fee_options.network).to_string(),
+                format!("{}/{}/transaction/broadcast", self.compiler_options.endpoint, self.fee_options.network)
+                    .to_string(),
                 name.clone(),
             ];
 


### PR DESCRIPTION
The `build` prelude of `leo deploy used `BuildOptions::default()` which set `conditional_block_max_depth` to `0` causing builds to panic that contained conditionals in async function scope. 