### PR TITLE
Introducing Leo Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     <a href="https://discord.gg/aleo"><img src="https://img.shields.io/discord/700454073459015690?logo=discord"/></a>
     <a href="https://github.com/ProvableHQ/leo/blob/mainnet/CONTRIBUTORS.md"><img src="https://img.shields.io/badge/contributors-393-ee8449"/></a>
      <a href="https://twitter.com/AleoHQ"><img src="https://img.shields.io/twitter/follow/AleoHQ?style=social"/></a>
+     <a href="https://gurubase.io/g/leo"><img src="https://img.shields.io/badge/Gurubase-Ask%20Leo%20Guru-006BFF"/></a>
 </p>
 <div id="top"></div>
 Leo is a functional, statically-typed programming language built for writing private applications.


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Leo Guru](https://gurubase.io/g/leo) to Gurubase. Leo Guru uses the data from this repo and data from the [docs](https://docs.leo-lang.org/leo) to answer questions by leveraging the LLM.

In this PR, I showcased the "Leo Guru", which highlights that Leo now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Leo Guru in Gurubase, just let me know that's totally fine.
