### PR TITLE
Allow executions and queries without fees.

### DIFF
--- a/leo/cli/commands/common/query.rs
+++ b/leo/cli/commands/common/query.rs
@@ -90,10 +90,13 @@ pub fn handle_broadcast<N: Network>(endpoint: &str, transaction: &Transaction<N>
     match response.status() {
         200..=299 => {
             println!(
-                "✉️ Broadcasted transaction with:\n  - transaction ID: '{}'\n  - fee ID: '{}'",
+                "✉️ Broadcasted transaction with:\n  - transaction ID: '{}'",
                 transaction.id().to_string().bold().yellow(),
-                transaction.fee_transition().expect("Expected a fee in transactions").id().to_string().bold().yellow()
             );
+            if let Some(fee) = transaction.fee_transition() {
+                // Most transactions will have fees, but some, like credits.aleo/upgrade executions, may not.
+                println!("  - fee ID: '{}'", fee.id().to_string().bold().yellow());
+            }
             Ok(response)
         }
         301 => {


### PR DESCRIPTION
This is necessary for credits.aleo/upgrade executions.