### PR TITLE
[Non-functional] Change the syntax tree converter to use a `ConversionContext`

### DIFF
--- a/compiler/ast/src/passes/reconstructor.rs
+++ b/compiler/ast/src/passes/reconstructor.rs
@@ -563,11 +563,7 @@ pub trait ProgramReconstructor: AstReconstructor {
         let program_scopes =
             input.program_scopes.into_iter().map(|(id, scope)| (id, self.reconstruct_program_scope(scope))).collect();
         Program {
-            imports: input
-                .imports
-                .into_iter()
-                .map(|(id, import)| (id, (self.reconstruct_import(import.0), import.1)))
-                .collect(),
+            imports: input.imports,
             stubs: input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect(),
             modules: input.modules.into_iter().map(|(id, module)| (id, self.reconstruct_module(module))).collect(),
             program_scopes,

--- a/compiler/ast/src/passes/visitor.rs
+++ b/compiler/ast/src/passes/visitor.rs
@@ -319,7 +319,6 @@ pub trait ProgramVisitor: AstVisitor {
     fn visit_program(&mut self, input: &Program) {
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
         input.modules.values().for_each(|module| self.visit_module(module));
-        input.imports.values().for_each(|import| self.visit_import(&import.0));
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
     }
 

--- a/compiler/ast/src/program/mod.rs
+++ b/compiler/ast/src/program/mod.rs
@@ -35,7 +35,7 @@ pub struct Program {
     /// A map from module paths to module definitions.
     pub modules: IndexMap<Vec<Symbol>, Module>,
     /// A map from import names to import definitions.
-    pub imports: IndexMap<Symbol, (Program, Span)>,
+    pub imports: IndexMap<Symbol, Span>,
     /// A map from program stub names to program stub scopes.
     pub stubs: IndexMap<Symbol, Stub>,
     /// A map from program names to program scopes.

--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -326,7 +326,7 @@ impl Compiler {
                 return Err(CompilerError::imported_program_not_found(
                     self.program_name.as_ref().unwrap(),
                     import,
-                    self.state.ast.ast.imports[&import].1,
+                    self.state.ast.ast.imports[&import],
                 )
                 .into());
             }

--- a/compiler/parser/src/conversions.rs
+++ b/compiler/parser/src/conversions.rs
@@ -36,1395 +36,1423 @@ use leo_span::{
     sym::{self},
 };
 
-fn to_identifier(node: &SyntaxNode<'_>, builder: &NodeBuilder) -> leo_ast::Identifier {
-    let name = Symbol::intern(node.text);
-    leo_ast::Identifier { name, span: node.span, id: builder.next_id() }
+pub struct ConversionContext<'a> {
+    handler: &'a Handler,
+    builder: &'a NodeBuilder,
 }
 
-fn path_to_parts(node: &SyntaxNode<'_>, builder: &NodeBuilder) -> Vec<leo_ast::Identifier> {
-    let mut identifiers = Vec::new();
-    let mut i = node.span.lo;
-    for text in node.text.split("::") {
-        let end = i + text.len() as u32;
-        let span = leo_span::Span { lo: i, hi: end };
-        let name = Symbol::intern(text);
-        identifiers.push(leo_ast::Identifier { name, span, id: builder.next_id() });
-        // Account for the "::".
-        i = end + 2;
+impl<'a> ConversionContext<'a> {
+    pub fn new(handler: &'a Handler, builder: &'a NodeBuilder) -> Self {
+        Self { builder, handler }
     }
-    identifiers
-}
 
-fn to_mode(node: &SyntaxNode<'_>) -> leo_ast::Mode {
-    match node.text {
-        "constant" => leo_ast::Mode::Constant,
-        "private" => leo_ast::Mode::Private,
-        "public" => leo_ast::Mode::Public,
-        _ => leo_ast::Mode::None,
+    fn to_identifier(&self, node: &SyntaxNode<'_>) -> leo_ast::Identifier {
+        let name = Symbol::intern(node.text);
+        leo_ast::Identifier { name, span: node.span, id: self.builder.next_id() }
     }
-}
 
-fn to_type(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Type> {
-    let SyntaxKind::Type(type_kind) = node.kind else { todo!() };
-
-    let type_ = match type_kind {
-        TypeKind::Address => leo_ast::Type::Address,
-        TypeKind::Array => {
-            let [_l, type_, _s, length, _r] = &node.children[..] else {
-                // This "Can't happen" panic, like others in this file, will not be triggered unless
-                // there is an error in grammar.lalrpop.
-                panic!("Can't happen");
-            };
-            let element_type = to_type(type_, builder, handler)?;
-            let length = to_expression(length, builder, handler)?;
-            leo_ast::ArrayType { element_type: Box::new(element_type), length: Box::new(length) }.into()
+    fn path_to_parts(&self, node: &SyntaxNode<'_>) -> Vec<leo_ast::Identifier> {
+        let mut identifiers = Vec::new();
+        let mut i = node.span.lo;
+        for text in node.text.split("::") {
+            let end = i + text.len() as u32;
+            let span = leo_span::Span { lo: i, hi: end };
+            let name = Symbol::intern(text);
+            identifiers.push(leo_ast::Identifier { name, span, id: self.builder.next_id() });
+            // Account for the "::".
+            i = end + 2;
         }
-        TypeKind::Boolean => leo_ast::Type::Boolean,
-        TypeKind::Composite => {
-            let name = &node.children[0];
-            if let Some((program, name_str)) = name.text.split_once(".aleo/") {
-                // This is a locator.
-                let name_id = leo_ast::Identifier {
-                    name: Symbol::intern(name_str),
-                    span: leo_span::Span {
-                        lo: name.span.lo + program.len() as u32 + 5,
-                        hi: name.span.lo + name.text.len() as u32,
-                    },
-                    id: builder.next_id(),
+        identifiers
+    }
+
+    fn to_mode(node: &SyntaxNode<'_>) -> leo_ast::Mode {
+        match node.text {
+            "constant" => leo_ast::Mode::Constant,
+            "private" => leo_ast::Mode::Private,
+            "public" => leo_ast::Mode::Public,
+            _ => leo_ast::Mode::None,
+        }
+    }
+
+    fn to_type(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Type> {
+        let SyntaxKind::Type(type_kind) = node.kind else { todo!() };
+
+        let type_ = match type_kind {
+            TypeKind::Address => leo_ast::Type::Address,
+            TypeKind::Array => {
+                let [_l, type_, _s, length, _r] = &node.children[..] else {
+                    // This "Can't happen" panic, like others in this file, will not be triggered unless
+                    // there is an error in grammar.lalrpop.
+                    panic!("Can't happen");
                 };
-                leo_ast::CompositeType {
-                    path: leo_ast::Path::new(Vec::new(), name_id, false, None, name_id.span, builder.next_id()),
-                    const_arguments: Vec::new(),
-                    program: Some(Symbol::intern(program)),
+                let element_type = self.to_type(type_)?;
+                let length = self.to_expression(length)?;
+                leo_ast::ArrayType { element_type: Box::new(element_type), length: Box::new(length) }.into()
+            }
+            TypeKind::Boolean => leo_ast::Type::Boolean,
+            TypeKind::Composite => {
+                let name = &node.children[0];
+                if let Some((program, name_str)) = name.text.split_once(".aleo/") {
+                    // This is a locator.
+                    let name_id = leo_ast::Identifier {
+                        name: Symbol::intern(name_str),
+                        span: leo_span::Span {
+                            lo: name.span.lo + program.len() as u32 + 5,
+                            hi: name.span.lo + name.text.len() as u32,
+                        },
+                        id: self.builder.next_id(),
+                    };
+                    leo_ast::CompositeType {
+                        path: leo_ast::Path::new(
+                            Vec::new(),
+                            name_id,
+                            false,
+                            None,
+                            name_id.span,
+                            self.builder.next_id(),
+                        ),
+                        const_arguments: Vec::new(),
+                        program: Some(Symbol::intern(program)),
+                    }
+                    .into()
+                } else {
+                    // It's a path.
+                    let mut path_components = self.path_to_parts(name);
+                    let mut const_arguments = Vec::new();
+                    if let Some(arg_list) = node.children.get(1) {
+                        const_arguments = arg_list
+                            .children
+                            .iter()
+                            .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
+                            .map(|child| self.to_expression(child))
+                            .collect::<Result<Vec<_>>>()?;
+                    }
+                    let identifier = path_components.pop().unwrap();
+                    let path =
+                        leo_ast::Path::new(path_components, identifier, false, None, name.span, self.builder.next_id());
+                    leo_ast::CompositeType { path, const_arguments, program: None }.into()
                 }
-                .into()
-            } else {
-                // It's a path.
-                let mut path_components = path_to_parts(name, builder);
-                let mut const_arguments = Vec::new();
-                if let Some(arg_list) = node.children.get(1) {
-                    const_arguments = arg_list
+            }
+            TypeKind::Field => leo_ast::Type::Field,
+            TypeKind::Future => {
+                if node.children.len() == 1 {
+                    leo_ast::FutureType::default().into()
+                } else {
+                    let types = node
                         .children
                         .iter()
-                        .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
-                        .map(|child| to_expression(child, builder, handler))
+                        .filter(|child| matches!(child.kind, SyntaxKind::Type(..)))
+                        .map(|child| self.to_type(child))
                         .collect::<Result<Vec<_>>>()?;
+                    leo_ast::FutureType::new(types, None, true).into()
                 }
-                let identifier = path_components.pop().unwrap();
-                let path = leo_ast::Path::new(path_components, identifier, false, None, name.span, builder.next_id());
-                leo_ast::CompositeType { path, const_arguments, program: None }.into()
             }
-        }
-        TypeKind::Field => leo_ast::Type::Field,
-        TypeKind::Future => {
-            if node.children.len() == 1 {
-                leo_ast::FutureType::default().into()
-            } else {
-                let types = node
+            TypeKind::Group => leo_ast::Type::Group,
+            TypeKind::Identifier => todo!(),
+            TypeKind::Integer(int_type_kind) => {
+                let int_type = match int_type_kind {
+                    IntegerTypeKind::U8 => leo_ast::IntegerType::U8,
+                    IntegerTypeKind::U16 => leo_ast::IntegerType::U16,
+                    IntegerTypeKind::U32 => leo_ast::IntegerType::U32,
+                    IntegerTypeKind::U64 => leo_ast::IntegerType::U64,
+                    IntegerTypeKind::U128 => leo_ast::IntegerType::U128,
+                    IntegerTypeKind::I8 => leo_ast::IntegerType::I8,
+                    IntegerTypeKind::I16 => leo_ast::IntegerType::I16,
+                    IntegerTypeKind::I32 => leo_ast::IntegerType::I32,
+                    IntegerTypeKind::I64 => leo_ast::IntegerType::I64,
+                    IntegerTypeKind::I128 => leo_ast::IntegerType::I128,
+                };
+                leo_ast::Type::Integer(int_type)
+            }
+            TypeKind::Mapping => {
+                todo!()
+            }
+            TypeKind::Optional => {
+                let [inner_type, _q] = &node.children[..] else {
+                    // This "Can't happen" panic, like others in this file, will not be triggered unless
+                    // there is an error in grammar.lalrpop.
+                    panic!("Can't happen");
+                };
+                leo_ast::Type::Optional(leo_ast::OptionalType { inner: Box::new(self.to_type(inner_type)?) })
+            }
+            TypeKind::Scalar => leo_ast::Type::Scalar,
+            TypeKind::Signature => leo_ast::Type::Signature,
+            TypeKind::String => leo_ast::Type::String,
+            TypeKind::Tuple => {
+                let elements = node
                     .children
                     .iter()
                     .filter(|child| matches!(child.kind, SyntaxKind::Type(..)))
-                    .map(|child| to_type(child, builder, handler))
+                    .map(|child| self.to_type(child))
                     .collect::<Result<Vec<_>>>()?;
-                leo_ast::FutureType::new(types, None, true).into()
+                leo_ast::TupleType::new(elements).into()
             }
-        }
-        TypeKind::Group => leo_ast::Type::Group,
-        TypeKind::Identifier => todo!(),
-        TypeKind::Integer(int_type_kind) => {
-            let int_type = match int_type_kind {
-                IntegerTypeKind::U8 => leo_ast::IntegerType::U8,
-                IntegerTypeKind::U16 => leo_ast::IntegerType::U16,
-                IntegerTypeKind::U32 => leo_ast::IntegerType::U32,
-                IntegerTypeKind::U64 => leo_ast::IntegerType::U64,
-                IntegerTypeKind::U128 => leo_ast::IntegerType::U128,
-                IntegerTypeKind::I8 => leo_ast::IntegerType::I8,
-                IntegerTypeKind::I16 => leo_ast::IntegerType::I16,
-                IntegerTypeKind::I32 => leo_ast::IntegerType::I32,
-                IntegerTypeKind::I64 => leo_ast::IntegerType::I64,
-                IntegerTypeKind::I128 => leo_ast::IntegerType::I128,
-            };
-            leo_ast::Type::Integer(int_type)
-        }
-        TypeKind::Mapping => {
-            todo!()
-        }
-        TypeKind::Optional => {
-            let [inner_type, _q] = &node.children[..] else {
-                // This "Can't happen" panic, like others in this file, will not be triggered unless
-                // there is an error in grammar.lalrpop.
-                panic!("Can't happen");
-            };
-            leo_ast::Type::Optional(leo_ast::OptionalType { inner: Box::new(to_type(inner_type, builder, handler)?) })
-        }
-        TypeKind::Scalar => leo_ast::Type::Scalar,
-        TypeKind::Signature => leo_ast::Type::Signature,
-        TypeKind::String => leo_ast::Type::String,
-        TypeKind::Tuple => {
-            let elements = node
-                .children
-                .iter()
-                .filter(|child| matches!(child.kind, SyntaxKind::Type(..)))
-                .map(|child| to_type(child, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-            leo_ast::TupleType::new(elements).into()
-        }
-        TypeKind::Vector => {
-            let [_l, type_, _r] = &node.children[..] else {
-                // This "Can't happen" panic, like others in this file, will not be triggered unless
-                // there is an error in grammar.lalrpop.
-                panic!("Can't happen");
-            };
-            let element_type = to_type(type_, builder, handler)?;
-            leo_ast::VectorType { element_type: Box::new(element_type) }.into()
-        }
-        TypeKind::Numeric => leo_ast::Type::Numeric,
-        TypeKind::Unit => leo_ast::Type::Unit,
-    };
-
-    Ok(type_)
-}
-
-fn to_block(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Block> {
-    assert_eq!(node.kind, SyntaxKind::Statement(StatementKind::Block));
-
-    let statements = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Statement(..)))
-        .map(|child| to_statement(child, builder, handler))
-        .collect::<Result<Vec<_>>>()?;
-    Ok(leo_ast::Block { statements, span: node.span, id: builder.next_id() })
-}
-
-pub fn to_statement(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Statement> {
-    let SyntaxKind::Statement(statement_kind) = node.kind else { todo!() };
-
-    let span = node.span;
-    let id = builder.next_id();
-
-    let value = match statement_kind {
-        StatementKind::Assert => {
-            let [_a, _left, expr, _right, _s] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let expr = to_expression(expr, builder, handler)?;
-            let variant = leo_ast::AssertVariant::Assert(expr);
-
-            leo_ast::AssertStatement { variant, span, id }.into()
-        }
-        StatementKind::AssertEq => {
-            let [_a, _left, e0, _c, e1, _right, _s] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let e0 = to_expression(e0, builder, handler)?;
-            let e1 = to_expression(e1, builder, handler)?;
-            let variant = leo_ast::AssertVariant::AssertEq(e0, e1);
-
-            leo_ast::AssertStatement { variant, span, id }.into()
-        }
-        StatementKind::AssertNeq => {
-            let [_a, _left, e0, _c, e1, _right, _s] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let e0 = to_expression(e0, builder, handler)?;
-            let e1 = to_expression(e1, builder, handler)?;
-            let variant = leo_ast::AssertVariant::AssertNeq(e0, e1);
-
-            leo_ast::AssertStatement { variant, span, id }.into()
-        }
-        StatementKind::Assign => {
-            let [lhs, a, rhs, _s] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let left = to_expression(lhs, builder, handler)?;
-            let right = to_expression(rhs, builder, handler)?;
-            if a.text == "=" {
-                // Just a regular assignment.
-                leo_ast::AssignStatement { place: left, value: right, span, id }.into()
-            } else {
-                // We have to translate it into a binary operation and assignment.
-                let op = match a.text {
-                    "+=" => leo_ast::BinaryOperation::Add,
-                    "-=" => leo_ast::BinaryOperation::Sub,
-                    "*=" => leo_ast::BinaryOperation::Mul,
-                    "/=" => leo_ast::BinaryOperation::Div,
-                    "%=" => leo_ast::BinaryOperation::Rem,
-                    "**=" => leo_ast::BinaryOperation::Pow,
-                    "<<=" => leo_ast::BinaryOperation::Shl,
-                    ">>=" => leo_ast::BinaryOperation::Shr,
-                    "&=" => leo_ast::BinaryOperation::BitwiseAnd,
-                    "|=" => leo_ast::BinaryOperation::BitwiseOr,
-                    "^=" => leo_ast::BinaryOperation::Xor,
-                    "&&=" => leo_ast::BinaryOperation::And,
-                    "||=" => leo_ast::BinaryOperation::Or,
-                    _ => panic!("Can't happen"),
+            TypeKind::Vector => {
+                let [_l, type_, _r] = &node.children[..] else {
+                    // This "Can't happen" panic, like others in this file, will not be triggered unless
+                    // there is an error in grammar.lalrpop.
+                    panic!("Can't happen");
                 };
-
-                let binary_expr = leo_ast::BinaryExpression { left: left.clone(), right, op, span, id };
-
-                leo_ast::AssignStatement { place: left, value: binary_expr.into(), span, id }.into()
+                let element_type = self.to_type(type_)?;
+                leo_ast::VectorType { element_type: Box::new(element_type) }.into()
             }
-        }
-        StatementKind::Block => to_block(node, builder, handler)?.into(),
-        StatementKind::Conditional => {
-            match &node.children[..] {
-                [_if, c, block] => {
-                    // No else.
-                    let condition = to_expression(c, builder, handler)?;
-                    let then = to_block(block, builder, handler)?;
-                    leo_ast::ConditionalStatement { condition, then, otherwise: None, span, id }.into()
-                }
-                [_if, c, block, _else, otherwise] => {
-                    // An else clause.
-                    let condition = to_expression(c, builder, handler)?;
-                    let then = to_block(block, builder, handler)?;
-                    let otherwise = to_statement(otherwise, builder, handler)?;
-                    leo_ast::ConditionalStatement { condition, then, otherwise: Some(Box::new(otherwise)), span, id }
-                        .into()
-                }
+            TypeKind::Numeric => leo_ast::Type::Numeric,
+            TypeKind::Unit => leo_ast::Type::Unit,
+        };
 
-                _ => panic!("Can't happen"),
-            }
-        }
-        StatementKind::Const => {
-            let [_const, name, _c, type_, _a, rhs, _s] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let place = to_identifier(name, builder);
-            let type_ = to_type(type_, builder, handler)?;
-            let value = to_expression(rhs, builder, handler)?;
-
-            leo_ast::ConstDeclaration { place, type_, value, span, id }.into()
-        }
-        StatementKind::Definition => {
-            match &node.children[..] {
-                [_let, name, _c, type_, _assign, e, _s] => {
-                    // Singe place, type.
-                    let name = to_identifier(name, builder);
-                    let place = leo_ast::DefinitionPlace::Single(name);
-                    let value = to_expression(e, builder, handler)?;
-                    let type_ = Some(to_type(type_, builder, handler)?);
-                    leo_ast::DefinitionStatement { place, type_, value, span, id }.into()
-                }
-                [_let, name, _assign, e, _s] => {
-                    // Single place, no type.
-                    let name = to_identifier(name, builder);
-                    let place = leo_ast::DefinitionPlace::Single(name);
-                    let value = to_expression(e, builder, handler)?;
-                    leo_ast::DefinitionStatement { place, type_: None, value, span, id }.into()
-                }
-                children => {
-                    // Multiple place, with or without type.
-                    let right_paren_index = children.iter().position(|child| child.text == ")").unwrap();
-
-                    // The items between parens.
-                    let names = children[2..right_paren_index].iter()
-                        // The ones that aren't commas - the identifiers.
-                        .filter(|child| child.text != ",")
-                        .map(|child| to_identifier(child, builder))
-                    .collect();
-
-                    // Get the type, if there is one.
-                    let type_ = children
-                        .iter()
-                        .find(|child| matches!(child.kind, SyntaxKind::Type(..)))
-                        .map(|child| to_type(child, builder, handler))
-                        .transpose()?;
-
-                    let expr = &children[children.len() - 2];
-                    let value = to_expression(expr, builder, handler)?;
-                    let place = leo_ast::DefinitionPlace::Multiple(names);
-                    leo_ast::DefinitionStatement { place, type_, value, span, id }.into()
-                }
-            }
-        }
-        StatementKind::Expression => {
-            let expression = to_expression(&node.children[0], builder, handler)?;
-            leo_ast::ExpressionStatement { expression, span, id }.into()
-        }
-        StatementKind::Iteration => {
-            match &node.children[..] {
-                [_f, i, _n, low, _d, hi, block] => {
-                    // No type.
-                    leo_ast::IterationStatement {
-                        variable: to_identifier(i, builder),
-                        type_: None,
-                        start: to_expression(low, builder, handler)?,
-                        stop: to_expression(hi, builder, handler)?,
-                        inclusive: false,
-                        block: to_block(block, builder, handler)?,
-                        span,
-                        id,
-                    }
-                    .into()
-                }
-                [_f, i, _c, type_, _n, low, _d, hi, block] => {
-                    // With type.
-                    leo_ast::IterationStatement {
-                        variable: to_identifier(i, builder),
-                        type_: Some(to_type(type_, builder, handler)?),
-                        start: to_expression(low, builder, handler)?,
-                        stop: to_expression(hi, builder, handler)?,
-                        inclusive: false,
-                        block: to_block(block, builder, handler)?,
-                        span,
-                        id,
-                    }
-                    .into()
-                }
-                _ => panic!("Can't happen"),
-            }
-        }
-        StatementKind::Return => {
-            match &node.children[..] {
-                [_r, e, _s] => {
-                    // With expression.
-                    let expression = to_expression(e, builder, handler)?;
-                    leo_ast::ReturnStatement { expression, span, id }.into()
-                }
-                [_r, _s] => {
-                    // No expression.
-                    leo_ast::ReturnStatement {
-                        expression: leo_ast::UnitExpression { span, id: builder.next_id() }.into(),
-                        span,
-                        id,
-                    }
-                    .into()
-                }
-                _ => panic!("Can't happen"),
-            }
-        }
-    };
-
-    Ok(value)
-}
-
-pub fn to_expression(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<Expression> {
-    let SyntaxKind::Expression(expression_kind) = node.kind else { panic!("Can't happen") };
-
-    let span = node.span;
-    let id = builder.next_id();
-    let text = || node.text.to_string();
-
-    let value = match expression_kind {
-        ExpressionKind::ArrayAccess => {
-            let [array, _left, index, _right] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let array = to_expression(array, builder, handler)?;
-            let index = to_expression(index, builder, handler)?;
-
-            leo_ast::ArrayAccess { array, index, span, id }.into()
-        }
-
-        ExpressionKind::Intrinsic => {
-            let name = Symbol::intern(node.children[0].text);
-
-            let mut type_parameters = Vec::new();
-            if let Some(parameter_list) =
-                node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstArgumentList))
-            {
-                type_parameters = parameter_list
-                    .children
-                    .iter()
-                    .filter(|child| match child.kind {
-                        SyntaxKind::Type(..) => true,
-                        SyntaxKind::Expression(..) => {
-                            handler.emit_err(ParserError::custom(
-                                "Intrinsics may only have type parameters as generic arguments",
-                                child.span,
-                            ));
-                            false
-                        }
-                        _ => false,
-                    })
-                    .map(|child| Ok((to_type(child, builder, handler)?, child.span)))
-                    .collect::<Result<Vec<_>>>()?;
-            }
-            let arguments = node
-                .children
-                .iter()
-                .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
-                .map(|child| to_expression(child, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-
-            leo_ast::IntrinsicExpression { name, type_parameters, arguments, span, id }.into()
-        }
-
-        ExpressionKind::AssociatedConstant => {
-            // This is the only associated constant parsed.
-            leo_ast::IntrinsicExpression { name: sym::_group_gen, type_parameters: vec![], arguments: vec![], span, id }
-                .into()
-        }
-        ExpressionKind::AssociatedFunctionCall => {
-            let mut components = path_to_parts(&node.children[0], builder);
-            let name = components.pop().unwrap();
-            let variant = components.pop().unwrap();
-
-            let mut type_parameters = Vec::new();
-            if let Some(parameter_list) =
-                node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstArgumentList))
-            {
-                type_parameters = parameter_list
-                    .children
-                    .iter()
-                    .filter(|child| match child.kind {
-                        SyntaxKind::Type(..) => true,
-                        SyntaxKind::Expression(..) => {
-                            handler.emit_err(ParserError::custom(
-                                "Associated function calls may only have type parameters as generic arguments",
-                                child.span,
-                            ));
-                            false
-                        }
-                        _ => false,
-                    })
-                    .map(|child| Ok((to_type(child, builder, handler)?, child.span)))
-                    .collect::<Result<Vec<_>>>()?;
-            }
-            let arguments = node
-                .children
-                .iter()
-                .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
-                .map(|child| to_expression(child, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-
-            if let Some(converted_name) = Intrinsic::convert_path_symbols(variant.name, name.name) {
-                leo_ast::IntrinsicExpression { name: converted_name, type_parameters, arguments, span, id }.into()
-            } else {
-                handler.emit_err(ParserError::custom(
-                    format!("Unknown associated function: {}::{}", variant, name,),
-                    span,
-                ));
-                leo_ast::ErrExpression { span, id }.into()
-            }
-        }
-        ExpressionKind::Async => {
-            let [_a, block] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-            leo_ast::AsyncExpression { block: to_block(block, builder, handler)?, span, id }.into()
-        }
-        ExpressionKind::Array => {
-            let elements = node
-                .children
-                .iter()
-                .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
-                .map(|child| to_expression(child, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-            leo_ast::ArrayExpression { elements, span, id }.into()
-        }
-        ExpressionKind::Binary => {
-            let [lhs, op, rhs] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-            // Matches against strings like this are linear searches
-            // which could potentially be improved to constant time by
-            // storing the logos token in the LALRPOP token and matching
-            // against it here.
-            let op = match op.text {
-                "==" => leo_ast::BinaryOperation::Eq,
-                "!=" => leo_ast::BinaryOperation::Neq,
-                "<" => leo_ast::BinaryOperation::Lt,
-                "<=" => leo_ast::BinaryOperation::Lte,
-                ">" => leo_ast::BinaryOperation::Gt,
-                ">=" => leo_ast::BinaryOperation::Gte,
-                "+" => leo_ast::BinaryOperation::Add,
-                "-" => leo_ast::BinaryOperation::Sub,
-                "*" => leo_ast::BinaryOperation::Mul,
-                "/" => leo_ast::BinaryOperation::Div,
-                "%" => leo_ast::BinaryOperation::Rem,
-                "||" => leo_ast::BinaryOperation::Or,
-                "&&" => leo_ast::BinaryOperation::And,
-                "|" => leo_ast::BinaryOperation::BitwiseOr,
-                "&" => leo_ast::BinaryOperation::BitwiseAnd,
-                "**" => leo_ast::BinaryOperation::Pow,
-                "<<" => leo_ast::BinaryOperation::Shl,
-                ">>" => leo_ast::BinaryOperation::Shr,
-                "^" => leo_ast::BinaryOperation::Xor,
-                _ => panic!("Can't happen"),
-            };
-            let left = to_expression(lhs, builder, handler)?;
-            let right = to_expression(rhs, builder, handler)?;
-
-            leo_ast::BinaryExpression { left, right, op, span, id }.into()
-        }
-        ExpressionKind::Call => {
-            let name = &node.children[0];
-
-            let arguments = node
-                .children
-                .iter()
-                .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
-                .map(|child| to_expression(child, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-
-            let (function, program) = if let Some((first, second)) = name.text.split_once(".aleo/") {
-                // This is a locator.
-                let symbol = Symbol::intern(second);
-                let lo = node.span.lo + first.len() as u32 + ".aleo/".len() as u32;
-                let second_span = Span { lo, hi: lo + second.len() as u32 };
-                let identifier = leo_ast::Identifier { name: symbol, span: second_span, id: builder.next_id() };
-                let function = leo_ast::Path::new(Vec::new(), identifier, false, None, span, builder.next_id());
-                (function, Some(Symbol::intern(first)))
-            } else {
-                // It's a path.
-                let mut components = path_to_parts(name, builder);
-                let identifier = components.pop().unwrap();
-                let function = leo_ast::Path::new(components, identifier, false, None, name.span, builder.next_id());
-                (function, None)
-            };
-
-            let mut const_arguments = Vec::new();
-            if let Some(argument_list) =
-                node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstArgumentList))
-            {
-                const_arguments = argument_list
-                    .children
-                    .iter()
-                    .filter(|child| match child.kind {
-                        SyntaxKind::Expression(..) => true,
-                        SyntaxKind::Type(..) => {
-                            handler.emit_err(ParserError::custom(
-                                "Function calls may only have constant expressions as generic arguments",
-                                child.span,
-                            ));
-                            false
-                        }
-                        _ => false,
-                    })
-                    .map(|child| to_expression(child, builder, handler))
-                    .collect::<Result<Vec<_>>>()?;
-            }
-
-            leo_ast::CallExpression { function, const_arguments, arguments, program, span, id }.into()
-        }
-        ExpressionKind::Cast => {
-            let [expression, _as, type_] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let expression = to_expression(expression, builder, handler)?;
-            let type_ = to_type(type_, builder, handler)?;
-
-            leo_ast::CastExpression { expression, type_, span, id }.into()
-        }
-        ExpressionKind::Path => {
-            // We need to find the spans of the individual path components, since the
-            // lossless tree just has the span of the entire path.
-            let mut identifiers = path_to_parts(&node.children[0], builder);
-            let identifier = identifiers.pop().unwrap();
-            leo_ast::Path::new(identifiers, identifier, false, None, span, id).into()
-        }
-        ExpressionKind::Literal(literal_kind) => match literal_kind {
-            LiteralKind::Address => {
-                let t = text();
-                if !t.contains(".aleo") && t.parse::<Address<TestnetV0>>().is_err() {
-                    // We do this check here rather than in `leo-parser-lossless` simply
-                    // to avoid a dependency on snarkvm for `leo-parser-lossless`.
-                    handler.emit_err(ParserError::invalid_address_lit(&t, span));
-                }
-                leo_ast::Literal::address(t, span, id).into()
-            }
-            LiteralKind::Boolean => match node.text {
-                "true" => leo_ast::Literal::boolean(true, span, id).into(),
-                "false" => leo_ast::Literal::boolean(false, span, id).into(),
-                _ => panic!("Can't happen"),
-            },
-            LiteralKind::Field => leo_ast::Literal::field(text(), span, id).into(),
-            LiteralKind::Group => leo_ast::Literal::group(text(), span, id).into(),
-            LiteralKind::Integer(integer_literal_kind) => {
-                let integer_type = match integer_literal_kind {
-                    IntegerLiteralKind::U8 => leo_ast::IntegerType::U8,
-                    IntegerLiteralKind::U16 => leo_ast::IntegerType::U16,
-                    IntegerLiteralKind::U32 => leo_ast::IntegerType::U32,
-                    IntegerLiteralKind::U64 => leo_ast::IntegerType::U64,
-                    IntegerLiteralKind::U128 => leo_ast::IntegerType::U128,
-                    IntegerLiteralKind::I8 => leo_ast::IntegerType::I8,
-                    IntegerLiteralKind::I16 => leo_ast::IntegerType::I16,
-                    IntegerLiteralKind::I32 => leo_ast::IntegerType::I32,
-                    IntegerLiteralKind::I64 => leo_ast::IntegerType::I64,
-                    IntegerLiteralKind::I128 => leo_ast::IntegerType::I128,
-                };
-                leo_ast::Literal::integer(integer_type, text(), span, id).into()
-            }
-            LiteralKind::None => leo_ast::Literal::none(span, id).into(),
-            LiteralKind::Scalar => leo_ast::Literal::scalar(text(), span, id).into(),
-            LiteralKind::Unsuffixed => leo_ast::Literal::unsuffixed(text(), span, id).into(),
-            LiteralKind::String => leo_ast::Literal::string(text(), span, id).into(),
-        },
-        ExpressionKind::Locator => {
-            let text = node.children[0].text;
-
-            // Parse the locator string in format "some_program.aleo/some_name"
-            if let Some((program_part, name_part)) = text.split_once(".aleo/") {
-                // Create the program identifier
-                let program_name_symbol = Symbol::intern(program_part);
-                let program_name_span = Span { lo: node.span.lo, hi: node.span.lo + program_part.len() as u32 };
-                let program_name =
-                    leo_ast::Identifier { name: program_name_symbol, span: program_name_span, id: builder.next_id() };
-
-                // Create the network identifier (always "aleo")
-                let network_start = node.span.lo + program_part.len() as u32 + 1; // +1 for the dot
-                let network_span = Span {
-                    lo: network_start,
-                    hi: network_start + 4, // "aleo" is 4 characters
-                };
-                let network =
-                    leo_ast::Identifier { name: Symbol::intern("aleo"), span: network_span, id: builder.next_id() };
-
-                // Create the program ID
-                let program_id = leo_ast::ProgramId { name: program_name, network };
-
-                // Create the resource name
-                let name_symbol = Symbol::intern(name_part);
-
-                leo_ast::LocatorExpression { program: program_id, name: name_symbol, span, id }.into()
-            } else {
-                // Invalid locator format - this should have been caught by the parser
-                handler.emit_err(ParserError::custom("Invalid locator format", span));
-                leo_ast::ErrExpression { span, id }.into()
-            }
-        }
-        ExpressionKind::MemberAccess => {
-            let [struct_, _dot, name] = &node.children[..] else {
-                panic!("Can't happen.");
-            };
-            let inner = to_expression(struct_, builder, handler)?;
-            let name = to_identifier(name, builder);
-
-            leo_ast::MemberAccess { inner, name, span, id }.into()
-        }
-        ExpressionKind::MethodCall => {
-            let [expr, _dot, name, ..] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let name = to_identifier(name, builder);
-            let receiver = to_expression(expr, builder, handler)?;
-
-            let mut args = node.children[3..]
-                .iter()
-                .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
-                .map(|child| to_expression(child, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-
-            if let (true, Some(op)) = (args.is_empty(), leo_ast::UnaryOperation::from_symbol(name.name)) {
-                // Found an unary operator and the argument list is empty.
-                leo_ast::UnaryExpression { span, op, receiver, id }.into()
-            } else if let (1, Some(op)) = (args.len(), leo_ast::BinaryOperation::from_symbol(name.name)) {
-                // Found a binary operator and the argument list contains a single argument.
-                leo_ast::BinaryExpression { span, op, left: receiver, right: args.pop().unwrap(), id }.into()
-            } else if let (2, Some(name @ sym::_signature_verify)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::signature, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: std::iter::once(receiver).chain(args).collect(),
-                    span,
-                    id,
-                }
-                .into()
-            } else if let (0, Some(name @ sym::_future_await)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Future, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: vec![receiver],
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (0, Some(name @ sym::_optional_unwrap)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Optional, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: vec![receiver],
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (1, Some(name @ sym::_optional_unwrap_or)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Optional, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: std::iter::once(receiver).chain(args).collect(),
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (1, sym::get) = (args.len(), name.name) {
-                leo_ast::IntrinsicExpression {
-                    name: Symbol::intern("__unresolved_get"),
-                    type_parameters: Vec::new(),
-                    arguments: std::iter::once(receiver).chain(args).collect(),
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (2, sym::set) = (args.len(), name.name) {
-                leo_ast::IntrinsicExpression {
-                    name: Symbol::intern("__unresolved_set"),
-                    type_parameters: Vec::new(),
-                    arguments: std::iter::once(receiver).chain(args).collect(),
-                    span,
-                    id,
-                }
-                .into()
-            } else if let (1, Some(name @ sym::_vector_push)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: std::iter::once(receiver).chain(args).collect(),
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (0, Some(name @ sym::_vector_len)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: vec![receiver],
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (0, Some(name @ sym::_vector_pop)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: vec![receiver],
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (0, Some(name @ sym::_vector_clear)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: vec![receiver],
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else if let (1, Some(name @ sym::_vector_swap_remove)) =
-                (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
-            {
-                leo_ast::IntrinsicExpression {
-                    name,
-                    type_parameters: Vec::new(),
-                    arguments: std::iter::once(receiver).chain(args).collect(),
-                    span,
-                    id: builder.next_id(),
-                }
-                .into()
-            } else {
-                // Attempt to parse the method call as a mapping operation.
-                match (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Mapping, name.name)) {
-                    (2, Some(name @ sym::_mapping_get_or_use))
-                    | (1, Some(name @ sym::_mapping_remove))
-                    | (1, Some(name @ sym::_mapping_contains)) => {
-                        // Found an instance of `<mapping>.get`, `<mapping>.get_or_use`, `<mapping>.set`, `<mapping>.remove`, or `<mapping>.contains`.
-                        leo_ast::IntrinsicExpression {
-                            name,
-                            type_parameters: Vec::new(),
-                            arguments: std::iter::once(receiver).chain(args).collect(),
-                            span,
-                            id: builder.next_id(),
-                        }
-                        .into()
-                    }
-                    _ => {
-                        // Either an invalid unary/binary operator, or more arguments given.
-                        handler.emit_err(ParserError::invalid_method_call(receiver, name, args.len(), span));
-                        leo_ast::ErrExpression { span, id: builder.next_id() }.into()
-                    }
-                }
-            }
-        }
-        ExpressionKind::Parenthesized => {
-            let [_left, expr, _right] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-            to_expression(expr, builder, handler)?
-        }
-        ExpressionKind::Repeat => {
-            let [_left, expr, _s, count, _right] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-            let expr = to_expression(expr, builder, handler)?;
-            let count = to_expression(count, builder, handler)?;
-            leo_ast::RepeatExpression { expr, count, span, id }.into()
-        }
-        ExpressionKind::SpecialAccess => {
-            let [qualifier, _dot, name] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let name = match (qualifier.text, name.text) {
-                ("self", "address") => Some(sym::_self_address),
-                ("self", "caller") => Some(sym::_self_caller),
-                ("self", "checksum") => Some(sym::_self_checksum),
-                ("self", "edition") => Some(sym::_self_edition),
-                ("self", "id") => Some(sym::_self_id),
-                ("self", "program_owner") => Some(sym::_self_program_owner),
-                ("self", "signer") => Some(sym::_self_signer),
-                ("block", "height") => Some(sym::_block_height),
-                ("block", "timestamp") => Some(sym::_block_timestamp),
-                ("network", "id") => Some(sym::_network_id),
-                _ => {
-                    handler.emit_err(ParserError::custom("Unsupported special access", node.span));
-                    None
-                }
-            };
-
-            if let Some(name) = name {
-                leo_ast::IntrinsicExpression { name, type_parameters: vec![], arguments: vec![], span, id }.into()
-            } else {
-                leo_ast::ErrExpression { span, id: builder.next_id() }.into()
-            }
-        }
-
-        ExpressionKind::Struct => {
-            let name = &node.children[0];
-            let mut members = Vec::new();
-            for initializer in node.children.iter().filter(|node| node.kind == SyntaxKind::StructMemberInitializer) {
-                let (init_name, expression) = match &initializer.children[..] {
-                    [init_name] => (init_name, None),
-                    [init_name, _c, expr] => (init_name, Some(to_expression(expr, builder, handler)?)),
-                    _ => panic!("Can't happen"),
-                };
-                let init_name = to_identifier(init_name, builder);
-
-                members.push(leo_ast::StructVariableInitializer {
-                    identifier: init_name,
-                    expression,
-                    span: initializer.span,
-                    id: builder.next_id(),
-                });
-            }
-
-            let mut const_arguments = Vec::new();
-            let maybe_const_params = &node.children[1];
-            if maybe_const_params.kind == SyntaxKind::ConstArgumentList {
-                for argument in &maybe_const_params.children {
-                    match argument.kind {
-                        SyntaxKind::Type(..) => {
-                            handler.emit_err(ParserError::custom(
-                                "Struct expressions may only have constant expressions as generic arguments",
-                                argument.span,
-                            ));
-                        }
-                        SyntaxKind::Expression(..) => {
-                            let expr = to_expression(argument, builder, handler)?;
-                            const_arguments.push(expr);
-                        }
-                        _ => {}
-                    }
-                }
-            }
-
-            let mut identifiers = path_to_parts(name, builder);
-            let identifier = identifiers.pop().unwrap();
-            let path = leo_ast::Path::new(identifiers, identifier, false, None, name.span, builder.next_id());
-
-            leo_ast::StructExpression { path, const_arguments, members, span, id }.into()
-        }
-        ExpressionKind::Ternary => {
-            let [cond, _q, if_, _c, then] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-            let condition = to_expression(cond, builder, handler)?;
-            let if_true = to_expression(if_, builder, handler)?;
-            let if_false = to_expression(then, builder, handler)?;
-            leo_ast::TernaryExpression { condition, if_true, if_false, span, id }.into()
-        }
-        ExpressionKind::Tuple => {
-            let elements = node
-                .children
-                .iter()
-                .filter(|expr| matches!(expr.kind, SyntaxKind::Expression(..)))
-                .map(|expr| to_expression(expr, builder, handler))
-                .collect::<Result<Vec<_>>>()?;
-            leo_ast::TupleExpression { elements, span, id }.into()
-        }
-        ExpressionKind::TupleAccess => {
-            let [expr, _dot, integer] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-
-            let tuple = to_expression(expr, builder, handler)?;
-            let integer_text = integer.text.replace("_", "");
-            let value: usize = integer_text.parse().expect("Integer should parse.");
-            let index = value.into();
-
-            leo_ast::TupleAccess { tuple, index, span, id }.into()
-        }
-        ExpressionKind::Unary => {
-            let [op, operand] = &node.children[..] else {
-                panic!("Can't happen");
-            };
-            let mut operand_expression = to_expression(operand, builder, handler)?;
-            let op_variant = match op.text {
-                "!" => leo_ast::UnaryOperation::Not,
-                "-" => leo_ast::UnaryOperation::Negate,
-                _ => panic!("Can't happen"),
-            };
-            if op_variant == leo_ast::UnaryOperation::Negate {
-                use leo_ast::LiteralVariant::*;
-                if let Expression::Literal(leo_ast::Literal {
-                    variant: Integer(_, string) | Field(string) | Group(string) | Scalar(string),
-                    span,
-                    ..
-                }) = &mut operand_expression
-                    && !string.starts_with('-')
-                {
-                    // The operation was a negation and the literal was not already negative, so fold it in
-                    // and discard the unary expression.
-                    string.insert(0, '-');
-                    *span = op.span + operand.span;
-                    return Ok(operand_expression);
-                }
-            }
-            leo_ast::UnaryExpression { receiver: operand_expression, op: op_variant, span, id }.into()
-        }
-        ExpressionKind::Unit => leo_ast::UnitExpression { span, id }.into(),
-    };
-
-    Ok(value)
-}
-
-fn to_const_parameters(
-    node: &SyntaxNode<'_>,
-    builder: &NodeBuilder,
-    handler: &Handler,
-) -> Result<Vec<leo_ast::ConstParameter>> {
-    assert_eq!(node.kind, SyntaxKind::ConstParameterList);
-
-    node.children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::ConstParameter))
-        .map(|child| {
-            let [id, _c, type_] = &child.children[..] else {
-                panic!("Can't happen");
-            };
-
-            Ok(leo_ast::ConstParameter {
-                identifier: to_identifier(id, builder),
-                type_: to_type(type_, builder, handler)?,
-                span: child.span,
-                id: builder.next_id(),
-            })
-        })
-        .collect::<Result<Vec<_>>>()
-}
-
-fn to_annotation(node: &SyntaxNode<'_>, builder: &NodeBuilder) -> Result<leo_ast::Annotation> {
-    assert_eq!(node.kind, SyntaxKind::Annotation);
-    let name = to_identifier(&node.children[1], builder);
-
-    let mut map = IndexMap::new();
-    node.children.get(2).inspect(|list| {
-        for member in list.children.iter() {
-            if member.kind != SyntaxKind::AnnotationMember {
-                continue;
-            }
-
-            let [key, _assign, value] = &member.children[..] else {
-                panic!("Can't happen");
-            };
-            let key = Symbol::intern(key.text);
-            // Get rid of the delimiting double quotes on the string.
-            let value = value.text[1..value.text.len() - 1].to_string();
-            map.insert(key, value);
-        }
-    });
-    Ok(leo_ast::Annotation { identifier: name, map, span: node.span, id: builder.next_id() })
-}
-
-fn to_function(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Function> {
-    assert_eq!(node.kind, SyntaxKind::Function);
-
-    let annotations = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Annotation))
-        .map(|child| to_annotation(child, builder))
-        .collect::<Result<Vec<_>>>()?;
-    let async_index = annotations.len();
-    let is_async = node.children[async_index].text == "async";
-
-    let function_variant_index = if is_async { async_index + 1 } else { async_index };
-
-    // The behavior here matches the old parser - "inline" and "script" may be marked async,
-    // but async is ignored. Presumably we should fix this but it's theoretically a breaking change.
-    let variant = match (is_async, node.children[function_variant_index].text) {
-        (true, "function") => leo_ast::Variant::AsyncFunction,
-        (false, "function") => leo_ast::Variant::Function,
-        (_, "inline") => leo_ast::Variant::Inline,
-        (_, "script") => leo_ast::Variant::Script,
-        (true, "transition") => leo_ast::Variant::AsyncTransition,
-        (false, "transition") => leo_ast::Variant::Transition,
-        _ => panic!("Can't happen"),
-    };
-
-    let name = &node.children[function_variant_index + 1];
-    let id = to_identifier(name, builder);
-
-    let mut const_parameters = Vec::new();
-    if let Some(const_param_list) =
-        node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstParameterList))
-    {
-        const_parameters = to_const_parameters(const_param_list, builder, handler)?;
+        Ok(type_)
     }
 
-    let parameter_list = node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ParameterList)).unwrap();
-    let input = parameter_list
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Parameter))
-        .map(|child| {
-            let mode = to_mode(&child.children[0]);
-            let index = if mode == leo_ast::Mode::None { 0 } else { 1 };
-            let [name, _c, type_] = &child.children[index..] else {
-                panic!("Can't happen");
-            };
-            Ok(leo_ast::Input {
-                identifier: to_identifier(name, builder),
-                mode,
-                type_: to_type(type_, builder, handler)?,
-                span: child.span,
-                id: builder.next_id(),
-            })
-        })
-        .collect::<Result<Vec<_>>>()?;
+    fn to_block(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Block> {
+        assert_eq!(node.kind, SyntaxKind::Statement(StatementKind::Block));
 
-    let [.., maybe_outputs, block] = &node.children[..] else {
-        panic!("Can't happen");
-    };
-    let block = to_block(block, builder, handler)?;
-
-    let to_output = |node: &SyntaxNode<'_>| -> Result<leo_ast::Output> {
-        let mode = to_mode(&node.children[0]);
-        let type_ = node.children.last().unwrap();
-
-        Ok(leo_ast::Output { mode, type_: to_type(type_, builder, handler)?, span: node.span, id: builder.next_id() })
-    };
-
-    let output = match maybe_outputs.kind {
-        SyntaxKind::FunctionOutput => {
-            let output = to_output(maybe_outputs)?;
-            vec![output]
-        }
-        SyntaxKind::FunctionOutputs => maybe_outputs
+        let statements = node
             .children
             .iter()
-            .filter(|child| matches!(child.kind, SyntaxKind::FunctionOutput))
-            .map(to_output)
-            .collect::<Result<Vec<_>>>()?,
-        _ => Vec::new(),
-    };
+            .filter(|child| matches!(child.kind, SyntaxKind::Statement(..)))
+            .map(|child| self.to_statement(child))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(leo_ast::Block { statements, span: node.span, id: self.builder.next_id() })
+    }
 
-    Ok(leo_ast::Function::new(
-        annotations,
-        variant,
-        id,
-        const_parameters,
-        input,
-        output,
-        block,
-        node.span,
-        builder.next_id(),
-    ))
-}
+    pub fn to_statement(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Statement> {
+        let SyntaxKind::Statement(statement_kind) = node.kind else { todo!() };
 
-fn to_composite(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Composite> {
-    assert_eq!(node.kind, SyntaxKind::StructDeclaration);
+        let span = node.span;
+        let id = self.builder.next_id();
 
-    let [struct_or_record, i, .., members] = &node.children[..] else {
-        panic!("Can't happen");
-    };
+        let value = match statement_kind {
+            StatementKind::Assert => {
+                let [_a, _left, expr, _right, _s] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
 
-    let members = members
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::StructMemberDeclaration))
-        .map(|child| {
-            let (mode, ident, type_) = match &child.children[..] {
-                [ident, _c, type_] => (leo_ast::Mode::None, ident, type_),
-                [privacy, ident, _c, type_] => (to_mode(privacy), ident, type_),
-                _ => panic!("Can't happen"),
-            };
+                let expr = self.to_expression(expr)?;
+                let variant = leo_ast::AssertVariant::Assert(expr);
 
-            Ok(leo_ast::Member {
-                mode,
-                identifier: to_identifier(ident, builder),
-                type_: to_type(type_, builder, handler)?,
-                span: child.span,
-                id: builder.next_id(),
+                leo_ast::AssertStatement { variant, span, id }.into()
+            }
+            StatementKind::AssertEq => {
+                let [_a, _left, e0, _c, e1, _right, _s] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let e0 = self.to_expression(e0)?;
+                let e1 = self.to_expression(e1)?;
+                let variant = leo_ast::AssertVariant::AssertEq(e0, e1);
+
+                leo_ast::AssertStatement { variant, span, id }.into()
+            }
+            StatementKind::AssertNeq => {
+                let [_a, _left, e0, _c, e1, _right, _s] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let e0 = self.to_expression(e0)?;
+                let e1 = self.to_expression(e1)?;
+                let variant = leo_ast::AssertVariant::AssertNeq(e0, e1);
+
+                leo_ast::AssertStatement { variant, span, id }.into()
+            }
+            StatementKind::Assign => {
+                let [lhs, a, rhs, _s] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let left = self.to_expression(lhs)?;
+                let right = self.to_expression(rhs)?;
+                if a.text == "=" {
+                    // Just a regular assignment.
+                    leo_ast::AssignStatement { place: left, value: right, span, id }.into()
+                } else {
+                    // We have to translate it into a binary operation and assignment.
+                    let op = match a.text {
+                        "+=" => leo_ast::BinaryOperation::Add,
+                        "-=" => leo_ast::BinaryOperation::Sub,
+                        "*=" => leo_ast::BinaryOperation::Mul,
+                        "/=" => leo_ast::BinaryOperation::Div,
+                        "%=" => leo_ast::BinaryOperation::Rem,
+                        "**=" => leo_ast::BinaryOperation::Pow,
+                        "<<=" => leo_ast::BinaryOperation::Shl,
+                        ">>=" => leo_ast::BinaryOperation::Shr,
+                        "&=" => leo_ast::BinaryOperation::BitwiseAnd,
+                        "|=" => leo_ast::BinaryOperation::BitwiseOr,
+                        "^=" => leo_ast::BinaryOperation::Xor,
+                        "&&=" => leo_ast::BinaryOperation::And,
+                        "||=" => leo_ast::BinaryOperation::Or,
+                        _ => panic!("Can't happen"),
+                    };
+
+                    let binary_expr = leo_ast::BinaryExpression { left: left.clone(), right, op, span, id };
+
+                    leo_ast::AssignStatement { place: left, value: binary_expr.into(), span, id }.into()
+                }
+            }
+            StatementKind::Block => self.to_block(node)?.into(),
+            StatementKind::Conditional => {
+                match &node.children[..] {
+                    [_if, c, block] => {
+                        // No else.
+                        let condition = self.to_expression(c)?;
+                        let then = self.to_block(block)?;
+                        leo_ast::ConditionalStatement { condition, then, otherwise: None, span, id }.into()
+                    }
+                    [_if, c, block, _else, otherwise] => {
+                        // An else clause.
+                        let condition = self.to_expression(c)?;
+                        let then = self.to_block(block)?;
+                        let otherwise = self.to_statement(otherwise)?;
+                        leo_ast::ConditionalStatement {
+                            condition,
+                            then,
+                            otherwise: Some(Box::new(otherwise)),
+                            span,
+                            id,
+                        }
+                        .into()
+                    }
+
+                    _ => panic!("Can't happen"),
+                }
+            }
+            StatementKind::Const => {
+                let [_const, name, _c, type_, _a, rhs, _s] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let place = self.to_identifier(name);
+                let type_ = self.to_type(type_)?;
+                let value = self.to_expression(rhs)?;
+
+                leo_ast::ConstDeclaration { place, type_, value, span, id }.into()
+            }
+            StatementKind::Definition => {
+                match &node.children[..] {
+                    [_let, name, _c, type_, _assign, e, _s] => {
+                        // Singe place, type.
+                        let name = self.to_identifier(name);
+                        let place = leo_ast::DefinitionPlace::Single(name);
+                        let value = self.to_expression(e)?;
+                        let type_ = Some(self.to_type(type_)?);
+                        leo_ast::DefinitionStatement { place, type_, value, span, id }.into()
+                    }
+                    [_let, name, _assign, e, _s] => {
+                        // Single place, no type.
+                        let name = self.to_identifier(name);
+                        let place = leo_ast::DefinitionPlace::Single(name);
+                        let value = self.to_expression(e)?;
+                        leo_ast::DefinitionStatement { place, type_: None, value, span, id }.into()
+                    }
+                    children => {
+                        // Multiple place, with or without type.
+                        let right_paren_index = children.iter().position(|child| child.text == ")").unwrap();
+
+                        // The items between parens.
+                        let names = children[2..right_paren_index].iter()
+                            // The ones that aren't commas - the identifiers.
+                            .filter(|child| child.text != ",")
+                            .map(|child| self.to_identifier(child))
+                        .collect();
+
+                        // Get the type, if there is one.
+                        let type_ = children
+                            .iter()
+                            .find(|child| matches!(child.kind, SyntaxKind::Type(..)))
+                            .map(|child| self.to_type(child))
+                            .transpose()?;
+
+                        let expr = &children[children.len() - 2];
+                        let value = self.to_expression(expr)?;
+                        let place = leo_ast::DefinitionPlace::Multiple(names);
+                        leo_ast::DefinitionStatement { place, type_, value, span, id }.into()
+                    }
+                }
+            }
+            StatementKind::Expression => {
+                let expression = self.to_expression(&node.children[0])?;
+                leo_ast::ExpressionStatement { expression, span, id }.into()
+            }
+            StatementKind::Iteration => {
+                match &node.children[..] {
+                    [_f, i, _n, low, _d, hi, block] => {
+                        // No type.
+                        leo_ast::IterationStatement {
+                            variable: self.to_identifier(i),
+                            type_: None,
+                            start: self.to_expression(low)?,
+                            stop: self.to_expression(hi)?,
+                            inclusive: false,
+                            block: self.to_block(block)?,
+                            span,
+                            id,
+                        }
+                        .into()
+                    }
+                    [_f, i, _c, type_, _n, low, _d, hi, block] => {
+                        // With type.
+                        leo_ast::IterationStatement {
+                            variable: self.to_identifier(i),
+                            type_: Some(self.to_type(type_)?),
+                            start: self.to_expression(low)?,
+                            stop: self.to_expression(hi)?,
+                            inclusive: false,
+                            block: self.to_block(block)?,
+                            span,
+                            id,
+                        }
+                        .into()
+                    }
+                    _ => panic!("Can't happen"),
+                }
+            }
+            StatementKind::Return => {
+                match &node.children[..] {
+                    [_r, e, _s] => {
+                        // With expression.
+                        let expression = self.to_expression(e)?;
+                        leo_ast::ReturnStatement { expression, span, id }.into()
+                    }
+                    [_r, _s] => {
+                        // No expression.
+                        leo_ast::ReturnStatement {
+                            expression: leo_ast::UnitExpression { span, id: self.builder.next_id() }.into(),
+                            span,
+                            id,
+                        }
+                        .into()
+                    }
+                    _ => panic!("Can't happen"),
+                }
+            }
+        };
+
+        Ok(value)
+    }
+
+    pub fn to_expression(&self, node: &SyntaxNode<'_>) -> Result<Expression> {
+        let SyntaxKind::Expression(expression_kind) = node.kind else { panic!("Can't happen") };
+
+        let span = node.span;
+        let id = self.builder.next_id();
+        let text = || node.text.to_string();
+
+        let value = match expression_kind {
+            ExpressionKind::ArrayAccess => {
+                let [array, _left, index, _right] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let array = self.to_expression(array)?;
+                let index = self.to_expression(index)?;
+
+                leo_ast::ArrayAccess { array, index, span, id }.into()
+            }
+
+            ExpressionKind::Intrinsic => {
+                let name = Symbol::intern(node.children[0].text);
+
+                let mut type_parameters = Vec::new();
+                if let Some(parameter_list) =
+                    node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstArgumentList))
+                {
+                    type_parameters = parameter_list
+                        .children
+                        .iter()
+                        .filter(|child| match child.kind {
+                            SyntaxKind::Type(..) => true,
+                            SyntaxKind::Expression(..) => {
+                                self.handler.emit_err(ParserError::custom(
+                                    "Intrinsics may only have type parameters as generic arguments",
+                                    child.span,
+                                ));
+                                false
+                            }
+                            _ => false,
+                        })
+                        .map(|child| Ok((self.to_type(child)?, child.span)))
+                        .collect::<Result<Vec<_>>>()?;
+                }
+                let arguments = node
+                    .children
+                    .iter()
+                    .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
+                    .map(|child| self.to_expression(child))
+                    .collect::<Result<Vec<_>>>()?;
+
+                leo_ast::IntrinsicExpression { name, type_parameters, arguments, span, id }.into()
+            }
+
+            ExpressionKind::AssociatedConstant => {
+                // This is the only associated constant parsed.
+                leo_ast::IntrinsicExpression {
+                    name: sym::_group_gen,
+                    type_parameters: vec![],
+                    arguments: vec![],
+                    span,
+                    id,
+                }
+                .into()
+            }
+            ExpressionKind::AssociatedFunctionCall => {
+                let mut components = self.path_to_parts(&node.children[0]);
+                let name = components.pop().unwrap();
+                let variant = components.pop().unwrap();
+
+                let mut type_parameters = Vec::new();
+                if let Some(parameter_list) =
+                    node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstArgumentList))
+                {
+                    type_parameters = parameter_list
+                        .children
+                        .iter()
+                        .filter(|child| match child.kind {
+                            SyntaxKind::Type(..) => true,
+                            SyntaxKind::Expression(..) => {
+                                self.handler.emit_err(ParserError::custom(
+                                    "Associated function calls may only have type parameters as generic arguments",
+                                    child.span,
+                                ));
+                                false
+                            }
+                            _ => false,
+                        })
+                        .map(|child| Ok((self.to_type(child)?, child.span)))
+                        .collect::<Result<Vec<_>>>()?;
+                }
+                let arguments = node
+                    .children
+                    .iter()
+                    .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
+                    .map(|child| self.to_expression(child))
+                    .collect::<Result<Vec<_>>>()?;
+
+                if let Some(converted_name) = Intrinsic::convert_path_symbols(variant.name, name.name) {
+                    leo_ast::IntrinsicExpression { name: converted_name, type_parameters, arguments, span, id }.into()
+                } else {
+                    self.handler.emit_err(ParserError::custom(
+                        format!("Unknown associated function: {}::{}", variant, name,),
+                        span,
+                    ));
+                    leo_ast::ErrExpression { span, id }.into()
+                }
+            }
+            ExpressionKind::Async => {
+                let [_a, block] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+                leo_ast::AsyncExpression { block: self.to_block(block)?, span, id }.into()
+            }
+            ExpressionKind::Array => {
+                let elements = node
+                    .children
+                    .iter()
+                    .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
+                    .map(|child| self.to_expression(child))
+                    .collect::<Result<Vec<_>>>()?;
+                leo_ast::ArrayExpression { elements, span, id }.into()
+            }
+            ExpressionKind::Binary => {
+                let [lhs, op, rhs] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+                // Matches against strings like this are linear searches
+                // which could potentially be improved to constant time by
+                // storing the logos token in the LALRPOP token and matching
+                // against it here.
+                let op = match op.text {
+                    "==" => leo_ast::BinaryOperation::Eq,
+                    "!=" => leo_ast::BinaryOperation::Neq,
+                    "<" => leo_ast::BinaryOperation::Lt,
+                    "<=" => leo_ast::BinaryOperation::Lte,
+                    ">" => leo_ast::BinaryOperation::Gt,
+                    ">=" => leo_ast::BinaryOperation::Gte,
+                    "+" => leo_ast::BinaryOperation::Add,
+                    "-" => leo_ast::BinaryOperation::Sub,
+                    "*" => leo_ast::BinaryOperation::Mul,
+                    "/" => leo_ast::BinaryOperation::Div,
+                    "%" => leo_ast::BinaryOperation::Rem,
+                    "||" => leo_ast::BinaryOperation::Or,
+                    "&&" => leo_ast::BinaryOperation::And,
+                    "|" => leo_ast::BinaryOperation::BitwiseOr,
+                    "&" => leo_ast::BinaryOperation::BitwiseAnd,
+                    "**" => leo_ast::BinaryOperation::Pow,
+                    "<<" => leo_ast::BinaryOperation::Shl,
+                    ">>" => leo_ast::BinaryOperation::Shr,
+                    "^" => leo_ast::BinaryOperation::Xor,
+                    _ => panic!("Can't happen"),
+                };
+                let left = self.to_expression(lhs)?;
+                let right = self.to_expression(rhs)?;
+
+                leo_ast::BinaryExpression { left, right, op, span, id }.into()
+            }
+            ExpressionKind::Call => {
+                let name = &node.children[0];
+
+                let arguments = node
+                    .children
+                    .iter()
+                    .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
+                    .map(|child| self.to_expression(child))
+                    .collect::<Result<Vec<_>>>()?;
+
+                let (function, program) = if let Some((first, second)) = name.text.split_once(".aleo/") {
+                    // This is a locator.
+                    let symbol = Symbol::intern(second);
+                    let lo = node.span.lo + first.len() as u32 + ".aleo/".len() as u32;
+                    let second_span = Span { lo, hi: lo + second.len() as u32 };
+                    let identifier =
+                        leo_ast::Identifier { name: symbol, span: second_span, id: self.builder.next_id() };
+                    let function =
+                        leo_ast::Path::new(Vec::new(), identifier, false, None, span, self.builder.next_id());
+                    (function, Some(Symbol::intern(first)))
+                } else {
+                    // It's a path.
+                    let mut components = self.path_to_parts(name);
+                    let identifier = components.pop().unwrap();
+                    let function =
+                        leo_ast::Path::new(components, identifier, false, None, name.span, self.builder.next_id());
+                    (function, None)
+                };
+
+                let mut const_arguments = Vec::new();
+                if let Some(argument_list) =
+                    node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstArgumentList))
+                {
+                    const_arguments = argument_list
+                        .children
+                        .iter()
+                        .filter(|child| match child.kind {
+                            SyntaxKind::Expression(..) => true,
+                            SyntaxKind::Type(..) => {
+                                self.handler.emit_err(ParserError::custom(
+                                    "Function calls may only have constant expressions as generic arguments",
+                                    child.span,
+                                ));
+                                false
+                            }
+                            _ => false,
+                        })
+                        .map(|child| self.to_expression(child))
+                        .collect::<Result<Vec<_>>>()?;
+                }
+
+                leo_ast::CallExpression { function, const_arguments, arguments, program, span, id }.into()
+            }
+            ExpressionKind::Cast => {
+                let [expression, _as, type_] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let expression = self.to_expression(expression)?;
+                let type_ = self.to_type(type_)?;
+
+                leo_ast::CastExpression { expression, type_, span, id }.into()
+            }
+            ExpressionKind::Path => {
+                // We need to find the spans of the individual path components, since the
+                // lossless tree just has the span of the entire path.
+                let mut identifiers = self.path_to_parts(&node.children[0]);
+                let identifier = identifiers.pop().unwrap();
+                leo_ast::Path::new(identifiers, identifier, false, None, span, id).into()
+            }
+            ExpressionKind::Literal(literal_kind) => match literal_kind {
+                LiteralKind::Address => {
+                    let t = text();
+                    if !t.contains(".aleo") && t.parse::<Address<TestnetV0>>().is_err() {
+                        // We do this check here rather than in `leo-parser-lossless` simply
+                        // to avoid a dependency on snarkvm for `leo-parser-lossless`.
+                        self.handler.emit_err(ParserError::invalid_address_lit(&t, span));
+                    }
+                    leo_ast::Literal::address(t, span, id).into()
+                }
+                LiteralKind::Boolean => match node.text {
+                    "true" => leo_ast::Literal::boolean(true, span, id).into(),
+                    "false" => leo_ast::Literal::boolean(false, span, id).into(),
+                    _ => panic!("Can't happen"),
+                },
+                LiteralKind::Field => leo_ast::Literal::field(text(), span, id).into(),
+                LiteralKind::Group => leo_ast::Literal::group(text(), span, id).into(),
+                LiteralKind::Integer(integer_literal_kind) => {
+                    let integer_type = match integer_literal_kind {
+                        IntegerLiteralKind::U8 => leo_ast::IntegerType::U8,
+                        IntegerLiteralKind::U16 => leo_ast::IntegerType::U16,
+                        IntegerLiteralKind::U32 => leo_ast::IntegerType::U32,
+                        IntegerLiteralKind::U64 => leo_ast::IntegerType::U64,
+                        IntegerLiteralKind::U128 => leo_ast::IntegerType::U128,
+                        IntegerLiteralKind::I8 => leo_ast::IntegerType::I8,
+                        IntegerLiteralKind::I16 => leo_ast::IntegerType::I16,
+                        IntegerLiteralKind::I32 => leo_ast::IntegerType::I32,
+                        IntegerLiteralKind::I64 => leo_ast::IntegerType::I64,
+                        IntegerLiteralKind::I128 => leo_ast::IntegerType::I128,
+                    };
+                    leo_ast::Literal::integer(integer_type, text(), span, id).into()
+                }
+                LiteralKind::None => leo_ast::Literal::none(span, id).into(),
+                LiteralKind::Scalar => leo_ast::Literal::scalar(text(), span, id).into(),
+                LiteralKind::Unsuffixed => leo_ast::Literal::unsuffixed(text(), span, id).into(),
+                LiteralKind::String => leo_ast::Literal::string(text(), span, id).into(),
+            },
+            ExpressionKind::Locator => {
+                let text = node.children[0].text;
+
+                // Parse the locator string in format "some_program.aleo/some_name"
+                if let Some((program_part, name_part)) = text.split_once(".aleo/") {
+                    // Create the program identifier
+                    let program_name_symbol = Symbol::intern(program_part);
+                    let program_name_span = Span { lo: node.span.lo, hi: node.span.lo + program_part.len() as u32 };
+                    let program_name = leo_ast::Identifier {
+                        name: program_name_symbol,
+                        span: program_name_span,
+                        id: self.builder.next_id(),
+                    };
+
+                    // Create the network identifier (always "aleo")
+                    let network_start = node.span.lo + program_part.len() as u32 + 1; // +1 for the dot
+                    let network_span = Span {
+                        lo: network_start,
+                        hi: network_start + 4, // "aleo" is 4 characters
+                    };
+                    let network = leo_ast::Identifier {
+                        name: Symbol::intern("aleo"),
+                        span: network_span,
+                        id: self.builder.next_id(),
+                    };
+
+                    // Create the program ID
+                    let program_id = leo_ast::ProgramId { name: program_name, network };
+
+                    // Create the resource name
+                    let name_symbol = Symbol::intern(name_part);
+
+                    leo_ast::LocatorExpression { program: program_id, name: name_symbol, span, id }.into()
+                } else {
+                    // Invalid locator format - this should have been caught by the parser
+                    self.handler.emit_err(ParserError::custom("Invalid locator format", span));
+                    leo_ast::ErrExpression { span, id }.into()
+                }
+            }
+            ExpressionKind::MemberAccess => {
+                let [struct_, _dot, name] = &node.children[..] else {
+                    panic!("Can't happen.");
+                };
+                let inner = self.to_expression(struct_)?;
+                let name = self.to_identifier(name);
+
+                leo_ast::MemberAccess { inner, name, span, id }.into()
+            }
+            ExpressionKind::MethodCall => {
+                let [expr, _dot, name, ..] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let name = self.to_identifier(name);
+                let receiver = self.to_expression(expr)?;
+
+                let mut args = node.children[3..]
+                    .iter()
+                    .filter(|child| matches!(child.kind, SyntaxKind::Expression(..)))
+                    .map(|child| self.to_expression(child))
+                    .collect::<Result<Vec<_>>>()?;
+
+                if let (true, Some(op)) = (args.is_empty(), leo_ast::UnaryOperation::from_symbol(name.name)) {
+                    // Found an unary operator and the argument list is empty.
+                    leo_ast::UnaryExpression { span, op, receiver, id }.into()
+                } else if let (1, Some(op)) = (args.len(), leo_ast::BinaryOperation::from_symbol(name.name)) {
+                    // Found a binary operator and the argument list contains a single argument.
+                    leo_ast::BinaryExpression { span, op, left: receiver, right: args.pop().unwrap(), id }.into()
+                } else if let (2, Some(name @ sym::_signature_verify)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::signature, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: std::iter::once(receiver).chain(args).collect(),
+                        span,
+                        id,
+                    }
+                    .into()
+                } else if let (0, Some(name @ sym::_future_await)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Future, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: vec![receiver],
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (0, Some(name @ sym::_optional_unwrap)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Optional, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: vec![receiver],
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (1, Some(name @ sym::_optional_unwrap_or)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Optional, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: std::iter::once(receiver).chain(args).collect(),
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (1, sym::get) = (args.len(), name.name) {
+                    leo_ast::IntrinsicExpression {
+                        name: Symbol::intern("__unresolved_get"),
+                        type_parameters: Vec::new(),
+                        arguments: std::iter::once(receiver).chain(args).collect(),
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (2, sym::set) = (args.len(), name.name) {
+                    leo_ast::IntrinsicExpression {
+                        name: Symbol::intern("__unresolved_set"),
+                        type_parameters: Vec::new(),
+                        arguments: std::iter::once(receiver).chain(args).collect(),
+                        span,
+                        id,
+                    }
+                    .into()
+                } else if let (1, Some(name @ sym::_vector_push)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: std::iter::once(receiver).chain(args).collect(),
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (0, Some(name @ sym::_vector_len)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: vec![receiver],
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (0, Some(name @ sym::_vector_pop)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: vec![receiver],
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (0, Some(name @ sym::_vector_clear)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: vec![receiver],
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else if let (1, Some(name @ sym::_vector_swap_remove)) =
+                    (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Vector, name.name))
+                {
+                    leo_ast::IntrinsicExpression {
+                        name,
+                        type_parameters: Vec::new(),
+                        arguments: std::iter::once(receiver).chain(args).collect(),
+                        span,
+                        id: self.builder.next_id(),
+                    }
+                    .into()
+                } else {
+                    // Attempt to parse the method call as a mapping operation.
+                    match (args.len(), leo_ast::Intrinsic::convert_path_symbols(sym::Mapping, name.name)) {
+                        (2, Some(name @ sym::_mapping_get_or_use))
+                        | (1, Some(name @ sym::_mapping_remove))
+                        | (1, Some(name @ sym::_mapping_contains)) => {
+                            // Found an instance of `<mapping>.get`, `<mapping>.get_or_use`, `<mapping>.set`, `<mapping>.remove`, or `<mapping>.contains`.
+                            leo_ast::IntrinsicExpression {
+                                name,
+                                type_parameters: Vec::new(),
+                                arguments: std::iter::once(receiver).chain(args).collect(),
+                                span,
+                                id: self.builder.next_id(),
+                            }
+                            .into()
+                        }
+                        _ => {
+                            // Either an invalid unary/binary operator, or more arguments given.
+                            self.handler.emit_err(ParserError::invalid_method_call(receiver, name, args.len(), span));
+                            leo_ast::ErrExpression { span, id: self.builder.next_id() }.into()
+                        }
+                    }
+                }
+            }
+            ExpressionKind::Parenthesized => {
+                let [_left, expr, _right] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+                self.to_expression(expr)?
+            }
+            ExpressionKind::Repeat => {
+                let [_left, expr, _s, count, _right] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+                let expr = self.to_expression(expr)?;
+                let count = self.to_expression(count)?;
+                leo_ast::RepeatExpression { expr, count, span, id }.into()
+            }
+            ExpressionKind::SpecialAccess => {
+                let [qualifier, _dot, name] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let name = match (qualifier.text, name.text) {
+                    ("self", "address") => Some(sym::_self_address),
+                    ("self", "caller") => Some(sym::_self_caller),
+                    ("self", "checksum") => Some(sym::_self_checksum),
+                    ("self", "edition") => Some(sym::_self_edition),
+                    ("self", "id") => Some(sym::_self_id),
+                    ("self", "program_owner") => Some(sym::_self_program_owner),
+                    ("self", "signer") => Some(sym::_self_signer),
+                    ("block", "height") => Some(sym::_block_height),
+                    ("block", "timestamp") => Some(sym::_block_timestamp),
+                    ("network", "id") => Some(sym::_network_id),
+                    _ => {
+                        self.handler.emit_err(ParserError::custom("Unsupported special access", node.span));
+                        None
+                    }
+                };
+
+                if let Some(name) = name {
+                    leo_ast::IntrinsicExpression { name, type_parameters: vec![], arguments: vec![], span, id }.into()
+                } else {
+                    leo_ast::ErrExpression { span, id: self.builder.next_id() }.into()
+                }
+            }
+
+            ExpressionKind::Struct => {
+                let name = &node.children[0];
+                let mut members = Vec::new();
+                for initializer in node.children.iter().filter(|node| node.kind == SyntaxKind::StructMemberInitializer)
+                {
+                    let (init_name, expression) = match &initializer.children[..] {
+                        [init_name] => (init_name, None),
+                        [init_name, _c, expr] => (init_name, Some(self.to_expression(expr)?)),
+                        _ => panic!("Can't happen"),
+                    };
+                    let init_name = self.to_identifier(init_name);
+
+                    members.push(leo_ast::StructVariableInitializer {
+                        identifier: init_name,
+                        expression,
+                        span: initializer.span,
+                        id: self.builder.next_id(),
+                    });
+                }
+
+                let mut const_arguments = Vec::new();
+                let maybe_const_params = &node.children[1];
+                if maybe_const_params.kind == SyntaxKind::ConstArgumentList {
+                    for argument in &maybe_const_params.children {
+                        match argument.kind {
+                            SyntaxKind::Type(..) => {
+                                self.handler.emit_err(ParserError::custom(
+                                    "Struct expressions may only have constant expressions as generic arguments",
+                                    argument.span,
+                                ));
+                            }
+                            SyntaxKind::Expression(..) => {
+                                let expr = self.to_expression(argument)?;
+                                const_arguments.push(expr);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                let mut identifiers = self.path_to_parts(name);
+                let identifier = identifiers.pop().unwrap();
+                let path = leo_ast::Path::new(identifiers, identifier, false, None, name.span, self.builder.next_id());
+
+                leo_ast::StructExpression { path, const_arguments, members, span, id }.into()
+            }
+            ExpressionKind::Ternary => {
+                let [cond, _q, if_, _c, then] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+                let condition = self.to_expression(cond)?;
+                let if_true = self.to_expression(if_)?;
+                let if_false = self.to_expression(then)?;
+                leo_ast::TernaryExpression { condition, if_true, if_false, span, id }.into()
+            }
+            ExpressionKind::Tuple => {
+                let elements = node
+                    .children
+                    .iter()
+                    .filter(|expr| matches!(expr.kind, SyntaxKind::Expression(..)))
+                    .map(|expr| self.to_expression(expr))
+                    .collect::<Result<Vec<_>>>()?;
+                leo_ast::TupleExpression { elements, span, id }.into()
+            }
+            ExpressionKind::TupleAccess => {
+                let [expr, _dot, integer] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                let tuple = self.to_expression(expr)?;
+                let integer_text = integer.text.replace("_", "");
+                let value: usize = integer_text.parse().expect("Integer should parse.");
+                let index = value.into();
+
+                leo_ast::TupleAccess { tuple, index, span, id }.into()
+            }
+            ExpressionKind::Unary => {
+                let [op, operand] = &node.children[..] else {
+                    panic!("Can't happen");
+                };
+                let mut operand_expression = self.to_expression(operand)?;
+                let op_variant = match op.text {
+                    "!" => leo_ast::UnaryOperation::Not,
+                    "-" => leo_ast::UnaryOperation::Negate,
+                    _ => panic!("Can't happen"),
+                };
+                if op_variant == leo_ast::UnaryOperation::Negate {
+                    use leo_ast::LiteralVariant::*;
+                    if let Expression::Literal(leo_ast::Literal {
+                        variant: Integer(_, string) | Field(string) | Group(string) | Scalar(string),
+                        span,
+                        ..
+                    }) = &mut operand_expression
+                        && !string.starts_with('-')
+                    {
+                        // The operation was a negation and the literal was not already negative, so fold it in
+                        // and discard the unary expression.
+                        string.insert(0, '-');
+                        *span = op.span + operand.span;
+                        return Ok(operand_expression);
+                    }
+                }
+                leo_ast::UnaryExpression { receiver: operand_expression, op: op_variant, span, id }.into()
+            }
+            ExpressionKind::Unit => leo_ast::UnitExpression { span, id }.into(),
+        };
+
+        Ok(value)
+    }
+
+    fn to_const_parameters(&self, node: &SyntaxNode<'_>) -> Result<Vec<leo_ast::ConstParameter>> {
+        assert_eq!(node.kind, SyntaxKind::ConstParameterList);
+
+        node.children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::ConstParameter))
+            .map(|child| {
+                let [id, _c, type_] = &child.children[..] else {
+                    panic!("Can't happen");
+                };
+
+                Ok(leo_ast::ConstParameter {
+                    identifier: self.to_identifier(id),
+                    type_: self.to_type(type_)?,
+                    span: child.span,
+                    id: self.builder.next_id(),
+                })
             })
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let mut const_parameters = Vec::new();
-    if let Some(const_param_list) =
-        node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstParameterList))
-    {
-        const_parameters = to_const_parameters(const_param_list, builder, handler)?;
+            .collect::<Result<Vec<_>>>()
     }
 
-    Ok(leo_ast::Composite {
-        identifier: to_identifier(i, builder),
-        const_parameters,
-        members,
-        external: None,
-        is_record: struct_or_record.text == "record",
-        span: node.span,
-        id: builder.next_id(),
-    })
-}
+    fn to_annotation(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Annotation> {
+        assert_eq!(node.kind, SyntaxKind::Annotation);
+        let name = self.to_identifier(&node.children[1]);
 
-fn to_global_const(
-    node: &SyntaxNode<'_>,
-    builder: &NodeBuilder,
-    handler: &Handler,
-) -> Result<leo_ast::ConstDeclaration> {
-    assert_eq!(node.kind, SyntaxKind::GlobalConst);
+        let mut map = IndexMap::new();
+        node.children.get(2).inspect(|list| {
+            for member in list.children.iter() {
+                if member.kind != SyntaxKind::AnnotationMember {
+                    continue;
+                }
 
-    let [_l, ident, _colon, type_, _a, expr, _s] = &node.children[..] else {
-        panic!("Can't happen");
-    };
-
-    Ok(leo_ast::ConstDeclaration {
-        place: to_identifier(ident, builder),
-        type_: to_type(type_, builder, handler)?,
-        value: to_expression(expr, builder, handler)?,
-        span: node.span,
-        id: builder.next_id(),
-    })
-}
-
-fn to_constructor(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Constructor> {
-    assert_eq!(node.kind, SyntaxKind::Constructor);
-    let annotations = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Annotation))
-        .map(|child| to_annotation(child, builder))
-        .collect::<Result<Vec<_>>>()?;
-    let block = to_block(node.children.last().unwrap(), builder, handler)?;
-
-    Ok(leo_ast::Constructor { annotations, block, span: node.span, id: builder.next_id() })
-}
-
-fn to_mapping(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Mapping> {
-    assert_eq!(node.kind, SyntaxKind::Mapping);
-
-    let [_mapping, name, _colon, key_type, _arrow, value_type, _s] = &node.children[..] else {
-        panic!("Can't happen");
-    };
-
-    Ok(leo_ast::Mapping {
-        identifier: to_identifier(name, builder),
-        key_type: to_type(key_type, builder, handler)?,
-        value_type: to_type(value_type, builder, handler)?,
-        span: node.span,
-        id: builder.next_id(),
-    })
-}
-
-fn to_storage_variable(
-    node: &SyntaxNode<'_>,
-    builder: &NodeBuilder,
-    handler: &Handler,
-) -> Result<leo_ast::StorageVariable> {
-    assert_eq!(node.kind, SyntaxKind::Storage);
-
-    let [_storage, name, _colon, type_, _s] = &node.children[..] else {
-        panic!("Can't happen");
-    };
-
-    Ok(leo_ast::StorageVariable {
-        identifier: to_identifier(name, builder),
-        type_: to_type(type_, builder, handler)?,
-        span: node.span,
-        id: builder.next_id(),
-    })
-}
-
-pub fn to_module(
-    node: &SyntaxNode<'_>,
-    builder: &NodeBuilder,
-    program_name: Symbol,
-    path: Vec<Symbol>,
-    handler: &Handler,
-) -> Result<leo_ast::Module> {
-    assert_eq!(node.kind, SyntaxKind::ModuleContents);
-
-    let mut functions = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Function))
-        .map(|child| {
-            let function = to_function(child, builder, handler)?;
-            Ok((function.identifier.name, function))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    // Passes like type checking expect transitions to come first.
-    // Irrelevant for modules at the moment.
-    functions.sort_by_key(|func| if func.1.variant.is_transition() { 0u8 } else { 1u8 });
-
-    let structs = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::StructDeclaration))
-        .map(|child| {
-            let composite = to_composite(child, builder, handler)?;
-            Ok((composite.identifier.name, composite))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let consts = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::GlobalConst))
-        .map(|child| {
-            let global_const = to_global_const(child, builder, handler)?;
-            Ok((global_const.place.name, global_const))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(leo_ast::Module { program_name, path, consts, structs, functions })
-}
-
-pub fn to_main(node: &SyntaxNode<'_>, builder: &NodeBuilder, handler: &Handler) -> Result<leo_ast::Program> {
-    assert_eq!(node.kind, SyntaxKind::MainContents);
-
-    let imports = node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Import))
-        .map(|child| {
-            let name = Symbol::intern(child.children[1].text.strip_suffix(".aleo").unwrap());
-            (name, (leo_ast::Program::default(), child.span))
-        })
-        .collect::<IndexMap<_, _>>();
-
-    let program_node = node.children.last().unwrap();
-
-    let mut functions = program_node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Function))
-        .map(|child| {
-            let function = to_function(child, builder, handler)?;
-            Ok((function.identifier.name, function))
-        })
-        .collect::<Result<Vec<_>>>()?;
-    // Passes like type checking expect transitions to come first.
-    functions.sort_by_key(|func| if func.1.variant.is_transition() { 0u8 } else { 1u8 });
-
-    let structs = program_node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::StructDeclaration))
-        .map(|child| {
-            let composite = to_composite(child, builder, handler)?;
-            Ok((composite.identifier.name, composite))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let consts = program_node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::GlobalConst))
-        .map(|child| {
-            let global_const = to_global_const(child, builder, handler)?;
-            Ok((global_const.place.name, global_const))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let mappings = program_node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Mapping))
-        .map(|child| {
-            let mapping = to_mapping(child, builder, handler)?;
-            Ok((mapping.identifier.name, mapping))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    let storage_variables = program_node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Storage))
-        .map(|child| {
-            let storage_variable = to_storage_variable(child, builder, handler)?;
-            Ok((storage_variable.identifier.name, storage_variable))
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    // This follows the behavior of the old parser - if multiple constructors are
-    // present, we silently throw out all but the last. Probably this should be
-    // changed but it would theoretically be a breaking change.
-    let mut constructors = program_node
-        .children
-        .iter()
-        .filter(|child| matches!(child.kind, SyntaxKind::Constructor))
-        .map(|child| to_constructor(child, builder, handler))
-        .collect::<Result<Vec<_>>>()?;
-
-    if let Some(extra) = constructors.get(1) {
-        return Err(TypeCheckerError::custom("A program can only have one constructor.", extra.span).into());
+                let [key, _assign, value] = &member.children[..] else {
+                    panic!("Can't happen");
+                };
+                let key = Symbol::intern(key.text);
+                // Get rid of the delimiting double quotes on the string.
+                let value = value.text[1..value.text.len() - 1].to_string();
+                map.insert(key, value);
+            }
+        });
+        Ok(leo_ast::Annotation { identifier: name, map, span: node.span, id: self.builder.next_id() })
     }
 
-    let program_id_node = &program_node.children[1];
-    let program_name_text = program_id_node.text.strip_suffix(".aleo").unwrap();
-    let program_name_symbol = Symbol::intern(program_name_text);
-    let hi = program_id_node.span.lo + program_name_text.len() as u32;
-    let program_id = leo_ast::ProgramId {
-        name: leo_ast::Identifier {
-            name: program_name_symbol,
-            span: Span { lo: program_id_node.span.lo, hi },
-            id: builder.next_id(),
-        },
-        network: leo_ast::Identifier { name: sym::aleo, span: Span { lo: hi + 1, hi: hi + 5 }, id: builder.next_id() },
-    };
-    let program_scope = leo_ast::ProgramScope {
-        program_id,
-        consts,
-        structs,
-        mappings,
-        storage_variables,
-        functions,
-        constructor: constructors.pop(),
-        span: node.span,
-    };
-    Ok(leo_ast::Program {
-        modules: Default::default(),
-        imports,
-        stubs: Default::default(),
-        program_scopes: std::iter::once((program_name_symbol, program_scope)).collect(),
-    })
+    fn to_function(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Function> {
+        assert_eq!(node.kind, SyntaxKind::Function);
+
+        let annotations = node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Annotation))
+            .map(|child| self.to_annotation(child))
+            .collect::<Result<Vec<_>>>()?;
+        let async_index = annotations.len();
+        let is_async = node.children[async_index].text == "async";
+
+        let function_variant_index = if is_async { async_index + 1 } else { async_index };
+
+        // The behavior here matches the old parser - "inline" and "script" may be marked async,
+        // but async is ignored. Presumably we should fix this but it's theoretically a breaking change.
+        let variant = match (is_async, node.children[function_variant_index].text) {
+            (true, "function") => leo_ast::Variant::AsyncFunction,
+            (false, "function") => leo_ast::Variant::Function,
+            (_, "inline") => leo_ast::Variant::Inline,
+            (_, "script") => leo_ast::Variant::Script,
+            (true, "transition") => leo_ast::Variant::AsyncTransition,
+            (false, "transition") => leo_ast::Variant::Transition,
+            _ => panic!("Can't happen"),
+        };
+
+        let name = &node.children[function_variant_index + 1];
+        let id = self.to_identifier(name);
+
+        let mut const_parameters = Vec::new();
+        if let Some(const_param_list) =
+            node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstParameterList))
+        {
+            const_parameters = self.to_const_parameters(const_param_list)?;
+        }
+
+        let parameter_list =
+            node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ParameterList)).unwrap();
+        let input = parameter_list
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Parameter))
+            .map(|child| {
+                let mode = Self::to_mode(&child.children[0]);
+                let index = if mode == leo_ast::Mode::None { 0 } else { 1 };
+                let [name, _c, type_] = &child.children[index..] else {
+                    panic!("Can't happen");
+                };
+                Ok(leo_ast::Input {
+                    identifier: self.to_identifier(name),
+                    mode,
+                    type_: self.to_type(type_)?,
+                    span: child.span,
+                    id: self.builder.next_id(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let [.., maybe_outputs, block] = &node.children[..] else {
+            panic!("Can't happen");
+        };
+        let block = self.to_block(block)?;
+
+        let to_output = |node: &SyntaxNode<'_>| -> Result<leo_ast::Output> {
+            let mode = Self::to_mode(&node.children[0]);
+            let type_ = node.children.last().unwrap();
+
+            Ok(leo_ast::Output { mode, type_: self.to_type(type_)?, span: node.span, id: self.builder.next_id() })
+        };
+
+        let output = match maybe_outputs.kind {
+            SyntaxKind::FunctionOutput => {
+                let output = to_output(maybe_outputs)?;
+                vec![output]
+            }
+            SyntaxKind::FunctionOutputs => maybe_outputs
+                .children
+                .iter()
+                .filter(|child| matches!(child.kind, SyntaxKind::FunctionOutput))
+                .map(to_output)
+                .collect::<Result<Vec<_>>>()?,
+            _ => Vec::new(),
+        };
+
+        Ok(leo_ast::Function::new(
+            annotations,
+            variant,
+            id,
+            const_parameters,
+            input,
+            output,
+            block,
+            node.span,
+            self.builder.next_id(),
+        ))
+    }
+
+    fn to_composite(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Composite> {
+        assert_eq!(node.kind, SyntaxKind::StructDeclaration);
+
+        let [struct_or_record, i, .., members] = &node.children[..] else {
+            panic!("Can't happen");
+        };
+
+        let members = members
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::StructMemberDeclaration))
+            .map(|child| {
+                let (mode, ident, type_) = match &child.children[..] {
+                    [ident, _c, type_] => (leo_ast::Mode::None, ident, type_),
+                    [privacy, ident, _c, type_] => (Self::to_mode(privacy), ident, type_),
+                    _ => panic!("Can't happen"),
+                };
+
+                Ok(leo_ast::Member {
+                    mode,
+                    identifier: self.to_identifier(ident),
+                    type_: self.to_type(type_)?,
+                    span: child.span,
+                    id: self.builder.next_id(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mut const_parameters = Vec::new();
+        if let Some(const_param_list) =
+            node.children.iter().find(|child| matches!(child.kind, SyntaxKind::ConstParameterList))
+        {
+            const_parameters = self.to_const_parameters(const_param_list)?;
+        }
+
+        Ok(leo_ast::Composite {
+            identifier: self.to_identifier(i),
+            const_parameters,
+            members,
+            external: None,
+            is_record: struct_or_record.text == "record",
+            span: node.span,
+            id: self.builder.next_id(),
+        })
+    }
+
+    fn to_global_const(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::ConstDeclaration> {
+        assert_eq!(node.kind, SyntaxKind::GlobalConst);
+
+        let [_l, ident, _colon, type_, _a, expr, _s] = &node.children[..] else {
+            panic!("Can't happen");
+        };
+
+        Ok(leo_ast::ConstDeclaration {
+            place: self.to_identifier(ident),
+            type_: self.to_type(type_)?,
+            value: self.to_expression(expr)?,
+            span: node.span,
+            id: self.builder.next_id(),
+        })
+    }
+
+    fn to_constructor(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Constructor> {
+        assert_eq!(node.kind, SyntaxKind::Constructor);
+        let annotations = node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Annotation))
+            .map(|child| self.to_annotation(child))
+            .collect::<Result<Vec<_>>>()?;
+        let block = self.to_block(node.children.last().unwrap())?;
+
+        Ok(leo_ast::Constructor { annotations, block, span: node.span, id: self.builder.next_id() })
+    }
+
+    fn to_mapping(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Mapping> {
+        assert_eq!(node.kind, SyntaxKind::Mapping);
+
+        let [_mapping, name, _colon, key_type, _arrow, value_type, _s] = &node.children[..] else {
+            panic!("Can't happen");
+        };
+
+        Ok(leo_ast::Mapping {
+            identifier: self.to_identifier(name),
+            key_type: self.to_type(key_type)?,
+            value_type: self.to_type(value_type)?,
+            span: node.span,
+            id: self.builder.next_id(),
+        })
+    }
+
+    fn to_storage_variable(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::StorageVariable> {
+        assert_eq!(node.kind, SyntaxKind::Storage);
+
+        let [_storage, name, _colon, type_, _s] = &node.children[..] else {
+            panic!("Can't happen");
+        };
+
+        Ok(leo_ast::StorageVariable {
+            identifier: self.to_identifier(name),
+            type_: self.to_type(type_)?,
+            span: node.span,
+            id: self.builder.next_id(),
+        })
+    }
+
+    pub fn to_module(&self, node: &SyntaxNode<'_>, program_name: Symbol, path: Vec<Symbol>) -> Result<leo_ast::Module> {
+        assert_eq!(node.kind, SyntaxKind::ModuleContents);
+
+        let mut functions = node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Function))
+            .map(|child| {
+                let function = self.to_function(child)?;
+                Ok((function.identifier.name, function))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // Passes like type checking expect transitions to come first.
+        // Irrelevant for modules at the moment.
+        functions.sort_by_key(|func| if func.1.variant.is_transition() { 0u8 } else { 1u8 });
+
+        let structs = node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::StructDeclaration))
+            .map(|child| {
+                let composite = self.to_composite(child)?;
+                Ok((composite.identifier.name, composite))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let consts = node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::GlobalConst))
+            .map(|child| {
+                let global_const = self.to_global_const(child)?;
+                Ok((global_const.place.name, global_const))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(leo_ast::Module { program_name, path, consts, structs, functions })
+    }
+
+    pub fn to_main(&self, node: &SyntaxNode<'_>) -> Result<leo_ast::Program> {
+        assert_eq!(node.kind, SyntaxKind::MainContents);
+
+        let imports = node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Import))
+            .map(|child| {
+                let name = Symbol::intern(child.children[1].text.strip_suffix(".aleo").unwrap());
+                (name, child.span)
+            })
+            .collect::<IndexMap<_, _>>();
+
+        let program_node = node.children.last().unwrap();
+
+        let mut functions = program_node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Function))
+            .map(|child| {
+                let function = self.to_function(child)?;
+                Ok((function.identifier.name, function))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        // Passes like type checking expect transitions to come first.
+        functions.sort_by_key(|func| if func.1.variant.is_transition() { 0u8 } else { 1u8 });
+
+        let structs = program_node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::StructDeclaration))
+            .map(|child| {
+                let composite = self.to_composite(child)?;
+                Ok((composite.identifier.name, composite))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let consts = program_node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::GlobalConst))
+            .map(|child| {
+                let global_const = self.to_global_const(child)?;
+                Ok((global_const.place.name, global_const))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let mappings = program_node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Mapping))
+            .map(|child| {
+                let mapping = self.to_mapping(child)?;
+                Ok((mapping.identifier.name, mapping))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        let storage_variables = program_node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Storage))
+            .map(|child| {
+                let storage_variable = self.to_storage_variable(child)?;
+                Ok((storage_variable.identifier.name, storage_variable))
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // This follows the behavior of the old parser - if multiple constructors are
+        // present, we silently throw out all but the last. Probably this should be
+        // changed but it would theoretically be a breaking change.
+        let mut constructors = program_node
+            .children
+            .iter()
+            .filter(|child| matches!(child.kind, SyntaxKind::Constructor))
+            .map(|child| self.to_constructor(child))
+            .collect::<Result<Vec<_>>>()?;
+
+        if let Some(extra) = constructors.get(1) {
+            return Err(TypeCheckerError::custom("A program can only have one constructor.", extra.span).into());
+        }
+
+        let program_id_node = &program_node.children[1];
+        let program_name_text = program_id_node.text.strip_suffix(".aleo").unwrap();
+        let program_name_symbol = Symbol::intern(program_name_text);
+        let hi = program_id_node.span.lo + program_name_text.len() as u32;
+        let program_id = leo_ast::ProgramId {
+            name: leo_ast::Identifier {
+                name: program_name_symbol,
+                span: Span { lo: program_id_node.span.lo, hi },
+                id: self.builder.next_id(),
+            },
+            network: leo_ast::Identifier {
+                name: sym::aleo,
+                span: Span { lo: hi + 1, hi: hi + 5 },
+                id: self.builder.next_id(),
+            },
+        };
+        let program_scope = leo_ast::ProgramScope {
+            program_id,
+            consts,
+            structs,
+            mappings,
+            storage_variables,
+            functions,
+            constructor: constructors.pop(),
+            span: node.span,
+        };
+        Ok(leo_ast::Program {
+            modules: Default::default(),
+            imports,
+            stubs: Default::default(),
+            program_scopes: std::iter::once((program_name_symbol, program_scope)).collect(),
+        })
+    }
 }

--- a/compiler/passes/src/option_lowering/program.rs
+++ b/compiler/passes/src/option_lowering/program.rs
@@ -48,11 +48,7 @@ impl ProgramReconstructor for OptionLoweringVisitor<'_> {
 
         // Now we're ready to reconstruct everything else.
         Program {
-            imports: input
-                .imports
-                .into_iter()
-                .map(|(id, import)| (id, (self.reconstruct_import(import.0), import.1)))
-                .collect(),
+            imports: input.imports,
             stubs: input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect(),
             program_scopes: input
                 .program_scopes

--- a/compiler/passes/src/static_single_assignment/program.rs
+++ b/compiler/passes/src/static_single_assignment/program.rs
@@ -145,11 +145,7 @@ impl ProgramConsumer for SsaFormingVisitor<'_> {
     fn consume_program(&mut self, input: Program) -> Self::Output {
         Program {
             modules: input.modules.into_iter().map(|(path, module)| (path, self.consume_module(module))).collect(),
-            imports: input
-                .imports
-                .into_iter()
-                .map(|(name, (import, span))| (name, (self.consume_program(import), span)))
-                .collect(),
+            imports: input.imports,
             stubs: input.stubs,
             program_scopes: input
                 .program_scopes

--- a/tests/expectations/parser/program/external_mapping.out
+++ b/tests/expectations/parser/program/external_mapping.out
@@ -1,18 +1,10 @@
 {
   "modules": {},
   "imports": {
-    "hello": [
-      {
-        "modules": {},
-        "imports": {},
-        "stubs": {},
-        "program_scopes": {}
-      },
-      {
-        "lo": 0,
-        "hi": 18
-      }
-    ]
+    "hello": {
+      "lo": 0,
+      "hi": 18
+    }
   },
   "stubs": {},
   "program_scopes": {

--- a/tests/expectations/parser/program/import.out
+++ b/tests/expectations/parser/program/import.out
@@ -1,18 +1,10 @@
 {
   "modules": {},
   "imports": {
-    "hello": [
-      {
-        "modules": {},
-        "imports": {},
-        "stubs": {},
-        "program_scopes": {}
-      },
-      {
-        "lo": 0,
-        "hi": 18
-      }
-    ]
+    "hello": {
+      "lo": 0,
+      "hi": 18
+    }
   },
   "stubs": {},
   "program_scopes": {


### PR DESCRIPTION
This is a non-functional change. I'm simply changing all the functions in `conversions.rs` to be method on a new `ConversionContext` which contains the error handler and the node builder.

For my work on reworking program imports, I need to add more things to the `ConversionContext` so this PR is a preparation for that. Regardless, I think this is a cleaner way of doing things anyways.

I also removed `Program` from import nodes since they are not used and I planned on removing them in my other PR anyways.