### PR TITLE
Adjust how SSA works for multi-place definitions

### DIFF
--- a/tests/expectations/compiler/bugs/b28963.out
+++ b/tests/expectations/compiler/bugs/b28963.out
@@ -1,0 +1,17 @@
+program simple.aleo;
+
+closure foo:
+    input r0 as u32;
+    input r1 as u32;
+    assert.eq true true;
+    output r0 as u32;
+    output r1 as u32;
+
+function main:
+    input r0 as u16.private;
+    input r1 as u16.private;
+    cast r0 into r2 as u32;
+    cast r1 into r3 as u32;
+    call foo r2 r3 into r4 r5;
+    add r4 r5 into r6;
+    output r6 as u32.private;

--- a/tests/expectations/passes/ssa_forming/multi_defs.out
+++ b/tests/expectations/passes/ssa_forming/multi_defs.out
@@ -1,0 +1,12 @@
+program test.aleo {
+    transition main(a$$0: u16, b$$1: u16) -> u32 {
+        let $var$4 = a$$0 as u32;
+        let $var$5 = b$$1 as u32;
+        let (x$#2, y$#3) = foo(::$var$4, ::$var$5);
+        let $var$6 = x$#2 + y$#3;
+        return ::$var$6;
+    }
+    function foo(x$$7: u32, y$$8: u32) -> (u32, u32) {
+        return (x$$7, y$$8);
+    }
+}

--- a/tests/tests/compiler/bugs/b28963.leo
+++ b/tests/tests/compiler/bugs/b28963.leo
@@ -1,0 +1,10 @@
+program simple.aleo {
+    transition main(a: u16, b: u16) -> u32 {
+        let (x, y) = foo(a as u32, b as u32);
+        return x + y;
+    }
+
+    function foo(x: u32, y: u32) -> (u32, u32) {
+        return (x, y);
+    }
+}

--- a/tests/tests/passes/ssa_forming/multi_defs.leo
+++ b/tests/tests/passes/ssa_forming/multi_defs.leo
@@ -1,0 +1,10 @@
+program test.aleo {
+    transition main(a: u16, b: u16) -> u32 {
+        let (x, y) = foo(a as u32, b as u32);
+        return x + y;
+    }
+
+    function foo(x: u32, y: u32) -> (u32, u32) {
+        return (x, y);
+    }
+}


### PR DESCRIPTION
Closes https://github.com/ProvableHQ/leo/issues/28963

I am not entirely sure why `Expression::Call` was singled out in the previous code. 

With this change, SSA actually converts 
```leo
let (x, y) = foo(a as u32, b as u32);
```
to
```leo
let $var$4 = a$$0 as u32;
let $var$5 = b$$1 as u32;
let (x$#2, y$#3) = foo(::$var$4, ::$var$5);
```
which is what CSE expects.