### PR TITLE
Fix duplicate futures in interpreter

### DIFF
--- a/interpreter/src/cursor.rs
+++ b/interpreter/src/cursor.rs
@@ -1317,7 +1317,9 @@ impl Cursor {
                 };
 
                 if let Some(asyncs) = maybe_future.as_ref().and_then(|fut| fut.as_future()) {
-                    self.futures.extend(asyncs.iter().cloned());
+                    if user_initiated {
+                        self.futures.extend(asyncs.iter().cloned());
+                    }
                 }
 
                 Ok(StepResult { finished, value })


### PR DESCRIPTION
## Motivation

I got 5 futures as output when I ran my transition that returns a record and a future:
```
✔ Command? · #set_program war_game.leo


✔ Command? · #into war_game.aleo/create_game(1u32, 1i8, 2i8, 3i8, 5u128, 29u128, 91u128)

war_game.aleo/create_game(1u32, 1i8, 2i8, 3i8, 5u128, 29u128, 91u128)
✔ Command? · #run


   0:  async call to credits.aleo/transfer_public_as_signer
   1:  async call to credits.aleo/transfer_public_as_signer
   2:  async call to war_game.aleo/finalize_create_game
   3:  async call to war_game.aleo/finalize_create_game
   4:  async call to war_game.aleo/finalize_create_game
```
This happens because it takes multiple steps to process the Element::Expression.
I added the check to only extend the futures vector once on the last step.

## Test Plan

After the change:
```
✔ Command? · #set_program war_game.leo


✔ Command? · #into war_game.aleo/create_game(1u32, 1i8, 2i8, 3i8, 5u128, 29u128, 91u128)

war_game.aleo/create_game(1u32, 1i8, 2i8, 3i8, 5u128, 29u128, 91u128)
✔ Command? · #run


   0:  async call to war_game.aleo/finalize_create_game
```
Fixes #28880