### PR TITLE
Target specific duplicate member span in error reporting

### DIFF
--- a/compiler/passes/src/type_checking/program.rs
+++ b/compiler/passes/src/type_checking/program.rs
@@ -225,17 +225,17 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
         // Check for conflicting struct/record member names.
         let mut used = HashSet::new();
-        // TODO: Better span to target duplicate member.
-        if !input.members.iter().all(|Member { identifier, type_, span, .. }| {
+        for Member { identifier, type_, span, .. } in &input.members {
             // Check that the member types are defined.
             self.assert_type_is_valid(type_, *span);
-            used.insert(identifier.name)
-        }) {
-            self.emit_err(if input.is_record {
-                TypeCheckerError::duplicate_record_variable(input.name(), input.span())
-            } else {
-                TypeCheckerError::duplicate_struct_member(input.name(), input.span())
-            });
+
+            if !used.insert(identifier.name) {
+                self.emit_err(if input.is_record {
+                    TypeCheckerError::duplicate_record_variable(input.name(), *span)
+                } else {
+                    TypeCheckerError::duplicate_struct_member(input.name(), *span)
+                });
+            }
         }
 
         // For records, enforce presence of the `owner: Address` member.

--- a/tests/expectations/compiler/records/duplicate_var_fail.out
+++ b/tests/expectations/compiler/records/duplicate_var_fail.out
@@ -1,22 +1,8 @@
 Error [ETYC0372016]: Record Token defined with more than one variable with the same name.
-    --> compiler-test:3:5
+    --> compiler-test:7:9
      |
-   3 |     record Token {
-     |     ^^^^^^^^^^^^^^
-   4 |         // The token owner.
-     |         ^^^^^^^^^^^^^^^^^^^
-   5 |         owner: address,
-     |         ^^^^^^^^^^^^^^^
-   6 |         // The token owner.
-     |         ^^^^^^^^^^^^^^^^^^^
    7 |         owner: address, // Cannot define two record variables with the same name.
-     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   8 |         // The token amount.
-     |         ^^^^^^^^^^^^^^^^^^^^
-   9 |         amount: u64,
-     |         ^^^^^^^^^^^^
-  10 |     }
-     |     ^
+     |         ^^^^^^^^^^^^^^
 Error [ETYC0372083]: A program must have at least one transition function.
     --> compiler-test:2:9
      |

--- a/tests/expectations/compiler/structs/duplicate_struct_variable.out
+++ b/tests/expectations/compiler/structs/duplicate_struct_variable.out
@@ -1,14 +1,8 @@
 Error [ETYC0372015]: Struct Bar defined with more than one member with the same name.
-    --> compiler-test:3:5
+    --> compiler-test:5:9
      |
-   3 |     struct Bar {
-     |     ^^^^^^^^^^^^
-   4 |         x: u32,
-     |         ^^^^^^^
    5 |         x: u32,
-     |         ^^^^^^^
-   6 |     }
-     |     ^
+     |         ^^^^^^
 Error [ETYC0372083]: A program must have at least one transition function.
     --> compiler-test:2:9
      |


### PR DESCRIPTION
Previously, duplicate struct/record member errors pointed to the entire struct/record span, making it difficult to locate the exact duplicate, so this patch makes sure to point directly to the duplicate member's span.