### PR TITLE
Change to codegen's visit_array.

### DIFF
--- a/tests/expectations/compiler/array/array_in_composite_data_types.out
+++ b/tests/expectations/compiler/array/array_in_composite_data_types.out
@@ -10,9 +10,9 @@ struct bar:
 
 function foo:
     input r0 as [[boolean; 8u32]; 8u32].private;
-    cast  1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r1 as [u8; 8u32];
+    cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r1 as [u8; 8u32];
     cast r1 into r2 as bar;
-    cast  1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r3 as [u8; 8u32];
+    cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r3 as [u8; 8u32];
     cast self.caller r3 into r4 as floo.record;
     output r0[0u32][0u32] as boolean.private;
     output r2 as bar.private;
@@ -30,9 +30,9 @@ struct bar:
 
 function foo:
     input r0 as [[boolean; 8u32]; 8u32].private;
-    cast  1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r1 as [u8; 8u32];
+    cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r1 as [u8; 8u32];
     cast r1 into r2 as bar;
-    cast  1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r3 as [u8; 8u32];
+    cast 1u8 1u8 1u8 1u8 1u8 1u8 1u8 1u8 into r3 as [u8; 8u32];
     cast self.caller r3 into r4 as floo.record;
     output r0[0u32][0u32] as boolean.private;
     output r2 as bar.private;

--- a/tests/expectations/compiler/array/array_initialization.out
+++ b/tests/expectations/compiler/array/array_initialization.out
@@ -3,7 +3,7 @@ program test.aleo;
 
 function bar:
     input r0 as boolean.private;
-    cast  r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [boolean; 8u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [boolean; 8u32];
     output r1 as [boolean; 8u32].private;
 
 DCE_DISABLED:
@@ -11,5 +11,5 @@ program test.aleo;
 
 function bar:
     input r0 as boolean.private;
-    cast  r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [boolean; 8u32];
+    cast r0 r0 r0 r0 r0 r0 r0 r0 into r1 as [boolean; 8u32];
     output r1 as [boolean; 8u32].private;

--- a/tests/expectations/compiler/const_prop/prop_literals.out
+++ b/tests/expectations/compiler/const_prop/prop_literals.out
@@ -8,7 +8,7 @@ function f2:
     output 0field as field.private;
 
 function f3:
-    cast  aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r0 as [address; 2u32];
+    cast aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r0 as [address; 2u32];
     output r0 as [address; 2u32].private;
 
 DCE_DISABLED:
@@ -21,5 +21,5 @@ function f2:
     output 0field as field.private;
 
 function f3:
-    cast  aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r0 as [address; 2u32];
+    cast aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r0 as [address; 2u32];
     output r0 as [address; 2u32].private;

--- a/tests/expectations/compiler/function/flatten_arrays.out
+++ b/tests/expectations/compiler/function/flatten_arrays.out
@@ -7,26 +7,26 @@ struct Data:
 closure foo:
     input r0 as u8;
     input r1 as u8;
-    cast  r0 r1 into r2 as [u8; 2u32];
+    cast r0 r1 into r2 as [u8; 2u32];
     cast r2 into r3 as Data;
-    cast  r1 r0 into r4 as [u8; 2u32];
+    cast r1 r0 into r4 as [u8; 2u32];
     cast r4 into r5 as Data;
     is.eq r0 r1 into r6;
-    cast  r3 r5 into r7 as [Data; 2u32];
+    cast r3 r5 into r7 as [Data; 2u32];
     mul 2u8 r3.data[0u32] into r8;
     mul 4u8 r5.data[1u32] into r9;
-    cast  r8 r9 into r10 as [u8; 2u32];
+    cast r8 r9 into r10 as [u8; 2u32];
     cast r10 into r11 as Data;
-    cast  r5 r11 into r12 as [Data; 2u32];
+    cast r5 r11 into r12 as [Data; 2u32];
     ternary r6 r7[0u32].data[0u32] r12[0u32].data[0u32] into r13;
     ternary r6 r7[0u32].data[1u32] r12[0u32].data[1u32] into r14;
-    cast  r13 r14 into r15 as [u8; 2u32];
+    cast r13 r14 into r15 as [u8; 2u32];
     cast r15 into r16 as Data;
     ternary r6 r7[1u32].data[0u32] r12[1u32].data[0u32] into r17;
     ternary r6 r7[1u32].data[1u32] r12[1u32].data[1u32] into r18;
-    cast  r17 r18 into r19 as [u8; 2u32];
+    cast r17 r18 into r19 as [u8; 2u32];
     cast r19 into r20 as Data;
-    cast  r16 r20 into r21 as [Data; 2u32];
+    cast r16 r20 into r21 as [Data; 2u32];
     output r21 as [Data; 2u32];
 
 function bar:
@@ -40,22 +40,22 @@ function bar:
     call foo r4[0u32].data[1u32] r4[1u32].data[0u32] into r7;
     ternary r1 r6[0u32].data[0u32] r7[0u32].data[0u32] into r8;
     ternary r1 r6[0u32].data[1u32] r7[0u32].data[1u32] into r9;
-    cast  r8 r9 into r10 as [u8; 2u32];
+    cast r8 r9 into r10 as [u8; 2u32];
     cast r10 into r11 as Data;
     ternary r1 r6[1u32].data[0u32] r7[1u32].data[0u32] into r12;
     ternary r1 r6[1u32].data[1u32] r7[1u32].data[1u32] into r13;
-    cast  r12 r13 into r14 as [u8; 2u32];
+    cast r12 r13 into r14 as [u8; 2u32];
     cast r14 into r15 as Data;
-    cast  r11 r15 into r16 as [Data; 2u32];
+    cast r11 r15 into r16 as [Data; 2u32];
     ternary r0 r5[0u32].data[0u32] r16[0u32].data[0u32] into r17;
     ternary r0 r5[0u32].data[1u32] r16[0u32].data[1u32] into r18;
-    cast  r17 r18 into r19 as [u8; 2u32];
+    cast r17 r18 into r19 as [u8; 2u32];
     cast r19 into r20 as Data;
     ternary r0 r5[1u32].data[0u32] r16[1u32].data[0u32] into r21;
     ternary r0 r5[1u32].data[1u32] r16[1u32].data[1u32] into r22;
-    cast  r21 r22 into r23 as [u8; 2u32];
+    cast r21 r22 into r23 as [u8; 2u32];
     cast r23 into r24 as Data;
-    cast  r20 r24 into r25 as [Data; 2u32];
+    cast r20 r24 into r25 as [Data; 2u32];
     output r25 as [Data; 2u32].private;
 
 DCE_DISABLED:
@@ -67,26 +67,26 @@ struct Data:
 closure foo:
     input r0 as u8;
     input r1 as u8;
-    cast  r0 r1 into r2 as [u8; 2u32];
+    cast r0 r1 into r2 as [u8; 2u32];
     cast r2 into r3 as Data;
-    cast  r1 r0 into r4 as [u8; 2u32];
+    cast r1 r0 into r4 as [u8; 2u32];
     cast r4 into r5 as Data;
     is.eq r0 r1 into r6;
-    cast  r3 r5 into r7 as [Data; 2u32];
+    cast r3 r5 into r7 as [Data; 2u32];
     mul 2u8 r3.data[0u32] into r8;
     mul 4u8 r5.data[1u32] into r9;
-    cast  r8 r9 into r10 as [u8; 2u32];
+    cast r8 r9 into r10 as [u8; 2u32];
     cast r10 into r11 as Data;
-    cast  r5 r11 into r12 as [Data; 2u32];
+    cast r5 r11 into r12 as [Data; 2u32];
     ternary r6 r7[0u32].data[0u32] r12[0u32].data[0u32] into r13;
     ternary r6 r7[0u32].data[1u32] r12[0u32].data[1u32] into r14;
-    cast  r13 r14 into r15 as [u8; 2u32];
+    cast r13 r14 into r15 as [u8; 2u32];
     cast r15 into r16 as Data;
     ternary r6 r7[1u32].data[0u32] r12[1u32].data[0u32] into r17;
     ternary r6 r7[1u32].data[1u32] r12[1u32].data[1u32] into r18;
-    cast  r17 r18 into r19 as [u8; 2u32];
+    cast r17 r18 into r19 as [u8; 2u32];
     cast r19 into r20 as Data;
-    cast  r16 r20 into r21 as [Data; 2u32];
+    cast r16 r20 into r21 as [Data; 2u32];
     output r21 as [Data; 2u32];
 
 function bar:
@@ -102,20 +102,20 @@ function bar:
     call foo r4[0u32].data[1u32] r4[1u32].data[0u32] into r9;
     ternary r1 r7[0u32].data[0u32] r9[0u32].data[0u32] into r10;
     ternary r1 r7[0u32].data[1u32] r9[0u32].data[1u32] into r11;
-    cast  r10 r11 into r12 as [u8; 2u32];
+    cast r10 r11 into r12 as [u8; 2u32];
     cast r12 into r13 as Data;
     ternary r1 r7[1u32].data[0u32] r9[1u32].data[0u32] into r14;
     ternary r1 r7[1u32].data[1u32] r9[1u32].data[1u32] into r15;
-    cast  r14 r15 into r16 as [u8; 2u32];
+    cast r14 r15 into r16 as [u8; 2u32];
     cast r16 into r17 as Data;
-    cast  r13 r17 into r18 as [Data; 2u32];
+    cast r13 r17 into r18 as [Data; 2u32];
     ternary r0 r5[0u32].data[0u32] r18[0u32].data[0u32] into r19;
     ternary r0 r5[0u32].data[1u32] r18[0u32].data[1u32] into r20;
-    cast  r19 r20 into r21 as [u8; 2u32];
+    cast r19 r20 into r21 as [u8; 2u32];
     cast r21 into r22 as Data;
     ternary r0 r5[1u32].data[0u32] r18[1u32].data[0u32] into r23;
     ternary r0 r5[1u32].data[1u32] r18[1u32].data[1u32] into r24;
-    cast  r23 r24 into r25 as [u8; 2u32];
+    cast r23 r24 into r25 as [u8; 2u32];
     cast r25 into r26 as Data;
-    cast  r22 r26 into r27 as [Data; 2u32];
+    cast r22 r26 into r27 as [Data; 2u32];
     output r27 as [Data; 2u32].private;

--- a/tests/expectations/compiler/structs/external_struct.out
+++ b/tests/expectations/compiler/structs/external_struct.out
@@ -24,17 +24,17 @@ struct Foo:
 function create:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     cast self.caller 10u32 into r14 as Boo.record;
     output r13 as Foo.private;
@@ -147,17 +147,17 @@ struct Foo:
 function create:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     cast self.caller 10u32 into r14 as Boo.record;
     output r13 as Foo.private;
@@ -194,17 +194,17 @@ struct Foo:
 function create_wrapper:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     call child.aleo/create into r14 r15;
     call child.aleo/create into r16 r17;
@@ -214,17 +214,17 @@ function create_wrapper:
 function create_another_wrapper:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     call child.aleo/create into r14 r15;
     cast 1u32 2u32 into r16 as Woo;

--- a/tests/expectations/compiler/structs/redefine_external_struct.out
+++ b/tests/expectations/compiler/structs/redefine_external_struct.out
@@ -20,17 +20,17 @@ struct Foo:
 function create:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     output r13 as Foo.private;
 // --- Next Program --- //
@@ -79,17 +79,17 @@ struct Foo:
 function create:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     output r13 as Foo.private;
 // --- Next Program --- //
@@ -115,17 +115,17 @@ struct Foo:
 function create_wrapper:
     cast 1u32 2u32 into r0 as Two;
     cast 3u32 4u32 into r1 as Two;
-    cast  r0 r1 into r2 as [Two; 2u32];
+    cast r0 r1 into r2 as [Two; 2u32];
     cast r2 into r3 as One;
     cast r3 into r4 as Baz;
     cast 5u32 6u32 into r5 as Two;
     cast 7u32 8u32 into r6 as Two;
-    cast  r5 r6 into r7 as [Two; 2u32];
+    cast r5 r6 into r7 as [Two; 2u32];
     cast r7 into r8 as One;
     cast r8 into r9 as Baz;
-    cast  r4 r9 into r10 as [Baz; 2u32];
+    cast r4 r9 into r10 as [Baz; 2u32];
     cast r10 into r11 as Bar;
-    cast  r11 into r12 as [Bar; 1u32];
+    cast r11 into r12 as [Bar; 1u32];
     cast r12 into r13 as Foo;
     call child.aleo/create into r14;
     output r14 as Foo.private;


### PR DESCRIPTION
An extra space was being produced after `cast`, and we can also save some allocations.