### PR TITLE
fix: tokenize group/signature/Future paths with regex

### DIFF
--- a/compiler/parser-lossless/src/tokens.rs
+++ b/compiler/parser-lossless/src/tokens.rs
@@ -109,9 +109,9 @@ pub enum Token {
     #[regex(r"_[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Intrinsic)]
     #[regex(r"[a-zA-Z][a-zA-Z0-9_]*", id_variant)]
     // We need to special case `group::abc` and `signature::abc` as otherwise these are keywords.
-    #[token(r"group::[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Path)]
-    #[token(r"signature::[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Path)]
-    #[token(r"Future::[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Path)]
+    #[regex(r"group::[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Path)]
+    #[regex(r"signature::[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Path)]
+    #[regex(r"Future::[a-zA-Z][a-zA-Z0-9_]*", |_| IdVariants::Path)]
     IdVariants(IdVariants),
 
     // Address literals should have exactly 58 characters, but we lex other lengths


### PR DESCRIPTION
## Motivation


Logos #[token] attributes only match exact string literals and do not interpret regex metacharacters. The existing definitions for group::*, signature::*, and Future::* used #[token(r"...[a-zA-Z]...")] and never matched real code like group::GEN, signature::verify, or Future::await. These paths were then not classified as IdVariants::Path, which the grammar expects for associated constants and associated function calls.

