### PR TITLE
Repo maintenance ahead of the release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 # - Incremental builds should be disabled in CI, since they don't provide much benefit.
 # - Enabling `--only_testnet` feature flag to reduce the amount of time spent building leo-lang, since it's not needed for the test suite.
 
-# Rust Version: 1.88.0
+# Rust Version: 1.90.0
 # Ensure that this matches the `rust-version` in `Cargo.toml`.
 # If this is changed, propogate the changes to all places in this file, including the `install-rust` command.
 
@@ -33,7 +33,7 @@ executors:
 
   linux-executor:
     docker:
-      - image: "cimg/rust:1.88"  # Ensure that this matches the `rust-version` in `Cargo.toml`.
+      - image: "cimg/rust:1.90"  # Ensure that this matches the `rust-version` in `Cargo.toml`.
     resource_class: 2xlarge
 
 commands:
@@ -44,12 +44,12 @@ commands:
           name: Install Rust
           command: |
             # If Rust is not installed on the machine, install it
-            # (temporarily install it regardless, as we want 1.88.0, not 1.85.0)
+            # (temporarily install it regardless, as we want 1.90.0, not 1.85.0)
             # if ! command -v rustc &> /dev/null; then
               curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
               source "$HOME/.cargo/env"
-              rustup install 1.88.0
-              rustup override set 1.88.0
+              rustup install 1.90.0
+              rustup override set 1.90.0
               cargo --version --verbose
               rustc --version
             # fi
@@ -71,8 +71,8 @@ commands:
             Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "C:\\rustup-init.exe"
             Start-Process "C:\\rustup-init.exe" -ArgumentList '-y' -Wait
             $Env:Path += ";$Env:USERPROFILE\.cargo\bin"
-            rustup install 1.88.0
-            rustup default 1.88.0
+            rustup install 1.90.0
+            rustup default 1.90.0
             cargo --version --verbose
             rustc --version | Out-File -FilePath "rust-version"
             if (!(Test-Path "Cargo.lock" -PathType Leaf)) {
@@ -109,6 +109,8 @@ jobs:
       size: xlarge
     environment:
       CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+      RUST_MIN_STACK: "16777216"    # 16 MB stack for rustc
+      CARGO_INCREMENTAL: 0
     steps:
       - run:
           name: Force git to use HTTPS
@@ -265,7 +267,7 @@ jobs:
 
   leo-new:
     docker:
-      - image: cimg/rust:1.88
+      - image: cimg/rust:1.90
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -278,7 +280,7 @@ jobs:
 
   leo-clean:
     docker:
-      - image: cimg/rust:1.88
+      - image: cimg/rust:1.90
     resource_class: xlarge
     steps:
       - attach_workspace:
@@ -291,7 +293,7 @@ jobs:
 
   test-examples:
     docker:
-      - image: cimg/rust:1.88
+      - image: cimg/rust:1.90
     resource_class: xlarge
     steps:
       - attach_workspace:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ebd144c81671193ed85aa2db9bb5e183421843e0485de8fffc07e5cf50e18a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "syn 1.0.109",
 ]
 
@@ -100,7 +100,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f6ff9e4c36858fa2c29e5284b77527b5a7466743976e1ba1f5824e16683545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "syn 1.0.109",
 ]
 
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
@@ -186,9 +186,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arbitrary"
@@ -227,8 +227,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -245,9 +245,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -255,17 +255,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "base62"
-version = "2.2.2"
+version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0104d4d8d15e458f21dcd027ea350bf38e4364954909402f4da075aca8d0f136"
-dependencies = [
- "rustversion",
-]
+checksum = "1adf9755786e27479693dedd3271691a92b5e242ab139cacb9fb8e7fb5381111"
 
 [[package]]
 name = "base64"
@@ -317,9 +314,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "blake2"
@@ -394,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -404,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -424,14 +421,14 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "f4512b90fa68d3a9932cea5184017c5d200f5921df706d45e853537dea51508f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -439,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "0025e98baa12e766c67ba13ff4695a887a1eba19569aad00a472546795bd6730"
 dependencies = [
  "anstream",
  "anstyle",
@@ -451,21 +448,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.47"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfd7eae0b0f1a6e63d4b13c9c478de77c2eb546fba158ad50b4203dc24b9f9c"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "color-backtrace"
@@ -675,7 +672,7 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -714,7 +711,7 @@ checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
 dependencies = [
  "dispatch",
  "nix",
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -770,8 +767,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -793,9 +790,9 @@ dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "strsim",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -805,8 +802,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -821,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
 ]
@@ -835,7 +832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "syn 1.0.109",
 ]
 
@@ -846,8 +843,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -867,8 +864,8 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -928,8 +925,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1024,8 +1021,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1052,12 +1049,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1074,9 +1071,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "fixedbitset"
@@ -1086,9 +1083,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "dc5a4e564e38c699f2880d3fda590bedc2e69f3f84cd48b457bd892ce61d0aa9"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1105,6 +1102,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1218,9 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1235,29 +1238,29 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.4+wasi-0.2.4",
+ "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -1286,7 +1289,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1413,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
@@ -1439,9 +1453,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1576,14 +1590,15 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.0",
  "rayon",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1614,19 +1629,8 @@ dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1677,9 +1681,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1976,15 +1980,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -2010,9 +2014,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -2028,11 +2032,10 @@ checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -2061,10 +2064,10 @@ dependencies = [
  "fnv",
  "lazy_static",
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2082,16 +2085,16 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "lru"
-version = "0.16.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea4e65087ff52f3862caff188d489f1fab49a0cb09e01b2e3f1a617b10aaed"
+checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -2102,9 +2105,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -2125,6 +2128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2135,7 +2139,7 @@ checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.59.0",
 ]
 
@@ -2186,11 +2190,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2216,8 +2220,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2266,9 +2270,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -2287,9 +2291,9 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2307,8 +2311,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2319,9 +2323,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
@@ -2331,9 +2335,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2341,15 +2345,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2488,7 +2492,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -2501,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "bytes",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.2",
  "ring",
@@ -2509,7 +2513,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2537,9 +2541,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
 dependencies = [
  "proc-macro2",
 ]
@@ -2606,7 +2610,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2661,9 +2665,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -2681,9 +2685,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2693,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2704,15 +2708,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.23"
+version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
  "base64",
  "bytes",
@@ -2825,22 +2829,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
  "log",
  "once_cell",
@@ -2872,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2913,11 +2917,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3014,41 +3018,52 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3084,8 +3099,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -3205,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f2562036f5c3610b3b6e1233025e48740eeaee6e8966a5b84c261f9d0813cf"
+checksum = "85856c203f95cb7fe5115f8f456009305f2ec3ca172826001b15cbcd22bb6178"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -3225,23 +3240,23 @@ dependencies = [
  "snarkvm-parameters",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "ureq",
  "walkdir",
 ]
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ff92927dbd501b3975f3a35be4514f154c7bfde0db3dae2c89a4ebd0a6c2a31"
+checksum = "5109ede2ee0c74ade2d3e4a3c66ae2312b1cb127b1df0e8d79a112762786a3fb"
 dependencies = [
  "aleo-std",
  "anyhow",
  "blake2",
  "cfg-if",
  "fxhash",
- "hashbrown",
+ "hashbrown 0.15.5",
  "hex",
  "indexmap",
  "itertools 0.14.0",
@@ -3255,14 +3270,14 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfedf2ae76fbb1b50228619777e403091d86afa68431977e3254047621d631eb"
+checksum = "9445069abc4f77ef2c08918d9a86f07e8449371fd76a802eceafb23e22191d06"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3275,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9ada6b1454609b36c1f3b7bc267730e2f0cd0417b0757d8418202b7fa10023"
+checksum = "e610b4f8238551f20a68726bd3e6e9287f6918cfd5c4d3cef278995c6de89ca5"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -3286,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f7d5a0455572948306431129ac86f66e5a826c4d6483003f63c1aa06d66dcb"
+checksum = "ddcafcd3ab0e9a7799190a8dce2cbf558451bdee1cbaa9426aafc1270a9394a9"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -3297,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "279271263ba9c9643e791fa7b8a445761a02ac56fbb530faac6c7c350b85f10b"
+checksum = "912ed23e9da17647ffe6c9aa2d483151566316d79368d55bd08aabee1ed43dc9"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -3308,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1024c91b9bf4cb14268fafd7945b9a68e462132cd5c834bcec8e04def98cd207"
+checksum = "1d38b225bf5f2310e3343c1e2ae785eb738ebbc782486a7cec7050d9a3687fb0"
 dependencies = [
  "indexmap",
  "itertools 0.14.0",
@@ -3327,15 +3342,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433b0c2fc969a514ac01f6e05756be6d928142eaae3f0ef6805aa6396159dd83"
+checksum = "9fda3fe972efa831af20c9ff0c4cde6d83afa0cad03b6739c159ed4fe36e8cfb"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220bee6126a7290a2697f44ba9dea9d46e586303827306637bd93a63ce505fe9"
+checksum = "de72982b2fd56fb21d18b5111eaca84b6a91b1a9b5bdaa31edec90ccae376c3a"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -3345,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf624e44496a2db2d28917acf62a3da026298909f60d051aae8ff022cb5e2f30"
+checksum = "76f4e227dfb913867d84db9b6a7fa5c70d2beb803c7149ce5e48dbde40b98b4e"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -3360,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e86fd576228776bcd748aca18926d17851120cfc8746bbf186481b9d7acdab"
+checksum = "aca8f0cafbab3b59bb78e1f26a954037fe9add7f2aa832ea9e2a118343e17901"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -3376,9 +3391,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fada6e6937fb8ae7d25ad0e84110f89492c30e079d71b25c4b952abb8ba5e0ee"
+checksum = "19fd4ef1efa8bb440a328e7b9da914e0e2932aa8ad604faabcb14041a14c9075"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3390,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b0dfd0497a5b5bede8cabbb79e5b95b9f2c0de6ff896e6f89295509243ef9d0"
+checksum = "81958244525db94f02ad296501eb720721befad5f4006350be4e0ae74f17425c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -3400,9 +3415,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9406f29259e02fc2a110022619cec95f8a7db420542c6daae6b8258ff7501205"
+checksum = "0cd463a6d8f5675ae13ab7e9542a0035473eb7e02f50249b8c950879e8290296"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3411,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9978e0b3331faec1244931a62bae48d79b5b8d2b0d247aa8bc6f945b650d95a"
+checksum = "3378c0b56b8093686a10cf622aa50e39e2af59de95e8b40449ea7017e5d40fab"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3424,9 +3439,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c68dd8c19158cf4734377ef906c3dab5c756465b05f7d5a838f4ee4adbca549"
+checksum = "bf890bee9e11553018b4a0b5a1ef16f418e9cdf2406ca9177a2d0399004cfad5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3437,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbea45346dc6247f31d294c84ef4595c784d16766939dceb8ddfe3b18ea9feb9"
+checksum = "14882074f2f1bd8a98ffd8d9fb0ba6c3cfb5b6fa71d56766ec957da3c221b3ee"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3449,9 +3464,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9467bba1edd47c201dfd863b8e5e67be6ea3c268bb705f084d98bbf72ff25385"
+checksum = "63445d7ca3a28047dd55363d7878515048453be68901e0279d3793a76f776eb4"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -3462,9 +3477,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8819ed1e129aa99dc5636017a9397e18d356dfbd13b1141e4275816a0d817968"
+checksum = "94af745b6a95d55e31a1ba070a5676a624a56d3eeaa34db79a26c6b779de4ef1"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -3476,9 +3491,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eaeb0b8c5402d1e9ec0e22466d87e621a72b5c4d191e9e4282a2b4aec21707b"
+checksum = "98c392fa0e55f758bd403431e44ed9ed7cb9c766f1351a532c9e9c88c9bfa9a2"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -3488,9 +3503,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09b9d82502ae99c20f335baa431977513e2676092970ff5deb9b8ef997b295"
+checksum = "935c825518415d3b36efadab062ca98091396d2ceb087b243a965023b6653cbc"
 dependencies = [
  "blake2s_simd",
  "smallvec",
@@ -3502,9 +3517,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e5d68b4a24c928ef579de5d46e882b0cf85d48206e29fd6f0413216204a249"
+checksum = "d6e166c5f1e018df26e35dc36e4f75591c7a16a97246e13296a8f6b18efa5312"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -3514,9 +3529,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1220d41581ac064d916e953d78fcca4ce13c28648bef3df71eadd1359d61f594"
+checksum = "9ff197ec057c6ba64b69f0e72cf55d4ebecbfd6c619424f8662105284edbc0e2"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -3535,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2cff4c435e430b62ee09304da850f26aa9839e5ccf0603618b62c2db745a2db"
+checksum = "35d8057effcc0e71e733cfc90bf33fdcb8d6e5bf1b42f28efe2eb62a1a477d52"
 dependencies = [
  "anyhow",
  "bech32",
@@ -3554,9 +3569,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86af968fb1d5777b235aca1a6819a291c2d89cdb971e939f60e0c8bebef169fb"
+checksum = "11e139ddb756a05463902c242ede3ef6f1ae397738594788a7a9c425721fdb91"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -3575,9 +3590,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdfc69ed664199bf8ec712dbba4174437f5b4e326b673c204d5070afcfd90d58"
+checksum = "08f3cf54fa88fe5c6713e1fd5759d8ebf9c9882fd0e91a4b8f1f5407a2a27842"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -3591,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a3c338adfab1d4171c1333ea971cf4506165cf6cd4be5128f044cd50cb926f"
+checksum = "2a2e33b3891601a4027fb89ccf6c9706cbb69ffc42ec67ea370195e43637a624"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3603,18 +3618,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5306794f9ec3e380f8de5d8e3f1674182a6f758892604861b85d7292bd8496"
+checksum = "3a1e1a83901796e92da6dd01d37300a31a02347d39860d23ea16d69341ee265c"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053872b00170acc87bbd010b6ec953e950cd80fd504aa9e789754358090bf2fc"
+checksum = "f1766fe487f9dd0c6f3359ca4bfb0280b3a92e5f84028bb7e7f2422b40a2afe7"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3623,9 +3638,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ccf05eb7691e7616fd5c8864d0be6b9c92664d9b360b14e41fe5b0c55f4c613"
+checksum = "e28a2e83cd8b712c1b173bc0f35f7c572b13eeabf4bc73515d38ab5accf26cb5"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3635,9 +3650,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafa8e38818b6886411204f6263c081f9119f0b8173eb1d824ff1fb0446f6f60"
+checksum = "f0f731df2996c2a325ab8107d83b241deaf3e7c6f48e7eb6fa871a69bd1f71ef"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3647,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14823c16c5a3e5bf70e2346994f43386967d327835b7a622dc2ed086266e790"
+checksum = "3c58188bb3108593475ee89fcc288c789153d1e41ec80b2f07ad1e416a27a0a2"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3659,9 +3674,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253940e1e7754a14b2cf4e72f56db50b8c34bb28a5b896b76e35f29b250d92a"
+checksum = "10e5f4e775c088b2cbc6d86a4cd3a58b08d911e4a9bcb7860a13b5ba4fb449e0"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -3671,9 +3686,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f4cae48b8f560acbf178616b781877b4fe752e44ec6925f53b5d4805d1b6fe"
+checksum = "f46a7fb8fa3d7087cf9c28d0f6d159ae8cb2265c994d919321737b9b5e661a2f"
 dependencies = [
  "rand 0.8.5",
  "rayon",
@@ -3681,14 +3696,14 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b58192c2da361f2b77b088d6da1c0e73d9f29cc6375cb3c03965a055bf0990"
+checksum = "fe670f9ed0af1ab07f272b75feea052bc8a00d34bf23c29980620c0b052c2419"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3698,20 +3713,20 @@ dependencies = [
  "rayon",
  "serde",
  "snarkvm-utilities",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-ledger"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c78ff62ba9dfc1158fc4f5d747862b0660a15002897d43b676b5958f2e7d4c"
+checksum = "f331784bb69fff458fe80b2d01531bf1ef88e9ce70febecc8eeaf81188dba2bf"
 dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap",
- "lru 0.16.0",
+ "lru 0.16.2",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -3730,9 +3745,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bda7ffa0ed7626b39b11a992ccfb41a1a977737194699c2804069900f6d28c"
+checksum = "0e78a35abdf6e4c09d9a846b8af820d368dc9256c1f9a6bee0aa8118c9ec3255"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -3743,9 +3758,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18338abd3ea59b4447c5e02681dfe2bccc5dbd5b7f62a2be3bfd4be2c6318e18"
+checksum = "74e26ce6baa14314e03bc602bbf65e5bb56603e000a176faa0af45dcb5a0de46"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3764,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54083bd33e3e8401672cab534e484362ff54a947f234e566a64a07e13ee6f818"
+checksum = "895b8c5024243b5ef4338fa880fae31b90b71a17a04114990e7fbf041014fdc9"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3777,9 +3792,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cc037b976887d628d226a7ecdf822a90d5107203da9cf414d1318a8c6239fe"
+checksum = "5ab00421bcfcaf9c779e17396e95a4b5ae7e7ffa897f3ea79c4ae7d63809ea5c"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -3791,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3bef13150d91e07d57109520b27d99731520386d529500b874e7378ff727d4"
+checksum = "d447fa9f35c9b4387e98a723f01ce8c6b7aff667f7344bcf38764cc97f65d681"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3805,9 +3820,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bd7ad7a309542acb0d640fefafb195d80b894c494a2c2c9c103017347ed87f"
+checksum = "ace7727a2bf02fffcb22ca058c95d6514e6a3a57a9839d7ad44f007b1e4bd11f"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3818,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae4b94d1c2899fac3ebc620f48c60ecd7ab9e27ced13efe1cf272cf4472a62"
+checksum = "05ac4be0d55ace0326cb2087463890c4eafbf7e0b405012a4df34414e0182d3b"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3830,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7123458b2e723fbe1f12f04fc145d77eaebf37dac4e4aff06c45e10b27ab0928"
+checksum = "ff3a08f9bb27da839b1ad20244470fa1824361fdd56f806e5e28e1cc38036a1e"
 dependencies = [
  "indexmap",
  "rayon",
@@ -3846,9 +3861,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa35891d54db4654af6d3adae19eb34ea3330aa4da51497e1d8cc72590048f1e"
+checksum = "e1873d3731212b8ebac907ef817154a36cee001b319d6d0d6534d4a66b3ad420"
 dependencies = [
  "bytes",
  "serde_json",
@@ -3860,9 +3875,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834e57f5d2f062aa27ecaca5e2a871e70014069030ec333bb263264899e8ecbd"
+checksum = "40ef0967fd51eb4e249e18d7625c8af2dee594d25e808827a886761007609859"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -3870,15 +3885,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa5d53b35ea5961ad0373a333a4804c0c98717b89788c0e10fb5431c4fb1b2b4"
+checksum = "b9d5adea7c8030dafe417c86cda0d5bff753e96ee02c7797e965ae5bd36c8485"
 dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
  "indexmap",
- "lru 0.16.0",
+ "lru 0.16.2",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3890,15 +3905,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c64b9c837315b38c736c4c7094e43b91f061404c526c81c7ffda7dcc5a4486"
+checksum = "3083c21cd197dfd9642b51997f244b0e12a5bdf252760f99e16fbb73e6cbb80a"
 dependencies = [
  "aleo-std",
  "anyhow",
  "colored 3.0.0",
  "indexmap",
- "lru 0.16.0",
+ "lru 0.16.2",
  "parking_lot",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -3913,9 +3928,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8919e7e17484d214a717960036496459a3c39862cc0a3ec685b808e6f73c2ba"
+checksum = "591aeb3d82f410d1a01e88670dfc668ca4317681554b289e1c673a191b86f195"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3931,9 +3946,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d63c2459f69ed66343c4f8258cb997b29be201b59ae6d32d4bb8f973c9dea8"
+checksum = "5934564cc667b67d0261178f0fa5376bced832775c6d143753cd55c9671ddb82"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -3955,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccae4ccd30d936f69a8470c1c06fdd53172ab25b6f0352c409205e6f0526213"
+checksum = "662b07d5ee980159251d92f42ed908f0839bb2737c032bea9ddb6e0268834b4d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -3973,20 +3988,20 @@ dependencies = [
  "sha2",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3f1b6a76f83dea1d10a36f51022507e38e04ea6420184522a12435e4e5bfb4"
+checksum = "65e3eb0d61d2671bc7c05cae718dbba5bbd2724547c6472e6ed6c1ce173f9cd1"
 dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap",
  "itertools 0.14.0",
- "lru 0.16.0",
+ "lru 0.16.2",
  "parking_lot",
  "rand 0.8.5",
  "rayon",
@@ -4010,9 +4025,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202f8993b1d84e4b435e6f06655e5faf8611318b49a724db3bcc6521061b846c"
+checksum = "bb7a18725bffbde26039ea1b589e99ae7af4068d0c86c9cdbe64e8c8e2f6a373"
 dependencies = [
  "aleo-std",
  "colored 3.0.0",
@@ -4035,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf311b775983ceeacd94a20e076b4cf37f2f2233177a5a332e48f8af2fdcf505"
+checksum = "4584929f5ccd4249edf719483ed982c9d5d8fe0347bf0118135250fde08c6497"
 dependencies = [
  "indexmap",
  "paste",
@@ -4054,9 +4069,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8497d8ffd96bab5dc5a4d2c1365598a7390f79ac75dd7961609e7f607b07840"
+checksum = "f0ae2ebd6aee32fd91bcd172afb768cbd03446874295a0fffb293cc7edaab0a8"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4068,9 +4083,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c752d0233bb34b61fefa01d20ed114c559950883d18a68a3023b91dced54a6"
+checksum = "7844107d86d4bf13775c1c336966180c9a628a4b9143978a88962b9fc12bd27e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4084,29 +4099,29 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "zeroize",
 ]
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd2e4465f1af843b2f9e4c83c97d48c4a9c9e3522b4020e8dd9ef82d0ce5324a"
+checksum = "f69be17b78dc0a81eff52f9dde3bdbf35f866778090fb0218c2806fb4dfe1df4"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4121,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -4166,9 +4181,9 @@ checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "rustversion",
- "syn 2.0.106",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4195,18 +4210,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
+ "quote 1.0.41",
  "unicode-ident",
 ]
 
@@ -4235,8 +4250,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4272,15 +4287,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix 1.0.8",
- "windows-sys 0.60.2",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4289,7 +4304,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4312,11 +4327,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -4326,19 +4341,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4352,11 +4367,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -4416,19 +4432,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
- "slab",
  "socket2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4443,9 +4456,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -4527,8 +4540,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4574,15 +4587,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4744,19 +4757,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4767,23 +4780,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4794,41 +4807,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
- "quote 1.0.40",
+ "quote 1.0.41",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4846,9 +4859,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4887,7 +4900,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4898,37 +4911,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -4939,9 +4952,9 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
@@ -4950,8 +4963,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -4964,12 +4977,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4996,16 +5027,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
 name = "windows-sys"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5026,19 +5057,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.1.3",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -5049,9 +5080,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5061,9 +5092,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5073,9 +5104,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -5085,9 +5116,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5097,9 +5128,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5109,9 +5140,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5121,9 +5152,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5133,15 +5164,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -5168,8 +5199,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
  "synstructure",
 ]
 
@@ -5189,8 +5220,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5209,16 +5240,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 dependencies = [
  "zeroize_derive",
 ]
@@ -5230,8 +5261,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5263,8 +5294,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.40",
- "syn 2.0.106",
+ "quote 1.0.41",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -5280,7 +5311,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
  "zopfli",
 ]
@@ -5292,7 +5323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "ed25519-dalek",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ include = [
 ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.90.0"
 
 [workspace]
 members = [

--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.snarkvm]
 workspace = true

--- a/compiler/ast/src/common/graph/mod.rs
+++ b/compiler/ast/src/common/graph/mod.rs
@@ -198,10 +198,10 @@ impl<N: GraphNode> DiGraph<N> {
                     return Some(child.clone());
                 }
                 // If the node has not been explored, explore it.
-                if !finished.contains(child) {
-                    if let Some(cycle_node) = self.contains_cycle_from(child, discovered, finished) {
-                        return Some(cycle_node);
-                    }
+                if !finished.contains(child)
+                    && let Some(cycle_node) = self.contains_cycle_from(child, discovered, finished)
+                {
+                    return Some(cycle_node);
                 }
             }
         }

--- a/compiler/ast/src/common/path.rs
+++ b/compiler/ast/src/common/path.rs
@@ -128,10 +128,10 @@ impl Path {
         self.identifier.name = new_symbol;
 
         // Update absolute_path's last symbol if present
-        if let Some(ref mut abs_path) = self.absolute_path {
-            if let Some(last) = abs_path.last_mut() {
-                *last = new_symbol;
-            }
+        if let Some(ref mut abs_path) = self.absolute_path
+            && let Some(last) = abs_path.last_mut()
+        {
+            *last = new_symbol;
         }
 
         self

--- a/compiler/ast/src/interpreter_value/value.rs
+++ b/compiler/ast/src/interpreter_value/value.rs
@@ -950,17 +950,17 @@ impl FromStr for Value {
         }
 
         // Or it's a tuple.
-        if let Some(s) = s.strip_prefix("(") {
-            if let Some(s) = s.strip_suffix(")") {
-                let mut results = Vec::new();
-                for item in s.split(',') {
-                    let item = item.trim();
-                    let value: Value = item.parse().map_err(|_| ())?;
-                    results.push(value);
-                }
-
-                return Ok(Value::make_tuple(results));
+        if let Some(s) = s.strip_prefix("(")
+            && let Some(s) = s.strip_suffix(")")
+        {
+            let mut results = Vec::new();
+            for item in s.split(',') {
+                let item = item.trim();
+                let value: Value = item.parse().map_err(|_| ())?;
+                results.push(value);
             }
+
+            return Ok(Value::make_tuple(results));
         }
 
         // Or it's an unsuffixed numeric literal.

--- a/compiler/ast/src/passes/visitor.rs
+++ b/compiler/ast/src/passes/visitor.rs
@@ -337,20 +337,20 @@ pub trait ProgramVisitor: AstVisitor {
     }
 
     fn visit_program_scope(&mut self, input: &ProgramScope) {
-        input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
-        input.structs.iter().for_each(|(_, c)| (self.visit_struct(c)));
-        input.mappings.iter().for_each(|(_, c)| (self.visit_mapping(c)));
-        input.storage_variables.iter().for_each(|(_, c)| (self.visit_storage_variable(c)));
-        input.functions.iter().for_each(|(_, c)| (self.visit_function(c)));
+        input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.structs.iter().for_each(|(_, c)| self.visit_struct(c));
+        input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
+        input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
+        input.functions.iter().for_each(|(_, c)| self.visit_function(c));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }
     }
 
     fn visit_module(&mut self, input: &Module) {
-        input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
-        input.structs.iter().for_each(|(_, c)| (self.visit_struct(c)));
-        input.functions.iter().for_each(|(_, c)| (self.visit_function(c)));
+        input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.structs.iter().for_each(|(_, c)| self.visit_struct(c));
+        input.functions.iter().for_each(|(_, c)| self.visit_function(c));
     }
 
     fn visit_stub(&mut self, _input: &Stub) {}

--- a/compiler/ast/src/types/array.rs
+++ b/compiler/ast/src/types/array.rs
@@ -63,10 +63,10 @@ impl ArrayType {
 impl fmt::Display for ArrayType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // For display purposes (in error messages for example.), do not include the type suffix.
-        if let Expression::Literal(literal) = &*self.length {
-            if let LiteralVariant::Integer(_, s) = &literal.variant {
-                return write!(f, "[{}; {s}]", self.element_type);
-            }
+        if let Expression::Literal(literal) = &*self.length
+            && let LiteralVariant::Integer(_, s) = &literal.variant
+        {
+            return write!(f, "[{}; {s}]", self.element_type);
         }
 
         write!(f, "[{}; {}]", self.element_type, self.length)

--- a/compiler/compiler/Cargo.toml
+++ b/compiler/compiler/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.leo-ast]
 workspace = true

--- a/compiler/parser-lossless/Cargo.toml
+++ b/compiler/parser-lossless/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.leo-span]
 workspace = true

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.leo-ast]
 workspace = true

--- a/compiler/parser/src/conversions.rs
+++ b/compiler/parser/src/conversions.rs
@@ -900,14 +900,13 @@ pub fn to_expression(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Han
                     span,
                     ..
                 }) = &mut operand_expression
+                    && !string.starts_with('-')
                 {
-                    if !string.starts_with('-') {
-                        // The operation was a negation and the literal was not already negative, so fold it in
-                        // and discard the unary expression.
-                        string.insert(0, '-');
-                        *span = op.span + operand.span;
-                        return Ok(operand_expression);
-                    }
+                    // The operation was a negation and the literal was not already negative, so fold it in
+                    // and discard the unary expression.
+                    string.insert(0, '-');
+                    *span = op.span + operand.span;
+                    return Ok(operand_expression);
                 }
             }
             leo_ast::UnaryExpression { receiver: operand_expression, op: op_variant, span, id }.into()

--- a/compiler/parser/src/lib.rs
+++ b/compiler/parser/src/lib.rs
@@ -205,11 +205,11 @@ fn compute_module_key(name: &FileName, root_dir: Option<&std::path::Path>) -> Op
         path.components().map(|comp| Symbol::intern(&comp.as_os_str().to_string_lossy())).collect();
 
     // Strip the file extension from the last component (e.g., "bar.leo" → "bar")
-    if let Some(last) = path.file_name() {
-        if let Some(stem) = std::path::Path::new(last).file_stem() {
-            key.pop(); // Remove "bar.leo"
-            key.push(Symbol::intern(&stem.to_string_lossy())); // Add "bar"
-        }
+    if let Some(last) = path.file_name()
+        && let Some(stem) = std::path::Path::new(last).file_stem()
+    {
+        key.pop(); // Remove "bar.leo"
+        key.push(Symbol::intern(&stem.to_string_lossy())); // Add "bar"
     }
 
     Some(key)

--- a/compiler/passes/Cargo.toml
+++ b/compiler/passes/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [lib]
 path = "src/lib.rs"

--- a/compiler/passes/src/code_generation/program.rs
+++ b/compiler/passes/src/code_generation/program.rs
@@ -237,10 +237,9 @@ impl<'a> CodeGeneratingVisitor<'a> {
                 let program = comp.program.unwrap_or(self.program_id.unwrap().name.name);
                 if let Some(record) =
                     self.state.symbol_table.lookup_record(&Location::new(program, comp.path.absolute_path().to_vec()))
+                    && (record.external.is_none() || record.external == self.program_id.map(|id| id.name.name))
                 {
-                    if record.external.is_none() || record.external == self.program_id.map(|id| id.name.name) {
-                        self.internal_record_inputs.insert(register_string.clone());
-                    }
+                    self.internal_record_inputs.insert(register_string.clone());
                 }
             }
 

--- a/compiler/passes/src/common/symbol_table/mod.rs
+++ b/compiler/passes/src/common/symbol_table/mod.rs
@@ -78,10 +78,10 @@ struct LocalTableInner {
 impl LocalTable {
     fn new(symbol_table: &mut SymbolTable, id: NodeID, parent: Option<NodeID>) -> Self {
         // If parent exists, register this scope as its child
-        if let Some(parent_id) = parent {
-            if let Some(parent_table) = symbol_table.all_locals.get_mut(&parent_id) {
-                parent_table.inner.borrow_mut().children.push(id);
-            }
+        if let Some(parent_id) = parent
+            && let Some(parent_table) = symbol_table.all_locals.get_mut(&parent_id)
+        {
+            parent_table.inner.borrow_mut().children.push(id);
         }
 
         LocalTable {
@@ -368,10 +368,10 @@ impl SymbolTable {
         let mut current = self.local.as_ref();
 
         while let Some(table) = current {
-            if let [name] = &path {
-                if table.inner.borrow().variables.contains_key(name) {
-                    return Err(AstError::shadowed_variable(name, span).into());
-                }
+            if let [name] = &path
+                && table.inner.borrow().variables.contains_key(name)
+            {
+                return Err(AstError::shadowed_variable(name, span).into());
             }
             current = table.inner.borrow().parent.map(|id| self.all_locals.get(&id).expect("Parent should exist."));
         }

--- a/compiler/passes/src/loop_unrolling/ast.rs
+++ b/compiler/passes/src/loop_unrolling/ast.rs
@@ -89,10 +89,10 @@ impl AstReconstructor for UnrollingVisitor<'_> {
         // Helper to clone and resolve Unsuffixed -> Integer literal based on type table
         let resolve_unsuffixed = |lit: &leo_ast::Literal, expr_id| {
             let mut resolved = lit.clone();
-            if let LiteralVariant::Unsuffixed(s) = &resolved.variant {
-                if let Some(Type::Integer(integer_type)) = self.state.type_table.get(&expr_id) {
-                    resolved.variant = LiteralVariant::Integer(integer_type, s.clone());
-                }
+            if let LiteralVariant::Unsuffixed(s) = &resolved.variant
+                && let Some(Type::Integer(integer_type)) = self.state.type_table.get(&expr_id)
+            {
+                resolved.variant = LiteralVariant::Integer(integer_type, s.clone());
             }
             resolved
         };

--- a/compiler/passes/src/static_analysis/program.rs
+++ b/compiler/passes/src/static_analysis/program.rs
@@ -24,11 +24,11 @@ impl ProgramVisitor for StaticAnalyzingVisitor<'_> {
         // Set the current program name.
         self.current_program = input.program_id.name.name;
         // Do the default implementation for visiting the program scope.
-        input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
-        input.structs.iter().for_each(|(_, c)| (self.visit_struct(c)));
-        input.mappings.iter().for_each(|(_, c)| (self.visit_mapping(c)));
-        input.storage_variables.iter().for_each(|(_, c)| (self.visit_storage_variable(c)));
-        input.functions.iter().for_each(|(_, c)| (self.visit_function(c)));
+        input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.structs.iter().for_each(|(_, c)| self.visit_struct(c));
+        input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
+        input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
+        input.functions.iter().for_each(|(_, c)| self.visit_function(c));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }

--- a/compiler/passes/src/static_single_assignment/expression.rs
+++ b/compiler/passes/src/static_single_assignment/expression.rs
@@ -69,10 +69,10 @@ impl ExpressionConsumer for SsaFormingVisitor<'_> {
 
     fn consume_member_access(&mut self, input: MemberAccess) -> Self::Output {
         // If the access expression is of the form `self.<name>`, then don't rename it.
-        if let Expression::Path(path) = &input.inner {
-            if path.identifier().name == sym::SelfLower {
-                return (input.into(), Vec::new());
-            }
+        if let Expression::Path(path) = &input.inner
+            && path.identifier().name == sym::SelfLower
+        {
+            return (input.into(), Vec::new());
         }
 
         let (inner, statements) = self.consume_expression_and_define(input.inner);

--- a/compiler/passes/src/symbol_table_creation/mod.rs
+++ b/compiler/passes/src/symbol_table_creation/mod.rs
@@ -116,11 +116,11 @@ impl ProgramVisitor for SymbolTableCreationVisitor<'_> {
         self.is_stub = false;
 
         // Visit the program scope
-        input.consts.iter().for_each(|(_, c)| (self.visit_const(c)));
-        input.structs.iter().for_each(|(_, c)| (self.visit_struct(c)));
-        input.mappings.iter().for_each(|(_, c)| (self.visit_mapping(c)));
-        input.storage_variables.iter().for_each(|(_, c)| (self.visit_storage_variable(c)));
-        input.functions.iter().for_each(|(_, c)| (self.visit_function(c)));
+        input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.structs.iter().for_each(|(_, c)| self.visit_struct(c));
+        input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
+        input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
+        input.functions.iter().for_each(|(_, c)| self.visit_function(c));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }
@@ -129,9 +129,9 @@ impl ProgramVisitor for SymbolTableCreationVisitor<'_> {
     fn visit_module(&mut self, input: &Module) {
         self.program_name = input.program_name;
         self.in_module_scope(&input.path.clone(), |slf| {
-            input.structs.iter().for_each(|(_, c)| (slf.visit_struct(c)));
-            input.functions.iter().for_each(|(_, c)| (slf.visit_function(c)));
-            input.consts.iter().for_each(|(_, c)| (slf.visit_const(c)));
+            input.structs.iter().for_each(|(_, c)| slf.visit_struct(c));
+            input.functions.iter().for_each(|(_, c)| slf.visit_function(c));
+            input.consts.iter().for_each(|(_, c)| slf.visit_const(c));
         })
     }
 
@@ -207,9 +207,9 @@ impl ProgramVisitor for SymbolTableCreationVisitor<'_> {
     fn visit_stub(&mut self, input: &Stub) {
         self.is_stub = true;
         self.program_name = input.stub_id.name.name;
-        input.functions.iter().for_each(|(_, c)| (self.visit_function_stub(c)));
-        input.structs.iter().for_each(|(_, c)| (self.visit_struct_stub(c)));
-        input.mappings.iter().for_each(|(_, c)| (self.visit_mapping(c)));
+        input.functions.iter().for_each(|(_, c)| self.visit_function_stub(c));
+        input.structs.iter().for_each(|(_, c)| self.visit_struct_stub(c));
+        input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
     }
 
     fn visit_function_stub(&mut self, input: &FunctionStub) {

--- a/compiler/passes/src/type_checking/ast.rs
+++ b/compiler/passes/src/type_checking/ast.rs
@@ -360,16 +360,16 @@ impl TypeCheckingVisitor<'_> {
             self.emit_err(TypeCheckerError::async_cannot_assign_outside_conditional(input, "block", var.span));
         }
 
-        if let Some(async_block_id) = self.async_block_id {
-            if !self.state.symbol_table.is_defined_in_scope_or_ancestor_until(async_block_id, input.identifier().name) {
-                // If we're inside an async block (i.e. in the scope of its block or one if its child scopes) and if
-                // we're trying to assign to a variable that is not local to the block (or its child scopes), then we
-                // should error out.
-                self.emit_err(TypeCheckerError::cannot_assign_to_vars_outside_async_block(
-                    input.identifier().name,
-                    input.span,
-                ));
-            }
+        if let Some(async_block_id) = self.async_block_id
+            && !self.state.symbol_table.is_defined_in_scope_or_ancestor_until(async_block_id, input.identifier().name)
+        {
+            // If we're inside an async block (i.e. in the scope of its block or one if its child scopes) and if
+            // we're trying to assign to a variable that is not local to the block (or its child scopes), then we
+            // should error out.
+            self.emit_err(TypeCheckerError::cannot_assign_to_vars_outside_async_block(
+                input.identifier().name,
+                input.span,
+            ));
         }
 
         (var.type_.clone(), false)
@@ -396,10 +396,10 @@ impl TypeCheckingVisitor<'_> {
         if inferred == Type::Numeric {
             inferred = Type::Integer(IntegerType::U32);
 
-            if let Expression::Literal(literal) = expr {
-                if !self.check_numeric_literal(literal, &inferred) {
-                    inferred = Type::Err;
-                }
+            if let Expression::Literal(literal) = expr
+                && !self.check_numeric_literal(literal, &inferred)
+            {
+                inferred = Type::Err;
             }
 
             self.state.type_table.insert(expr.id(), inferred.clone());
@@ -1436,20 +1436,15 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
             //
             // Multiple occurrences of `owner` here is an error but that should be flagged somewhere else.
             input.members.iter().filter(|init| init.identifier.name == sym::owner).for_each(|init| {
-                if let Some(Expression::MemberAccess(access)) = &init.expression {
-                    if let MemberAccess {
+                if let Some(Expression::MemberAccess(access)) = &init.expression
+                    && let MemberAccess {
                         inner: Expression::Path(path),
                         name: Identifier { name: sym::caller, .. },
                         ..
                     } = &**access
-                    {
-                        if path.identifier().name == sym::SelfLower {
-                            self.emit_warning(TypeCheckerWarning::caller_as_record_owner(
-                                input.path.clone(),
-                                access.span(),
-                            ));
-                        }
-                    }
+                    && path.identifier().name == sym::SelfLower
+                {
+                    self.emit_warning(TypeCheckerWarning::caller_as_record_owner(input.path.clone(), access.span()));
                 }
             });
         }
@@ -1639,10 +1634,10 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         }
 
         // None of its members may be external record types either.
-        if let Type::Tuple(tuple) = &typ {
-            if tuple.elements().iter().any(|ty| self.is_external_record(ty)) {
-                self.emit_err(TypeCheckerError::ternary_over_external_records(&typ, input.span));
-            }
+        if let Type::Tuple(tuple) = &typ
+            && tuple.elements().iter().any(|ty| self.is_external_record(ty))
+        {
+            self.emit_err(TypeCheckerError::ternary_over_external_records(&typ, input.span));
         }
 
         typ

--- a/compiler/passes/src/type_checking/visitor.rs
+++ b/compiler/passes/src/type_checking/visitor.rs
@@ -1292,10 +1292,10 @@ impl TypeCheckingVisitor<'_> {
 
             // Arrays
             Type::Array(array_type) => {
-                if let Some(length) = array_type.length.as_u32() {
-                    if length == 0 || length > self.limits.max_array_elements as u32 {
-                        self.emit_err(TypeCheckerError::invalid_storage_type("array", span));
-                    }
+                if let Some(length) = array_type.length.as_u32()
+                    && (length == 0 || length > self.limits.max_array_elements as u32)
+                {
+                    self.emit_err(TypeCheckerError::invalid_storage_type("array", span));
                 }
 
                 let element_ty = array_type.element_type();
@@ -1564,14 +1564,13 @@ impl TypeCheckingVisitor<'_> {
 
             // If the function is not a transition function, then it cannot output a record.
             // Note that an external output must always be a record.
-            if let Type::Composite(struct_) = function_output.type_.clone() {
-                if let Some(val) =
+            if let Type::Composite(struct_) = function_output.type_.clone()
+                && let Some(val) =
                     self.lookup_struct(struct_.program.or(self.scope_state.program_name), &struct_.path.absolute_path())
-                {
-                    if val.is_record && !function.variant.is_transition() {
-                        self.emit_err(TypeCheckerError::function_cannot_input_or_output_a_record(function_output.span));
-                    }
-                }
+                && val.is_record
+                && !function.variant.is_transition()
+            {
+                self.emit_err(TypeCheckerError::function_cannot_input_or_output_a_record(function_output.span));
             }
 
             // Check that the output type is valid.

--- a/compiler/span/Cargo.toml
+++ b/compiler/span/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.indexmap]
 workspace = true

--- a/docs/grammar/Cargo.toml
+++ b/docs/grammar/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.anyhow]
 version = "1.0"

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.leo-span]
 workspace = true

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.snarkvm]
 workspace = true

--- a/interpreter/src/cursor.rs
+++ b/interpreter/src/cursor.rs
@@ -1314,10 +1314,10 @@ impl Cursor {
                     value.clone()
                 };
 
-                if let Some(asyncs) = maybe_future.as_ref().and_then(|fut| fut.as_future()) {
-                    if user_initiated {
-                        self.futures.extend(asyncs.iter().cloned());
-                    }
+                if let Some(asyncs) = maybe_future.as_ref().and_then(|fut| fut.as_future())
+                    && user_initiated
+                {
+                    self.futures.extend(asyncs.iter().cloned());
                 }
 
                 Ok(StepResult { finished, value })

--- a/interpreter/src/cursor_aleo.rs
+++ b/interpreter/src/cursor_aleo.rs
@@ -919,11 +919,11 @@ impl Cursor {
             panic!();
         };
         for (i, cmd) in finalize.commands().iter().enumerate() {
-            if let Command::Position(position) = cmd {
-                if position.name() == label {
-                    *instruction_index = i;
-                    return;
-                }
+            if let Command::Position(position) = cmd
+                && position.name() == label
+            {
+                *instruction_index = i;
+                return;
             }
         }
         panic!("branch to nonexistent label {label}");

--- a/interpreter/src/interpreter.rs
+++ b/interpreter/src/interpreter.rs
@@ -442,10 +442,10 @@ impl Interpreter {
 
             Run => {
                 while !self.cursor.frames.is_empty() {
-                    if let Some((program, line)) = self.current_program_and_line() {
-                        if self.breakpoints.iter().any(|bp| bp.program == program && bp.line == line) {
-                            return Ok(None);
-                        }
+                    if let Some((program, line)) = self.current_program_and_line()
+                        && self.breakpoints.iter().any(|bp| bp.program == program && bp.line == line)
+                    {
+                        return Ok(None);
                     }
                     self.cursor.step()?;
                     if self.update_watchpoints()? {
@@ -462,10 +462,10 @@ impl Interpreter {
     }
 
     pub fn view_current(&self) -> Option<impl Display> {
-        if let Some(span) = self.current_span() {
-            if span != Default::default() {
-                return with_session_globals(|s| s.source_map.contents_of_span(span));
-            }
+        if let Some(span) = self.current_span()
+            && span != Default::default()
+        {
+            return with_session_globals(|s| s.source_map.contents_of_span(span));
         }
 
         Some(match &self.cursor.frames.last()?.element {
@@ -556,14 +556,14 @@ impl Interpreter {
     }
 
     fn current_program_and_line(&self) -> Option<(String, usize)> {
-        if let Some(span) = self.current_span() {
-            if let Some(source_file) = with_session_globals(|s| s.source_map.find_source_file(span.lo)) {
-                let (line, _) = source_file.line_col(span.lo);
-                if let FileName::Real(name) = &source_file.name {
-                    if let Some(program) = self.filename_to_program.get(name) {
-                        return Some((program.clone(), line as usize + 1));
-                    }
-                }
+        if let Some(span) = self.current_span()
+            && let Some(source_file) = with_session_globals(|s| s.source_map.find_source_file(span.lo))
+        {
+            let (line, _) = source_file.line_col(span.lo);
+            if let FileName::Real(name) = &source_file.name
+                && let Some(program) = self.filename_to_program.get(name)
+            {
+                return Some((program.clone(), line as usize + 1));
             }
         }
         None

--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -122,11 +122,11 @@ Input history is available - use the up and down arrow keys.
 
 fn parse_breakpoint(s: &str) -> Option<Breakpoint> {
     let strings: Vec<&str> = s.split_whitespace().collect();
-    if strings.len() == 2 {
-        if let Ok(line) = strings[1].parse::<usize>() {
-            let program = strings[0].strip_suffix(".aleo").unwrap_or(strings[0]).to_string();
-            return Some(Breakpoint { program, line });
-        }
+    if strings.len() == 2
+        && let Ok(line) = strings[1].parse::<usize>()
+    {
+        let program = strings[0].strip_suffix(".aleo").unwrap_or(strings[0]).to_string();
+        return Some(Breakpoint { program, line });
     }
     None
 }

--- a/interpreter/src/ratatui_ui.rs
+++ b/interpreter/src/ratatui_ui.rs
@@ -90,7 +90,7 @@ fn append_lines<'a>(
     last_chunk
 }
 
-fn code_text(s: &str, highlight: Option<(usize, usize)>) -> (Text, usize) {
+fn code_text(s: &str, highlight: Option<(usize, usize)>) -> (Text<'_>, usize) {
     let Some((lo, hi)) = highlight else {
         return (Text::from(s), 0);
     };

--- a/leo/cli/commands/common/options.rs
+++ b/leo/cli/commands/common/options.rs
@@ -246,10 +246,10 @@ pub fn get_consensus_version(
 
     // Check `{endpoint}/{network}/consensus_version` endpoint for the consensus version.
     // If it returns a result and does not match the given version, print a warning.
-    if let Ok(consensus_version) = result {
-        if let Err(e) = check_consensus_version_mismatch(consensus_version, endpoint, network) {
-            println!("⚠️ Warning: {e}");
-        }
+    if let Ok(consensus_version) = result
+        && let Err(e) = check_consensus_version_mismatch(consensus_version, endpoint, network)
+    {
+        println!("⚠️ Warning: {e}");
     }
 
     result
@@ -262,12 +262,12 @@ pub fn check_consensus_version_mismatch(
     network: NetworkName,
 ) -> anyhow::Result<()> {
     // Check the `{endpoint}/{network}/consensus_version` endpoint for the consensus version.
-    if let Ok(response) = fetch_from_network(&format!("{endpoint}/{network}/consensus_version")) {
-        if let Ok(response) = response.parse::<u8>() {
-            let consensus_version = consensus_version as u8;
-            if response != consensus_version {
-                bail!("Expected consensus version {consensus_version} but found {response} at {endpoint}",);
-            }
+    if let Ok(response) = fetch_from_network(&format!("{endpoint}/{network}/consensus_version"))
+        && let Ok(response) = response.parse::<u8>()
+    {
+        let consensus_version = consensus_version as u8;
+        if response != consensus_version {
+            bail!("Expected consensus version {consensus_version} but found {response} at {endpoint}",);
         }
     }
     Ok(())

--- a/leo/cli/commands/deploy.rs
+++ b/leo/cli/commands/deploy.rs
@@ -420,12 +420,12 @@ fn check_tasks_for_warnings<N: Network>(
                 .push(format!("The program '{id}' already exists on the network. Please use `leo upgrade` instead.",));
         }
         // Check if the program has a valid naming scheme.
-        if consensus_version >= ConsensusVersion::V7 {
-            if let Err(e) = program.check_program_naming_structure() {
-                warnings.push(format!(
-                    "The program '{id}' has an invalid naming scheme: {e}. The deployment will likely fail."
-                ));
-            }
+        if consensus_version >= ConsensusVersion::V7
+            && let Err(e) = program.check_program_naming_structure()
+        {
+            warnings.push(format!(
+                "The program '{id}' has an invalid naming scheme: {e}. The deployment will likely fail."
+            ));
         }
 
         // Check if the program contains restricted keywords.

--- a/leo/cli/commands/devnet/mod.rs
+++ b/leo/cli/commands/devnet/mod.rs
@@ -130,11 +130,11 @@ impl LeoDevnet {
 
         if self.install {
             // If installing, make sure we can write to a file at the path.
-            if let Some(parent) = self.snarkos.parent() {
-                if !parent.exists() {
-                    std::fs::create_dir_all(parent)
-                        .with_context(|| format!("Failed to create directory for binary: {}", parent.display()))?;
-                }
+            if let Some(parent) = self.snarkos.parent()
+                && !parent.exists()
+            {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create directory for binary: {}", parent.display()))?;
             }
             std::fs::write(&self.snarkos, [0u8]).with_context(|| {
                 format!("Failed to write to path {} for snarkos installation", self.snarkos.display())

--- a/leo/cli/commands/upgrade.rs
+++ b/leo/cli/commands/upgrade.rs
@@ -443,12 +443,12 @@ fn check_tasks_for_warnings<N: Network>(
             warnings.push(format!("The program '{id}' does not exist on the network. The upgrade will likely fail.",));
         }
         // Check if the program has a valid naming scheme.
-        if consensus_version >= ConsensusVersion::V7 {
-            if let Err(e) = program.check_program_naming_structure() {
-                warnings.push(format!(
-                    "The program '{id}' has an invalid naming scheme: {e}. The deployment will likely fail."
-                ));
-            }
+        if consensus_version >= ConsensusVersion::V7
+            && let Err(e) = program.check_program_naming_structure()
+        {
+            warnings.push(format!(
+                "The program '{id}' has an invalid naming scheme: {e}. The deployment will likely fail."
+            ));
         }
         // Check if the program contains restricted keywords.
         if let Err(e) = program.check_restricted_keywords_for_consensus_version(consensus_version) {

--- a/leo/package/Cargo.toml
+++ b/leo/package/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.leo-ast]
 workspace = true

--- a/leo/package/src/program.rs
+++ b/leo/package/src/program.rs
@@ -237,13 +237,13 @@ impl Program {
                     })?;
 
                 // If the file already exists, compare it to the new contents.
-                if let Some(existing_contents) = existing {
-                    if existing_contents != contents {
-                        println!(
-                            "Warning: The cached file at `{}` is different from the one fetched from the network. The cached file will be overwritten.",
-                            full_cache_path.display()
-                        );
-                    }
+                if let Some(existing_contents) = existing
+                    && existing_contents != contents
+                {
+                    println!(
+                        "Warning: The cached file at `{}` is different from the one fetched from the network. The cached file will be overwritten.",
+                        full_cache_path.display()
+                    );
                 }
 
                 // Write the bytecode to the cache.
@@ -276,11 +276,11 @@ impl Program {
 /// This needs to be done when collecting local dependencies from manifests which
 /// may be located at different places on the file system.
 fn canonicalize_dependency_path_relative_to(base: &Path, mut dependency: Dependency) -> Result<Dependency> {
-    if let Some(path) = &mut dependency.path {
-        if !path.is_absolute() {
-            let joined = base.join(&path);
-            *path = joined.canonicalize().map_err(|e| PackageError::failed_path(joined.display(), e))?;
-        }
+    if let Some(path) = &mut dependency.path
+        && !path.is_absolute()
+    {
+        let joined = base.join(&path);
+        *path = joined.canonicalize().map_err(|e| PackageError::failed_path(joined.display(), e))?;
     }
     Ok(dependency)
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.88.0"
+channel = "1.90.0"

--- a/test-framework/Cargo.toml
+++ b/test-framework/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography" ]
 include = [ "Cargo.toml", "src", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [dependencies.rayon]
 version = "1.10"

--- a/utils/disassembler/Cargo.toml
+++ b/utils/disassembler/Cargo.toml
@@ -16,7 +16,6 @@ categories = [ "compilers", "cryptography", "web-programming" ]
 include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
-rust-version = "1.88.0"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
- Update Rust version
- Let all crates inherit the Rust version from the workspace's `Cargo.toml`
- Run `cargo update`.