### PR TITLE
Name Validation pass

### DIFF
--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -145,6 +145,8 @@ impl Compiler {
     pub fn intermediate_passes(&mut self) -> Result<()> {
         let type_checking_config = TypeCheckingInput::new(self.state.network);
 
+        self.do_pass::<NameValidation>(())?;
+
         self.do_pass::<PathResolution>(())?;
 
         self.do_pass::<SymbolTableCreation>(())?;

--- a/compiler/passes/src/lib.rs
+++ b/compiler/passes/src/lib.rs
@@ -80,6 +80,9 @@ pub use symbol_table_creation::*;
 mod type_checking;
 pub use type_checking::*;
 
+mod name_validation;
+pub use name_validation::*;
+
 mod write_transforming;
 pub use write_transforming::*;
 

--- a/compiler/passes/src/name_validation/ast.rs
+++ b/compiler/passes/src/name_validation/ast.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::*;
+
+use leo_ast::AstVisitor;
+
+impl AstVisitor for NameValidationVisitor<'_> {
+    type AdditionalInput = ();
+    type Output = ();
+}

--- a/compiler/passes/src/name_validation/mod.rs
+++ b/compiler/passes/src/name_validation/mod.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+mod program;
+
+mod ast;
+
+mod visitor;
+use visitor::*;
+
+use crate::{CompilerState, Pass};
+
+use leo_ast::ProgramVisitor;
+use leo_errors::Result;
+
+/// A pass to validate names.
+///
+/// Enforces various naming rules such as preventing SnarkVM keywords or the use of "aleo" where relevant.
+pub struct NameValidation;
+
+impl Pass for NameValidation {
+    type Input = ();
+    type Output = ();
+
+    const NAME: &'static str = "NameValidation";
+
+    fn do_pass(_: Self::Input, state: &mut CompilerState) -> Result<Self::Output> {
+        let mut visitor = NameValidationVisitor { handler: &mut state.handler };
+        visitor.visit_program(state.ast.as_repr());
+        state.handler.last_err()?;
+
+        Ok(())
+    }
+}

--- a/compiler/passes/src/name_validation/program.rs
+++ b/compiler/passes/src/name_validation/program.rs
@@ -1,0 +1,86 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::NameValidationVisitor;
+
+use leo_ast::*;
+
+impl ProgramVisitor for NameValidationVisitor<'_> {
+    fn visit_program(&mut self, input: &Program) {
+        input.stubs.iter().for_each(|(_symbol, stub)| self.visit_stub(stub));
+        input.modules.values().for_each(|module| self.visit_module(module));
+        input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
+    }
+
+    fn visit_program_scope(&mut self, input: &ProgramScope) {
+        let program_name = input.program_id.name;
+        self.does_not_contain_aleo(program_name, "program");
+        self.is_not_keyword(program_name, "program", &[]);
+
+        input.structs.iter().for_each(|(_, function)| self.visit_struct(function));
+        input.functions.iter().for_each(|(_, function)| self.visit_function(function));
+    }
+
+    fn visit_module(&mut self, input: &Module) {
+        input.structs.iter().for_each(|(_, function)| self.visit_struct(function));
+        input.functions.iter().for_each(|(_, function)| self.visit_function(function));
+    }
+
+    fn visit_stub(&mut self, input: &Stub) {
+        input.structs.iter().for_each(|(_, function)| self.visit_struct_stub(function));
+        input.functions.iter().for_each(|(_, function)| self.visit_function_stub(function));
+    }
+
+    fn visit_struct(&mut self, input: &Composite) {
+        let struct_name = input.identifier;
+        let item_type = if input.is_record { "record" } else { "struct" };
+        self.is_not_keyword(struct_name, item_type, &[]);
+        if input.is_record {
+            self.does_not_contain_aleo(struct_name, item_type);
+        }
+
+        for Member { identifier: member_name, .. } in &input.members {
+            if input.is_record {
+                self.is_not_keyword(*member_name, "record member", &["owner"]);
+                self.does_not_contain_aleo(*member_name, "record member");
+            } else {
+                self.is_not_keyword(*member_name, "struct member", &[]);
+            }
+        }
+    }
+
+    fn visit_function(&mut self, function: &Function) {
+        use Variant::*;
+        match function.variant {
+            Transition | AsyncTransition => self.is_not_keyword(function.identifier, "transition", &[]),
+            Function => self.is_not_keyword(function.identifier, "function", &[]),
+            Inline | AsyncFunction | Script => {}
+        }
+    }
+
+    fn visit_function_stub(&mut self, input: &FunctionStub) {
+        use Variant::*;
+        match input.variant {
+            Transition | AsyncTransition => self.is_not_keyword(input.identifier, "transition", &[]),
+            Function => self.is_not_keyword(input.identifier, "function", &[]),
+            Inline | AsyncFunction | Script => {}
+        }
+    }
+
+    fn visit_struct_stub(&mut self, input: &Composite) {
+        self.visit_struct(input);
+    }
+}

--- a/compiler/passes/src/name_validation/visitor.rs
+++ b/compiler/passes/src/name_validation/visitor.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use leo_ast::*;
+use leo_errors::{Handler, NameValidationError};
+use snarkvm::prelude::{Program, TestnetV0};
+
+pub struct NameValidationVisitor<'a> {
+    pub handler: &'a mut Handler,
+}
+
+impl NameValidationVisitor<'_> {
+    pub fn does_not_contain_aleo(&self, name: Identifier, item_type: &str) {
+        if name.to_string().contains("aleo") {
+            self.handler.emit_err(NameValidationError::illegal_name_content(name, item_type, "aleo", name.span));
+        }
+    }
+
+    pub fn is_not_keyword(&self, name: Identifier, item_type: &str, whitelist: &[&str]) {
+        // Flatten RESTRICTED_KEYWORDS by ignoring ConsensusVersion
+        let restricted = Program::<TestnetV0>::RESTRICTED_KEYWORDS.iter().flat_map(|(_, kws)| kws.iter().copied());
+        let keywords = Program::<TestnetV0>::KEYWORDS.iter().copied();
+        let aleo = std::iter::once("aleo");
+
+        let it = keywords.chain(restricted).chain(aleo).filter(|w| !whitelist.contains(w));
+
+        for word in it {
+            if name.to_string() == word {
+                self.handler.emit_err(NameValidationError::illegal_name(name, item_type, word, name.span));
+                break;
+            }
+        }
+    }
+}

--- a/compiler/passes/src/type_checking/program.rs
+++ b/compiler/passes/src/type_checking/program.rs
@@ -51,9 +51,6 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         let program_name = input.program_id.name;
 
-        // Ensure that the program name is legal, i.e., it does not contain the keyword `aleo`
-        check_name(&self.state.handler, program_name, "program");
-
         // Set the current program name.
         self.scope_state.program_name = Some(program_name.name);
 
@@ -255,15 +252,6 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
         // For records, enforce presence of the `owner: Address` member.
         if input.is_record {
-            // Ensure that the record name is legal, i.e., it does not contain the keyword `aleo`
-            check_name(&self.state.handler, input.identifier, "record");
-
-            // Ensure that the names of the record entries are all legal, i.e., they do not contain the
-            // keyword `aleo`
-            input.members.iter().for_each(|member| {
-                check_name(&self.state.handler, member.identifier, "record entry");
-            });
-
             let check_has_field =
                 |need, expected_ty: Type| match input.members.iter().find_map(|Member { identifier, type_, .. }| {
                     (identifier.name == need).then_some((identifier, type_))
@@ -671,11 +659,5 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
     fn visit_struct_stub(&mut self, input: &Composite) {
         self.visit_struct(input);
-    }
-}
-
-fn check_name(handler: &leo_errors::Handler, name: Identifier, item_type: &str) {
-    if name.to_string().contains(&sym::aleo.to_string()) {
-        handler.emit_err(TypeCheckerError::illegal_name(name, item_type, sym::aleo, name.span));
     }
 }

--- a/errors/src/errors/mod.rs
+++ b/errors/src/errors/mod.rs
@@ -56,6 +56,10 @@ pub use self::static_analyzer::*;
 mod type_checker;
 pub use self::type_checker::*;
 
+/// Contains the Name Validation error definitions.
+mod name_validation;
+pub use self::name_validation::*;
+
 /// Contains the Utils error definitions.
 mod utils;
 pub use self::utils::*;
@@ -87,6 +91,9 @@ pub enum LeoError {
     /// Represents a Type Checker Error in a Leo Error.
     #[error(transparent)]
     TypeCheckerError(#[from] TypeCheckerError),
+    /// Represents a Name Validation Error in a Leo Error.
+    #[error(transparent)]
+    NameValidationError(#[from] NameValidationError),
     /// Represents a Loop Unroller Error in a Leo Error.
     #[error(transparent)]
     LoopUnrollerError(#[from] LoopUnrollerError),
@@ -118,6 +125,7 @@ impl LeoError {
             PackageError(error) => error.error_code(),
             StaticAnalyzerError(error) => error.error_code(),
             TypeCheckerError(error) => error.error_code(),
+            NameValidationError(error) => error.error_code(),
             LoopUnrollerError(error) => error.error_code(),
             FlattenError(error) => error.error_code(),
             UtilError(error) => error.error_code(),
@@ -139,6 +147,7 @@ impl LeoError {
             PackageError(error) => error.exit_code(),
             StaticAnalyzerError(error) => error.exit_code(),
             TypeCheckerError(error) => error.exit_code(),
+            NameValidationError(error) => error.exit_code(),
             LoopUnrollerError(error) => error.exit_code(),
             FlattenError(error) => error.exit_code(),
             UtilError(error) => error.exit_code(),

--- a/errors/src/errors/name_validation.rs
+++ b/errors/src/errors/name_validation.rs
@@ -1,0 +1,37 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::fmt::{Debug, Display};
+
+create_messages!(
+    NameValidationError,
+    code_mask: 11000i32,
+    code_prefix: "NV",
+
+    @formatted
+    illegal_name {
+        args: (item_name: impl Display, item_type: impl Display, keyword: impl Display),
+        msg: format!("`{item_name}` is an invalid {item_type} name. A {item_type} cannot be called \"{keyword}\"."),
+        help: None,
+    }
+
+    @formatted
+    illegal_name_content {
+        args: (item_name: impl Display, item_type: impl Display, keyword: impl Display),
+        msg: format!("`{item_name}` is an invalid {item_type} name. A {item_type} cannot have \"{keyword}\" in its name."),
+        help: None,
+    }
+);

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -1049,6 +1049,7 @@ create_messages!(
         help: Some("External record types and tuples containing them may not be assigned to.".to_string()),
     }
 
+    // TODO This error is unused. Remove it in a future version.
     @formatted
     illegal_name {
         args: (item_name: impl Display, item_type: impl Display, keyword: impl Display),

--- a/tests/expectations/compiler/finalize/get_or_incorrect_type_fail.out
+++ b/tests/expectations/compiler/finalize/get_or_incorrect_type_fail.out
@@ -29,15 +29,15 @@ Error [ETYC0372117]: Expected type `u128` but type `u8` was found.
   21 |         amounts.get_or_use(addr, 1u8);
      |                                  ^^^
 Error [ETYC0372117]: Expected type `u128` but type `u8` was found.
-    --> compiler-test:22:72
+    --> compiler-test:22:77
      |
-  22 |         Mapping::get_or_use(tokens, addr, Token { owner: addr, amount: 1u8 });
-     |                                                                        ^^^
+  22 |         Mapping::get_or_use(tokens, addr, Token { owner_addr: addr, amount: 1u8 });
+     |                                                                             ^^^
 Error [ETYC0372117]: Expected type `u128` but type `u8` was found.
-    --> compiler-test:23:62
+    --> compiler-test:23:67
      |
-  23 |         tokens.get_or_use(addr, Token { owner: addr, amount: 1u8 });
-     |                                                              ^^^
+  23 |         tokens.get_or_use(addr, Token { owner_addr: addr, amount: 1u8 });
+     |                                                                   ^^^
 Error [ETYC0372005]: Unknown variable `foo`
     --> compiler-test:24:29
      |

--- a/tests/expectations/compiler/finalize/set_incorrect_type_fail.out
+++ b/tests/expectations/compiler/finalize/set_incorrect_type_fail.out
@@ -29,15 +29,15 @@ Error [ETYC0372117]: Expected type `u128` but type `u8` was found.
   21 |         amounts.set(addr, 1u8);
      |                           ^^^
 Error [ETYC0372117]: Expected type `u128` but type `u8` was found.
-    --> compiler-test:22:65
+    --> compiler-test:22:70
      |
-  22 |         Mapping::set(tokens, addr, Token { owner: addr, amount: 1u8 });
-     |                                                                 ^^^
+  22 |         Mapping::set(tokens, addr, Token { owner_addr: addr, amount: 1u8 });
+     |                                                                      ^^^
 Error [ETYC0372117]: Expected type `u128` but type `u8` was found.
-    --> compiler-test:23:55
+    --> compiler-test:23:60
      |
-  23 |         tokens.set(addr, Token { owner: addr, amount: 1u8 });
-     |                                                       ^^^
+  23 |         tokens.set(addr, Token { owner_addr: addr, amount: 1u8 });
+     |                                                            ^^^
 Error [ETYC0372005]: Unknown variable `foo`
     --> compiler-test:24:22
      |

--- a/tests/expectations/compiler/option/optional_record_fail.out
+++ b/tests/expectations/compiler/option/optional_record_fail.out
@@ -5,7 +5,7 @@ Error [ETYC0372159]: The type `Foo` cannot be wrapped in an optional because it 
      |         ^^^^^^^^^^^^^^^^^^^
   11 |             owner: self.signer,
      |             ^^^^^^^^^^^^^^^^^^^
-  12 |             value: 5,
-     |             ^^^^^^^^^
+  12 |             val: 5,
+     |             ^^^^^^^
   13 |         };
      |         ^^

--- a/tests/expectations/compiler/structs/duplicate_struct_variable.out
+++ b/tests/expectations/compiler/structs/duplicate_struct_variable.out
@@ -21,14 +21,14 @@ Error [ETYC0372015]: Struct field `id` is already declared.
   20 |
   21 |           id: u32,
      |           ^^^^^^^ struct field already declared
-Error [ETYC0372015]: Struct field `value` is already declared.
+Error [ETYC0372015]: Struct field `val` is already declared.
     --> compiler-test:22:9
      |
-  20 |           value: u64,
-     |           ^^^^^^^^^^ `value` first declared here
+  20 |           val: u64,
+     |           ^^^^^^^^ `val` first declared here
   21 |
-  22 |           value: u64,
-     |           ^^^^^^^^^^ struct field already declared
+  22 |           val: u64,
+     |           ^^^^^^^^ struct field already declared
 Error [ETYC0372015]: Struct field `host` is already declared.
     --> compiler-test:36:9
      |

--- a/tests/expectations/compiler/symbols/illegal_names_fail.out
+++ b/tests/expectations/compiler/symbols/illegal_names_fail.out
@@ -1,35 +1,25 @@
-Error [ETYC0372132]: `fooaleobar` is an invalid program name. A program cannot have "aleo" in its name.
+Error [ENV03711001]: `fooaleobar` is an invalid program name. A program cannot have "aleo" in its name.
+    --> compiler-test:1:9
+     |
+   1 | program fooaleobar.aleo {
+     |         ^^^^^^^^^^
+Error [ENV03711001]: `FooaleoBar` is an invalid record name. A record cannot have "aleo" in its name.
+    --> compiler-test:3:12
+     |
+   3 |     record FooaleoBar {
+     |            ^^^^^^^^^^
+Error [ENV03711001]: `aaleob` is an invalid record member name. A record member cannot have "aleo" in its name.
     --> compiler-test:5:9
      |
-   5 | program fooaleobar.aleo {
-     |         ^^^^^^^^^^
-Error [ETYC0372133]: Record name `FooBar` is prefixed by the record name `Foo`. Record names must not be prefixes of other record names.
-    --> compiler-test:17:12
-     |
-  17 |     record FooBar {
-     |            ^^^^^^
-Error [ETYC0372133]: Record name `FooBarBaz` is prefixed by the record name `FooBar`. Record names must not be prefixes of other record names.
-    --> compiler-test:12:12
-     |
-  12 |     record FooBarBaz {
-     |            ^^^^^^^^^
-Error [ETYC0372132]: `FooaleoBar` is an invalid record name. A record cannot have "aleo" in its name.
-    --> compiler-test:22:12
-     |
-  22 |     record FooaleoBar {
-     |            ^^^^^^^^^^
-Error [ETYC0372132]: `aaleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
-    --> compiler-test:24:9
-     |
-  24 |         aaleob: u32,
+   5 |         aaleob: u32,
      |         ^^^^^^
-Error [ETYC0372132]: `aleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
-    --> compiler-test:25:9
+Error [ENV03711001]: `aleob` is an invalid record member name. A record member cannot have "aleo" in its name.
+    --> compiler-test:6:9
      |
-  25 |         aleob: u32,
+   6 |         aleob: u32,
      |         ^^^^^
-Error [ETYC0372132]: `daleo` is an invalid record entry name. A record entry cannot have "aleo" in its name.
-    --> compiler-test:26:9
+Error [ENV03711001]: `daleo` is an invalid record member name. A record member cannot have "aleo" in its name.
+    --> compiler-test:7:9
      |
-  26 |         daleo: u32,
+   7 |         daleo: u32,
      |         ^^^^^

--- a/tests/expectations/compiler/symbols/illegal_names_in_library_fail.out
+++ b/tests/expectations/compiler/symbols/illegal_names_in_library_fail.out
@@ -1,34 +1,24 @@
-Error [ETYC0372132]: `childaleo` is an invalid program name. A program cannot have "aleo" in its name.
+Error [ENV03711001]: `childaleo` is an invalid program name. A program cannot have "aleo" in its name.
     --> compiler-test:1:9
      |
    1 | program childaleo.aleo {
      |         ^^^^^^^^^
-Error [ETYC0372133]: Record name `FooBar` is prefixed by the record name `Foo`. Record names must not be prefixes of other record names.
-    --> compiler-test:10:12
-     |
-  10 |     record FooBar {
-     |            ^^^^^^
-Error [ETYC0372133]: Record name `FooBarBaz` is prefixed by the record name `FooBar`. Record names must not be prefixes of other record names.
-    --> compiler-test:6:12
-     |
-   6 |     record FooBarBaz {
-     |            ^^^^^^^^^
-Error [ETYC0372132]: `FooaleoBar` is an invalid record name. A record cannot have "aleo" in its name.
+Error [ENV03711001]: `FooaleoBar` is an invalid record name. A record cannot have "aleo" in its name.
     --> compiler-test:14:12
      |
   14 |     record FooaleoBar {
      |            ^^^^^^^^^^
-Error [ETYC0372132]: `aaleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+Error [ENV03711001]: `aaleob` is an invalid record member name. A record member cannot have "aleo" in its name.
     --> compiler-test:16:9
      |
   16 |         aaleob: u32,
      |         ^^^^^^
-Error [ETYC0372132]: `aleob` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+Error [ENV03711001]: `aleob` is an invalid record member name. A record member cannot have "aleo" in its name.
     --> compiler-test:17:9
      |
   17 |         aleob: u32,
      |         ^^^^^
-Error [ETYC0372132]: `daleo` is an invalid record entry name. A record entry cannot have "aleo" in its name.
+Error [ENV03711001]: `daleo` is an invalid record member name. A record member cannot have "aleo" in its name.
     --> compiler-test:18:9
      |
   18 |         daleo: u32,

--- a/tests/expectations/compiler/symbols/illegal_prefix_fail.out
+++ b/tests/expectations/compiler/symbols/illegal_prefix_fail.out
@@ -1,0 +1,10 @@
+Error [ETYC0372133]: Record name `FooBar` is prefixed by the record name `Foo`. Record names must not be prefixes of other record names.
+    --> compiler-test:17:12
+     |
+  17 |     record FooBar {
+     |            ^^^^^^
+Error [ETYC0372133]: Record name `FooBarBaz` is prefixed by the record name `FooBar`. Record names must not be prefixes of other record names.
+    --> compiler-test:12:12
+     |
+  12 |     record FooBarBaz {
+     |            ^^^^^^^^^

--- a/tests/expectations/compiler/symbols/reserved_keyword_fail.out
+++ b/tests/expectations/compiler/symbols/reserved_keyword_fail.out
@@ -1,0 +1,45 @@
+Error [ENV03711000]: `finalize` is an invalid program name. A program cannot be called "finalize".
+    --> compiler-test:1:9
+     |
+   1 | program finalize.aleo {
+     |         ^^^^^^^^
+Error [ENV03711000]: `value` is an invalid struct member name. A struct member cannot be called "value".
+    --> compiler-test:3:9
+     |
+   3 |         value: u32,
+     |         ^^^^^
+Error [ENV03711000]: `value` is an invalid struct name. A struct cannot be called "value".
+    --> compiler-test:6:12
+     |
+   6 |     struct value {
+     |            ^^^^^
+Error [ENV03711000]: `owner` is an invalid struct member name. A struct member cannot be called "owner".
+    --> compiler-test:7:9
+     |
+   7 |         owner: u32,
+     |         ^^^^^
+Error [ENV03711000]: `value` is an invalid record name. A record cannot be called "value".
+    --> compiler-test:10:12
+     |
+  10 |     record value {
+     |            ^^^^^
+Error [ENV03711000]: `value` is an invalid record member name. A record member cannot be called "value".
+    --> compiler-test:11:9
+     |
+  11 |         value: u32,
+     |         ^^^^^
+Error [ENV03711000]: `value` is an invalid transition name. A transition cannot be called "value".
+    --> compiler-test:15:16
+     |
+  15 |     transition value() {}
+     |                ^^^^^
+Error [ENV03711000]: `output` is an invalid transition name. A transition cannot be called "output".
+    --> compiler-test:17:22
+     |
+  17 |     async transition output() -> Future {
+     |                      ^^^^^^
+Error [ENV03711000]: `key` is an invalid function name. A function cannot be called "key".
+    --> compiler-test:22:14
+     |
+  22 |     function key() {}
+     |              ^^^

--- a/tests/tests/compiler/finalize/get_or_incorrect_type_fail.leo
+++ b/tests/tests/compiler/finalize/get_or_incorrect_type_fail.leo
@@ -1,7 +1,7 @@
 
 program test.aleo {
     struct Token {
-        owner: address,
+        owner_addr: address,
         amount: u128,
     }
 
@@ -19,8 +19,8 @@ program test.aleo {
         amounts.get_or_use(1u8, amount);
         Mapping::get_or_use(amounts, addr, 1u8);
         amounts.get_or_use(addr, 1u8);
-        Mapping::get_or_use(tokens, addr, Token { owner: addr, amount: 1u8 });
-        tokens.get_or_use(addr, Token { owner: addr, amount: 1u8 });
+        Mapping::get_or_use(tokens, addr, Token { owner_addr: addr, amount: 1u8 });
+        tokens.get_or_use(addr, Token { owner_addr: addr, amount: 1u8 });
         Mapping::get_or_use(foo, addr, amount);
         foo.get_or_use(addr, amount);
     }

--- a/tests/tests/compiler/finalize/set_incorrect_type_fail.leo
+++ b/tests/tests/compiler/finalize/set_incorrect_type_fail.leo
@@ -1,7 +1,7 @@
 
 program test.aleo {
     struct Token {
-        owner: address,
+        owner_addr: address,
         amount: u128,
     }
 
@@ -19,8 +19,8 @@ program test.aleo {
         amounts.set(1u8, amount);
         Mapping::set(amounts, addr, 1u8);
         amounts.set(addr, 1u8);
-        Mapping::set(tokens, addr, Token { owner: addr, amount: 1u8 });
-        tokens.set(addr, Token { owner: addr, amount: 1u8 });
+        Mapping::set(tokens, addr, Token { owner_addr: addr, amount: 1u8 });
+        tokens.set(addr, Token { owner_addr: addr, amount: 1u8 });
         Mapping::set(foo, addr, amount);
         foo.set(addr, amount);
     }

--- a/tests/tests/compiler/option/optional_record_fail.leo
+++ b/tests/tests/compiler/option/optional_record_fail.leo
@@ -3,13 +3,13 @@ program optional_record_test.aleo {
     // === Record ===
     record Foo {
         owner: address,
-        value: u64,
+        val: u64,
     }
 
     transition handle_optional_record() -> u64 {
         let f: Foo? = Foo {
             owner: self.signer,
-            value: 5,
+            val: 5,
         };
         return 0;
     }

--- a/tests/tests/compiler/records/duplicate_var_fail.leo
+++ b/tests/tests/compiler/records/duplicate_var_fail.leo
@@ -10,7 +10,7 @@ program test.aleo {
     // test 2: duplicate with gap - "..." marker
     record Asset {
         owner: address,
-        value: u64,
+        val: u64,
         description: field,
         owner: address,
     }

--- a/tests/tests/compiler/structs/duplicate_struct_variable.leo
+++ b/tests/tests/compiler/structs/duplicate_struct_variable.leo
@@ -17,9 +17,9 @@ program test.aleo {
     // test 3: multiple different duplicates
     struct Data {
         id: u32,
-        value: u64,
+        val: u64,
         id: u32,
-        value: u64,
+        val: u64,
     }
 
     // test 4: large gap between duplicates

--- a/tests/tests/compiler/symbols/illegal_names_fail.leo
+++ b/tests/tests/compiler/symbols/illegal_names_fail.leo
@@ -1,33 +1,5 @@
-program child.aleo {
-    record Foo {
-        owner: address,
-        val: u32,
-    }
-
-    transition bar() {}
-}
-
-// --- Next Program --- //
-
-import child.aleo;
-
 program fooaleobar.aleo {
-    // This shouldn't conflict with child.aleo/Foo
-    record Foo {
-        owner: address,
-    }
-
-    // Foo and FooBar are both prefixes. Shouldn't conflict with child.aleo/Foo though.
-    record FooBarBaz {
-        owner: address,
-    }
-
-    // Foo is a prefix
-    record FooBar {
-        owner: address,
-    }
-
-    // Foo is a prefix and also it has aleo in the name. Also, the fields have aleo in their names.
+    // it has aleo in the name. Also, the fields have aleo in their names.
     record FooaleoBar {
         owner: address,
         aaleob: u32,

--- a/tests/tests/compiler/symbols/illegal_prefix_fail.leo
+++ b/tests/tests/compiler/symbols/illegal_prefix_fail.leo
@@ -1,0 +1,31 @@
+program child.aleo {
+    record Foo {
+        owner: address,
+        val: u32,
+    }
+
+    transition bar() {}
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+
+program parent.aleo {
+    // This shouldn't conflict with child.aleo/Foo
+    record Foo {
+        owner: address,
+    }
+
+    // Foo and FooBar are both prefixes. Shouldn't conflict with child.aleo/Foo though.
+    record FooBarBaz {
+        owner: address,
+    }
+
+    // Foo is a prefix
+    record FooBar {
+        owner: address,
+    }
+
+    transition foo () {}
+}

--- a/tests/tests/compiler/symbols/reserved_keyword_fail.leo
+++ b/tests/tests/compiler/symbols/reserved_keyword_fail.leo
@@ -1,0 +1,29 @@
+program finalize.aleo {
+    struct Foo {
+        value: u32,
+    }
+
+    struct value {
+        owner: u32,
+    }
+
+    record value {
+        value: u32,
+        owner: u32,
+    }
+
+    transition value() {}
+
+    async transition output() -> Future {
+        return finalize();
+    }
+    async function finalize() {}
+
+    function key() {}
+
+    inline value() {}
+
+    transition main(f: Foo) -> Foo {
+        return f;
+    }
+}


### PR DESCRIPTION
This change adds a pass that consolidates checking of names that may contain keywords

It checks for relevant keywords in:

* program names
* struct names
* record names
* function names
* struct fields
* record fields

and produce well formatted errors early.

Fix #28764