### PR TITLE
fix: remove shadowed predeclared code and redundant clear() in interpret()

### DIFF
--- a/interpreter/src/lib.rs
+++ b/interpreter/src/lib.rs
@@ -260,14 +260,12 @@ pub fn interpret(
     let mut user_interface: Box<dyn Ui> =
         if tui { Box::new(ratatui_ui::RatatuiUi::new()) } else { Box::new(dialoguer_input::DialoguerUi::new()) };
 
-    let mut code = String::new();
     let mut futures = Vec::new();
     let mut watchpoints = Vec::new();
     let mut message = INTRO.to_string();
     let mut result = String::new();
 
     loop {
-        code.clear();
         futures.clear();
         watchpoints.clear();
 


### PR DESCRIPTION
In interpret() in interpreter/src/lib.rs a String named code was predeclared, cleared at the top of each loop iteration, and then immediately shadowed by a new code binding produced by view_current_in_context()/view_current. The outer variable was never read after being cleared, making both the allocation and clear pointless. Removing the outer declaration and its clear eliminates dead code, improves readability, and has no behavioral impact because the displayed content continues to come from the inner code String. No other changes were necessary.