### PR TITLE
[Feature] Support querying unconfirmed transactions

### DIFF
--- a/leo/cli/commands/query/transaction.rs
+++ b/leo/cli/commands/query/transaction.rs
@@ -26,7 +26,12 @@ use clap::Parser;
 ))]
 #[command(group(
     // Ensure at most one mode is specified and ony if using "id" as a source.
-    clap::ArgGroup::new("mode").required(false).multiple(false).requires("id")
+    // The `conflicts_with_all` here should not be required but it looks like Clap is getting a little confused
+    clap::ArgGroup::new("mode")
+        .required(false)
+        .multiple(false)
+        .requires("ID").conflicts_with_all(["from_io", "from_transition", "from_program"]
+    )
 ))]
 pub struct LeoTransaction {
     #[clap(name = "ID", help = "The ID of the transaction to fetch", group = "source")]
@@ -38,21 +43,21 @@ pub struct LeoTransaction {
     #[arg(
         value_name = "INPUT_OR_OUTPUT_ID",
         long,
-        help = "Get the transition id that an input or output id occurred in",
+        help = "Get the ID of the transaction that an input or output ID occurred in",
         group = "source"
     )]
     pub(crate) from_io: Option<String>,
     #[arg(
         value_name = "TRANSITION_ID",
         long,
-        help = "Get the id of the transaction containing the specified transition",
+        help = "Get the ID of the transaction containing the specified transition",
         group = "source"
     )]
     pub(crate) from_transition: Option<String>,
     #[arg(
         value_name = "PROGRAM",
         long,
-        help = "Get the id of the transaction id that the specified program was deployed in",
+        help = "Get the ID of the transaction that the specified program was deployed in",
         group = "source"
     )]
     pub(crate) from_program: Option<String>,


### PR DESCRIPTION
This PR enables the command line interface to access the `/transaction/unconfirmed` endpoint using `leo query transaction --unconfirmed <ID>`.

`--unconfirmed` still returns the original transaction if it was already confirmed, which is useful because the default query returns only the fee transaction for rejected transactions.
`--confirmed` returns, both, the original and fee transaction. The PR changes its help text to be a little clearer that the returned data is different from the default query.

The second commit ([01923c4](https://github.com/ProvableHQ/leo/commit/01923c4f11eb8530032adf022ba0739bf69336f7)) refactors the transaction query arguments to use `clap::ArgGroup` instead of manually listing all conflicts. In my opinion, that makes the code much easier to read as the transaction query arguments are getting more complex. 

This PR is a clone https://github.com/ProvableHQ/leo/pull/28655