### PR TITLE
Handle parenthesizing operands of ? : correctly.

### DIFF
--- a/compiler/ast/src/expressions/mod.rs
+++ b/compiler/ast/src/expressions/mod.rs
@@ -276,7 +276,7 @@ impl Expression {
         match self {
             Binary(e) => e.precedence(),
             Cast(_) => 12,
-            Ternary(_) => 14,
+            Ternary(_) => 0,
             Array(_)
             | ArrayAccess(_)
             | AssociatedConstant(_)

--- a/compiler/ast/src/expressions/ternary.rs
+++ b/compiler/ast/src/expressions/ternary.rs
@@ -33,21 +33,15 @@ pub struct TernaryExpression {
 
 impl fmt::Display for TernaryExpression {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.condition.precedence() > 14 {
-            write!(f, "{}", self.condition)?;
-        } else {
-            write!(f, "({})", self.condition)?;
-        }
+        let maybe_paren = |f: &mut fmt::Formatter, expr: &Expression| {
+            if expr.precedence() > 0 { write!(f, "{expr}") } else { write!(f, "({expr})") }
+        };
 
-        write!(f, " ? {} : ", self.if_true)?;
-
-        if self.if_false.precedence() > 14 {
-            write!(f, "{}", self.if_false)?;
-        } else {
-            write!(f, "({})", self.if_false)?;
-        }
-
-        Ok(())
+        maybe_paren(f, &self.condition)?;
+        write!(f, " ? ")?;
+        maybe_paren(f, &self.if_true)?;
+        write!(f, " : ")?;
+        maybe_paren(f, &self.if_false)
     }
 }
 


### PR DESCRIPTION
There were two problems:
1. One of the operands just always wrote without parentheses.
2. I incorrectly gave ? : a precedence higher than other operations, when in fact it should be lower.

This only affects printing the AST for display purposes, as when printing snapshots after compiler passes.