### PR TITLE
perf: remove unnecessary clone when reconstructing functions

### DIFF
--- a/compiler/passes/src/monomorphization/program.rs
+++ b/compiler/passes/src/monomorphization/program.rs
@@ -78,7 +78,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
             // Reconstruct functions in post-order.
             if let Some(function) = self.function_map.swap_remove(&function_name.path) {
                 // Reconstruct the function.
-                let reconstructed_function = self.reconstruct_function(function.clone());
+                let reconstructed_function = self.reconstruct_function(function);
                 // Add the reconstructed function to the mapping.
                 self.reconstructed_functions.insert(function_name.path.clone(), reconstructed_function);
             }


### PR DESCRIPTION
The function reconstruction loop removed a redundant clone by moving the Function obtained via swap_remove directly into 
reconstruct_function. The reconstructor consumes its argument by value (see compiler/ast/src/passes/reconstructor.rs), so cloning provided no benefit and incurred extra allocations and copies of nested structures. This change is purely an optimization with no behavioral impact and is consistent with other passes that already pass owned values by move. The clone in monomorphization/ast.rs remains intentional because the source there is a borrowed reference.