### PR TITLE
Display compiled program size in `leo build`, `leo deploy`, and `leo upgrade` output

### DIFF
--- a/leo/cli/commands/build.rs
+++ b/leo/cli/commands/build.rs
@@ -248,6 +248,12 @@ fn compile_leo_source_directory(
     tracing::info!("    {} statements after dead code elimination.", compiler.statements_after_dce);
     tracing::info!("    The program checksum is: '[{checksum}]'.");
 
+    let (size_kb, max_kb, warning) = format_program_size(program_size, MAX_PROGRAM_SIZE);
+    tracing::info!("    Program size: {size_kb:.2} KB / {max_kb:.2} KB");
+    if let Some(msg) = warning {
+        tracing::warn!("⚠️  Program '{program_name}' is {msg}.");
+    }
+
     tracing::info!("✅ Compiled '{program_name}.aleo' into Aleo instructions.");
     Ok(bytecode)
 }

--- a/leo/cli/commands/common/util.rs
+++ b/leo/cli/commands/common/util.rs
@@ -21,6 +21,27 @@ use indexmap::IndexSet;
 use std::path::PathBuf;
 use walkdir::WalkDir;
 
+/// Threshold percentage for program size warnings.
+const PROGRAM_SIZE_WARNING_THRESHOLD: usize = 90;
+
+/// Formats program size as KB and returns a warning message if approaching the limit.
+///
+/// Both `size` and `max_size` are expected in bytes.
+/// Returns `(size_kb, max_kb, warning)` where `warning` is `Some` if size exceeds 90% of max.
+pub fn format_program_size(size: usize, max_size: usize) -> (f64, f64, Option<String>) {
+    let size_kb = size as f64 / 1024.0;
+    let max_kb = max_size as f64 / 1024.0;
+    let percentage = (size as f64 / max_size as f64) * 100.0;
+
+    let warning = if size > max_size * PROGRAM_SIZE_WARNING_THRESHOLD / 100 {
+        Some(format!("approaching the size limit ({percentage:.1}% of {max_kb:.2} KB)"))
+    } else {
+        None
+    };
+
+    (size_kb, max_kb, warning)
+}
+
 /// Collects paths to Leo source files for each program in the package.
 ///
 /// For each non-test program, it searches the `src` directory for `.leo` files.

--- a/tests/expectations/cli/network_dependency/STDOUT
+++ b/tests/expectations/cli/network_dependency/STDOUT
@@ -2,6 +2,7 @@ DEPLOYMENT 1
        Leo     1 statements before dead code elimination.
        Leo     1 statements after dead code elimination.
        Leo     The program checksum is: '[192u8, 225u8, 38u8, 151u8, 139u8, 155u8, 148u8, 209u8, 105u8, 110u8, 246u8, 83u8, 90u8, 243u8, 78u8, 35u8, 155u8, 186u8, 242u8, 17u8, 196u8, 169u8, 179u8, 144u8, 71u8, 227u8, 34u8, 207u8, 121u8, 158u8, 34u8, 25u8]'.
+       Leo     Program size: 0.14 KB / 97.66 KB
        Leo ✅ Compiled 'test_program1.aleo' into Aleo instructions.
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11
@@ -40,6 +41,7 @@ Once it is deployed, it CANNOT be changed.
 
 📊 Deployment Summary for test_program1.aleo
 ──────────────────────────────────────────────
+  Program Size:         0.14 KB / 97.66 KB
   Total Variables:      16,517
   Total Constraints:    12,379
   Max Variables:        XXXXXX
@@ -71,6 +73,7 @@ DEPLOYMENT 2
        Leo     3 statements before dead code elimination.
        Leo     3 statements after dead code elimination.
        Leo     The program checksum is: '[206u8, 255u8, 111u8, 48u8, 59u8, 85u8, 122u8, 166u8, 182u8, 205u8, 10u8, 141u8, 58u8, 23u8, 70u8, 232u8, 105u8, 221u8, 83u8, 216u8, 186u8, 14u8, 207u8, 24u8, 13u8, 221u8, 236u8, 0u8, 143u8, 199u8, 151u8, 2u8]'.
+       Leo     Program size: 0.19 KB / 97.66 KB
        Leo ✅ Compiled 'test_program2.aleo' into Aleo instructions.
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11
@@ -113,6 +116,7 @@ Once it is deployed, it CANNOT be changed.
 
 📊 Deployment Summary for test_program2.aleo
 ──────────────────────────────────────────────
+  Program Size:         0.19 KB / 97.66 KB
   Total Variables:      19,757
   Total Constraints:    13,944
   Max Variables:        XXXXXX
@@ -144,6 +148,7 @@ EXECUTION
        Leo     3 statements before dead code elimination.
        Leo     3 statements after dead code elimination.
        Leo     The program checksum is: '[206u8, 255u8, 111u8, 48u8, 59u8, 85u8, 122u8, 166u8, 182u8, 205u8, 10u8, 141u8, 58u8, 23u8, 70u8, 232u8, 105u8, 221u8, 83u8, 216u8, 186u8, 14u8, 207u8, 24u8, 13u8, 221u8, 236u8, 0u8, 143u8, 199u8, 151u8, 2u8]'.
+       Leo     Program size: 0.19 KB / 97.66 KB
        Leo ✅ Compiled 'test_program2.aleo' into Aleo instructions.
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11

--- a/tests/expectations/cli/test_add/STDOUT
+++ b/tests/expectations/cli/test_add/STDOUT
@@ -4,10 +4,12 @@
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[208u8, 46u8, 107u8, 120u8, 67u8, 35u8, 254u8, 232u8, 167u8, 173u8, 0u8, 130u8, 249u8, 123u8, 65u8, 159u8, 169u8, 93u8, 168u8, 232u8, 33u8, 125u8, 49u8, 130u8, 118u8, 142u8, 183u8, 31u8, 60u8, 106u8, 136u8, 65u8]'.
+       Leo     Program size: 0.18 KB / 97.66 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[208u8, 46u8, 107u8, 120u8, 67u8, 35u8, 254u8, 232u8, 167u8, 173u8, 0u8, 130u8, 249u8, 123u8, 65u8, 159u8, 169u8, 93u8, 168u8, 232u8, 33u8, 125u8, 49u8, 130u8, 118u8, 142u8, 183u8, 31u8, 60u8, 106u8, 136u8, 65u8]'.
+       Leo     Program size: 0.18 KB / 97.66 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
 
 📢 Using the following consensus heights: 0,2950000,4800000,6625000,6765000,7600000,8365000,9173000,9800000,10525000,11952000,12669000
@@ -64,6 +66,7 @@ Attempting to determine the consensus version from the latest block height at ht
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[208u8, 46u8, 107u8, 120u8, 67u8, 35u8, 254u8, 232u8, 167u8, 173u8, 0u8, 130u8, 249u8, 123u8, 65u8, 159u8, 169u8, 93u8, 168u8, 232u8, 33u8, 125u8, 49u8, 130u8, 118u8, 142u8, 183u8, 31u8, 60u8, 106u8, 136u8, 65u8]'.
+       Leo     Program size: 0.18 KB / 97.66 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
 
 📢 Using the following consensus heights: 0,2950000,4800000,6625000,6765000,7600000,8365000,9173000,9800000,10525000,11952000,12669000

--- a/tests/expectations/cli/test_command_shortcuts/STDOUT
+++ b/tests/expectations/cli/test_command_shortcuts/STDOUT
@@ -3,12 +3,14 @@
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[243u8, 135u8, 116u8, 66u8, 246u8, 27u8, 131u8, 192u8, 145u8, 195u8, 150u8, 1u8, 217u8, 146u8, 63u8, 42u8, 159u8, 224u8, 25u8, 105u8, 240u8, 197u8, 236u8, 236u8, 115u8, 219u8, 254u8, 62u8, 5u8, 44u8, 74u8, 93u8]'.
+       Leo     Program size: 0.19 KB / 97.66 KB
        Leo ✅ Compiled 'test_shortcuts.aleo' into Aleo instructions.
 ⚠️ No network specified, defaulting to 'testnet'.
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[243u8, 135u8, 116u8, 66u8, 246u8, 27u8, 131u8, 192u8, 145u8, 195u8, 150u8, 1u8, 217u8, 146u8, 63u8, 42u8, 159u8, 224u8, 25u8, 105u8, 240u8, 197u8, 236u8, 236u8, 115u8, 219u8, 254u8, 62u8, 5u8, 44u8, 74u8, 93u8]'.
+       Leo     Program size: 0.19 KB / 97.66 KB
        Leo ✅ Compiled 'test_shortcuts.aleo' into Aleo instructions.
 ⚠️ No network specified, defaulting to 'testnet'.
 ⚠️ No valid private key specified, defaulting to 'APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH'.

--- a/tests/expectations/cli/test_deploy/STDOUT
+++ b/tests/expectations/cli/test_deploy/STDOUT
@@ -1,6 +1,7 @@
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[95u8, 99u8, 136u8, 243u8, 82u8, 169u8, 200u8, 72u8, 133u8, 227u8, 122u8, 161u8, 195u8, 178u8, 69u8, 37u8, 167u8, 114u8, 104u8, 192u8, 161u8, 175u8, 195u8, 180u8, 120u8, 4u8, 192u8, 16u8, 86u8, 199u8, 76u8, 235u8]'.
+       Leo     Program size: 0.20 KB / 97.66 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11
@@ -39,6 +40,7 @@ Once it is deployed, it CANNOT be changed.
 
 📊 Deployment Summary for some_sample_leo_program.aleo
 ──────────────────────────────────────────────
+  Program Size:         0.20 KB / 97.66 KB
   Total Variables:      17,516
   Total Constraints:    12,927
   Max Variables:        XXXXXX

--- a/tests/expectations/cli/test_simple_build/STDOUT
+++ b/tests/expectations/cli/test_simple_build/STDOUT
@@ -3,4 +3,5 @@
        Leo     2 statements before dead code elimination.
        Leo     2 statements after dead code elimination.
        Leo     The program checksum is: '[95u8, 99u8, 136u8, 243u8, 82u8, 169u8, 200u8, 72u8, 133u8, 227u8, 122u8, 161u8, 195u8, 178u8, 69u8, 37u8, 167u8, 114u8, 104u8, 192u8, 161u8, 175u8, 195u8, 180u8, 120u8, 4u8, 192u8, 16u8, 86u8, 199u8, 76u8, 235u8]'.
+       Leo     Program size: 0.20 KB / 97.66 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.


### PR DESCRIPTION
Displays the compiled program size alongside the max limit (e.g., `0.20 KB / 97.66 KB`) in `leo build`, `leo deploy`, and `leo upgrade` output. 

Warns when size exceeds 90% of the limit. Feel free to suggest a better % number we should emit warnings from if you think 90 is too high / low for this to kick in. 

Closes https://github.com/ProvableHQ/leo/issues/28976