### PR TITLE
fix: update .rustfmt.toml link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Please follow the instructions below when filing pull requests:
 
 - Ensure that your branch is forked from the current [mainnet](https://github.com/ProvableHQ/leo/tree/mainnet) branch.
 - Fill out the provided markdown template for the feature or proposal. Be sure to link the pull request to any issues by using keywords. Example: "closes #130".
-- Run `cargo fmt` before you commit; we use the `nightly` version of `rustfmt` to format the code, so you'll need to have the `nightly` toolchain installed on your machine; there's a [git hook](https://git-scm.com/docs/githooks) that ensures proper formatting before any commits can be made, and [`.rustfmt.toml`](https://github.com/AleoHQ/Leo/blob/mainnet/rustfmt.toml) specifies some of the formatting conventions.
+- Run `cargo fmt` before you commit; we use the `nightly` version of `rustfmt` to format the code, so you'll need to have the `nightly` toolchain installed on your machine; there's a [git hook](https://git-scm.com/docs/githooks) that ensures proper formatting before any commits can be made, and [`rustfmt.toml`](https://github.com/AleoHQ/Leo/blob/mainnet/rustfmt.toml) specifies some of the formatting conventions.
 - Run `cargo clippy` to ensure that popular correctness and performance pitfalls are avoided.
 
 ## Style


### PR DESCRIPTION
The link was broken because '.' so it didn't work, don't know it's worth merging but the change really can be useful if it's needed