### PR TITLE
Cache snarkOS binary in CI to avoid 5+ minute rebuild

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+parameters:
+  snarkos-rev:
+    type: string
+    default: "v4.4.0"
+
 # Notes
 # - `sccache` was removed because it doesn't actually provide much benefit in CI. Lots of cache misses.
 # - https://github.com/Swatinem/rust-cache?tab=readme-ov-file#cache-details provides guidance on which directories to cache.
@@ -29,9 +34,6 @@ executors:
     docker:
       - image: "cimg/rust:1.90"  # Ensure that this matches the `rust-version` in `Cargo.toml`.
     resource_class: 2xlarge
-
-test-env: &test-env
-  SNARKOS_REV: "10759d44a02942b72faa5f6e3bf56ed58a8f3204" # v4.4.0
 
 commands:
   install-rust:
@@ -79,22 +81,31 @@ commands:
 
   install-snarkos:
     description: "Install snarkOS (Linux/macOS)"
-    parameters:
-      revision:
-        type: string
-        description: "The git revision of snarkOS to check out"
     steps:
+      - restore_cache:
+          keys:
+            - snarkos-bin-v1-{{ arch }}-<< pipeline.parameters.snarkos-rev >>
       - run:
           name: Install snarkOS
           command: |
             set -euo pipefail
+            # Skip build if binary already exists from cache
+            if command -v snarkos &> /dev/null; then
+              echo "snarkOS found in cache, skipping build"
+              snarkos --version
+              exit 0
+            fi
             git clone https://github.com/ProvableHQ/snarkOS.git
             cd snarkOS
-            git checkout << parameters.revision >>
+            git checkout << pipeline.parameters.snarkos-rev >>
             cargo install --path . --features test_network --locked --force
             cd ..
             rm -rf snarkOS
             ulimit -n 65535
+      - save_cache:
+          key: snarkos-bin-v1-{{ arch }}-<< pipeline.parameters.snarkos-rev >>
+          paths:
+            - ~/.cargo/bin/snarkos
 
   build-and-test:
     description: "Build and run tests"
@@ -152,8 +163,6 @@ jobs:
 
   test-macos:
     executor: macos-executor
-    environment:
-      <<: *test-env
     steps:
       - checkout
       - restore_cache:
@@ -162,8 +171,7 @@ jobs:
             - cargo-v1-{{ arch }}-{{ checksum "Cargo.toml" }}
             - cargo-v1-{{ arch }}
       - install-rust
-      - install-snarkos:
-          revision: $SNARKOS_REV
+      - install-snarkos
       - run:
           name: Verify SnarkOS installation
           command: |
@@ -180,8 +188,6 @@ jobs:
 
   test-linux:
     executor: linux-executor
-    environment:
-      <<: *test-env
     steps:
       - checkout
       - restore_cache:
@@ -201,8 +207,7 @@ jobs:
               llvm \
               lld \
               pkg-config
-      - install-snarkos:
-          revision: $SNARKOS_REV
+      - install-snarkos
       - run:
           name: Verify SnarkOS installation
           command: |


### PR DESCRIPTION
Closes #29030

Caches the snarkOS binary for both Linux and macOS to skip the 5+ minute build on CI runs.

**How it works:**
- Adds a `snarkos-rev` pipeline parameter at the top of the CircleCI config
- Cache key includes the version tag (e.g. `snarkos-bin-v1-{arch}-v4.4.0`)
- On cache hit, skips the build entirely

To update snarkOS version: change `snarkos-rev` default value at the top of `.circleci/config.yml`

