### PR TITLE
Fix an issue with indexing an array with a const initialized with an unsuffixed integer

### DIFF
--- a/compiler/passes/src/destructuring/expression.rs
+++ b/compiler/passes/src/destructuring/expression.rs
@@ -50,14 +50,17 @@ impl ExpressionReconstructor for DestructuringVisitor<'_> {
                     panic!("Type checking guarantees that all tuple accesses are declared and indices are valid.");
                 }
 
-                let expr = ArrayAccess {
-                    array: (*identifier).into(),
-                    index: Literal::integer(IntegerType::U32, input.index.to_string(), input.span, Default::default())
-                        .into(),
-                    span: input.span,
-                    id: input.id,
-                }
-                .into();
+                let index = Literal::integer(
+                    IntegerType::U32,
+                    input.index.to_string(),
+                    input.span,
+                    self.state.node_builder.next_id(),
+                );
+                self.state.type_table.insert(index.id(), Type::Integer(IntegerType::U32));
+
+                let expr =
+                    ArrayAccess { array: (*identifier).into(), index: index.into(), span: input.span, id: input.id }
+                        .into();
 
                 (expr, Default::default())
             }

--- a/tests/expectations/compiler/array/array_index_by_const.out
+++ b/tests/expectations/compiler/array/array_index_by_const.out
@@ -1,0 +1,10 @@
+program test.aleo;
+
+function main:
+    cast 1u32 2u32 3u32 4u32 5u32 6u32 into r0 as [u32; 6u32];
+    add r0[0u32] r0[1u32] into r1;
+    add r1 r0[2u32] into r2;
+    add r2 r0[3u32] into r3;
+    add r3 r0[4u32] into r4;
+    add r4 r0[5u32] into r5;
+    output r5 as u32.private;

--- a/tests/tests/compiler/array/array_index_by_const.leo
+++ b/tests/tests/compiler/array/array_index_by_const.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    const N1: u8 = 0;
+    const N2: u16 = 1;
+    const N3: u32 = 2;
+    const N4: u8 = 3u8;
+    const N5: u16 = 4u16;
+    const N6: u32 = 5u32;
+    transition main() -> u32 {
+        let arr: [u32; 6] = [1, 2, 3, 4, 5, 6];
+        return arr[N1] + arr[N2] + arr[N3] + arr[N4] + arr[N5] + arr[N6];
+    }
+}


### PR DESCRIPTION
Closes #28677

Fairly simple change to handle the case where the integer is unsuffixed, in codegen.

~I took the liberty to also disallow array indices from being anything other than `u8`, `u16`, or `u32`. We seem to be implicitly casting to a `u32` in codegen (because the VM expects it) which seems unsafe unless the array index type is one of these three types. We should encourage explicit casting for other integer types if needed.~