### PR TITLE
Expression::SpecialAccess variant

### DIFF
--- a/compiler/ast/src/expressions/mod.rs
+++ b/compiler/ast/src/expressions/mod.rs
@@ -77,6 +77,9 @@ pub use literal::*;
 pub mod locator;
 pub use locator::*;
 
+pub mod special_access;
+pub use special_access::*;
+
 /// Expression that evaluates to a value.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Expression {
@@ -107,6 +110,8 @@ pub enum Expression {
     Locator(LocatorExpression),
     /// An access of a struct member, e.g. `struc.member`.
     MemberAccess(Box<MemberAccess>),
+    /// A special access expression e.g. `self.id`, `block.height` etc.
+    SpecialAccess(SpecialAccess),
     /// An array expression constructed from one repeated element, e.g., `[1u32; 5]`.
     Repeat(Box<RepeatExpression>),
     /// An expression constructing a struct like `Foo { bar: 42, baz }`.
@@ -146,6 +151,7 @@ impl Node for Expression {
             Literal(n) => n.span(),
             Locator(n) => n.span(),
             MemberAccess(n) => n.span(),
+            SpecialAccess(n) => n.span(),
             Repeat(n) => n.span(),
             Struct(n) => n.span(),
             Ternary(n) => n.span(),
@@ -172,6 +178,7 @@ impl Node for Expression {
             Literal(n) => n.set_span(span),
             Locator(n) => n.set_span(span),
             MemberAccess(n) => n.set_span(span),
+            SpecialAccess(n) => n.set_span(span),
             Repeat(n) => n.set_span(span),
             Struct(n) => n.set_span(span),
             Ternary(n) => n.set_span(span),
@@ -197,6 +204,7 @@ impl Node for Expression {
             Literal(n) => n.id(),
             Locator(n) => n.id(),
             MemberAccess(n) => n.id(),
+            SpecialAccess(n) => n.id(),
             Repeat(n) => n.id(),
             Err(n) => n.id(),
             Struct(n) => n.id(),
@@ -223,6 +231,7 @@ impl Node for Expression {
             Literal(n) => n.set_id(id),
             Locator(n) => n.set_id(id),
             MemberAccess(n) => n.set_id(id),
+            SpecialAccess(n) => n.set_id(id),
             Repeat(n) => n.set_id(id),
             Err(n) => n.set_id(id),
             Struct(n) => n.set_id(id),
@@ -252,6 +261,7 @@ impl fmt::Display for Expression {
             Literal(n) => n.fmt(f),
             Locator(n) => n.fmt(f),
             MemberAccess(n) => n.fmt(f),
+            SpecialAccess(n) => n.fmt(f),
             Repeat(n) => n.fmt(f),
             Struct(n) => n.fmt(f),
             Ternary(n) => n.fmt(f),
@@ -288,6 +298,7 @@ impl Expression {
             | Literal(_)
             | Locator(_)
             | MemberAccess(_)
+            | SpecialAccess(_)
             | Repeat(_)
             | Struct(_)
             | Tuple(_)

--- a/compiler/ast/src/expressions/special_access.rs
+++ b/compiler/ast/src/expressions/special_access.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Expression, Node, NodeID};
+use leo_span::Span;
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A special access expression e.g. `self.id`, `block.height` etc.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpecialAccess {
+    /// The special access variant.
+    pub variant: SpecialAccessVariant,
+    /// The span covering all of special access expression.
+    pub span: Span,
+    /// The ID of the node.
+    pub id: NodeID,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SpecialAccessVariant {
+    Id,
+    Caller,
+    Signer,
+    Address,
+    Edition,
+    Checksum,
+    ProgramOwner,
+    NetworkId,
+    BlockHeight,
+}
+
+impl fmt::Display for SpecialAccess {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.variant {
+            SpecialAccessVariant::Id => write!(f, "self.id"),
+            SpecialAccessVariant::Caller => write!(f, "self.caller"),
+            SpecialAccessVariant::Signer => write!(f, "self.signer"),
+            SpecialAccessVariant::Address => write!(f, "self.address"),
+            SpecialAccessVariant::Edition => write!(f, "self.edition"),
+            SpecialAccessVariant::Checksum => write!(f, "self.checksum"),
+            SpecialAccessVariant::ProgramOwner => write!(f, "self.program_owner"),
+            SpecialAccessVariant::NetworkId => write!(f, "network.id"),
+            SpecialAccessVariant::BlockHeight => write!(f, "block.height"),
+        }
+    }
+}
+
+impl fmt::Display for SpecialAccessVariant {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            SpecialAccessVariant::Id => write!(f, "self.id"),
+            SpecialAccessVariant::Caller => write!(f, "self.caller"),
+            SpecialAccessVariant::Signer => write!(f, "self.signer"),
+            SpecialAccessVariant::Address => write!(f, "self.address"),
+            SpecialAccessVariant::Edition => write!(f, "self.edition"),
+            SpecialAccessVariant::Checksum => write!(f, "self.checksum"),
+            SpecialAccessVariant::ProgramOwner => write!(f, "self.program_owner"),
+            SpecialAccessVariant::NetworkId => write!(f, "network.id"),
+            SpecialAccessVariant::BlockHeight => write!(f, "block.height"),
+        }
+    }
+}
+
+impl From<SpecialAccess> for Expression {
+    fn from(value: SpecialAccess) -> Self {
+        Expression::SpecialAccess(value)
+    }
+}
+
+crate::simple_node_impl!(SpecialAccess);

--- a/compiler/ast/src/passes/consumer.rs
+++ b/compiler/ast/src/passes/consumer.rs
@@ -39,6 +39,7 @@ pub trait ExpressionConsumer {
             Expression::Literal(value) => self.consume_literal(value),
             Expression::Locator(locator) => self.consume_locator(locator),
             Expression::MemberAccess(access) => self.consume_member_access(*access),
+            Expression::SpecialAccess(access) => self.consume_special_access(access),
             Expression::Repeat(repeat) => self.consume_repeat(*repeat),
             Expression::Ternary(ternary) => self.consume_ternary(*ternary),
             Expression::Tuple(tuple) => self.consume_tuple(tuple),
@@ -51,6 +52,8 @@ pub trait ExpressionConsumer {
     fn consume_array_access(&mut self, _input: ArrayAccess) -> Self::Output;
 
     fn consume_member_access(&mut self, _input: MemberAccess) -> Self::Output;
+
+    fn consume_special_access(&mut self, _input: SpecialAccess) -> Self::Output;
 
     fn consume_tuple_access(&mut self, _input: TupleAccess) -> Self::Output;
 

--- a/compiler/ast/src/passes/reconstructor.rs
+++ b/compiler/ast/src/passes/reconstructor.rs
@@ -136,6 +136,7 @@ pub trait AstReconstructor {
             Expression::Literal(value) => self.reconstruct_literal(value, additional),
             Expression::Locator(locator) => self.reconstruct_locator(locator, additional),
             Expression::MemberAccess(access) => self.reconstruct_member_access(*access, additional),
+            Expression::SpecialAccess(access) => self.reconstruct_special_access(access, additional),
             Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, additional),
             Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, additional),
             Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, additional),
@@ -205,6 +206,14 @@ pub trait AstReconstructor {
             MemberAccess { inner: self.reconstruct_expression(input.inner, &Default::default()).0, ..input }.into(),
             Default::default(),
         )
+    }
+
+    fn reconstruct_special_access(
+        &mut self,
+        input: SpecialAccess,
+        _additional: &Self::AdditionalInput,
+    ) -> (Expression, Self::AdditionalOutput) {
+        (input.into(), Default::default())
     }
 
     fn reconstruct_repeat(

--- a/compiler/ast/src/passes/visitor.rs
+++ b/compiler/ast/src/passes/visitor.rs
@@ -121,6 +121,7 @@ pub trait AstVisitor {
             Expression::Literal(literal) => self.visit_literal(literal, additional),
             Expression::Locator(locator) => self.visit_locator(locator, additional),
             Expression::MemberAccess(access) => self.visit_member_access(access, additional),
+            Expression::SpecialAccess(access) => self.visit_special_access(access, additional),
             Expression::Repeat(repeat) => self.visit_repeat(repeat, additional),
             Expression::Ternary(ternary) => self.visit_ternary(ternary, additional),
             Expression::Tuple(tuple) => self.visit_tuple(tuple, additional),
@@ -141,8 +142,12 @@ pub trait AstVisitor {
         Default::default()
     }
 
-    fn visit_tuple_access(&mut self, input: &TupleAccess, _additional: &Self::AdditionalInput) -> Self::Output {
-        self.visit_expression(&input.tuple, &Default::default());
+    fn visit_special_access(&mut self, _input: &SpecialAccess, _additional: &Self::AdditionalInput) -> Self::Output {
+        Default::default()
+    }
+
+    fn visit_tuple_access(&mut self, input: &TupleAccess, additional: &Self::AdditionalInput) -> Self::Output {
+        self.visit_expression(&input.tuple, additional);
         Default::default()
     }
 

--- a/compiler/parser-lossless/src/grammar.lalrpop
+++ b/compiler/parser-lossless/src/grammar.lalrpop
@@ -336,17 +336,45 @@ Expr0: SyntaxNode<'a> = {
 
     // Special access.
     <x:WithTrivia<Block>> <d:WithTrivia<Dot>> <y:WithTrivia<Identifier>> => {
-        SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y])
+        match y.text {
+            "height" => SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y]),
+            _ => {
+                let node = SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y]);
+                handler.emit_err(ParserError::invalid_block_access(node.span));
+                node
+            }
+        }
     },
     <x:WithTrivia<SelfLower>> <d:WithTrivia<Dot>> <y:WithTrivia<Identifier>> => {
-        SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y])
+        match y.text {
+            "caller"
+            | "checksum"
+            | "edition"
+            | "program_owner"
+            | "signer"
+            | "address"
+            | "id" => SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y]),
+
+            _ => {
+                let node = SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y]);
+                handler.emit_err(ParserError::invalid_self_access(node.span));
+                node
+            }
+        }
     },
     // `address` is otherwise a keyword, so special case it.
     <x:WithTrivia<SelfLower>> <d:WithTrivia<Dot>> <y:WithTrivia<Address>> => {
         SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y])
     },
     <x:WithTrivia<Network>> <d:WithTrivia<Dot>> <y:WithTrivia<Identifier>> => {
-        SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y])
+        match y.text {
+            "id" => SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y]),
+            _ => {
+                let node = SyntaxNode::new(ExpressionKind::SpecialAccess, [x, d, y]);
+                handler.emit_err(ParserError::invalid_network_access(node.span));
+                node
+            }
+        }
     },
 
     // async block.

--- a/compiler/parser/src/conversions.rs
+++ b/compiler/parser/src/conversions.rs
@@ -855,10 +855,20 @@ pub fn to_expression(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Han
                 panic!("Can't happen");
             };
 
-            let inner = to_identifier(qualifier, builder).into();
-            let name = to_identifier(name, builder);
+            let access = match (qualifier.text, name.text) {
+                ("self", "id") => leo_ast::SpecialAccessVariant::Id,
+                ("self", "caller") => leo_ast::SpecialAccessVariant::Caller,
+                ("self", "signer") => leo_ast::SpecialAccessVariant::Signer,
+                ("self", "edition") => leo_ast::SpecialAccessVariant::Edition,
+                ("self", "address") => leo_ast::SpecialAccessVariant::Address,
+                ("self", "checksum") => leo_ast::SpecialAccessVariant::Checksum,
+                ("self", "program_owner") => leo_ast::SpecialAccessVariant::ProgramOwner,
+                ("network", "id") => leo_ast::SpecialAccessVariant::NetworkId,
+                ("block", "height") => leo_ast::SpecialAccessVariant::BlockHeight,
+                _ => panic!("Can't happen"),
+            };
 
-            leo_ast::MemberAccess { inner, name, span, id }.into()
+            leo_ast::SpecialAccess { variant: access, span, id }.into()
         }
         ExpressionKind::Struct => {
             let name = &node.children[0];

--- a/compiler/passes/src/common/replacer/mod.rs
+++ b/compiler/passes/src/common/replacer/mod.rs
@@ -81,6 +81,7 @@ where
                 Expression::Literal(value) => self.reconstruct_literal(value, &()),
                 Expression::Locator(locator) => self.reconstruct_locator(locator, &()),
                 Expression::MemberAccess(access) => self.reconstruct_member_access(*access, &()),
+                Expression::SpecialAccess(access) => self.reconstruct_special_access(access, &()),
                 Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, &()),
                 Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, &()),
                 Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, &()),

--- a/compiler/passes/src/common_subexpression_elimination/visitor.rs
+++ b/compiler/passes/src/common_subexpression_elimination/visitor.rs
@@ -116,6 +116,7 @@ impl CommonSubexpressionEliminatingVisitor<'_> {
             | Expression::Err(_)
             | Expression::Locator(_)
             | Expression::MemberAccess(_)
+            | Expression::SpecialAccess(_)
             | Expression::Repeat(_)
             | Expression::Struct(_)
             | Expression::Ternary(_)
@@ -244,6 +245,7 @@ impl CommonSubexpressionEliminatingVisitor<'_> {
             Expression::Locator(_)
             | Expression::Async(_)
             | Expression::AssociatedConstant(_)
+            | Expression::SpecialAccess(_)
             | Expression::Err(_)
             | Expression::Unit(_) => {
                 return Some((expression, false));

--- a/compiler/passes/src/const_propagation/ast.rs
+++ b/compiler/passes/src/const_propagation/ast.rs
@@ -65,6 +65,7 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
             Expression::Literal(value) => self.reconstruct_literal(value, &()),
             Expression::Locator(locator) => self.reconstruct_locator(locator, &()),
             Expression::MemberAccess(access) => self.reconstruct_member_access(*access, &()),
+            Expression::SpecialAccess(access) => self.reconstruct_special_access(access, &()),
             Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, &()),
             Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, &()),
             Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, &()),

--- a/compiler/passes/src/dead_code_elimination/visitor.rs
+++ b/compiler/passes/src/dead_code_elimination/visitor.rs
@@ -105,7 +105,7 @@ impl DeadCodeEliminatingVisitor<'_> {
                 !halting_op && sef(&un.receiver)
             }
             Err(_) => false,
-            Path(_) | Literal(_) | Locator(_) | Unit(_) => true,
+            Path(_) | SpecialAccess(_) | Literal(_) | Locator(_) | Unit(_) => true,
         }
     }
 }

--- a/compiler/passes/src/monomorphization/ast.rs
+++ b/compiler/passes/src/monomorphization/ast.rs
@@ -103,6 +103,7 @@ impl AstReconstructor for MonomorphizationVisitor<'_> {
             Expression::Literal(value) => self.reconstruct_literal(value, &()),
             Expression::Locator(locator) => self.reconstruct_locator(locator, &()),
             Expression::MemberAccess(access) => self.reconstruct_member_access(*access, &()),
+            Expression::SpecialAccess(access) => self.reconstruct_special_access(access, &()),
             Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, &()),
             Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, &()),
             Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, &()),

--- a/compiler/passes/src/option_lowering/ast.rs
+++ b/compiler/passes/src/option_lowering/ast.rs
@@ -100,6 +100,7 @@ impl leo_ast::AstReconstructor for OptionLoweringVisitor<'_> {
             Expression::Literal(e) => self.reconstruct_literal(e, additional),
             Expression::Locator(e) => self.reconstruct_locator(e, additional),
             Expression::MemberAccess(e) => self.reconstruct_member_access(*e, additional),
+            Expression::SpecialAccess(e) => self.reconstruct_special_access(e, additional),
             Expression::Repeat(e) => self.reconstruct_repeat(*e, additional),
             Expression::Ternary(e) => self.reconstruct_ternary(*e, additional),
             Expression::Tuple(e) => self.reconstruct_tuple(e, additional),

--- a/compiler/passes/src/static_analysis/future_checker.rs
+++ b/compiler/passes/src/static_analysis/future_checker.rs
@@ -103,6 +103,7 @@ impl AstVisitor for FutureChecker<'_> {
             Expression::Literal(literal) => self.visit_literal(literal, &Position::Misc),
             Expression::Locator(locator) => self.visit_locator(locator, &Position::Misc),
             Expression::MemberAccess(access) => self.visit_member_access(access, &Position::Misc),
+            Expression::SpecialAccess(access) => self.visit_special_access(access, &Position::Misc),
             Expression::Repeat(repeat) => self.visit_repeat(repeat, &Position::Misc),
             Expression::Ternary(ternary) => self.visit_ternary(ternary, &Position::Misc),
             Expression::Tuple(tuple) => self.visit_tuple(tuple, additional),

--- a/compiler/passes/src/static_single_assignment/expression.rs
+++ b/compiler/passes/src/static_single_assignment/expression.rs
@@ -68,15 +68,13 @@ impl ExpressionConsumer for SsaFormingVisitor<'_> {
     }
 
     fn consume_member_access(&mut self, input: MemberAccess) -> Self::Output {
-        // If the access expression is of the form `self.<name>`, then don't rename it.
-        if let Expression::Path(path) = &input.inner
-            && path.identifier().name == sym::SelfLower
-        {
-            return (input.into(), Vec::new());
-        }
-
         let (inner, statements) = self.consume_expression_and_define(input.inner);
         (MemberAccess { inner, ..input }.into(), statements)
+    }
+
+    fn consume_special_access(&mut self, input: leo_ast::SpecialAccess) -> Self::Output {
+        // Special variables don't need single static assignment.
+        (input.into(), Vec::new())
     }
 
     fn consume_tuple_access(&mut self, input: TupleAccess) -> Self::Output {

--- a/errors/src/errors/parser/parser_errors.rs
+++ b/errors/src/errors/parser/parser_errors.rs
@@ -478,4 +478,26 @@ create_messages!(
         msg: "Identifiers cannot start with an underscore.",
         help: Some("Identifiers must start with a letter.".to_string()),
     }
+
+    /// For when an invalid field of block is called.
+    @formatted
+    invalid_block_access {
+        args: (),
+        msg: format!("The allowed accesses to `block` are `block.height`."),
+        help: None,
+    }
+
+    @formatted
+    invalid_self_access {
+        args: (),
+        msg: format!("The allowed accesses to `self` are `self.{{caller, checksum, edition, program_owner, signer, address, id}}`."),
+        help: None,
+    }
+
+    @formatted
+    invalid_network_access {
+        args: (),
+        msg: format!("The allowed accesses to `network` are `network.id`."),
+        help: None,
+    }
 );

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -364,6 +364,7 @@ create_messages!(
         help: None,
     }
 
+    // TODO This error is unused. Remove it in a future version.
     @formatted
     invalid_self_access {
         args: (),
@@ -553,6 +554,7 @@ create_messages!(
         help: None,
     }
 
+    // TODO This error is unused. Remove it in a future version.
     /// For when an invalid field of block is called.
     @formatted
     invalid_block_access {

--- a/interpreter/src/cursor.rs
+++ b/interpreter/src/cursor.rs
@@ -434,6 +434,7 @@ impl Cursor {
                 | Expression::Cast(..)
                 | Expression::Err(..)
                 | Expression::Literal(..)
+                | Expression::SpecialAccess(..)
                 | Expression::Locator(..)
                 | Expression::Repeat(..)
                 | Expression::Struct(..)

--- a/tests/expectations/compiler/async_blocks/invalid_expr_in_async_block_fail.out
+++ b/tests/expectations/compiler/async_blocks/invalid_expr_in_async_block_fail.out
@@ -1,10 +1,10 @@
 Error [ETYC0372147]: Invalid expression in an async block. `self.signer` cannot be used directly here
-    --> compiler-test:4:26
+    --> compiler-test:4:21
      |
    4 |             let s = self.signer;
-     |                          ^^^^^^
+     |                     ^^^^^^^^^^^
 Error [ETYC0372147]: Invalid expression in an async block. `self.caller` cannot be used directly here
-    --> compiler-test:5:26
+    --> compiler-test:5:21
      |
    5 |             let c = self.caller;
-     |                          ^^^^^^
+     |                     ^^^^^^^^^^^

--- a/tests/expectations/compiler/finalize/block_height_fail.out
+++ b/tests/expectations/compiler/finalize/block_height_fail.out
@@ -1,5 +1,5 @@
 Error [ETYC0372034]: `block.height` must be inside an async function block.
-    --> compiler-test:4:33
+    --> compiler-test:4:27
      |
    4 |         assert_eq(height, block.height);
-     |                                 ^^^^^^
+     |                           ^^^^^^^^^^^^

--- a/tests/expectations/compiler/function/self_fail.out
+++ b/tests/expectations/compiler/function/self_fail.out
@@ -1,5 +1,5 @@
-Error [ETYC0372040]: The allowed accesses to `self` are `self.{caller, checksum, edition, program_owner, signer}`.
-    --> compiler-test:4:21
+Error [EPAR0370054]: The allowed accesses to `self` are `self.{caller, checksum, edition, program_owner, signer, address, id}`.
+    --> compiler-test:4:16
      |
    4 |         return self.foo == addr;
-     |                     ^^^
+     |                ^^^^^^^^

--- a/tests/expectations/compiler/function/self_finalize_fail.out
+++ b/tests/expectations/compiler/function/self_finalize_fail.out
@@ -1,5 +1,5 @@
 Error [ETYC0372066]: `self.caller` is not a valid operand in an async function call context.
-    --> compiler-test:7:30
+    --> compiler-test:7:25
      |
    7 |         assert_eq(addr, self.caller);
-     |                              ^^^^^^
+     |                         ^^^^^^^^^^^


### PR DESCRIPTION
## Motivation
It seems special accesses like `block.height`, `self.id` should not belong in the normal struct member access category.
This pr cleans up the distinction.
Also closes #28834.

## Test Plan
No need for new tests, CI should catch any regressions.