### PR TITLE
Allow external record assignment.

### DIFF
--- a/compiler/passes/src/type_checking/visitor.rs
+++ b/compiler/passes/src/type_checking/visitor.rs
@@ -96,7 +96,8 @@ impl TypeCheckingVisitor<'_> {
     /// Use this method when you know the actual type.
     /// Emits an error to the handler if the `actual` type is not equal to the `expected` type.
     pub fn assert_and_return_type(&mut self, actual: Type, expected: &Option<Type>, span: Span) -> Type {
-        if expected.is_some() {
+        // If expected is `Type::Err`, we don't want to actually report a redundant error.
+        if expected.is_some() && !matches!(expected, Some(Type::Err)) {
             self.check_eq_types(&Some(actual.clone()), expected, span);
         }
         actual

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -1039,6 +1039,7 @@ create_messages!(
         help: Some("Ternary conditionals may not contain an external record type.".to_string()),
     }
 
+    // TODO: unused.
     @formatted
     assignment_to_external_record {
         args: (ty: impl Display),
@@ -1059,10 +1060,32 @@ create_messages!(
         msg: format!("Record name `{r1}` is prefixed by the record name `{r2}`. Record names must not be prefixes of other record names."),
         help: None,
     }
+
     @formatted
     range_bounds_type_mismatch{
         args: (),
         msg: format!("mismatched types in loop iterator range bounds"),
         help: None,
+    }
+
+    @formatted
+    assignment_to_external_record_member {
+        args: (ty: impl Display),
+        msg: format!("Cannot assign to a member of the external record `{ty}`."),
+        help: None,
+    }
+
+    @formatted
+    assignment_to_external_record_cond {
+        args: (ty: impl Display),
+        msg: format!("Cannot assign to the external record type `{ty}` in this location."),
+        help: Some("External record variables may not be assigned to in narrower conditonal scopes than they were defined.".into()),
+    }
+
+    @formatted
+    assignment_to_external_record_tuple_cond {
+        args: (ty: impl Display),
+        msg: format!("Cannot assign to the tuple type `{ty}` containing an external record in this location."),
+        help: Some("Tuples containing external records may not be assigned to in narrower conditonal scopes than they were defined.".into()),
     }
 );

--- a/tests/expectations/compiler/statements/assign_external_record_fail.out
+++ b/tests/expectations/compiler/statements/assign_external_record_fail.out
@@ -1,28 +1,26 @@
-Error [ETYC0372131]: Cannot assign to type `test0.aleo/R` or a member thereof.
+Error [ETYC0372136]: Cannot assign to the external record type `test0.aleo/R` in this location.
     --> compiler-test:12:13
      |
   12 |             r1 = test0.aleo/foo();
      |             ^^
      |
-     = External record types and tuples containing them may not be assigned to.
-Error [ETYC0372131]: Cannot assign to type `(test0.aleo/R, test0.aleo/R)` or a member thereof.
-    --> compiler-test:20:13
+     = External record variables may not be assigned to in narrower conditonal scopes than they were defined.
+Error [ETYC0372137]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
+    --> compiler-test:21:13
      |
-  20 |             tupl.0 = test0.aleo/foo();
+  21 |             tupl.0 = test0.aleo/foo();
      |             ^^^^
      |
-     = External record types and tuples containing them may not be assigned to.
-Error [ETYC0372131]: Cannot assign to type `test0.aleo/R` or a member thereof.
-    --> compiler-test:20:18
+     = Tuples containing external records may not be assigned to in narrower conditonal scopes than they were defined.
+Error [ETYC0372137]: Cannot assign to the tuple type `(test0.aleo/R, test0.aleo/R)` containing an external record in this location.
+    --> compiler-test:25:13
      |
-  20 |             tupl.0 = test0.aleo/foo();
-     |                  ^
+  25 |             tupl = (test0.aleo/foo(), test0.aleo/foo());
+     |             ^^^^
      |
-     = External record types and tuples containing them may not be assigned to.
-Error [ETYC0372131]: Cannot assign to type `test0.aleo/R` or a member thereof.
-    --> compiler-test:27:9
+     = Tuples containing external records may not be assigned to in narrower conditonal scopes than they were defined.
+Error [ETYC0372135]: Cannot assign to a member of the external record `test0.aleo/R`.
+    --> compiler-test:33:9
      |
-  27 |         r.x = x;
-     |         ^
-     |
-     = External record types and tuples containing them may not be assigned to.
+  33 |         r.x = x;
+     |         ^^^

--- a/tests/tests/compiler/statements/assign_external_record_fail.leo
+++ b/tests/tests/compiler/statements/assign_external_record_fail.leo
@@ -32,14 +32,35 @@ program test1.aleo {
     transition bar2(x: bool) -> test0.aleo/R {
         let tupl: (test0.aleo/R, test0.aleo/R) = (test0.aleo/foo(), test0.aleo/foo());
         if x {
+            // This should fail - external record assignment in narrower conditional scope.
             tupl.0 = test0.aleo/foo();
+        }
+        if x {
+            // Ditto.
+            tupl = (test0.aleo/foo(), test0.aleo/foo());
         }
         return tupl.0;
     }
 
     transition bar3(x: bool) -> test0.aleo/R {
         let r: test0.aleo/R = test0.aleo/foo();
+        // This should fail.
         r.x = x;
+        if x {
+            let r2: test0.aleo/R = test0.aleo/foo();
+            // This should pass.
+            r2 = test0.aleo/foo();
+        }
+        return r;
+    }
+
+    transition bar4() -> test0.aleo/R {
+        let r: test0.aleo/R = test0.aleo/foo();
+        for i: u8 in 0u8..4u8 {
+            // This should pass - it's an external record assignment but
+            // not in a narrower conditional scope..
+            r = test0.aleo/foo();
+        }
         return r;
     }
 }


### PR DESCRIPTION
We still have to forbid it in a narrower conditional scope than where the variable was defined, though.