### PR TITLE
Clone all internal record inputs as outputs.

### DIFF
--- a/compiler/ast/src/struct/mod.rs
+++ b/compiler/ast/src/struct/mod.rs
@@ -38,7 +38,7 @@ use snarkvm::{
 /// Type identity is decided by the full path including `struct_name`,
 /// as the record is nominal, not structural.
 /// The fields are named so `struct Foo(u8, u16)` is not allowed.
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Composite {
     /// The name of the type in the type system in this module.
     pub identifier: Identifier,
@@ -123,12 +123,6 @@ impl Composite {
             span: Default::default(),
             id: Default::default(),
         }
-    }
-}
-
-impl fmt::Debug for Composite {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <Self as fmt::Display>::fmt(self, f)
     }
 }
 

--- a/compiler/passes/src/code_generation/program.rs
+++ b/compiler/passes/src/code_generation/program.rs
@@ -191,7 +191,7 @@ impl<'a> CodeGeneratingVisitor<'a> {
             if let Type::Composite(comp) = &input.type_ {
                 let program = comp.program.unwrap_or(self.program_id.unwrap().name.name);
                 if let Some(record) = self.state.symbol_table.lookup_record(Location::new(program, comp.id.name)) {
-                    if record.external.is_none() || record.external == Some(program) {
+                    if record.external.is_none() || record.external == self.program_id.map(|id| id.name.name) {
                         self.internal_record_inputs.insert(register_string.clone());
                     }
                 }

--- a/compiler/passes/src/code_generation/statement.rs
+++ b/compiler/passes/src/code_generation/statement.rs
@@ -112,8 +112,16 @@ impl CodeGeneratingVisitor<'_> {
         } else {
             // Not a tuple - only one output.
             let (operand, op_instructions) = self.visit_expression(&input.expression);
-            instructions = op_instructions;
-            operands.insert(operand);
+            if self.internal_record_inputs.contains(&operand) {
+                // We can't output an internal record we received as input.
+                let (new_operand, new_instr) =
+                    self.clone_register(&operand, &self.current_function.unwrap().output_type);
+                instructions.push_str(&new_instr);
+                operands.insert(new_operand);
+            } else {
+                instructions = op_instructions;
+                operands.insert(operand);
+            }
         }
 
         for (operand, output) in operands.iter().zip(&self.current_function.unwrap().output) {

--- a/tests/expectations/compiler/return/external_record.out
+++ b/tests/expectations/compiler/return/external_record.out
@@ -1,0 +1,15 @@
+program test0.aleo;
+
+record R:
+    owner as address.private;
+
+function foo:
+    cast self.signer into r0 as R.record;
+    output r0 as R.record;
+// --- Next Program --- //
+import test0.aleo;
+program test1.aleo;
+
+function bar:
+    input r0 as test0.aleo/R.record;
+    output r0 as test0.aleo/R.record;

--- a/tests/expectations/compiler/return/record_out.out
+++ b/tests/expectations/compiler/return/record_out.out
@@ -1,0 +1,9 @@
+program test.aleo;
+
+record R:
+    owner as address.private;
+
+function foo:
+    input r0 as R.record;
+    cast r0.owner into r1 as R.record;
+    output r1 as R.record;

--- a/tests/tests/compiler/return/external_record.leo
+++ b/tests/tests/compiler/return/external_record.leo
@@ -1,0 +1,22 @@
+
+program test0.aleo {
+    record R {
+        owner: address,
+    }
+
+    transition foo() -> R {
+        return R {
+            owner: self.signer,
+        };
+    }
+}
+
+// --- Next Program --- //
+
+import test0.aleo;
+program test1.aleo {
+    // This should compile fine without attempting to clone.
+    transition bar(x: test0.aleo/R) -> test0.aleo/R {
+        return x;
+    }
+}

--- a/tests/tests/compiler/return/record_out.leo
+++ b/tests/tests/compiler/return/record_out.leo
@@ -1,0 +1,13 @@
+// As of commit 2fdad2fa89e6e47444676dbc2558c45d53550225,
+// programs with an internal record received as input
+// and output by themselves were not properly cloned.
+program test.aleo {
+    record R {
+        owner: address,
+    }
+
+    transition foo(r: R) -> R {
+        // This should be cloned.
+        return r;
+    }
+}


### PR DESCRIPTION
I messed this up in my previous commit, not
handling the case of a single output. I also
didn't correctly mark which record inputs
were internal, potentially trying to tag some that were actually external.

Fixes #28429