### PR TITLE
fix: correct error message variable in Package::initialize test file creation

### DIFF
--- a/leo/package/src/package.rs
+++ b/leo/package/src/package.rs
@@ -152,8 +152,9 @@ impl Package {
             .map_err(|e| PackageError::failed_to_create_source_directory(tests_path.display(), e))?;
 
         let test_file_path = tests_path.join(format!("test_{name_no_aleo}.leo"));
-        std::fs::write(&test_file_path, test_template(name_no_aleo))
-            .map_err(|e| UtilError::util_file_io_error(format_args!("Failed to write `{}`", test_file_path.display()), e))?;
+        std::fs::write(&test_file_path, test_template(name_no_aleo)).map_err(|e| {
+            UtilError::util_file_io_error(format_args!("Failed to write `{}`", test_file_path.display()), e)
+        })?;
 
         Ok(full_path)
     }


### PR DESCRIPTION
PR originally opened in https://github.com/ProvableHQ/leo/pull/28860

Fix incorrect variable reference in error message for test file creation in Package::initialize.

The error message was using main_path.display() instead of test_file_path.display(), 
causing misleading error messages that showed the wrong file path when test file 
write operations failed.