### PR TITLE
Specify exact snarkvm version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ default-features = false
 version = "1.11.1"
 
 [workspace.dependencies.snarkvm]
-version = "1.3.0"
+version = "=1.3.0"
 
 [workspace.dependencies.serde]
 version = "1.0.214"


### PR DESCRIPTION
snarkvm doesn't follow semantic versioning,
so if we allow higher versions we can get breakages.

Fixes #28539
