### PR TITLE
fix duplication of children in the symbol during loop unrolling.

### DIFF
--- a/compiler/passes/src/loop_unrolling/duplicate.rs
+++ b/compiler/passes/src/loop_unrolling/duplicate.rs
@@ -31,7 +31,7 @@ struct Duplicator<'a> {
 
 impl Duplicator<'_> {
     fn in_scope_duped<T>(&mut self, new_id: NodeID, old_id: NodeID, func: impl FnOnce(&mut Self) -> T) -> T {
-        self.symbol_table.enter_scope_duped(new_id, old_id);
+        self.symbol_table.enter_scope_duped(new_id, old_id, self.node_builder);
         let result = func(self);
         self.symbol_table.enter_parent();
         result


### PR DESCRIPTION
## Motivation

Children in the symbol table were being duplicated by cloning without the consideration for their scopes. This PR assigns new ids to children for duplicating them.

closes #28743 

## Test Plan
I don't think this one needs a separate test other than the CI. As also, as of yet children are only used in ProcessingAsync pass and all the wrong duplication happens during the loop unrolling.

