### PR TITLE
Remove some options.

### DIFF
--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -142,10 +142,7 @@ impl<N: Network> Compiler<N> {
             max_functions: N::MAX_FUNCTIONS,
         })?;
 
-        self.do_pass::<StaticAnalyzing>(StaticAnalyzingInput {
-            max_depth: self.compiler_options.build.conditional_block_max_depth,
-            conditional_branch_type_checking: !self.compiler_options.build.disable_conditional_branch_type_checking,
-        })?;
+        self.do_pass::<StaticAnalyzing>(())?;
 
         self.do_pass::<ConstPropagationAndUnrolling>(())?;
 

--- a/compiler/compiler/src/options.rs
+++ b/compiler/compiler/src/options.rs
@@ -30,15 +30,11 @@ pub struct CompilerOptions {
 pub struct BuildOptions {
     /// Whether to enable dead code elimination.
     pub dce_enabled: bool,
-    /// Max depth to type check nested conditionals.
-    pub conditional_block_max_depth: usize,
-    /// Whether to disable type checking for nested conditionals.
-    pub disable_conditional_branch_type_checking: bool,
 }
 
 impl Default for BuildOptions {
     fn default() -> Self {
-        Self { dce_enabled: true, conditional_block_max_depth: 0, disable_conditional_branch_type_checking: false }
+        Self { dce_enabled: true }
     }
 }
 

--- a/compiler/compiler/src/test_compiler.rs
+++ b/compiler/compiler/src/test_compiler.rs
@@ -39,7 +39,7 @@ pub fn whole_compile(
     handler: &Handler,
     import_stubs: IndexMap<Symbol, Stub>,
 ) -> Result<(String, String), LeoError> {
-    let options = CompilerOptions { build: BuildOptions { dce_enabled, ..Default::default() }, ..Default::default() };
+    let options = CompilerOptions { build: BuildOptions { dce_enabled }, ..Default::default() };
 
     let mut compiler = Compiler::<TestnetV0>::new(
         None,

--- a/compiler/passes/src/static_analysis/mod.rs
+++ b/compiler/passes/src/static_analysis/mod.rs
@@ -34,24 +34,19 @@ use leo_ast::ProgramVisitor;
 use leo_errors::Result;
 use leo_span::Symbol;
 
-pub struct StaticAnalyzingInput {
-    pub max_depth: usize,
-    pub conditional_branch_type_checking: bool,
-}
-
 pub struct StaticAnalyzing;
 
 impl Pass for StaticAnalyzing {
-    type Input = StaticAnalyzingInput;
+    type Input = ();
     type Output = ();
 
     const NAME: &str = "StaticAnalyzing";
 
-    fn do_pass(input: Self::Input, state: &mut crate::CompilerState) -> Result<Self::Output> {
+    fn do_pass(_input: Self::Input, state: &mut crate::CompilerState) -> Result<Self::Output> {
         let ast = std::mem::take(&mut state.ast);
         let mut visitor = StaticAnalyzingVisitor {
             state,
-            await_checker: AwaitChecker::new(input.max_depth, input.conditional_branch_type_checking),
+            await_checker: AwaitChecker::new(),
             current_program: Symbol::intern(""),
             variant: None,
             non_async_external_call_seen: false,

--- a/compiler/passes/src/static_analysis/program.rs
+++ b/compiler/passes/src/static_analysis/program.rs
@@ -71,7 +71,7 @@ impl ProgramVisitor for StaticAnalyzingVisitor<'_> {
                         .join(", "),
                     function.span(),
                 ));
-            } else if self.await_checker.enabled && !self.await_checker.to_await.is_empty() {
+            } else if !self.await_checker.to_await.is_empty() {
                 // Tally up number of paths that are unawaited and number of paths that are awaited more than once.
                 let (num_paths_unawaited, num_paths_duplicate_awaited, num_perfect) =
                     self.await_checker.to_await.iter().fold((0, 0, 0), |(unawaited, duplicate, perfect), path| {

--- a/errors/src/errors/type_checker/type_checker_warning.rs
+++ b/errors/src/errors/type_checker/type_checker_warning.rs
@@ -46,6 +46,7 @@ create_messages!(
         help: None,
     }
 
+    // TODO: This warning is unused, remove it in the future.
     @formatted
     max_conditional_block_depth_exceeded {
         args: (max: impl Display),

--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -31,11 +31,7 @@ use std::path::Path;
 impl From<BuildOptions> for CompilerOptions {
     fn from(options: BuildOptions) -> Self {
         Self {
-            build: leo_compiler::BuildOptions {
-                dce_enabled: options.enable_dce,
-                conditional_block_max_depth: options.conditional_block_max_depth,
-                disable_conditional_branch_type_checking: options.disable_conditional_branch_type_checking,
-            },
+            build: leo_compiler::BuildOptions { dce_enabled: options.enable_dce },
             output: OutputOptions {
                 ast_spans_enabled: options.enable_ast_spans,
                 ast_snapshots: if options.enable_all_ast_snapshots {

--- a/leo/cli/commands/mod.rs
+++ b/leo/cli/commands/mod.rs
@@ -144,10 +144,6 @@ pub struct BuildOptions {
     pub enable_ast_spans: bool,
     #[clap(long, help = "Enables dead code elimination in the compiler.", default_value = "true")]
     pub enable_dce: bool,
-    #[clap(long, help = "Max depth to type check nested conditionals.", default_value = "10")]
-    pub conditional_block_max_depth: usize,
-    #[clap(long, help = "Disable type checking of nested conditional branches in finalize scope.")]
-    pub disable_conditional_branch_type_checking: bool,
     #[clap(long, help = "Write an AST snapshot immediately after parsing.")]
     pub enable_initial_ast_snapshot: bool,
     #[clap(long, help = "Writes all AST snapshots for the different compiler phases.")]
@@ -165,8 +161,6 @@ impl Default for BuildOptions {
             offline: false,
             enable_ast_spans: false,
             enable_dce: true,
-            conditional_block_max_depth: 10,
-            disable_conditional_branch_type_checking: false,
             enable_initial_ast_snapshot: false,
             enable_all_ast_snapshots: false,
             ast_snapshots: Vec::new(),

--- a/tests/expectations/compiler/futures/nested.out
+++ b/tests/expectations/compiler/futures/nested.out
@@ -1,18 +1,5 @@
 DCE_ENABLED:
-Warning [WSAZ0374002]: The type checker has exceeded the max depth of nested conditional blocks: 0.
-    --> compiler-test:24:9
-     |
-  24 |         if a == 2u32 {
-     |         ^^^^^^^^^^^^^^
-  25 |             //f2.await();
-     |             ^^^^^^^^^^^^^
-  26 |             Mapping::set(ayo, 1u32, 1u32);
-     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  27 |         }
-     |         ^
-     |
-     = Re-run with a larger maximum depth using the `--conditional_block_max_depth` build option. Ex: `leo run main --conditional_block_max_depth 25`.
-Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2 paths contain at least one future that is never awaited.
+Warning [WSAZ0374000]: Not all paths through the function await all futures. 2/4 paths contain at least one future that is never awaited.
     --> compiler-test:17:5
      |
   17 |     async function finalize_main(f: Future, f2: Future, a: u32) {
@@ -47,20 +34,7 @@ Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2
      = Ex: `f.await()` to await a future. Remove this warning by including the `--disable-conditional-branch-type-checking` flag.
 
 DCE_DISABLED:
-Warning [WSAZ0374002]: The type checker has exceeded the max depth of nested conditional blocks: 0.
-    --> compiler-test:24:9
-     |
-  24 |         if a == 2u32 {
-     |         ^^^^^^^^^^^^^^
-  25 |             //f2.await();
-     |             ^^^^^^^^^^^^^
-  26 |             Mapping::set(ayo, 1u32, 1u32);
-     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  27 |         }
-     |         ^
-     |
-     = Re-run with a larger maximum depth using the `--conditional_block_max_depth` build option. Ex: `leo run main --conditional_block_max_depth 25`.
-Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2 paths contain at least one future that is never awaited.
+Warning [WSAZ0374000]: Not all paths through the function await all futures. 2/4 paths contain at least one future that is never awaited.
     --> compiler-test:17:5
      |
   17 |     async function finalize_main(f: Future, f2: Future, a: u32) {

--- a/tests/expectations/compiler/futures/partial_type_specification.out
+++ b/tests/expectations/compiler/futures/partial_type_specification.out
@@ -1,18 +1,5 @@
 DCE_ENABLED:
-Warning [WSAZ0374002]: The type checker has exceeded the max depth of nested conditional blocks: 0.
-    --> compiler-test:24:9
-     |
-  24 |         if a == 2u32 {
-     |         ^^^^^^^^^^^^^^
-  25 |             //f2.await();
-     |             ^^^^^^^^^^^^^
-  26 |             Mapping::set(ayo, 1u32, 1u32);
-     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  27 |         }
-     |         ^
-     |
-     = Re-run with a larger maximum depth using the `--conditional_block_max_depth` build option. Ex: `leo run main --conditional_block_max_depth 25`.
-Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2 paths contain at least one future that is never awaited.
+Warning [WSAZ0374000]: Not all paths through the function await all futures. 2/4 paths contain at least one future that is never awaited.
     --> compiler-test:17:5
      |
   17 |     async function finalize_main(f: Future, f2: Future, a: u32) {
@@ -47,20 +34,7 @@ Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2
      = Ex: `f.await()` to await a future. Remove this warning by including the `--disable-conditional-branch-type-checking` flag.
 
 DCE_DISABLED:
-Warning [WSAZ0374002]: The type checker has exceeded the max depth of nested conditional blocks: 0.
-    --> compiler-test:24:9
-     |
-  24 |         if a == 2u32 {
-     |         ^^^^^^^^^^^^^^
-  25 |             //f2.await();
-     |             ^^^^^^^^^^^^^
-  26 |             Mapping::set(ayo, 1u32, 1u32);
-     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  27 |         }
-     |         ^
-     |
-     = Re-run with a larger maximum depth using the `--conditional_block_max_depth` build option. Ex: `leo run main --conditional_block_max_depth 25`.
-Warning [WSAZ0374000]: Not all paths through the function await all futures. 1/2 paths contain at least one future that is never awaited.
+Warning [WSAZ0374000]: Not all paths through the function await all futures. 2/4 paths contain at least one future that is never awaited.
     --> compiler-test:17:5
      |
   17 |     async function finalize_main(f: Future, f2: Future, a: u32) {


### PR DESCRIPTION
Specifically, remove --conditional-block-max-depth and --disable-conditional-branch-type-checking. These options seem to have been intended to circumvent potential perfomance problems in await checking deeply nested conditionals, but these problems don't appear in practice.