### PR TITLE
Display annotations correctly.

### DIFF
--- a/compiler/ast/src/constructor/mod.rs
+++ b/compiler/ast/src/constructor/mod.rs
@@ -27,7 +27,6 @@ use crate::{Annotation, Block, Indent, IntegerType, Location, NetworkName, Node,
 use leo_span::{Span, sym};
 
 use anyhow::{anyhow, bail};
-use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use snarkvm::prelude::{Address, Literal, Locator, Network};
 use std::{fmt, str::FromStr};
@@ -116,7 +115,9 @@ impl Constructor {
 
 impl fmt::Display for Constructor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.annotations.iter().join("\n"))?;
+        for annotation in &self.annotations {
+            writeln!(f, "{annotation}")?;
+        }
 
         writeln!(f, "async constructor() {{")?;
         for stmt in self.block.statements.iter() {

--- a/compiler/ast/src/functions/mod.rs
+++ b/compiler/ast/src/functions/mod.rs
@@ -126,7 +126,9 @@ impl fmt::Debug for Function {
 
 impl fmt::Display for Function {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.annotations.iter().join("\n"))?;
+        for annotation in &self.annotations {
+            writeln!(f, "{annotation}")?;
+        }
 
         match self.variant {
             Variant::Inline => write!(f, "inline ")?,


### PR DESCRIPTION
In displaying constructors and functions the final annotation didn't have a newline after it.