### PR TITLE
Enforce usage of latest program edition

### DIFF
--- a/leo/cli/commands/common/util.rs
+++ b/leo/cli/commands/common/util.rs
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use leo_errors::CliError;
 use leo_package::{Package, ProgramData};
 use leo_span::Symbol;
 
 use indexmap::IndexSet;
+use snarkvm::prelude::{ConsensusVersion, Network, Program};
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
@@ -134,4 +136,81 @@ pub fn collect_aleo_paths(package: &Package) -> Vec<PathBuf> {
             }
         })
         .collect()
+}
+
+/// Default edition for local programs during local operations (run, execute, synthesize).
+///
+/// Local programs don't have an on-chain edition yet. We default to edition 1 to avoid
+/// snarkVM's V8+ check that rejects edition 0 programs without constructors. That check
+/// is only relevant for deployed programs, not local development.
+pub const LOCAL_PROGRAM_DEFAULT_EDITION: leo_package::Edition = 1;
+
+/// Prints a program's ID and source (local or network edition).
+pub fn print_program_source(id: &str, edition: Option<leo_package::Edition>) {
+    match (id, edition) {
+        ("credits.aleo", _) => println!("  - {id} (already included)"),
+        (_, Some(e)) => println!("  - {id} (edition: {e})"),
+        (_, None) => println!("  - {id} (local)"),
+    }
+}
+
+/// Checks if any programs violate edition/constructor requirements.
+///
+/// Programs at edition 0 without a constructor cannot be executed after ConsensusVersion::V8.
+/// This check should be performed before attempting execution to provide a clear error message.
+///
+/// # Arguments
+/// * `programs` - Slice of (program, edition) tuples to check
+/// * `consensus_version` - The current consensus version
+/// * `action` - Description of the action being attempted (e.g., "deploy", "execute", "upgrade")
+///
+/// # Returns
+/// `Ok(())` if all programs pass the check, or an error with a descriptive message if not.
+pub fn check_edition_constructor_requirements<N: Network>(
+    programs: &[(Program<N>, leo_package::Edition)],
+    consensus_version: ConsensusVersion,
+    action: &str,
+) -> Result<(), CliError> {
+    // Only check for V8+ consensus versions.
+    if consensus_version < ConsensusVersion::V8 {
+        return Ok(());
+    }
+
+    for (program, edition) in programs {
+        // Programs at edition 0 without a constructor cannot be executed after V8.
+        if *edition == 0 && !program.contains_constructor() {
+            let id = program.id();
+            // Skip credits.aleo as it's a special case.
+            if id.to_string() != "credits.aleo" {
+                return Err(CliError::custom(format!(
+                    "Cannot {action} with dependency '{id}' (edition 0)\n\n\
+                    Programs at edition 0 without a constructor cannot be executed under \
+                    consensus version V8 or later (current: V{}).\n\n\
+                    The program '{id}' must be upgraded on-chain before it can be used.",
+                    consensus_version as u8
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snarkvm::prelude::TestnetV0;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_edition_constructor_error_message() {
+        // A program without a constructor at edition 0 should fail under V8+
+        let program = Program::<TestnetV0>::from_str(
+            "program old_program.aleo;\nfunction main:\n    input r0 as u32.public;\n    output r0 as u32.public;\n",
+        )
+        .unwrap();
+
+        let result = check_edition_constructor_requirements(&[(program, 0)], ConsensusVersion::V9, "deploy");
+        assert!(result.is_err());
+    }
 }

--- a/leo/cli/commands/execute.rs
+++ b/leo/cli/commands/execute.rs
@@ -327,15 +327,8 @@ fn handle_execute<A: Aleo>(
     let programs_and_editions = programs
         .into_iter()
         .map(|(program, edition)| {
-            // Note: We default to edition 1 since snarkVM execute may produce spurious errors if the program does not have a constructor but uses edition 0.
-            let edition = edition.unwrap_or(1);
-            // Get the program ID.
-            let id = program.id().to_string();
-            // Print the program ID and edition.
-            match id == "credits.aleo" {
-                true => println!("  - {id} (already included)"),
-                false => println!("  - {id} (edition: {edition})"),
-            }
+            print_program_source(&program.id().to_string(), edition);
+            let edition = edition.unwrap_or(LOCAL_PROGRAM_DEFAULT_EDITION);
             (program, edition)
         })
         .collect::<Vec<_>>();

--- a/leo/cli/commands/run.rs
+++ b/leo/cli/commands/run.rs
@@ -251,15 +251,8 @@ fn handle_run<A: Aleo>(
     let programs_and_editions = programs
         .into_iter()
         .map(|(program, edition)| {
-            // Note: We default to edition 1 since snarkVM execute may produce spurious errors if the program does not have a constructor but uses edition 0.
-            let edition = edition.unwrap_or(1);
-            // Get the program ID.
-            let id = program.id().to_string();
-            // Print the program ID and edition.
-            match id == "credits.aleo" {
-                true => println!("  - {id} (already included)"),
-                false => println!("  - {id} (edition: {edition})"),
-            }
+            print_program_source(&program.id().to_string(), edition);
+            let edition = edition.unwrap_or(LOCAL_PROGRAM_DEFAULT_EDITION);
             (program, edition)
         })
         .collect::<Vec<_>>();

--- a/leo/cli/commands/synthesize.rs
+++ b/leo/cli/commands/synthesize.rs
@@ -211,19 +211,8 @@ fn handle_synthesize<A: Aleo>(
     let programs_and_editions = programs
         .into_iter()
         .map(|(program, edition)| {
-            // Note: We default to edition 1 since snarkVM execute may produce spurious errors if the program does not have a constructor but uses edition 0.
-            let is_default = edition.is_none();
-            let edition = edition.unwrap_or(1);
-            // Get the program ID.
-            let id = program.id().to_string();
-            // Print the program ID and edition.
-            match id == "credits.aleo" {
-                true => println!("  - {id} (already included)"),
-                false => match is_default {
-                    true => println!(" - {id} (defaulting to edition {edition})"),
-                    false => println!("  - {id} (edition: {edition})"),
-                },
-            }
+            print_program_source(&program.id().to_string(), edition);
+            let edition = edition.unwrap_or(LOCAL_PROGRAM_DEFAULT_EDITION);
             (program, edition)
         })
         .collect::<Vec<_>>();

--- a/tests/expectations/cli/network_dependency/STDOUT
+++ b/tests/expectations/cli/network_dependency/STDOUT
@@ -183,7 +183,7 @@ Attempting to determine the consensus version from the latest block height at ht
 
 ➕Adding programs to the VM in the following order:
   - test_program1.aleo (edition: 0)
-  - test_program2.aleo (edition: 1)
+  - test_program2.aleo (local)
 
 ⚙️ Executing test_program2.aleo/main...
 

--- a/tests/expectations/cli/test_add/STDOUT
+++ b/tests/expectations/cli/test_add/STDOUT
@@ -46,7 +46,7 @@ Attempting to determine the consensus version from the latest block height at ht
 
 ➕Adding programs to the VM in the following order:
   - credits.aleo (already included)
-  - some_sample_leo_program.aleo (edition: 1)
+  - some_sample_leo_program.aleo (local)
 
 ⚙️ Executing some_sample_leo_program.aleo/main...
 
@@ -105,7 +105,7 @@ Attempting to determine the consensus version from the latest block height at ht
 
 ➕Adding programs to the VM in the following order:
   - credits.aleo (already included)
-  - some_sample_leo_program.aleo (edition: 1)
+  - some_sample_leo_program.aleo (local)
 
 ⚙️ Executing some_sample_leo_program.aleo/main...
 

--- a/tests/expectations/cli/test_command_shortcuts/STDOUT
+++ b/tests/expectations/cli/test_command_shortcuts/STDOUT
@@ -16,7 +16,7 @@
 ⚠️ No valid private key specified, defaulting to 'APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH'.
 
 ➕Adding programs to the VM in the following order:
-  - test_shortcuts.aleo (edition: 1)
+  - test_shortcuts.aleo (local)
 
 ➡️  Output
 


### PR DESCRIPTION
## Summary

Closes #28983

This PR improves how Leo handles program editions, ensuring we use actual editions from the network rather than arbitrary defaults.

## Changes

### Edition Handling by Command

| Command | Local Programs | Network Dependencies |
|---------|---------------|---------------------|
| `run` | Default to edition 1 | Fetch from network |
| `execute` | Default to edition 1 | Fetch from network |
| `synthesize` | Default to edition 1 | Fetch from network |
| `deploy` | N/A | Fetch from network + V8 constructor check |
| `upgrade` | N/A | Fetch from network + V8 constructor check |

### Why edition 1 for local programs?

Local programs haven't been deployed yet, so they don't have a real on-chain edition. We default to edition 1 to avoid snarkVM's V8+ check that rejects edition 0 programs without constructors. This keeps local development frictionless.

### V8 Constructor Check

The `check_edition_constructor_requirements` validation is **only** applied during `deploy` and `upgrade` - the commands that actually interact with on-chain programs. If a network dependency is at edition 0 without a constructor, we error early with a clear message explaining the program needs to be upgraded on-chain.

<img width="819" height="106" alt="image" src="https://github.com/user-attachments/assets/3006d4a5-4f96-45cf-bb38-35dde212c566" />