### PR TITLE
ci: Change integration test condition to allow testing on unix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,9 @@ executors:
       - image: "cimg/rust:1.90"  # Ensure that this matches the `rust-version` in `Cargo.toml`.
     resource_class: 2xlarge
 
+test-env: &test-env
+  SNARKOS_REV: "10759d44a02942b72faa5f6e3bf56ed58a8f3204" # v4.4.0
+
 commands:
   install-rust:
     description: "Install Rust (Linux/macOS)"
@@ -51,8 +54,8 @@ commands:
               cargo generate-lockfile
             fi
             cargo install cargo-mtime
-            
-            
+
+
 
   install-rust-windows:
     description: "Install Rust (Windows)"
@@ -82,7 +85,7 @@ commands:
         description: "The git revision of snarkOS to check out"
     steps:
       - run:
-          name: Install snarkOS 
+          name: Install snarkOS
           command: |
             set -euo pipefail
             git clone https://github.com/ProvableHQ/snarkOS.git
@@ -91,7 +94,7 @@ commands:
             cargo install --path . --features test_network --locked --force
             cd ..
             rm -rf snarkOS
-            ulimit -n 65535 
+            ulimit -n 65535
 
   build-and-test:
     description: "Build and run tests"
@@ -150,7 +153,7 @@ jobs:
   test-macos:
     executor: macos-executor
     environment:
-      SNARKOS_REV: "10759d44a02942b72faa5f6e3bf56ed58a8f3204" # v4.4.0
+      <<: *test-env
     steps:
       - checkout
       - restore_cache:
@@ -177,6 +180,8 @@ jobs:
 
   test-linux:
     executor: linux-executor
+    environment:
+      <<: *test-env
     steps:
       - checkout
       - restore_cache:
@@ -185,6 +190,23 @@ jobs:
             - cargo-v1-{{ arch }}-{{ checksum "Cargo.toml" }}
             - cargo-v1-{{ arch }}
       - install-rust
+      - run:
+          name: Install snarkos dependencies
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y \
+              build-essential \
+              clang \
+              libssl-dev \
+              llvm \
+              lld \
+              pkg-config
+      - install-snarkos:
+          revision: $SNARKOS_REV
+      - run:
+          name: Verify SnarkOS installation
+          command: |
+            snarkos --version
       - run:
             name: Update Submodules
             command: git submodule update --init --recursive
@@ -320,7 +342,7 @@ jobs:
 
 workflows:
   version: 2
-  
+
   test-windows:
     jobs:
       - test-windows
@@ -336,7 +358,7 @@ workflows:
   code-quality:
     jobs:
       - check-style-clippy-docs
-  
+
   leo-executable:
     jobs:
       - leo-executable

--- a/leo/tests/integration.rs
+++ b/leo/tests/integration.rs
@@ -183,8 +183,8 @@ const BINARY_PATH: &str = env!("CARGO_BIN_EXE_leo");
 
 #[test]
 fn integration_tests() {
-    if !cfg!(target_os = "macos") {
-        println!("Skipping CLI integration tests (they only run on macos).");
+    if !cfg!(target_family = "unix") {
+        println!("Skipping CLI integration tests (they only run on unix systems).");
         return;
     }
 
@@ -362,7 +362,7 @@ fn run_leo_devnet(num_validators: usize) -> io::Result<Child> {
         (0..ConsensusVersion::latest() as usize).map(|n| n.to_string()).collect::<Vec<_>>().join(",");
 
     // Configure the Leo devnet command with all necessary arguments
-    leo_devnet_cmd.arg("devnet")        
+    leo_devnet_cmd.arg("devnet")
         .arg("-y")
         .arg("--snarkos")
         .arg(&snarkos_path)
@@ -372,7 +372,7 @@ fn run_leo_devnet(num_validators: usize) -> io::Result<Child> {
         .arg(num_validators.to_string())
         .arg("--consensus-heights")             // Define consensus heights for testing
         .arg(&consensus_heights)
-        .arg("--clear-storage")                 
+        .arg("--clear-storage")
         .stdout(Stdio::null())
         .stderr(Stdio::null());
 


### PR DESCRIPTION
Previously, this condition would only allow running integration tests on macos. This changes the condition to at least allow testing on unix systems more generally (i.e. linux too).

Ideally we'd remove this condition altogether, but I thought I'd just land this at least for now as I don't have a local windows machine or VM setup to test with at the moment.

Related #29014 

Edit: Ahh looks like there's quite a bit of trailing whitespace that my editor is culling on write- I'll see if there's some way I can disable this locally for the provable repos for future PRs. I would have thought the cargo fmt check would catch the trailing whitespace :thinking: 