### PR TITLE
Split platform tests into three separate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,12 +320,18 @@ jobs:
 workflows:
   version: 2
   
-  platform-tests:
+  test-windows:
     jobs:
       - test-windows
+
+  test-macos:
+    jobs:
       - test-macos
+
+  test-linux:
+    jobs:
       - test-linux
-  
+
   code-quality:
     jobs:
       - check-style-clippy-docs


### PR DESCRIPTION
Closes https://github.com/ProvableHQ/leo/issues/28937

It is common to want to rerun a failed `test-*` jobs, especially `test-linux`. It would be nice if don't have to rerun all three platforms.