### PR TITLE
Fix a bug where CONSENSUS_VERSION_HEIGHTS did not get properly set

### DIFF
--- a/leo/cli/commands/devnet/mod.rs
+++ b/leo/cli/commands/devnet/mod.rs
@@ -344,9 +344,23 @@ impl LeoDevnet {
         //────────────── tmux branch ──────────────
         if self.tmux {
             // Create session.
-            ensure!(
+            let mut args: Vec<String> = vec!["new-session", "-d", "-s", "devnet", "-n", "validator-0"]
+                .into_iter()
+                .map(Into::into)
+                .collect();
+
+            // If a tmux server is already running, the new session will inherit the environment
+            // variables of the server. As such, we need to explicitly set the CONSENSUS_VERSION_HEIGHTS
+            // env var in the new session we are creatomg.
+            if let Some(ref heights) = self.consensus_heights {
+                let heights = heights.iter().join(",");
+                args.push("-e".to_string());
+                args.push(format!("CONSENSUS_VERSION_HEIGHTS={heights}"));
+            }
+
+             ensure!(
                 StdCommand::new("tmux")
-                    .args(["new-session", "-d", "-s", "devnet", "-n", "validator-0"])
+                    .args(args)
                     .status()?
                     .success(),
                 "tmux failed to create session"


### PR DESCRIPTION
## Motivation

When running `leo devnet` on a machine that already has a `tmux` server running, the environment variables of the existing server are used. This results in `CONSENSUS_VERSION_HEIGHTS` not being properly set.

## Test Plan

I tested this locally. Before this change, I was getting the wrong `CONSENSUS_VERSION_HEIGHTS` (it was being set to whatever it was set to when I started my `tmux` server).
After this change, the `devnet` starts with the correct consensus version heights.

## Related PRs

N/A