### PR TITLE
Small fixes to errors.

### DIFF
--- a/errors/src/errors/utils/util_errors.rs
+++ b/errors/src/errors/utils/util_errors.rs
@@ -61,7 +61,7 @@ create_messages!(
         help: None,
     }
 
-    @formatted
+    @backtraced
     network_error {
         args: (url: impl Display, status: impl Display),
         msg: format!("Failed network request to {url}. Status: {status}"),
@@ -138,7 +138,7 @@ create_messages!(
         help: None,
     }
 
-    @formatted
+    @backtraced
     failed_to_retrieve_from_endpoint {
         args: (error: impl ErrorArg),
         msg: format!("{error}"),

--- a/leo/package/src/lib.rs
+++ b/leo/package/src/lib.rs
@@ -158,11 +158,11 @@ pub fn fetch_from_network(url: &str) -> Result<String, UtilError> {
         .get(url)
         .set("X-Leo-Version", env!("CARGO_PKG_VERSION"))
         .call()
-        .map_err(|err| UtilError::failed_to_retrieve_from_endpoint(err, Default::default()))?;
+        .map_err(UtilError::failed_to_retrieve_from_endpoint)?;
     match response.status() {
         200 => Ok(response.into_string().unwrap().replace("\\n", "\n").replace('\"', "")),
         301 => Err(UtilError::endpoint_moved_error(url)),
-        _ => Err(UtilError::network_error(url, response.status(), Default::default())),
+        _ => Err(UtilError::network_error(url, response.status())),
     }
 }
 


### PR DESCRIPTION
Specifically:

UtilError::{network_error, failed_to_retrieve_from_endpoint} are both now @backtraced instead of @formatted, as they don't have associated spans.

The Display implementation for Formatted now prints the error message even if it can't find a source file.

Fixes #28649