### PR TITLE
add missing '/unconfirmed' route to devnode mode

### DIFF
--- a/leo/cli/commands/devnode/rest/mod.rs
+++ b/leo/cli/commands/devnode/rest/mod.rs
@@ -145,6 +145,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             // GET and POST ../transaction/..
             .route("/transaction/broadcast", post(Self::transaction_broadcast))
             .route("/transaction/confirmed/{id}", get(Self::get_confirmed_transaction))
+            .route("/transaction/unconfirmed/{id}", get(Self::get_unconfirmed_transaction))
             .route("/transaction/{id}", get(Self::get_transaction))
 
             // GET ../find/..

--- a/leo/cli/commands/devnode/rest/routes.rs
+++ b/leo/cli/commands/devnode/rest/routes.rs
@@ -208,6 +208,17 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         })?))
     }
 
+    /// GET /<network>/transaction/unconfirmed/{transactionID}
+    pub(crate) async fn get_unconfirmed_transaction(
+        State(rest): State<Self>,
+        Path(tx_id): Path<N::TransactionID>,
+    ) -> Result<ErasedJson, RestError> {
+        // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
+        Ok(ErasedJson::pretty(rest.ledger.get_unconfirmed_transaction(&tx_id).map_err(|err| {
+            if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
+        })?))
+    }
+
     /// GET /<network>/program/{programID}
     /// GET /<network>/program/{programID}?metadata={true}
     pub(crate) async fn get_program(


### PR DESCRIPTION
## Motivation

Evaluating the new leo devnode mode for local/ci dev/test Aleo node as a light-weight altenative to leo devnet. Tested using a doko-js based testing suite in [sealance-io/compliant-transfer-aleo](https://github.com/sealance-io/compliant-transfer-aleo) repo.
 It seems that all requests to `/testnet/transaction/unconfirmed/<TX_ID>` result in HTTP 404 error. Added that route to devnode mode.

## Test Plan

Using the patched compiled leo binary's devnode mode seem to have solved that issue. 
Let me know if there's anything else to do.
Should make sure if that make sense when `CREATE_BLOCK ` is 'false'