### PR TITLE
Replace shorthand struct initializers in const prop.

### DIFF
--- a/compiler/passes/src/const_propagation/ast.rs
+++ b/compiler/passes/src/const_propagation/ast.rs
@@ -88,12 +88,11 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
             *arg = self.reconstruct_expression(std::mem::take(arg)).0;
         });
         for member in input.members.iter_mut() {
-            if let Some(expr) = std::mem::take(&mut member.expression) {
-                let (new_expr, value_opt) = self.reconstruct_expression(expr);
-                member.expression = Some(new_expr);
-                if let Some(value) = value_opt {
-                    values.push(value);
-                }
+            let expression = member.expression.take().unwrap_or_else(|| member.identifier.into());
+            let (new_expr, value_opt) = self.reconstruct_expression(expression);
+            member.expression = Some(new_expr);
+            if let Some(value) = value_opt {
+                values.push(value);
             }
         }
 

--- a/tests/expectations/compiler/bugs/b28778.out
+++ b/tests/expectations/compiler/bugs/b28778.out
@@ -1,0 +1,10 @@
+program b28788.aleo;
+
+struct Foo:
+    x as u32;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    cast 42u32 into r2 as Foo;
+    output r2.x as u32.private;

--- a/tests/tests/compiler/bugs/b28778.leo
+++ b/tests/tests/compiler/bugs/b28778.leo
@@ -1,0 +1,13 @@
+program b28788.aleo {
+    const x: u32 = 42;
+
+    struct Foo {
+        x: u32,
+    }
+
+    transition main(public a: u32, b: u32) -> u32 {
+        // Previously the `x` would lead to a panic in codegen.
+        let f = Foo { x };
+        return f.x;
+    }
+}


### PR DESCRIPTION
This way if they're consts they'll actually be seen as such, whereas previously this would lead to a panic in codegen.

Fixes #28778
