### PR TITLE
Remove extraneous '$' prompt from cargo install command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ git clone --recurse-submodules https://github.com/ProvableHQ/leo
 cd leo
 
 # Install 'leo'
-$ cargo install --path .
+cargo install --path .
 ```
 
 Now to use leo, in your terminal, run:


### PR DESCRIPTION
This PR updates the installation instructions by removing the unnecessary '$' shell prompt symbol from the cargo install command. This change improves clarity and makes it easier for users to copy-paste the command directly.