### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,8 +93,9 @@ jobs:
           fi
 
       - name: Build
+        # Use an older version of this Docker image as newer versions don't have OpenSSL.
         run: |
-          docker pull clux/muslrust:stable
+          docker pull clux/muslrust:1.85.1-stable
           docker run \
             -v ${{ github.workspace }}:/volume \
             -v cargo-cache:/root/.cargo/registry \


### PR DESCRIPTION
Use an older version of the Linux musl docker image as newer versions don't have OpenSSL.