### PR TITLE
Hide `--clear` flag for `leo add`.

### DIFF
--- a/leo/cli/commands/add.rs
+++ b/leo/cli/commands/add.rs
@@ -28,7 +28,13 @@ pub struct LeoAdd {
     #[clap(flatten)]
     pub(crate) source: DependencySource,
 
-    #[clap(short = 'c', long, help = "Clear all previous dependencies.", default_value = "false")]
+    #[clap(
+        short = 'c',
+        long,
+        hide = true,
+        help = "[UNUSED] Clear all previous dependencies.",
+        default_value = "false"
+    )]
     pub(crate) clear: bool,
 
     #[clap(long, help = "This is a development dependency.", default_value = "false")]


### PR DESCRIPTION
This flag has apparently been broken for some time. I don't think it's particularly useful as we have `leo remove`. So let's deprecate it instead of just immediately removing it.

Fixes #28802
