### PR TITLE
support CONSENSUS_VERSION_HEIGHTS env var in devnet command

### DIFF
--- a/leo/cli/commands/devnet/mod.rs
+++ b/leo/cli/commands/devnet/mod.rs
@@ -77,7 +77,8 @@ pub struct LeoDevnet {
     #[clap(
         long,
         help = "Optional consensus heights to use. The `test_network` feature must be enabled for this to work.",
-        value_delimiter = ','
+        value_delimiter = ',',
+        env = "CONSENSUS_VERSION_HEIGHTS"
     )]
     pub(crate) consensus_heights: Option<Vec<u32>>,
     #[clap(long, help = "Run nodes in tmux (only available on Unix)")]


### PR DESCRIPTION
Fixes #28967

I tested this locally by setting the environment variable and saw this being printed:
```
% CONSENSUS_VERSION_HEIGHTS=0,1,2,300 ./target/debug/leo devnet --storage ~/Projects/aleo/devnet/tmp --clear-storage --snarkos ~/Projects/aleo/devnet/tmp/snarkos --snarkos-features test_network --tmux
🔧  Starting devnet with the following options:
  • Network: testnet
  • Validators: 4
  • Clients: 2
  • Storage: /Users/eran/Projects/aleo/devnet/tmp
  • Using snarkOS binary at: /Users/eran/Projects/aleo/devnet/tmp/snarkos
  • Consensus heights: 0,1,2,300
  • Clear storage: yes
  • Verbosity: 1
  • tmux: yes
🔍  Detected: snarkos unknown_branch 79936b5bfce6b158fe942c6cfb44a0cc07a7a3e0 features=[default,snarkos_node_metrics,test_network]
```

`Consensus heights: 0,1,2,300` indicates the env var is being correctly parsed