### PR TITLE
Allow `address` in optionals and storage

### DIFF
--- a/compiler/ast/src/expressions/mod.rs
+++ b/compiler/ast/src/expressions/mod.rs
@@ -436,6 +436,18 @@ impl Expression {
             // Boolean
             Type::Boolean => Some(Literal::boolean(false, span, id).into()),
 
+            // Address: addresses don't have a well defined _zero_ but this value is often used as
+            // the "zero" address in practical applications. It really should never be used directly though.
+            // It should only be used as a placeholder for representating `none` for example.
+            Type::Address => Some(
+                Literal::address(
+                    "aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc".to_string(),
+                    span,
+                    id,
+                )
+                .into(),
+            ),
+
             // Field, Group, Scalar
             Type::Field => Some(Literal::field("0".to_string(), span, id).into()),
             Type::Group => Some(Literal::group("0".to_string(), span, id).into()),

--- a/compiler/passes/src/type_checking/visitor.rs
+++ b/compiler/passes/src/type_checking/visitor.rs
@@ -1170,34 +1170,87 @@ impl TypeCheckingVisitor<'_> {
                 }
                 self.assert_type_is_valid(array_type.element_type(), span);
             }
+
             Type::Optional(OptionalType { inner }) => {
-                match &**inner {
-                    Type::Composite(struct_type) => {
-                        // Look up the type.
-                        if let Some(struct_) = self.lookup_struct(
-                            struct_type.program.or(self.scope_state.program_name),
-                            &struct_type.path.absolute_path(),
-                        ) {
-                            // Check that the type is not a record.
-                            if struct_.is_record {
-                                self.emit_err(TypeCheckerError::optional_wrapping_of_records_unsupported(inner, span));
-                            }
+                // Some types cannot be wrapped in an optional
+                if self.disallowed_inside_optional(inner) {
+                    self.emit_err(TypeCheckerError::optional_wrapping_unsupported(inner, span));
+                }
+
+                // Validate inner type normally
+                self.assert_type_is_valid(inner, span);
+            }
+
+            Type::Address
+            | Type::Boolean
+            | Type::Composite(_)
+            | Type::Field
+            | Type::Future(_)
+            | Type::Group
+            | Type::Identifier(_)
+            | Type::Integer(_)
+            | Type::Scalar
+            | Type::Signature
+            | Type::Vector(_)
+            | Type::Numeric
+            | Type::Err => {} // Do nothing.
+        }
+    }
+
+    /// Can type `ty` be used inside an optional?
+    fn disallowed_inside_optional(&mut self, ty: &Type) -> bool {
+        match ty {
+            Type::Unit
+            | Type::Err
+            | Type::Future(_)
+            | Type::Identifier(_)
+            | Type::Mapping(_)
+            | Type::Optional(_)
+            | Type::String
+            | Type::Signature
+            | Type::Tuple(_)
+            | Type::Vector(_) => true,
+
+            Type::Composite(struct_type) => {
+                if let Some(struct_) = self.lookup_struct(
+                    struct_type.program.or(self.scope_state.program_name),
+                    &struct_type.path.absolute_path(),
+                ) {
+                    if struct_.is_record {
+                        return true;
+                    }
+
+                    // recursively check all fields
+                    for field in &struct_.members {
+                        let field_ty = &field.type_;
+                        // unwrap optional fields for the check
+                        let ty_to_check = match field_ty {
+                            Type::Optional(OptionalType { inner }) => inner,
+                            _ => field_ty,
+                        };
+                        if self.disallowed_inside_optional(ty_to_check) {
+                            return true;
                         }
                     }
-                    Type::Future(_)
-                    | Type::Identifier(_)
-                    | Type::Mapping(_)
-                    | Type::Optional(_)
-                    | Type::String
-                    | Type::Address
-                    | Type::Signature
-                    | Type::Tuple(_) => {
-                        self.emit_err(TypeCheckerError::optional_wrapping_unsupported(inner, span));
-                    }
-                    _ => self.assert_type_is_valid(inner, span),
                 }
+                false
             }
-            _ => {} // Do nothing.
+
+            Type::Array(array_type) => {
+                let elem_type = match array_type.element_type() {
+                    Type::Optional(OptionalType { inner }) => inner,
+                    other => other,
+                };
+                self.disallowed_inside_optional(elem_type)
+            }
+
+            Type::Address
+            | Type::Boolean
+            | Type::Field
+            | Type::Group
+            | Type::Integer(_)
+            | Type::Numeric
+            | Type::Scalar => false,
         }
     }
 
@@ -1214,9 +1267,6 @@ impl TypeCheckingVisitor<'_> {
             }
             Type::String => {
                 self.emit_err(TypeCheckerError::invalid_storage_type("string", span));
-            }
-            Type::Address => {
-                self.emit_err(TypeCheckerError::invalid_storage_type("address", span));
             }
             Type::Signature => {
                 self.emit_err(TypeCheckerError::invalid_storage_type("signature", span));
@@ -1274,7 +1324,16 @@ impl TypeCheckingVisitor<'_> {
             }
 
             // Everything else (integers, bool, group, etc.)
-            _ => {} // valid
+            Type::Address
+            | Type::Boolean
+            | Type::Field
+            | Type::Group
+            | Type::Identifier(_)
+            | Type::Integer(_)
+            | Type::Scalar
+            | Type::Numeric
+            | Type::Err
+            | Type::Vector(_) => {} // valid
         }
     }
 

--- a/errors/src/errors/type_checker/type_checker_error.rs
+++ b/errors/src/errors/type_checker/type_checker_error.rs
@@ -1252,6 +1252,7 @@ create_messages!(
         help: None,
     }
 
+    // TODO This error is unused. Remove it in a future version.
     @formatted
     optional_wrapping_of_records_unsupported {
         args: (ty: impl Display),
@@ -1267,7 +1268,8 @@ create_messages!(
         msg: format!(
             "The type `{ty}` cannot be wrapped in an optional.",
         ),
-        help: None,
+        help: Some("Optionals cannot wrap signatures, futures, mappings, tuples, vectors, records, arrays whose \
+                    elements are optional-unsafe, or structures containing any such types.".to_string()),
     }
 
     @formatted

--- a/tests/expectations/compiler/option/all_types.out
+++ b/tests/expectations/compiler/option/all_types.out
@@ -49,6 +49,20 @@ struct Optional__Iw7fQz4CKJ0:
 struct Top:
     container as Optional__Iw7fQz4CKJ0;
 
+struct Optional__HdJPTit9rcT:
+    is_some as boolean;
+    val as address;
+
+struct AddrStruct:
+    a as address;
+    b as Optional__HdJPTit9rcT;
+
+struct InnerAddr:
+    val as Optional__HdJPTit9rcT;
+
+struct WrapperAddr:
+    inner as InnerAddr;
+
 struct Optional__EsDmm5O6sv6:
     is_some as boolean;
     val as u32;
@@ -76,6 +90,10 @@ struct Optional__K4XRQPOk9yX:
 struct Optional__JYP65FYVVJA:
     is_some as boolean;
     val as scalar;
+
+struct Optional__Jyc4bxRuQrs:
+    is_some as boolean;
+    val as AddrStruct;
 
 function optional_basic_primitives:
     cast true 10u32 into r0 as Optional__EsDmm5O6sv6;
@@ -178,3 +196,24 @@ function optional_misc_primitive_types:
     output r0.val as group.private;
     output r3 as field.private;
     output r2.val as scalar.private;
+
+function optional_address_allowed:
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r0 as Optional__HdJPTit9rcT;
+    cast true aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r1 as Optional__HdJPTit9rcT;
+    ternary r0.is_some r0.val aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r2;
+    ternary r1.is_some r1.val r2 into r3;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r4 as Optional__HdJPTit9rcT;
+    cast aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta r4 into r5 as AddrStruct;
+    ternary r5.b.is_some r5.b.val r5.a into r6;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r7 as Optional__HdJPTit9rcT;
+    cast aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta r7 into r8 as AddrStruct;
+    cast true r8 into r9 as Optional__Jyc4bxRuQrs;
+    assert.eq r9.is_some true;
+    cast true aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r10 as Optional__HdJPTit9rcT;
+    cast r10 into r11 as InnerAddr;
+    cast r11 into r12 as WrapperAddr;
+    assert.eq r12.inner.val.is_some true;
+    output r3 as address.private;
+    output r6 as address.private;
+    output r9.val.a as address.private;
+    output r12.inner.val.val as address.private;

--- a/tests/expectations/compiler/option/optional_in_mapping_fail.out
+++ b/tests/expectations/compiler/option/optional_in_mapping_fail.out
@@ -1,8 +1,3 @@
-Error [ETYC0372160]: The type `address` cannot be wrapped in an optional.
-    --> compiler-test:6:5
-     |
-   6 |     mapping optional_balances: address? => Foo;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372161]: The type `address?` is or contains an optional type which cannot be used as the key in a mapping
     --> compiler-test:6:5
      |

--- a/tests/expectations/compiler/option/optional_record_fail.out
+++ b/tests/expectations/compiler/option/optional_record_fail.out
@@ -1,4 +1,4 @@
-Error [ETYC0372159]: The type `Foo` cannot be wrapped in an optional because it is a record.
+Error [ETYC0372160]: The type `Foo` cannot be wrapped in an optional.
     --> compiler-test:10:9
      |
   10 |         let f: Foo? = Foo {
@@ -9,3 +9,5 @@ Error [ETYC0372159]: The type `Foo` cannot be wrapped in an optional because it 
      |             ^^^^^^^
   13 |         };
      |         ^^
+     |
+     = Optionals cannot wrap signatures, futures, mappings, tuples, vectors, records, arrays whose elements are optional-unsafe, or structures containing any such types.

--- a/tests/expectations/compiler/option/unsupported_optional_fail.out
+++ b/tests/expectations/compiler/option/unsupported_optional_fail.out
@@ -3,6 +3,8 @@ Error [ETYC0372160]: The type `(u8, u8)` cannot be wrapped in an optional.
      |
    4 |         let a: (u8, u8)? = (1u8, 2u8); // ERROR: Tuples cannot be optional just yet
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Optionals cannot wrap signatures, futures, mappings, tuples, vectors, records, arrays whose elements are optional-unsafe, or structures containing any such types.
 Error [ETYC0372117]: Expected (u8, u8)? but type `(u8, u8)` was found.
     --> compiler-test:4:28
      |
@@ -13,16 +15,15 @@ Error [ETYC0372160]: The type `signature` cannot be wrapped in an optional.
      |
    8 |         let s: signature? = s_;
      |         ^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372160]: The type `address` cannot be wrapped in an optional.
-    --> compiler-test:9:9
      |
-   9 |         let a: address? = a_;
-     |         ^^^^^^^^^^^^^^^^^^^^^
+     = Optionals cannot wrap signatures, futures, mappings, tuples, vectors, records, arrays whose elements are optional-unsafe, or structures containing any such types.
 Error [ETYC0372160]: The type `Future<Fn()>` cannot be wrapped in an optional.
     --> compiler-test:14:9
      |
   14 |         let fut: Future? = finalize(); // ERROR: Future? is not allowed
      |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Optionals cannot wrap signatures, futures, mappings, tuples, vectors, records, arrays whose elements are optional-unsafe, or structures containing any such types.
 Error [ETYC0372003]: Expected type `Future<Fn()>?` but type `Future<Fn()>` was found
     --> compiler-test:14:28
      |

--- a/tests/expectations/compiler/storage/bad_storage_types_fail.out
+++ b/tests/expectations/compiler/storage/bad_storage_types_fail.out
@@ -1,70 +1,135 @@
-Error [ETYC0372166]: tuple is an invalid storage type
+Error [ETYC0372166]: A zero sized type is an invalid storage type
+    --> compiler-test:3:5
+     |
+   3 |     storage unit_storage: ();
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: unit is an invalid storage type
+    --> compiler-test:3:5
+     |
+   3 |     storage unit_storage: ();
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: string is an invalid storage type
+    --> compiler-test:4:5
+     |
+   4 |     storage string_storage: string;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: signature is an invalid storage type
+    --> compiler-test:5:5
+     |
+   5 |     storage signature_storage: signature;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: future is an invalid storage type
+    --> compiler-test:6:5
+     |
+   6 |     storage future_storage: Future;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: optional is an invalid storage type
     --> compiler-test:7:5
      |
-   7 |     storage tuple_storage: (u32, u32);
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: future is an invalid storage type
+   7 |     storage optional_storage: u32?;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: tuple is an invalid storage type
     --> compiler-test:8:5
      |
-   8 |     storage future_storage: Future;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: address is an invalid storage type
-    --> compiler-test:9:5
-     |
-   9 |     storage address_storage: address;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: signature is an invalid storage type
-    --> compiler-test:10:5
-     |
-  10 |     storage signature_storage: signature;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   8 |     storage tuple_storage: (u32, u32);
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: record is an invalid storage type
-    --> compiler-test:11:5
+    --> compiler-test:14:5
      |
-  11 |     storage record_storage: MyRecord;
+  14 |     storage record_storage: MyRecord;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: A zero sized type is an invalid storage type
-    --> compiler-test:12:5
-     |
-  12 |     storage unit_storage: ();
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: unit is an invalid storage type
-    --> compiler-test:12:5
-     |
-  12 |     storage unit_storage: ();
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: tuple is an invalid storage type
-    --> compiler-test:15:5
-     |
-  15 |     storage vec_tuple: [(u32, u32)];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: future is an invalid storage type
-    --> compiler-test:16:5
-     |
-  16 |     storage vec_future: [Future];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: address is an invalid storage type
     --> compiler-test:17:5
      |
-  17 |     storage vec_address: [address];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: signature is an invalid storage type
+  17 |     storage array_unit: [(); 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: unit is an invalid storage type
+    --> compiler-test:17:5
+     |
+  17 |     storage array_unit: [(); 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: string is an invalid storage type
     --> compiler-test:18:5
      |
-  18 |     storage vec_signature: [signature];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: record is an invalid storage type
+  18 |     storage array_string: [string; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: signature is an invalid storage type
     --> compiler-test:19:5
      |
-  19 |     storage vec_record: [MyRecord];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: A zero sized type is an invalid storage type
+  19 |     storage array_signature: [signature; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: future is an invalid storage type
     --> compiler-test:20:5
      |
-  20 |     storage vec_unit: [()];
+  20 |     storage array_future: [Future; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: future is an invalid storage type
+    --> compiler-test:20:5
+     |
+  20 |     storage array_future: [Future; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: optional is an invalid storage type
+    --> compiler-test:21:5
+     |
+  21 |     storage array_optional: [u32?; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: optional is an invalid storage type
+    --> compiler-test:21:5
+     |
+  21 |     storage array_optional: [u32?; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: tuple is an invalid storage type
+    --> compiler-test:22:5
+     |
+  22 |     storage array_tuple: [(u32, u32); 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: tuple is an invalid storage type
+    --> compiler-test:22:5
+     |
+  22 |     storage array_tuple: [(u32, u32); 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: record is an invalid storage type
+    --> compiler-test:23:5
+     |
+  23 |     storage array_record: [MyRecord; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: A zero sized type is an invalid storage type
+    --> compiler-test:26:5
+     |
+  26 |     storage vec_unit: [()];
      |     ^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: unit is an invalid storage type
-    --> compiler-test:20:5
+    --> compiler-test:26:5
      |
-  20 |     storage vec_unit: [()];
+  26 |     storage vec_unit: [()];
      |     ^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: string is an invalid storage type
+    --> compiler-test:27:5
+     |
+  27 |     storage vec_string: [string];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: signature is an invalid storage type
+    --> compiler-test:28:5
+     |
+  28 |     storage vec_signature: [signature];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: future is an invalid storage type
+    --> compiler-test:29:5
+     |
+  29 |     storage vec_future: [Future];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: optional is an invalid storage type
+    --> compiler-test:30:5
+     |
+  30 |     storage vec_optional: [u32?];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: tuple is an invalid storage type
+    --> compiler-test:31:5
+     |
+  31 |     storage vec_tuple: [(u32, u32)];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: record is an invalid storage type
+    --> compiler-test:32:5
+     |
+  32 |     storage vec_record: [MyRecord];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/storage/good_storage_types.out
+++ b/tests/expectations/compiler/storage/good_storage_types.out
@@ -1,0 +1,120 @@
+program good_storage_tests.aleo;
+
+struct MyStruct:
+    a as u32;
+    b as boolean;
+    c as address;
+
+mapping bool_storage__:
+    key as boolean.public;
+    value as boolean.public;
+
+mapping scalar_storage__:
+    key as boolean.public;
+    value as scalar.public;
+
+mapping field_storage__:
+    key as boolean.public;
+    value as field.public;
+
+mapping group_storage__:
+    key as boolean.public;
+    value as group.public;
+
+mapping address_storage__:
+    key as boolean.public;
+    value as address.public;
+
+mapping u32_storage__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping i8_storage__:
+    key as boolean.public;
+    value as i8.public;
+
+mapping struct_storage__:
+    key as boolean.public;
+    value as MyStruct.public;
+
+mapping array_u32__:
+    key as boolean.public;
+    value as [u32; 3u32].public;
+
+mapping array_bool__:
+    key as boolean.public;
+    value as [boolean; 2u32].public;
+
+mapping array_address__:
+    key as boolean.public;
+    value as [address; 2u32].public;
+
+mapping array_struct__:
+    key as boolean.public;
+    value as [MyStruct; 2u32].public;
+
+mapping vec_bool__:
+    key as u32.public;
+    value as boolean.public;
+
+mapping vec_bool__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_scalar__:
+    key as u32.public;
+    value as scalar.public;
+
+mapping vec_scalar__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_field__:
+    key as u32.public;
+    value as field.public;
+
+mapping vec_field__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_group__:
+    key as u32.public;
+    value as group.public;
+
+mapping vec_group__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_address__:
+    key as u32.public;
+    value as address.public;
+
+mapping vec_address__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_u32__:
+    key as u32.public;
+    value as u32.public;
+
+mapping vec_u32__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_i8__:
+    key as u32.public;
+    value as i8.public;
+
+mapping vec_i8__len__:
+    key as boolean.public;
+    value as u32.public;
+
+mapping vec_struct__:
+    key as u32.public;
+    value as MyStruct.public;
+
+mapping vec_struct__len__:
+    key as boolean.public;
+    value as u32.public;
+
+function foo:

--- a/tests/expectations/compiler/storage/primitives.out
+++ b/tests/expectations/compiler/storage/primitives.out
@@ -16,6 +16,10 @@ struct Optional__8aTicnNTOvk:
     is_some as boolean;
     val as group;
 
+struct Optional__HdJPTit9rcT:
+    is_some as boolean;
+    val as address;
+
 mapping flag__:
     key as boolean.public;
     value as boolean.public;
@@ -32,6 +36,10 @@ mapping group_val__:
     key as boolean.public;
     value as group.public;
 
+mapping addr_val__:
+    key as boolean.public;
+    value as address.public;
+
 function initialize:
     async initialize into r0;
     output r0 as primitives.aleo/initialize.future;
@@ -41,6 +49,7 @@ finalize initialize:
     set 1scalar into scalar_val__[false];
     set 42field into field_val__[false];
     set 0group into group_val__[false];
+    set aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into addr_val__[false];
 
 function to_none:
     async to_none into r0;
@@ -51,6 +60,7 @@ finalize to_none:
     remove scalar_val__[false];
     remove field_val__[false];
     remove group_val__[false];
+    remove addr_val__[false];
 
 function check1:
     async check1 into r0;
@@ -125,6 +135,23 @@ finalize check1:
     cast r56 r57 into r58 as Optional__8aTicnNTOvk;
     is.eq r58.val 0group into r59;
     assert.eq r59 true;
+    contains addr_val__[false] into r60;
+    get.or_use addr_val__[false] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r61;
+    cast true r61 into r62 as Optional__HdJPTit9rcT;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r63 as Optional__HdJPTit9rcT;
+    ternary r60 r62.is_some r63.is_some into r64;
+    ternary r60 r62.val r63.val into r65;
+    cast r64 r65 into r66 as Optional__HdJPTit9rcT;
+    assert.eq r66.is_some true;
+    contains addr_val__[false] into r67;
+    get.or_use addr_val__[false] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r68;
+    cast true r68 into r69 as Optional__HdJPTit9rcT;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r70 as Optional__HdJPTit9rcT;
+    ternary r67 r69.is_some r70.is_some into r71;
+    ternary r67 r69.val r70.val into r72;
+    cast r71 r72 into r73 as Optional__HdJPTit9rcT;
+    is.eq r73.val aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r74;
+    assert.eq r74 true;
 
 function check2:
     async check2 into r0;
@@ -199,6 +226,23 @@ finalize check2:
     ternary r54.is_some r61.val 0group into r62;
     is.eq r62 0group into r63;
     assert.eq r63 true;
+    contains addr_val__[false] into r64;
+    get.or_use addr_val__[false] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r65;
+    cast true r65 into r66 as Optional__HdJPTit9rcT;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r67 as Optional__HdJPTit9rcT;
+    ternary r64 r66.is_some r67.is_some into r68;
+    ternary r64 r66.val r67.val into r69;
+    cast r68 r69 into r70 as Optional__HdJPTit9rcT;
+    contains addr_val__[false] into r71;
+    get.or_use addr_val__[false] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r72;
+    cast true r72 into r73 as Optional__HdJPTit9rcT;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r74 as Optional__HdJPTit9rcT;
+    ternary r71 r73.is_some r74.is_some into r75;
+    ternary r71 r73.val r74.val into r76;
+    cast r75 r76 into r77 as Optional__HdJPTit9rcT;
+    ternary r70.is_some r77.val aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r78;
+    is.eq r78 aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r79;
+    assert.eq r79 true;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/execution/optional_types.out
+++ b/tests/expectations/execution/optional_types.out
@@ -49,6 +49,20 @@ struct Optional__Iw7fQz4CKJ0:
 struct Top:
     container as Optional__Iw7fQz4CKJ0;
 
+struct Optional__HdJPTit9rcT:
+    is_some as boolean;
+    val as address;
+
+struct AddrStruct:
+    a as address;
+    b as Optional__HdJPTit9rcT;
+
+struct InnerAddr:
+    val as Optional__HdJPTit9rcT;
+
+struct WrapperAddr:
+    inner as InnerAddr;
+
 struct Optional__EsDmm5O6sv6:
     is_some as boolean;
     val as u32;
@@ -84,6 +98,10 @@ struct Optional__K4XRQPOk9yX:
 struct Optional__JYP65FYVVJA:
     is_some as boolean;
     val as scalar;
+
+struct Optional__Jyc4bxRuQrs:
+    is_some as boolean;
+    val as AddrStruct;
 
 function optional_basic_primitives:
     cast true 10u32 into r0 as Optional__EsDmm5O6sv6;
@@ -199,6 +217,27 @@ function optional_misc_primitive_types:
     output r3 as field.private;
     output r2.val as scalar.private;
 
+function optional_address:
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r0 as Optional__HdJPTit9rcT;
+    cast true aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r1 as Optional__HdJPTit9rcT;
+    ternary r0.is_some r0.val aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r2;
+    ternary r1.is_some r1.val r2 into r3;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r4 as Optional__HdJPTit9rcT;
+    cast aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta r4 into r5 as AddrStruct;
+    ternary r5.b.is_some r5.b.val r5.a into r6;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r7 as Optional__HdJPTit9rcT;
+    cast aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta r7 into r8 as AddrStruct;
+    cast true r8 into r9 as Optional__Jyc4bxRuQrs;
+    assert.eq r9.is_some true;
+    cast true aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r10 as Optional__HdJPTit9rcT;
+    cast r10 into r11 as InnerAddr;
+    cast r11 into r12 as WrapperAddr;
+    assert.eq r12.inner.val.is_some true;
+    output r3 as address.private;
+    output r6 as address.private;
+    output r9.val.a as address.private;
+    output r12.inner.val.val as address.private;
+
 constructor:
     assert.eq edition 0u16;
 verified: true
@@ -206,20 +245,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au136tagfvaf3sxgvak2q3n84jmta2yy5clr6lefnnrvrlsxgzvkv9sahams0",
+      "id": "au1fuc8nxhx9qgeh8fwuavkdmtrrpwfr9jylvh6p2vde5x29mx76gzqrvklg9",
       "program": "all_types.aleo",
       "function": "optional_basic_primitives",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "2601215692614856085038855928040848032597789677409541904645117423664448650813field",
-          "value": "ciphertext1qyqv7ga5trjcswm5v9w8cp2r3j350tz8a0ahnhpgjznzesxw829k7rgmq2hl9"
+          "id": "3309194570735646905700631931296571042556811751933365652455202157216835655298field",
+          "value": "ciphertext1qyq90scl5ht9z53m6kcvfxyku0v5uhhv0tuul4wnkp23nqzmr6z45rqkk0fpk"
         }
       ],
-      "tpk": "6436250505729030327561312370514985398391203870244299067437496960585219711134group",
-      "tcm": "5598012722759062928202960694337682154750003852737662174753247311981057631334field",
-      "scm": "2802007035778210620307543289028508671504868802455176135001652758235595148912field"
+      "tpk": "2415597687875864464573881446772256259277995056059838820677625792296401632956group",
+      "tcm": "7030616420779954453202522695381761571266035039024289043304784858376983631346field",
+      "scm": "3936933350473325683667474309316199471088087623872846294952761378365987359295field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -230,20 +269,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au1gd69kk86puwtg4f5zvxa6r6ua9uf3xwrygl3ktcraufmjvwafspq36lu3k",
+      "id": "au10nqg705lmfqq4hmj8aayjk70j73vnu4ccxal74a4c7wyjykaks8sf8ml7d",
       "program": "all_types.aleo",
       "function": "array_of_optionals",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "2149749916105601420044831516907384125447683208206161391261938759239920428969field",
-          "value": "ciphertext1qyq8vje8yr3n37xpx6lv8sffaja73h6egynsm2sc07upgqrmg4nkvzgh4cvfs"
+          "id": "5535989363752379003548191036263852093021543829106054891829253583699768841031field",
+          "value": "ciphertext1qyqwsz7wxufl5l7h3t84q7d8ny4zddqjsnxntumpelgzqjj9zlstuqqnqzhpa"
         }
       ],
-      "tpk": "6786135613619843748146614580089562483895036696711585156953209952956860676041group",
-      "tcm": "6407685360286932042211028631660080432142764188188039268613005835108370846188field",
-      "scm": "4868417000827980165156721392525551216603527886799024241341899532694170066746field"
+      "tpk": "5466505310294086924103545360731590025026200720728371644332209498202660949024group",
+      "tcm": "1953578802671817876821875836970287188082753230488288335979815221105281278268field",
+      "scm": "3077554771235291623934426301173437571081379403479720366015815056426622056911field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -254,20 +293,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au1s4us7djxtnsxvw66vzzpnqd63txpyafs9y5sjrmccpgwesed0v8srm824f",
+      "id": "au15lxq0dzw4pvhva4uz966jx8meedf5pduaf2lgy9erj3mzt7a5gpsq0dajp",
       "program": "all_types.aleo",
       "function": "optional_array",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "3455666462057586983405955319399191419770843186268746811266971239437723998307field",
-          "value": "ciphertext1qyqfgwmn0wz0s766sfq5wskhhhvq2srsy2jexaxpd3vjc5hksqv5syguc3u0c"
+          "id": "3338231952673354668153140100729914110435986004992164868098456718858196553385field",
+          "value": "ciphertext1qyqzv4fjtc30fq987w8vu6ahva2thttf7026tw33jc6hme3er40muyg4t9ugu"
         }
       ],
-      "tpk": "8191546365494449229401516388481043144655589173963588590944159348037087855025group",
-      "tcm": "8046240212188331625358725707776239735269026822733856529176775015360561937656field",
-      "scm": "2014050716866634138966875710420931753046444864710769839418540621410826778576field"
+      "tpk": "4992035945666664908061453332740615848169879702876390314624888179955435569547group",
+      "tcm": "3810617196216387173190075999251790995021271756824199539373498589995979552208field",
+      "scm": "3213875867725384973184303058159290629068215106403570968848656153679073078964field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -278,20 +317,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au1r9x833emkej8yrk0tjznyl5a96h6td7058s8r5k3q6e9q6u6k5yq7r8x2p",
+      "id": "au1xfvsujcpzrsjvv4zwnvmuwhd9y3u08yxyq0lz2ne3kxw9rak2ygslj25zz",
       "program": "all_types.aleo",
       "function": "optional_struct_field",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "4105569341380744293624662384686652516879508864911300079638996613685027165392field",
-          "value": "ciphertext1qyqxa99k8jjrsxtn6l6sxlpsqx4xpwnv3tjnepge662a0mx6lrukuqgdwjnap"
+          "id": "7163172993379756429047357662517872973635099904127199998349353808804083163836field",
+          "value": "ciphertext1qyq9rrx5hzutfu3c7cr62lr3q7jquh68d40z78v8zdtf9u2vclns5zca9j0cn"
         }
       ],
-      "tpk": "4877838345181325883827558671281373550857926792444056396585216165970432239467group",
-      "tcm": "8439925514848762466688326976376142902739786938622236636633231609901594560196field",
-      "scm": "8028448733154396976620603174671657708725815500189185292785432988058042146848field"
+      "tpk": "5664984702487408174999842195162338402954764243480477531714159675012802402250group",
+      "tcm": "5730257958854767184941154943815313702085565561868828946368342126372862990517field",
+      "scm": "1448984613864406657913023728372949128389034604712458287572565011547859776332field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -302,20 +341,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au173fjrr4ajq4rqfs5pnnkydxqmxl4f45kjp8fjadye0k03dedmgpqr655wt",
+      "id": "au1n2y82esrwfn3fp8skjs9slvjjqcaquwy9kz9a59h2dh2cdvd7cqqmhfts8",
       "program": "all_types.aleo",
       "function": "optional_struct",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "6082260092756690594855284232256480839051989258380292649706677058450111159891field",
-          "value": "ciphertext1qyqzu297ga8lqhwdt4ag353ftj29e7ectje8ncwup2y39let9kp7yrcs8wpeq"
+          "id": "3200365395389875441482352262327913835445800731680207329579552565869155913021field",
+          "value": "ciphertext1qyqq8lzj0u9q456ve0ss4ew0k0tukkfv9e0vwellcwwdx0c4sjnaypgpu9n3j"
         }
       ],
-      "tpk": "4135025974138612617261046774461402712019420122105546996744996614359607664247group",
-      "tcm": "3705469511728816695989358826219302358361849544077628566493049642336732299283field",
-      "scm": "5836476873390401550928241349458644496695772233774092343017116844891757847513field"
+      "tpk": "5716346167061947876039353832410009417710171858479578869841312711073176286056group",
+      "tcm": "4545325222683698250345203315811523755714393663174710516132245353640494220950field",
+      "scm": "3751601472167538964022384145938981290214743145450081360113128036365710796120field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -326,20 +365,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au1xk289xfmps4x7dxc0qkhw6jk85jzlqel5km66x0yakycpgfvdgqqc5r0un",
+      "id": "au1l9xkl3djwu2urz7cmpjuulnmvhgze3rlm9fqnq9ehq5vca2lrqgqwvk0sg",
       "program": "all_types.aleo",
       "function": "array_of_optional_structs",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "324463623834985510916849806973830314502313967395121675708492650314655147992field",
-          "value": "ciphertext1qyqxjaxjcxd2sfje3rlkc5x80p63ws99pap0ea6wcsr8ztqkfq3czqg9t2utn"
+          "id": "7523592130461002041732877271190035337682137052357592132521134302637956368005field",
+          "value": "ciphertext1qyqggwhn37mlgmz8ljne83jpxl5wkd67ceec4yrkrgt37agcqdgt5qsu8268v"
         }
       ],
-      "tpk": "6496535265321109031029060098856298027858333263459100343007460696876835767432group",
-      "tcm": "926098341429471817322625708353250205134422914426293724514836796053988667216field",
-      "scm": "4114269927895187194633538980108352893441497499085254434006322953148750415149field"
+      "tpk": "556800128497712643687090848279892806139543069358649061616143407627195846389group",
+      "tcm": "689219327633666947350993834087701359625723040876198597147883022104574478226field",
+      "scm": "5287624562745835022975780757772758206748572089518394980160983858882548260610field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -350,20 +389,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au1ngvzgfq3zv96z0ug5zzshuju247f7u5k5365076lfmryj0x3pcqqz79ear",
+      "id": "au1eq6jrfc6aksn5c09tzt7ey2p98ufq73ekrckzwuunf89vrs7ugrqlj35gy",
       "program": "all_types.aleo",
       "function": "nested_optional_structs",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "2656007234008086588979994848998536846442386140512433002575439243471208011437field",
-          "value": "ciphertext1qyqzg9rlte672xczdh5m9yjpp5q3fs439f4twckjc3akr49ygues7qcvgzh97"
+          "id": "3329507399497536454161852859614960018681101885787998376800406213233225918788field",
+          "value": "ciphertext1qyq2str4yce2tgkql80xhfjhmcuq7ne2t66h7cshs3ne4y8448jv5ygf2gkpr"
         }
       ],
-      "tpk": "2261227453945003598263461379146391274177136306629169660358771596122812570996group",
-      "tcm": "5554256120492743867151681764642827853054452209759420357299484427620560265058field",
-      "scm": "209964094582281996778484636175196610356142815072943500240824064949375117104field"
+      "tpk": "400902385254709873795896857423261102196649937170597371486022035263922532820group",
+      "tcm": "5418687594143978278629941107957170628076585443551316118182906694679252450494field",
+      "scm": "2725178225702072881634035291100141934989014265084304638024545458406419345909field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -374,20 +413,20 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au146g8fz294752ufmwsq2syrww0r54m28m9hy45yg85hgl4w0pfgqqahm0m5",
+      "id": "au1f3sez0czg9l029z6wwj90rx7dzl7elnnu9gysgfht4msm0x745qs643w9y",
       "program": "all_types.aleo",
       "function": "tuples_with_optional_elements",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "3141309502009903367933533388700325646690320877694298508353471724458088313133field",
-          "value": "ciphertext1qyqvltca2skjs2c8r6j7ra7pu0gghg86e4fanhwanfsjuexqt5kz7qckn4n03"
+          "id": "4154192667696752976305978251255381627401900599007707583304289582347714996938field",
+          "value": "ciphertext1qyq8ys8mt5f5uxn948dn7e0wpws4shj26zywwkkgzzy902gqxtlhkqcn4dmuk"
         }
       ],
-      "tpk": "2227698038741924746581939728715608003629119259813872257725277359168031465910group",
-      "tcm": "5831426835574479832155682599727483960612566430794219073650056826402038447803field",
-      "scm": "1261648328259358643240919449648989366412674394411414795744504155107411138175field"
+      "tpk": "10926576121576149496477219119721819123915930082097658239022427275501546844group",
+      "tcm": "1342630757455154053568917696755419164931066786648734807951084014150709649827field",
+      "scm": "6989069330670487938019095497905918336876017297134394921142477370290659658383field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
@@ -398,30 +437,69 @@ status: accepted
 {
   "transitions": [
     {
-      "id": "au1c8uas7yunq6w27n0ecqvjq9y78zvxhs9ums29fthdwmh38qtcuzs95smw3",
+      "id": "au1ey4myydfp06fpdlv3yh32fk236w265pznan6vtzqum75c24g6q9qctpeq9",
       "program": "all_types.aleo",
       "function": "optional_misc_primitive_types",
       "inputs": [],
       "outputs": [
         {
           "type": "private",
-          "id": "1180262416597255810781168434758483212171796561909263419941341581272999447098field",
-          "value": "ciphertext1qgqraz6gmfe3qum54739vcvefne7rfv7v6ty4v9gfxe7r0r0gr4sspdrh7gc6y4w9swdyhy9h9mgjqd44h3z5g6epfletsxkm0f35dr4zqwms8um"
+          "id": "3459365869179049740860113214466800204381291640599301848464120971502408704253field",
+          "value": "ciphertext1qgqyw2leuwglxg8pej5ut2wfjskklh84hppk9hlwsj6f2n6zpfs2qp742uctlwvmul3hgr4kvkfldtm0yy6kwwpd3hqyl7hqxrnw69q7qc46h5kq"
         },
         {
           "type": "private",
-          "id": "5702072204372985714389352165913600463585086340357384315087144256555092744122field",
-          "value": "ciphertext1qgq83fpcglthfunkspv97rxj9ky3ts7u0994wd7xnfvpy6krkjdf7p6u6hraf93revrgzswzg8lrmgzhy73e9n9ayyd4757zrugsxu03q5tvjctd"
+          "id": "1043517705812122183352787197382565931248101026178319145662823369007065593620field",
+          "value": "ciphertext1qgq2dawejca8ywhfm4j0cjft2jr5jm94g86yh6ga63zuxnahsa2eur6wgveeuu66rnft5stxwkum83nk3as7ukwkt69ccfvfnxkmx707zqsggj8l"
         },
         {
           "type": "private",
-          "id": "1103754568956441981627442156423690578333910745004291245888793774653343621317field",
-          "value": "ciphertext1qgqf676hq0zey79j4vex9j8r7dxlu36fmdjgez6vakqf95y7eg7azrv7r7yhhqn4f2s7puhln05vawzqcwr7st2cmzh8aeg7jxy8j474qvt9s6e7"
+          "id": "3336846143410693652961885514652627166408266716035452116354183434316607902009field",
+          "value": "ciphertext1qgqt5h00wneddavaf80kjc96dqgx6jx7u7gmnf23avxe0anejvgzyq2lxlz5hvz3s7dgum9zqnpvjqf54jyhyrlxxncejhjq0pe69q68qgs0pp8n"
         }
       ],
-      "tpk": "6838050402083592367515869547007272624111061174708028339432350957519822426237group",
-      "tcm": "6735950385326710153657245501969490508447021559566631158535358666175457439895field",
-      "scm": "2238511267097530226753579814091738303828962831320733810559296347804455866839field"
+      "tpk": "3068831351743405691969429266219668515579922413004105968786374094762939635262group",
+      "tcm": "439005278619003483345885230129056065666903417873926830962028502684745003015field",
+      "scm": "2741018383278221024661073352600163402476179589197075995659072539703317069333field"
+    }
+  ],
+  "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
+}
+
+verified: true
+status: accepted
+{
+  "transitions": [
+    {
+      "id": "au10r993u6wszq4uzr4263jsj46kp85ju8cyneuvw72yrf7l927a59sq4lkx0",
+      "program": "all_types.aleo",
+      "function": "optional_address",
+      "inputs": [],
+      "outputs": [
+        {
+          "type": "private",
+          "id": "7073176777691935103843080221387370317341601680653364571571600770652078253732field",
+          "value": "ciphertext1qgq9ty6zlu2y6tr5en48ckvhzem9ggt50neyd4psn6fcu28pr3kj5rd30hzmlmq63qwtxt58fa5yqwgj3ztxjx3uk790843fys6fteu7pyw2c52h"
+        },
+        {
+          "type": "private",
+          "id": "4687673634006300516616925902885354327474019036739606014590904900130873554743field",
+          "value": "ciphertext1qgqwp97f7ygt2wnk5kp2zqnd7h6pwtnka3xryrdujzm2ld0jgsfljz2gzakxzzzmu9fytaw74cxd0he3ahxjfd35uaxyxunrlj22hwxzpqe34pnh"
+        },
+        {
+          "type": "private",
+          "id": "7834724083906944168127303963377000822595042965994744535463035889213559916689field",
+          "value": "ciphertext1qgqt0v3qq8jy82t9njdh6j3076ct3ad4a3574yul6e473slknupzyq8hrp2hazvhl6d39qxwrmr22c6upttazq8zf5qnsnwnm9welngfpypde7s8"
+        },
+        {
+          "type": "private",
+          "id": "820577969999319988373293908008252218725751862611191704876497996475937263935field",
+          "value": "ciphertext1qgqrecjnvrm3vaj0u2rczgnzlj96qcvva6sgu6rfhq7hvk74gpldkpvkm77pmy3gu2nkadzkz2sy5lwk2asvu34n7460kyzata6tdwz9pqkaccvf"
+        }
+      ],
+      "tpk": "4392511100182032228972950088763335445823612498567363746733313083841668125899group",
+      "tcm": "725421541543410556169105149117668768116186234567846669017129281018491576188field",
+      "scm": "1666945715891796234592282446632550161338740423520948308342486846105277407437field"
     }
   ],
   "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"

--- a/tests/expectations/execution/various_storage_types.out
+++ b/tests/expectations/execution/various_storage_types.out
@@ -32,6 +32,10 @@ struct Optional__8aTicnNTOvk:
     is_some as boolean;
     val as group;
 
+struct Optional__HdJPTit9rcT:
+    is_some as boolean;
+    val as address;
+
 struct Optional__Db820DkWf1z:
     is_some as boolean;
     val as [Container; 2u32];
@@ -63,6 +67,10 @@ mapping field_val__:
 mapping group_val__:
     key as boolean.public;
     value as group.public;
+
+mapping address_val__:
+    key as boolean.public;
+    value as address.public;
 
 mapping containers__:
     key as boolean.public;
@@ -231,6 +239,7 @@ finalize primitive_types:
     set 2scalar into scalar_val__[false];
     set 21field into field_val__[false];
     set 0group into group_val__[false];
+    set aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into address_val__[false];
     contains flag__[false] into r0;
     get.or_use flag__[false] false into r1;
     cast true r1 into r2 as Optional__DbbQYuLaHdi;
@@ -299,23 +308,23 @@ finalize primitive_types:
     cast r56 r57 into r58 as Optional__8aTicnNTOvk;
     is.eq r58.val 0group into r59;
     assert.eq r59 true;
-    contains flag__[false] into r60;
-    get.or_use flag__[false] false into r61;
-    cast true r61 into r62 as Optional__DbbQYuLaHdi;
-    cast false false into r63 as Optional__DbbQYuLaHdi;
+    contains address_val__[false] into r60;
+    get.or_use address_val__[false] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r61;
+    cast true r61 into r62 as Optional__HdJPTit9rcT;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r63 as Optional__HdJPTit9rcT;
     ternary r60 r62.is_some r63.is_some into r64;
     ternary r60 r62.val r63.val into r65;
-    cast r64 r65 into r66 as Optional__DbbQYuLaHdi;
+    cast r64 r65 into r66 as Optional__HdJPTit9rcT;
     assert.eq r66.is_some true;
-    contains flag__[false] into r67;
-    get.or_use flag__[false] false into r68;
-    cast true r68 into r69 as Optional__DbbQYuLaHdi;
-    cast false false into r70 as Optional__DbbQYuLaHdi;
+    contains address_val__[false] into r67;
+    get.or_use address_val__[false] aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r68;
+    cast true r68 into r69 as Optional__HdJPTit9rcT;
+    cast false aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc into r70 as Optional__HdJPTit9rcT;
     ternary r67 r69.is_some r70.is_some into r71;
     ternary r67 r69.val r70.val into r72;
-    cast r71 r72 into r73 as Optional__DbbQYuLaHdi;
-    not r73.val into r74;
-    set r74 into flag__[false];
+    cast r71 r72 into r73 as Optional__HdJPTit9rcT;
+    is.eq r73.val aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta into r74;
+    assert.eq r74 true;
     contains flag__[false] into r75;
     get.or_use flag__[false] false into r76;
     cast true r76 into r77 as Optional__DbbQYuLaHdi;
@@ -331,8 +340,8 @@ finalize primitive_types:
     ternary r82 r84.is_some r85.is_some into r86;
     ternary r82 r84.val r85.val into r87;
     cast r86 r87 into r88 as Optional__DbbQYuLaHdi;
-    is.eq r88.val false into r89;
-    assert.eq r89 true;
+    not r88.val into r89;
+    set r89 into flag__[false];
     contains flag__[false] into r90;
     get.or_use flag__[false] false into r91;
     cast true r91 into r92 as Optional__DbbQYuLaHdi;
@@ -340,6 +349,7 @@ finalize primitive_types:
     ternary r90 r92.is_some r93.is_some into r94;
     ternary r90 r92.val r93.val into r95;
     cast r94 r95 into r96 as Optional__DbbQYuLaHdi;
+    assert.eq r96.is_some true;
     contains flag__[false] into r97;
     get.or_use flag__[false] false into r98;
     cast true r98 into r99 as Optional__DbbQYuLaHdi;
@@ -347,26 +357,42 @@ finalize primitive_types:
     ternary r97 r99.is_some r100.is_some into r101;
     ternary r97 r99.val r100.val into r102;
     cast r101 r102 into r103 as Optional__DbbQYuLaHdi;
-    ternary r96.is_some r103.val true into r104;
-    is.eq r104 false into r105;
-    assert.eq r105 true;
-    contains field_val__[false] into r106;
-    get.or_use field_val__[false] 0field into r107;
-    cast true r107 into r108 as Optional__K4XRQPOk9yX;
-    cast false 0field into r109 as Optional__K4XRQPOk9yX;
-    ternary r106 r108.is_some r109.is_some into r110;
-    ternary r106 r108.val r109.val into r111;
-    cast r110 r111 into r112 as Optional__K4XRQPOk9yX;
-    contains field_val__[false] into r113;
-    get.or_use field_val__[false] 0field into r114;
-    cast true r114 into r115 as Optional__K4XRQPOk9yX;
-    cast false 0field into r116 as Optional__K4XRQPOk9yX;
-    ternary r113 r115.is_some r116.is_some into r117;
-    ternary r113 r115.val r116.val into r118;
-    cast r117 r118 into r119 as Optional__K4XRQPOk9yX;
-    ternary r112.is_some r119.val 0field into r120;
-    is.eq r120 21field into r121;
-    assert.eq r121 true;
+    is.eq r103.val false into r104;
+    assert.eq r104 true;
+    contains flag__[false] into r105;
+    get.or_use flag__[false] false into r106;
+    cast true r106 into r107 as Optional__DbbQYuLaHdi;
+    cast false false into r108 as Optional__DbbQYuLaHdi;
+    ternary r105 r107.is_some r108.is_some into r109;
+    ternary r105 r107.val r108.val into r110;
+    cast r109 r110 into r111 as Optional__DbbQYuLaHdi;
+    contains flag__[false] into r112;
+    get.or_use flag__[false] false into r113;
+    cast true r113 into r114 as Optional__DbbQYuLaHdi;
+    cast false false into r115 as Optional__DbbQYuLaHdi;
+    ternary r112 r114.is_some r115.is_some into r116;
+    ternary r112 r114.val r115.val into r117;
+    cast r116 r117 into r118 as Optional__DbbQYuLaHdi;
+    ternary r111.is_some r118.val true into r119;
+    is.eq r119 false into r120;
+    assert.eq r120 true;
+    contains field_val__[false] into r121;
+    get.or_use field_val__[false] 0field into r122;
+    cast true r122 into r123 as Optional__K4XRQPOk9yX;
+    cast false 0field into r124 as Optional__K4XRQPOk9yX;
+    ternary r121 r123.is_some r124.is_some into r125;
+    ternary r121 r123.val r124.val into r126;
+    cast r125 r126 into r127 as Optional__K4XRQPOk9yX;
+    contains field_val__[false] into r128;
+    get.or_use field_val__[false] 0field into r129;
+    cast true r129 into r130 as Optional__K4XRQPOk9yX;
+    cast false 0field into r131 as Optional__K4XRQPOk9yX;
+    ternary r128 r130.is_some r131.is_some into r132;
+    ternary r128 r130.val r131.val into r133;
+    cast r132 r133 into r134 as Optional__K4XRQPOk9yX;
+    ternary r127.is_some r134.val 0field into r135;
+    is.eq r135 21field into r136;
+    assert.eq r136 true;
 
 function structs_and_arrays:
     async structs_and_arrays into r0;

--- a/tests/tests/compiler/option/all_types.leo
+++ b/tests/tests/compiler/option/all_types.leo
@@ -107,4 +107,37 @@ program all_types.aleo {
             sc.unwrap(),
         );
     }
+
+    // --- Section 10: Optionals with Address ---
+    struct AddrStruct { a: address, b: address? }
+    struct InnerAddr { val: address? }
+    struct WrapperAddr { inner: InnerAddr }
+    transition optional_address_allowed() -> (address, address, address, address) {
+        // Case 1: Direct optional address
+        let a: address? = none;
+        let b: address? = aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta;
+        let val1 = b.unwrap_or(a.unwrap_or(aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta));
+
+        // Case 2: Struct containing address and optional address
+        let s = AddrStruct { 
+            a: aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta, 
+            b: none 
+        };
+        let val2 = s.b.unwrap_or(s.a);
+
+        // Case 3: Optional struct containing address
+        let s_opt: AddrStruct? = AddrStruct { 
+            a: aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta, 
+            b: none 
+        };
+        let val3 = s_opt.unwrap().a;
+
+        // Case 4: Nested struct with optional address field
+
+        let wrapper = WrapperAddr { inner: InnerAddr { val: aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta } };
+        let val4 = wrapper.inner.val.unwrap();
+
+        // Just return one of the addresses to satisfy return type
+        return (val1, val2, val3, val4);
+    }
 }

--- a/tests/tests/compiler/storage/bad_storage_types_fail.leo
+++ b/tests/tests/compiler/storage/bad_storage_types_fail.leo
@@ -1,23 +1,35 @@
 program negative_storage_tests.aleo {
+    // --- Top-level illegal types ---
+    storage unit_storage: ();
+    storage string_storage: string;
+    storage signature_storage: signature;
+    storage future_storage: Future;
+    storage optional_storage: u32?;
+    storage tuple_storage: (u32, u32);
+
+    // --- Record (disallowed composite) ---
     record MyRecord {
         owner: address
     }
-
-    // 1. Illegal storage types
-    storage tuple_storage: (u32, u32);
-    storage future_storage: Future;
-    storage address_storage: address;
-    storage signature_storage: signature;
     storage record_storage: MyRecord;
-    storage unit_storage: ();
 
-    // 2. Storage vectors containing illegal types
-    storage vec_tuple: [(u32, u32)];
-    storage vec_future: [Future];
-    storage vec_address: [address];
-    storage vec_signature: [signature];
-    storage vec_record: [MyRecord];
+    // --- Arrays of illegal types ---
+    storage array_unit: [(); 2];
+    storage array_string: [string; 2];
+    storage array_signature: [signature; 2];
+    storage array_future: [Future; 2];
+    storage array_optional: [u32?; 2];
+    storage array_tuple: [(u32, u32); 2];
+    storage array_record: [MyRecord; 2];
+
+    // --- Vectors of illegal types ---
     storage vec_unit: [()];
+    storage vec_string: [string];
+    storage vec_signature: [signature];
+    storage vec_future: [Future];
+    storage vec_optional: [u32?];
+    storage vec_tuple: [(u32, u32)];
+    storage vec_record: [MyRecord];
 
     transition foo() {}
 }

--- a/tests/tests/compiler/storage/good_storage_types.leo
+++ b/tests/tests/compiler/storage/good_storage_types.leo
@@ -1,0 +1,37 @@
+program good_storage_tests.aleo {
+    // --- Primitives ---
+    storage bool_storage: bool;
+    storage scalar_storage: scalar;
+    storage field_storage: field;
+    storage group_storage: group;
+    storage address_storage: address;
+    storage u32_storage: u32;
+    storage i8_storage: i8;
+
+    // --- Structs ---
+    struct MyStruct {
+        a: u32,
+        b: bool,
+        c: address,
+    }
+    storage struct_storage: MyStruct;
+
+    // --- Arrays ---
+    storage array_u32: [u32; 3];
+    storage array_bool: [bool; 2];
+    storage array_address: [address; 2];
+    storage array_struct: [MyStruct; 2];
+
+    // --- Vectors ---
+    storage vec_bool: [bool];
+    storage vec_scalar: [scalar];
+    storage vec_field: [field];
+    storage vec_group: [group];
+    storage vec_address: [address];
+    storage vec_u32: [u32];
+    storage vec_i8: [i8];
+    storage vec_struct: [MyStruct];
+
+    transition foo() {}
+}
+

--- a/tests/tests/compiler/storage/primitives.leo
+++ b/tests/tests/compiler/storage/primitives.leo
@@ -3,6 +3,7 @@ program primitives.aleo {
     storage scalar_val: scalar;
     storage field_val: field;
     storage group_val: group;
+    storage addr_val: address;
 
     async transition initialize() -> Future {
         return async {
@@ -10,16 +11,18 @@ program primitives.aleo {
             scalar_val = 1;
             field_val = 42;
             group_val = 0;
+            addr_val = aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta;
         };
     }
 
     async transition to_none() -> Future {
         return async {
-            // Integers
+            // Reset all storages to none
             flag = none;
             scalar_val = none;
             field_val = none;
             group_val = none;
+            addr_val = none;
         };
     }
 
@@ -29,6 +32,7 @@ program primitives.aleo {
             assert(scalar_val.unwrap() == 1);
             assert(field_val.unwrap() == 42);
             assert(group_val.unwrap() == 0);
+            assert(addr_val.unwrap() == aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta);
         };
     }
 
@@ -38,6 +42,8 @@ program primitives.aleo {
             assert(scalar_val.unwrap_or(0) == 1);
             assert(field_val.unwrap_or(0) == 42);
             assert(group_val.unwrap_or(0) == 0);
+            assert(addr_val.unwrap_or(aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta) ==
+                   aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta);
         };
     }
 

--- a/tests/tests/execution/optional_types.leo
+++ b/tests/tests/execution/optional_types.leo
@@ -45,6 +45,11 @@ input = []
 program = "all_types.aleo"
 function = "optional_misc_primitive_types"
 input = [] 
+
+[case]
+program = "all_types.aleo"
+function = "optional_address"
+input = [] 
 */
 
 program all_types.aleo {
@@ -159,6 +164,39 @@ program all_types.aleo {
             fl.unwrap_or(2),
             sc.unwrap(),
         );
+    }
+
+    // --- Section 10: Optionals with Address ---
+    struct AddrStruct { a: address, b: address? }
+    struct InnerAddr { val: address? }
+    struct WrapperAddr { inner: InnerAddr }
+    transition optional_address() -> (address, address, address, address) {
+        // Case 1: Direct optional address
+        let a: address? = none;
+        let b: address? = aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta;
+        let val1 = b.unwrap_or(a.unwrap_or(aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta));
+
+        // Case 2: Struct containing address and optional address
+        let s = AddrStruct { 
+            a: aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta, 
+            b: none 
+        };
+        let val2 = s.b.unwrap_or(s.a);
+
+        // Case 3: Optional struct containing address
+        let s_opt: AddrStruct? = AddrStruct { 
+            a: aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta, 
+            b: none 
+        };
+        let val3 = s_opt.unwrap().a;
+
+        // Case 4: Nested struct with optional address field
+
+        let wrapper = WrapperAddr { inner: InnerAddr { val: aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta } };
+        let val4 = wrapper.inner.val.unwrap();
+
+        // Just return one of the addresses to satisfy return type
+        return (val1, val2, val3, val4);
     }
 
     @noupgrade

--- a/tests/tests/execution/various_storage_types.leo
+++ b/tests/tests/execution/various_storage_types.leo
@@ -39,6 +39,7 @@ program mixed_types.aleo {
     storage scalar_val: scalar;
     storage field_val: field;
     storage group_val: group;
+    storage address_val: address;
     storage containers: [Container; 2];
     storage points_array: [Point; 3];
 
@@ -103,11 +104,13 @@ program mixed_types.aleo {
             scalar_val = 2scalar;
             field_val = 21field;
             group_val = 0group;
+            address_val = aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta;
 
             assert(flag.unwrap() == true);
             assert(scalar_val.unwrap() == 2scalar);
             assert(field_val.unwrap() == 21field);
             assert(group_val.unwrap() == 0group);
+            assert(address_val.unwrap() == aleo10qerras5799u6k7rjtc9y3hcwxuykr45qra7x7dp6jgnc0923czqm0lgta);
 
             // Flip and recheck
             flag = !flag.unwrap();


### PR DESCRIPTION
This PR allows `address` in optionals and storage. This was previously disallowed because `address` has no clear default, which is needed when representing `none`. Instead, we now just use the commonly used zero address: `aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc`

Closes https://github.com/ProvableHQ/leo/issues/28991

Also closes https://github.com/ProvableHQ/leo/issues/28985