### PR TITLE
fix(finalize): consume Position command by incrementing instruction index

### DIFF
--- a/interpreter/src/cursor_aleo.rs
+++ b/interpreter/src/cursor_aleo.rs
@@ -17,19 +17,14 @@
 use super::*;
 
 use leo_ast::{
-    BinaryOperation,
-    CoreFunction,
-    IntegerType,
-    Type,
-    UnaryOperation,
+    BinaryOperation, CoreFunction, IntegerType, Type, UnaryOperation,
     interpreter_value::{self, AsyncExecution, GlobalId, Value},
 };
 
 use snarkvm::{
     prelude::{Identifier, LiteralType, PlaintextType, Register, TestnetV0},
     synthesizer::{
-        Command,
-        Instruction,
+        Command, Instruction,
         program::{CallOperator, CastType, Operand},
     },
 };
@@ -900,7 +895,10 @@ impl Cursor {
                 }
                 return Ok(());
             }
-            Position(_) => return Ok(()),
+            Position(_) => {
+                self.increment_instruction_index();
+                return Ok(());
+            }
         };
 
         self.set_register(destination, value);


### PR DESCRIPTION
Fixes an infinite loop when executing finalize code: Position commands were returned without advancing the instruction index, causing the executor to repeatedly fetch the same Position. We now increment the instruction index upon encountering Position, ensuring labels are consumed both during linear execution and after branch() sets the index to a label. This aligns with how other commands advance control flow and prevents hangs.