### PR TITLE
Add Nix flake for reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Leo is an imperative, statically-typed programming language built for writing pr
 * [🍎 Overview](#-overview)
 * [⚙️️ Build Guide](#-build-guide)
     * [🦀 Install Rust](#-install-rust)
+    * [❄️ Build with Nix](#-build-with-nix)
     * [🐙 Build from Source Code](#-build-from-source-code)
     * [🦁 Update from Leo](#-update-from-leo)
     * [📦 Download using Cargo](#-download-using-cargo)
@@ -67,6 +68,14 @@ We recommend installing Rust using [rustup](https://www.rustup.rs/). You can ins
 - Windows (32-bit):  
   
   Download the [Windows 32-bit executable](https://win.rustup.rs/i686) and follow the on-screen instructions.
+
+### ❄️ Build with Nix
+
+If you have [Nix](https://nixos.org/) installed, you can use the provided flake to build and run Leo:
+
+```bash
+nix run github:ProvableHQ/leo
+```
 
 ### 🐙 Simple build
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1764950072,
+        "narHash": "sha256-BmPWzogsG2GsXZtlT+MTcAWeDK5hkbGRZTeZNW42fwA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f61125a668a320878494449750330ca58b78c557",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1765248027,
+        "narHash": "sha256-ngar+yP06x3+2k2Iey29uU0DWx5ur06h3iPBQXlU+yI=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7b50ad68415ae5be7ee4cc68fa570c420741b644",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,84 @@
+{
+  description = "The Leo programming language";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        
+        # Read Rust toolchain from rust-toolchain.toml
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        
+        # Read version from Cargo.toml
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        version = cargoToml.package.version;
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            rust
+            curl
+            openssl
+            pkg-config
+            # Additional tools that might be useful
+            cargo-watch
+            cargo-udeps
+            rust-analyzer
+          ];
+
+          shellHook = ''
+            echo "Leo development environment"
+            echo "Rust version: $(rustc --version)"
+            echo "Cargo version: $(cargo --version)"
+          '';
+
+          # Set environment variables for Rust
+          RUST_BACKTRACE = "1";
+          
+          # Ensure pkg-config can find openssl
+          PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+        };
+
+        # Optional: provide a package for building leo
+        packages.default = pkgs.rustPlatform.buildRustPackage {
+          pname = "leo-lang";
+          inherit version;
+          src = ./.;
+          
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+          };
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+            openssl
+          ];
+
+          buildInputs = with pkgs; [
+            openssl
+          ];
+
+          # Build flags
+          buildFeatures = [ ];
+          
+          # Skip tests during build (can be overridden)
+          doCheck = false;
+        };
+
+        # App to run leo via nix run
+        apps.default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/leo";
+        };
+      }
+    );
+}


### PR DESCRIPTION
Add a flake.nix to enable Nix users to build and develop Leo in a reproducible environment. This provides:

- Development shell with all necessary dependencies
- Reproducible builds across different systems
- Easy integration with NixOS and other Nix-based systems
- Consistent toolchain versions for all contributors

This change does not affect non-Nix users and maintains backward compatibility with existing build processes.

Nix flakes provide a standardized way to define inputs and outputs for Nix projects, making it easier for users of NixOS, nix-darwin, and other Nix-based systems to work with Leo.