### PR TITLE
Remove superfluous lifetime parameters.

### DIFF
--- a/compiler/ast/src/passes/visitor.rs
+++ b/compiler/ast/src/passes/visitor.rs
@@ -43,11 +43,11 @@ use crate::*;
 // }
 
 /// A Visitor trait for expressions in the AST.
-pub trait ExpressionVisitor<'a> {
+pub trait ExpressionVisitor {
     type AdditionalInput: Default;
     type Output: Default;
 
-    fn visit_expression(&mut self, input: &'a Expression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_expression(&mut self, input: &Expression, additional: &Self::AdditionalInput) -> Self::Output {
         match input {
             Expression::Access(access) => self.visit_access(access, additional),
             Expression::Array(array) => self.visit_array(array, additional),
@@ -66,7 +66,7 @@ pub trait ExpressionVisitor<'a> {
         }
     }
 
-    fn visit_access(&mut self, input: &'a AccessExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_access(&mut self, input: &AccessExpression, additional: &Self::AdditionalInput) -> Self::Output {
         match input {
             AccessExpression::Array(array) => {
                 self.visit_expression(&array.array, additional);
@@ -89,32 +89,32 @@ pub trait ExpressionVisitor<'a> {
         Default::default()
     }
 
-    fn visit_array(&mut self, input: &'a ArrayExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_array(&mut self, input: &ArrayExpression, additional: &Self::AdditionalInput) -> Self::Output {
         input.elements.iter().for_each(|expr| {
             self.visit_expression(expr, additional);
         });
         Default::default()
     }
 
-    fn visit_binary(&mut self, input: &'a BinaryExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_binary(&mut self, input: &BinaryExpression, additional: &Self::AdditionalInput) -> Self::Output {
         self.visit_expression(&input.left, additional);
         self.visit_expression(&input.right, additional);
         Default::default()
     }
 
-    fn visit_call(&mut self, input: &'a CallExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_call(&mut self, input: &CallExpression, additional: &Self::AdditionalInput) -> Self::Output {
         input.arguments.iter().for_each(|expr| {
             self.visit_expression(expr, additional);
         });
         Default::default()
     }
 
-    fn visit_cast(&mut self, input: &'a CastExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_cast(&mut self, input: &CastExpression, additional: &Self::AdditionalInput) -> Self::Output {
         self.visit_expression(&input.expression, additional);
         Default::default()
     }
 
-    fn visit_struct_init(&mut self, input: &'a StructExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_struct_init(&mut self, input: &StructExpression, additional: &Self::AdditionalInput) -> Self::Output {
         for StructVariableInitializer { expression, .. } in input.members.iter() {
             if let Some(expression) = expression {
                 self.visit_expression(expression, additional);
@@ -123,49 +123,49 @@ pub trait ExpressionVisitor<'a> {
         Default::default()
     }
 
-    fn visit_err(&mut self, _input: &'a ErrExpression, _additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_err(&mut self, _input: &ErrExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         unreachable!("`ErrExpression`s should not be in the AST at this phase of compilation.")
     }
 
-    fn visit_identifier(&mut self, _input: &'a Identifier, _additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_identifier(&mut self, _input: &Identifier, _additional: &Self::AdditionalInput) -> Self::Output {
         Default::default()
     }
 
-    fn visit_literal(&mut self, _input: &'a Literal, _additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_literal(&mut self, _input: &Literal, _additional: &Self::AdditionalInput) -> Self::Output {
         Default::default()
     }
 
-    fn visit_locator(&mut self, _input: &'a LocatorExpression, _additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_locator(&mut self, _input: &LocatorExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         Default::default()
     }
 
-    fn visit_ternary(&mut self, input: &'a TernaryExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_ternary(&mut self, input: &TernaryExpression, additional: &Self::AdditionalInput) -> Self::Output {
         self.visit_expression(&input.condition, additional);
         self.visit_expression(&input.if_true, additional);
         self.visit_expression(&input.if_false, additional);
         Default::default()
     }
 
-    fn visit_tuple(&mut self, input: &'a TupleExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_tuple(&mut self, input: &TupleExpression, additional: &Self::AdditionalInput) -> Self::Output {
         input.elements.iter().for_each(|expr| {
             self.visit_expression(expr, additional);
         });
         Default::default()
     }
 
-    fn visit_unary(&mut self, input: &'a UnaryExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_unary(&mut self, input: &UnaryExpression, additional: &Self::AdditionalInput) -> Self::Output {
         self.visit_expression(&input.receiver, additional);
         Default::default()
     }
 
-    fn visit_unit(&mut self, _input: &'a UnitExpression, _additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_unit(&mut self, _input: &UnitExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         Default::default()
     }
 }
 
 /// A Visitor trait for statements in the AST.
-pub trait StatementVisitor<'a>: ExpressionVisitor<'a> {
-    fn visit_statement(&mut self, input: &'a Statement) {
+pub trait StatementVisitor: ExpressionVisitor {
+    fn visit_statement(&mut self, input: &Statement) {
         match input {
             Statement::Assert(stmt) => self.visit_assert(stmt),
             Statement::Assign(stmt) => self.visit_assign(stmt),
@@ -180,7 +180,7 @@ pub trait StatementVisitor<'a>: ExpressionVisitor<'a> {
         }
     }
 
-    fn visit_assert(&mut self, input: &'a AssertStatement) {
+    fn visit_assert(&mut self, input: &AssertStatement) {
         match &input.variant {
             AssertVariant::Assert(expr) => self.visit_expression(expr, &Default::default()),
             AssertVariant::AssertEq(left, right) | AssertVariant::AssertNeq(left, right) => {
@@ -190,15 +190,15 @@ pub trait StatementVisitor<'a>: ExpressionVisitor<'a> {
         };
     }
 
-    fn visit_assign(&mut self, input: &'a AssignStatement) {
+    fn visit_assign(&mut self, input: &AssignStatement) {
         self.visit_expression(&input.value, &Default::default());
     }
 
-    fn visit_block(&mut self, input: &'a Block) {
+    fn visit_block(&mut self, input: &Block) {
         input.statements.iter().for_each(|stmt| self.visit_statement(stmt));
     }
 
-    fn visit_conditional(&mut self, input: &'a ConditionalStatement) {
+    fn visit_conditional(&mut self, input: &ConditionalStatement) {
         self.visit_expression(&input.condition, &Default::default());
         self.visit_block(&input.then);
         if let Some(stmt) = input.otherwise.as_ref() {
@@ -206,7 +206,7 @@ pub trait StatementVisitor<'a>: ExpressionVisitor<'a> {
         }
     }
 
-    fn visit_console(&mut self, input: &'a ConsoleStatement) {
+    fn visit_console(&mut self, input: &ConsoleStatement) {
         match &input.function {
             ConsoleFunction::Assert(expr) => {
                 self.visit_expression(expr, &Default::default());
@@ -222,38 +222,38 @@ pub trait StatementVisitor<'a>: ExpressionVisitor<'a> {
         };
     }
 
-    fn visit_const(&mut self, input: &'a ConstDeclaration) {
+    fn visit_const(&mut self, input: &ConstDeclaration) {
         self.visit_expression(&input.value, &Default::default());
     }
 
-    fn visit_definition(&mut self, input: &'a DefinitionStatement) {
+    fn visit_definition(&mut self, input: &DefinitionStatement) {
         self.visit_expression(&input.value, &Default::default());
     }
 
-    fn visit_expression_statement(&mut self, input: &'a ExpressionStatement) {
+    fn visit_expression_statement(&mut self, input: &ExpressionStatement) {
         self.visit_expression(&input.expression, &Default::default());
     }
 
-    fn visit_iteration(&mut self, input: &'a IterationStatement) {
+    fn visit_iteration(&mut self, input: &IterationStatement) {
         self.visit_expression(&input.start, &Default::default());
         self.visit_expression(&input.stop, &Default::default());
         self.visit_block(&input.block);
     }
 
-    fn visit_return(&mut self, input: &'a ReturnStatement) {
+    fn visit_return(&mut self, input: &ReturnStatement) {
         self.visit_expression(&input.expression, &Default::default());
     }
 }
 
 /// A Visitor trait for the program represented by the AST.
-pub trait ProgramVisitor<'a>: StatementVisitor<'a> {
-    fn visit_program(&mut self, input: &'a Program) {
+pub trait ProgramVisitor: StatementVisitor {
+    fn visit_program(&mut self, input: &Program) {
         input.imports.values().for_each(|import| self.visit_import(&import.0));
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
     }
 
-    fn visit_program_scope(&mut self, input: &'a ProgramScope) {
+    fn visit_program_scope(&mut self, input: &ProgramScope) {
         input.structs.iter().for_each(|(_, c)| (self.visit_struct(c)));
 
         input.mappings.iter().for_each(|(_, c)| (self.visit_mapping(c)));
@@ -263,21 +263,21 @@ pub trait ProgramVisitor<'a>: StatementVisitor<'a> {
         input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
     }
 
-    fn visit_stub(&mut self, _input: &'a Stub) {}
+    fn visit_stub(&mut self, _input: &Stub) {}
 
-    fn visit_import(&mut self, input: &'a Program) {
+    fn visit_import(&mut self, input: &Program) {
         self.visit_program(input)
     }
 
-    fn visit_struct(&mut self, _input: &'a Composite) {}
+    fn visit_struct(&mut self, _input: &Composite) {}
 
-    fn visit_mapping(&mut self, _input: &'a Mapping) {}
+    fn visit_mapping(&mut self, _input: &Mapping) {}
 
-    fn visit_function(&mut self, input: &'a Function) {
+    fn visit_function(&mut self, input: &Function) {
         self.visit_block(&input.block);
     }
 
-    fn visit_function_stub(&mut self, _input: &'a FunctionStub) {}
+    fn visit_function_stub(&mut self, _input: &FunctionStub) {}
 
-    fn visit_struct_stub(&mut self, _input: &'a Composite) {}
+    fn visit_struct_stub(&mut self, _input: &Composite) {}
 }

--- a/compiler/compiler/tests/integration/utilities/check_unique_node_ids.rs
+++ b/compiler/compiler/tests/integration/utilities/check_unique_node_ids.rs
@@ -16,19 +16,18 @@
 
 use leo_ast::*;
 
-use std::{collections::HashSet, marker::PhantomData};
+use std::collections::HashSet;
 
 /// A utility that checks that each node in the AST has a unique `NodeID`.
-pub struct CheckUniqueNodeIds<'a> {
+pub struct CheckUniqueNodeIds {
     /// The set of `NodeID`s that have been seen.
     seen: HashSet<NodeID>,
-    _phantom: PhantomData<&'a ()>,
 }
 
-impl<'a> CheckUniqueNodeIds<'a> {
+impl CheckUniqueNodeIds {
     /// Creates a new `CheckUniqueNodeId`.
     pub fn new() -> Self {
-        Self { seen: HashSet::new(), _phantom: PhantomData }
+        Self { seen: HashSet::new() }
     }
 
     /// Checks that the given `NodeID` has not been seen before.
@@ -39,7 +38,7 @@ impl<'a> CheckUniqueNodeIds<'a> {
     }
 
     /// Checks that the given `Type` has a unique `NodeID`.
-    pub fn check_ty(&mut self, ty: &'a Type) {
+    pub fn check_ty(&mut self, ty: &Type) {
         match ty {
             Type::Identifier(identifier) => self.visit_identifier(identifier, &Default::default()),
             Type::Mapping(mapping) => {
@@ -56,11 +55,11 @@ impl<'a> CheckUniqueNodeIds<'a> {
     }
 }
 
-impl<'a> ExpressionVisitor<'a> for CheckUniqueNodeIds<'a> {
+impl ExpressionVisitor for CheckUniqueNodeIds {
     type AdditionalInput = ();
     type Output = ();
 
-    fn visit_access(&mut self, input: &'a AccessExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_access(&mut self, input: &AccessExpression, _: &Self::AdditionalInput) -> Self::Output {
         match input {
             AccessExpression::Array(ArrayAccess { array, index, id, .. }) => {
                 self.visit_expression(array, &Default::default());
@@ -93,14 +92,14 @@ impl<'a> ExpressionVisitor<'a> for CheckUniqueNodeIds<'a> {
         }
     }
 
-    fn visit_binary(&mut self, input: &'a BinaryExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_binary(&mut self, input: &BinaryExpression, _: &Self::AdditionalInput) -> Self::Output {
         let BinaryExpression { left, right, id, .. } = input;
         self.visit_expression(left, &Default::default());
         self.visit_expression(right, &Default::default());
         self.check(*id);
     }
 
-    fn visit_call(&mut self, input: &'a CallExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_call(&mut self, input: &CallExpression, _: &Self::AdditionalInput) -> Self::Output {
         let CallExpression { function, arguments, program: _external, id, .. } = input;
         self.visit_expression(function, &Default::default());
         for argument in arguments {
@@ -109,14 +108,14 @@ impl<'a> ExpressionVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(*id);
     }
 
-    fn visit_cast(&mut self, input: &'a CastExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_cast(&mut self, input: &CastExpression, _: &Self::AdditionalInput) -> Self::Output {
         let CastExpression { expression, type_, id, .. } = input;
         self.visit_expression(expression, &Default::default());
         self.check_ty(type_);
         self.check(*id);
     }
 
-    fn visit_struct_init(&mut self, input: &'a StructExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_struct_init(&mut self, input: &StructExpression, _: &Self::AdditionalInput) -> Self::Output {
         let StructExpression { name, members, id, .. } = input;
         self.visit_identifier(name, &Default::default());
         for StructVariableInitializer { identifier, expression, id, .. } in members {
@@ -129,19 +128,19 @@ impl<'a> ExpressionVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(*id);
     }
 
-    fn visit_err(&mut self, input: &'a ErrExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_err(&mut self, input: &ErrExpression, _: &Self::AdditionalInput) -> Self::Output {
         self.check(input.id);
     }
 
-    fn visit_identifier(&mut self, input: &'a Identifier, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_identifier(&mut self, input: &Identifier, _: &Self::AdditionalInput) -> Self::Output {
         self.check(input.id)
     }
 
-    fn visit_literal(&mut self, input: &'a Literal, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_literal(&mut self, input: &Literal, _: &Self::AdditionalInput) -> Self::Output {
         self.check(input.id())
     }
 
-    fn visit_ternary(&mut self, input: &'a TernaryExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_ternary(&mut self, input: &TernaryExpression, _: &Self::AdditionalInput) -> Self::Output {
         let TernaryExpression { condition, if_true, if_false, id, .. } = input;
         self.visit_expression(condition, &Default::default());
         self.visit_expression(if_true, &Default::default());
@@ -149,7 +148,7 @@ impl<'a> ExpressionVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(*id);
     }
 
-    fn visit_tuple(&mut self, input: &'a TupleExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_tuple(&mut self, input: &TupleExpression, _: &Self::AdditionalInput) -> Self::Output {
         let TupleExpression { elements, id, .. } = input;
         for element in elements {
             self.visit_expression(element, &Default::default());
@@ -157,19 +156,19 @@ impl<'a> ExpressionVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(*id);
     }
 
-    fn visit_unary(&mut self, input: &'a UnaryExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_unary(&mut self, input: &UnaryExpression, _: &Self::AdditionalInput) -> Self::Output {
         let UnaryExpression { receiver, id, .. } = input;
         self.visit_expression(receiver, &Default::default());
         self.check(*id);
     }
 
-    fn visit_unit(&mut self, input: &'a UnitExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_unit(&mut self, input: &UnitExpression, _: &Self::AdditionalInput) -> Self::Output {
         self.check(input.id)
     }
 }
 
-impl<'a> StatementVisitor<'a> for CheckUniqueNodeIds<'a> {
-    fn visit_assert(&mut self, input: &'a AssertStatement) {
+impl StatementVisitor for CheckUniqueNodeIds {
+    fn visit_assert(&mut self, input: &AssertStatement) {
         match &input.variant {
             AssertVariant::Assert(expr) => self.visit_expression(expr, &Default::default()),
             AssertVariant::AssertEq(left, right) | AssertVariant::AssertNeq(left, right) => {
@@ -180,18 +179,18 @@ impl<'a> StatementVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(input.id)
     }
 
-    fn visit_assign(&mut self, input: &'a AssignStatement) {
+    fn visit_assign(&mut self, input: &AssignStatement) {
         self.visit_expression(&input.place, &Default::default());
         self.visit_expression(&input.value, &Default::default());
         self.check(input.id)
     }
 
-    fn visit_block(&mut self, input: &'a Block) {
+    fn visit_block(&mut self, input: &Block) {
         input.statements.iter().for_each(|stmt| self.visit_statement(stmt));
         self.check(input.id)
     }
 
-    fn visit_conditional(&mut self, input: &'a ConditionalStatement) {
+    fn visit_conditional(&mut self, input: &ConditionalStatement) {
         self.visit_expression(&input.condition, &Default::default());
         self.visit_block(&input.then);
         if let Some(stmt) = input.otherwise.as_ref() {
@@ -200,7 +199,7 @@ impl<'a> StatementVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(input.id)
     }
 
-    fn visit_console(&mut self, input: &'a ConsoleStatement) {
+    fn visit_console(&mut self, input: &ConsoleStatement) {
         match &input.function {
             ConsoleFunction::Assert(expr) => {
                 self.visit_expression(expr, &Default::default());
@@ -217,19 +216,19 @@ impl<'a> StatementVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(input.id)
     }
 
-    fn visit_definition(&mut self, input: &'a DefinitionStatement) {
+    fn visit_definition(&mut self, input: &DefinitionStatement) {
         self.visit_expression(&input.place, &Default::default());
         self.check_ty(&input.type_);
         self.visit_expression(&input.value, &Default::default());
         self.check(input.id)
     }
 
-    fn visit_expression_statement(&mut self, input: &'a ExpressionStatement) {
+    fn visit_expression_statement(&mut self, input: &ExpressionStatement) {
         self.visit_expression(&input.expression, &Default::default());
         self.check(input.id)
     }
 
-    fn visit_iteration(&mut self, input: &'a IterationStatement) {
+    fn visit_iteration(&mut self, input: &IterationStatement) {
         self.visit_identifier(&input.variable, &Default::default());
         self.check_ty(&input.type_);
         self.visit_expression(&input.start, &Default::default());
@@ -238,14 +237,14 @@ impl<'a> StatementVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(input.id)
     }
 
-    fn visit_return(&mut self, input: &'a ReturnStatement) {
+    fn visit_return(&mut self, input: &ReturnStatement) {
         self.visit_expression(&input.expression, &Default::default());
         self.check(input.id)
     }
 }
 
-impl<'a> ProgramVisitor<'a> for CheckUniqueNodeIds<'a> {
-    fn visit_struct(&mut self, input: &'a Composite) {
+impl ProgramVisitor for CheckUniqueNodeIds {
+    fn visit_struct(&mut self, input: &Composite) {
         let Composite { identifier, members, id, .. } = input;
         self.visit_identifier(identifier, &Default::default());
         for Member { identifier, type_, id, .. } in members {
@@ -256,7 +255,7 @@ impl<'a> ProgramVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(*id);
     }
 
-    fn visit_mapping(&mut self, input: &'a Mapping) {
+    fn visit_mapping(&mut self, input: &Mapping) {
         let Mapping { identifier, key_type, value_type, id, .. } = input;
         self.visit_identifier(identifier, &Default::default());
         self.check_ty(key_type);
@@ -264,7 +263,7 @@ impl<'a> ProgramVisitor<'a> for CheckUniqueNodeIds<'a> {
         self.check(*id);
     }
 
-    fn visit_function(&mut self, input: &'a Function) {
+    fn visit_function(&mut self, input: &Function) {
         let Function { annotations, identifier, input, output, block, id, .. } = input;
         // Check the annotations.
         for Annotation { identifier, id, .. } in annotations {

--- a/compiler/passes/src/static_analysis/analyze_expression.rs
+++ b/compiler/passes/src/static_analysis/analyze_expression.rs
@@ -20,11 +20,11 @@ use leo_ast::*;
 
 use snarkvm::console::network::Network;
 
-impl<'a, N: Network> ExpressionVisitor<'a> for StaticAnalyzer<'a, N> {
+impl<N: Network> ExpressionVisitor for StaticAnalyzer<'_, N> {
     type AdditionalInput = ();
     type Output = ();
 
-    fn visit_access(&mut self, input: &'a AccessExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_access(&mut self, input: &AccessExpression, _: &Self::AdditionalInput) -> Self::Output {
         if let AccessExpression::AssociatedFunction(access) = input {
             // Get the core function.
             let core_function = match CoreFunction::from_symbols(access.variant.name, access.name.name) {
@@ -39,7 +39,7 @@ impl<'a, N: Network> ExpressionVisitor<'a> for StaticAnalyzer<'a, N> {
         }
     }
 
-    fn visit_call(&mut self, input: &'a CallExpression, _: &Self::AdditionalInput) -> Self::Output {
+    fn visit_call(&mut self, input: &CallExpression, _: &Self::AdditionalInput) -> Self::Output {
         let Expression::Identifier(ident) = &*input.function else {
             unreachable!("Parsing guarantees that a function name is always an identifier.");
         };

--- a/compiler/passes/src/static_analysis/analyze_program.rs
+++ b/compiler/passes/src/static_analysis/analyze_program.rs
@@ -21,8 +21,8 @@ use leo_errors::{StaticAnalyzerError, StaticAnalyzerWarning};
 
 use snarkvm::console::network::Network;
 
-impl<'a, N: Network> ProgramVisitor<'a> for StaticAnalyzer<'a, N> {
-    fn visit_program_scope(&mut self, input: &'a ProgramScope) {
+impl<N: Network> ProgramVisitor for StaticAnalyzer<'_, N> {
+    fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set the current program name.
         self.current_program = Some(input.program_id.name.name);
         // Do the default implementation for visiting the program scope.
@@ -32,7 +32,7 @@ impl<'a, N: Network> ProgramVisitor<'a> for StaticAnalyzer<'a, N> {
         input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
     }
 
-    fn visit_function(&mut self, function: &'a Function) {
+    fn visit_function(&mut self, function: &Function) {
         // Set the function name and variant.
         self.variant = Some(function.variant);
 

--- a/compiler/passes/src/static_analysis/analyze_statement.rs
+++ b/compiler/passes/src/static_analysis/analyze_statement.rs
@@ -19,8 +19,8 @@ use crate::ConditionalTreeNode;
 
 use leo_ast::*;
 
-impl<'a, N: Network> StatementVisitor<'a> for StaticAnalyzer<'a, N> {
-    fn visit_conditional(&mut self, input: &'a ConditionalStatement) {
+impl<N: Network> StatementVisitor for StaticAnalyzer<'_, N> {
+    fn visit_conditional(&mut self, input: &ConditionalStatement) {
         self.visit_expression(&input.condition, &Default::default());
 
         // Create scope for checking awaits in `then` branch of conditional.

--- a/compiler/passes/src/static_analysis/future_checker.rs
+++ b/compiler/passes/src/static_analysis/future_checker.rs
@@ -50,11 +50,11 @@ impl<'a> FutureChecker<'a> {
     }
 }
 
-impl<'a> ExpressionVisitor<'a> for FutureChecker<'a> {
+impl ExpressionVisitor for FutureChecker<'_> {
     type AdditionalInput = Position;
     type Output = ();
 
-    fn visit_expression(&mut self, input: &'a Expression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_expression(&mut self, input: &Expression, additional: &Self::AdditionalInput) -> Self::Output {
         use Position::*;
         let is_call = matches!(input, Expression::Call(..));
         match self.type_table.get(&input.id()) {
@@ -104,11 +104,7 @@ impl<'a> ExpressionVisitor<'a> for FutureChecker<'a> {
         }
     }
 
-    fn visit_access(
-        &mut self,
-        input: &'a leo_ast::AccessExpression,
-        _additional: &Self::AdditionalInput,
-    ) -> Self::Output {
+    fn visit_access(&mut self, input: &leo_ast::AccessExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         match input {
             leo_ast::AccessExpression::Array(array) => {
                 self.visit_expression(&array.array, &Position::Misc);
@@ -135,14 +131,14 @@ impl<'a> ExpressionVisitor<'a> for FutureChecker<'a> {
         Default::default()
     }
 
-    fn visit_call(&mut self, input: &'a leo_ast::CallExpression, _additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_call(&mut self, input: &leo_ast::CallExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         input.arguments.iter().for_each(|expr| {
             self.visit_expression(expr, &Position::FunctionArgument);
         });
         Default::default()
     }
 
-    fn visit_tuple(&mut self, input: &'a leo_ast::TupleExpression, additional: &Self::AdditionalInput) -> Self::Output {
+    fn visit_tuple(&mut self, input: &leo_ast::TupleExpression, additional: &Self::AdditionalInput) -> Self::Output {
         let next_position = match additional {
             Position::Definition | Position::Return => Position::LastTupleLiteral,
             _ => Position::Misc,
@@ -156,12 +152,12 @@ impl<'a> ExpressionVisitor<'a> for FutureChecker<'a> {
     }
 }
 
-impl<'a> StatementVisitor<'a> for FutureChecker<'a> {
-    fn visit_definition(&mut self, input: &'a leo_ast::DefinitionStatement) {
+impl StatementVisitor for FutureChecker<'_> {
+    fn visit_definition(&mut self, input: &leo_ast::DefinitionStatement) {
         self.visit_expression(&input.value, &Position::Definition);
     }
 
-    fn visit_return(&mut self, input: &'a leo_ast::ReturnStatement) {
+    fn visit_return(&mut self, input: &leo_ast::ReturnStatement) {
         self.visit_expression(&input.expression, &Position::Return);
     }
 }

--- a/compiler/passes/src/symbol_table_creation/mod.rs
+++ b/compiler/passes/src/symbol_table_creation/mod.rs
@@ -63,15 +63,15 @@ impl<'a> SymbolTableCreator<'a> {
     }
 }
 
-impl<'a> ExpressionVisitor<'a> for SymbolTableCreator<'a> {
+impl ExpressionVisitor for SymbolTableCreator<'_> {
     type AdditionalInput = ();
     type Output = ();
 }
 
-impl<'a> StatementVisitor<'a> for SymbolTableCreator<'a> {}
+impl StatementVisitor for SymbolTableCreator<'_> {}
 
-impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
-    fn visit_program_scope(&mut self, input: &'a ProgramScope) {
+impl ProgramVisitor for SymbolTableCreator<'_> {
+    fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set current program name
         self.program_name = input.program_id.name.name;
         self.is_stub = false;
@@ -83,11 +83,11 @@ impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
         input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
     }
 
-    fn visit_import(&mut self, input: &'a Program) {
+    fn visit_import(&mut self, input: &Program) {
         self.visit_program(input)
     }
 
-    fn visit_struct(&mut self, input: &'a Composite) {
+    fn visit_struct(&mut self, input: &Composite) {
         // Allow up to one local redefinition for each external struct.
         if !input.is_record && !self.structs.insert(input.name()) {
             return self.handler.emit_err::<LeoError>(AstError::shadowed_struct(input.name(), input.span).into());
@@ -103,7 +103,7 @@ impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
         }
     }
 
-    fn visit_mapping(&mut self, input: &'a Mapping) {
+    fn visit_mapping(&mut self, input: &Mapping) {
         // Add the variable associated with the mapping to the symbol table.
         if let Err(err) =
             self.symbol_table.insert_global(Location::new(self.program_name, input.identifier.name), VariableSymbol {
@@ -120,7 +120,7 @@ impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
         }
     }
 
-    fn visit_function(&mut self, input: &'a Function) {
+    fn visit_function(&mut self, input: &Function) {
         if let Err(err) =
             self.symbol_table.insert_function(Location::new(self.program_name, input.name()), input.clone())
         {
@@ -128,7 +128,7 @@ impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
         }
     }
 
-    fn visit_stub(&mut self, input: &'a Stub) {
+    fn visit_stub(&mut self, input: &Stub) {
         self.is_stub = true;
         self.program_name = input.stub_id.name.name;
         input.functions.iter().for_each(|(_, c)| (self.visit_function_stub(c)));
@@ -136,7 +136,7 @@ impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
         input.mappings.iter().for_each(|(_, c)| (self.visit_mapping(c)));
     }
 
-    fn visit_function_stub(&mut self, input: &'a FunctionStub) {
+    fn visit_function_stub(&mut self, input: &FunctionStub) {
         // Construct the location for the function.
         let location = Location::new(self.program_name, input.name());
         // Initialize the function symbol.
@@ -162,7 +162,7 @@ impl<'a> ProgramVisitor<'a> for SymbolTableCreator<'a> {
         }
     }
 
-    fn visit_struct_stub(&mut self, input: &'a Composite) {
+    fn visit_struct_stub(&mut self, input: &Composite) {
         if let Some(program) = input.external {
             assert_eq!(program, self.program_name);
         }

--- a/compiler/passes/src/type_checking/check_program.rs
+++ b/compiler/passes/src/type_checking/check_program.rs
@@ -24,8 +24,8 @@ use std::collections::HashSet;
 
 // TODO: Cleanup logic for tuples.
 
-impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
-    fn visit_program(&mut self, input: &'a Program) {
+impl ProgramVisitor for TypeChecker<'_> {
+    fn visit_program(&mut self, input: &Program) {
         // Typecheck the program's stubs.
         input.stubs.iter().for_each(|(symbol, stub)| {
             // Check that naming and ordering is consistent.
@@ -44,7 +44,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
     }
 
-    fn visit_program_scope(&mut self, input: &'a ProgramScope) {
+    fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set the current program name.
         self.scope_state.program_name = Some(input.program_id.name.name);
 
@@ -103,7 +103,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_stub(&mut self, input: &'a Stub) {
+    fn visit_stub(&mut self, input: &Stub) {
         // Set the current program name.
         self.scope_state.program_name = Some(input.stub_id.name.name);
 
@@ -119,7 +119,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         input.functions.iter().for_each(|(_, function)| self.visit_function_stub(function));
     }
 
-    fn visit_struct(&mut self, input: &'a Composite) {
+    fn visit_struct(&mut self, input: &Composite) {
         // Check for conflicting struct/record member names.
         let mut used = HashSet::new();
         // TODO: Better span to target duplicate member.
@@ -195,7 +195,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_mapping(&mut self, input: &'a Mapping) {
+    fn visit_mapping(&mut self, input: &Mapping) {
         // Check that a mapping's key type is valid.
         self.assert_type_is_valid(&input.key_type, input.span);
         // Check that a mapping's key type is not a future, tuple, record, or mapping.
@@ -241,7 +241,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_function(&mut self, function: &'a Function) {
+    fn visit_function(&mut self, function: &Function) {
         // Check that the function's annotations are valid.
         // Note that Leo does not natively support any specific annotations.
         for annotation in function.annotations.iter() {
@@ -284,7 +284,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_function_stub(&mut self, input: &'a FunctionStub) {
+    fn visit_function_stub(&mut self, input: &FunctionStub) {
         // Must not be an inline function
         if input.variant == Variant::Inline {
             self.emit_err(TypeCheckerError::stub_functions_must_not_be_inlines(input.span));
@@ -319,7 +319,7 @@ impl<'a> ProgramVisitor<'a> for TypeChecker<'a> {
         self.check_function_signature(&Function::from(input.clone()), /* is_stub */ true);
     }
 
-    fn visit_struct_stub(&mut self, input: &'a Composite) {
+    fn visit_struct_stub(&mut self, input: &Composite) {
         self.visit_struct(input);
     }
 }

--- a/compiler/passes/src/type_checking/check_statements.rs
+++ b/compiler/passes/src/type_checking/check_statements.rs
@@ -22,8 +22,8 @@ use leo_ast::{
 };
 use leo_errors::TypeCheckerError;
 
-impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
-    fn visit_statement(&mut self, input: &'a Statement) {
+impl StatementVisitor for TypeChecker<'_> {
+    fn visit_statement(&mut self, input: &Statement) {
         // No statements can follow a return statement.
         if self.scope_state.has_return {
             self.emit_err(TypeCheckerError::unreachable_code_after_return(input.span()));
@@ -44,7 +44,7 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_assert(&mut self, input: &'a AssertStatement) {
+    fn visit_assert(&mut self, input: &AssertStatement) {
         match &input.variant {
             AssertVariant::Assert(expr) => {
                 let _type = self.visit_expression(expr, &Some(Type::Boolean));
@@ -62,7 +62,7 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_assign(&mut self, input: &'a AssignStatement) {
+    fn visit_assign(&mut self, input: &AssignStatement) {
         let Expression::Identifier(var_name) = input.place else {
             self.emit_err(TypeCheckerError::invalid_assignment_target(input.place.span()));
             return;
@@ -95,13 +95,13 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         self.visit_expression(&input.value, &Some(var.type_.clone()));
     }
 
-    fn visit_block(&mut self, input: &'a Block) {
+    fn visit_block(&mut self, input: &Block) {
         self.in_scope(input.id, |slf| {
             input.statements.iter().for_each(|stmt| slf.visit_statement(stmt));
         });
     }
 
-    fn visit_conditional(&mut self, input: &'a ConditionalStatement) {
+    fn visit_conditional(&mut self, input: &ConditionalStatement) {
         self.visit_expression(&input.condition, &Some(Type::Boolean));
 
         let mut then_block_has_return = false;
@@ -141,11 +141,11 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         self.scope_state.is_conditional = previous_is_conditional;
     }
 
-    fn visit_console(&mut self, _: &'a ConsoleStatement) {
+    fn visit_console(&mut self, _: &ConsoleStatement) {
         unreachable!("Parsing guarantees that console statements are not present in the AST.");
     }
 
-    fn visit_const(&mut self, input: &'a ConstDeclaration) {
+    fn visit_const(&mut self, input: &ConstDeclaration) {
         // Check that the type of the definition is not a unit type, singleton tuple type, or nested tuple type.
         match &input.type_ {
             // If the type is an empty tuple, return an error.
@@ -179,7 +179,7 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_definition(&mut self, input: &'a DefinitionStatement) {
+    fn visit_definition(&mut self, input: &DefinitionStatement) {
         // Check that the type of the definition is defined.
         self.assert_type_is_valid(&input.type_, input.span);
 
@@ -247,7 +247,7 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_expression_statement(&mut self, input: &'a ExpressionStatement) {
+    fn visit_expression_statement(&mut self, input: &ExpressionStatement) {
         // Expression statements can only be function calls.
         if !matches!(
             input.expression,
@@ -260,7 +260,7 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         }
     }
 
-    fn visit_iteration(&mut self, input: &'a IterationStatement) {
+    fn visit_iteration(&mut self, input: &IterationStatement) {
         self.assert_int_type(&input.type_, input.variable.span);
 
         self.in_scope(input.id(), |slf| {
@@ -295,7 +295,7 @@ impl<'a> StatementVisitor<'a> for TypeChecker<'a> {
         self.visit_expression(&input.stop, &Some(input.type_.clone()));
     }
 
-    fn visit_return(&mut self, input: &'a ReturnStatement) {
+    fn visit_return(&mut self, input: &ReturnStatement) {
         let func_name = self.scope_state.function.unwrap();
         let func_symbol = self
             .symbol_table


### PR DESCRIPTION
The visitor traits and `CheckUniqueNodeIds` seem to have no need for these lifetimes.