### PR TITLE
Explicit intrinsic disambiguation

### DIFF
--- a/compiler/ast/src/interpreter_value/intrinsic.rs
+++ b/compiler/ast/src/interpreter_value/intrinsic.rs
@@ -254,8 +254,7 @@ pub fn evaluate_intrinsic(
             helper.set_signer(private_key)?;
             Value::make_unit()
         }
-        Intrinsic::Get => {
-            // TODO handle vector get
+        Intrinsic::MappingGet => {
             let key = helper.pop_value().expect_tc(span)?;
             let (program, name) = match &arguments[0] {
                 Expression::Path(path) => (None, path.identifier().name),
@@ -264,8 +263,7 @@ pub fn evaluate_intrinsic(
             };
             helper.mapping_get(program, name, &key).expect_tc(span)?.clone()
         }
-        Intrinsic::Set => {
-            // TODO handle vector set
+        Intrinsic::MappingSet => {
             let value = helper.pop_value().expect_tc(span)?;
             let key = helper.pop_value().expect_tc(span)?;
             let (program, name) = match &arguments[0] {
@@ -318,6 +316,8 @@ pub fn evaluate_intrinsic(
         | Intrinsic::VectorLen
         | Intrinsic::VectorClear
         | Intrinsic::VectorPop
+        | Intrinsic::VectorGet
+        | Intrinsic::VectorSet
         | Intrinsic::VectorSwapRemove
         | Intrinsic::SelfAddress
         | Intrinsic::SelfCaller

--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -153,6 +153,8 @@ impl Compiler {
 
         self.do_pass::<TypeChecking>(type_checking_config.clone())?;
 
+        self.do_pass::<Disambiguate>(())?;
+
         self.do_pass::<ProcessingAsync>(type_checking_config.clone())?;
 
         self.do_pass::<StaticAnalyzing>(())?;

--- a/compiler/passes/src/disambiguate.rs
+++ b/compiler/passes/src/disambiguate.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2019-2025 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{CompilerState, Pass};
+
+use leo_ast::*;
+use leo_errors::Result;
+use leo_span::{Symbol, sym};
+
+/// Pass that turns ambiguous calls into their proper form after type checking
+/// such as get and set for mappings/vectors
+pub struct Disambiguate;
+
+impl Pass for Disambiguate {
+    type Input = ();
+    type Output = ();
+
+    const NAME: &str = "Disambiguate";
+
+    fn do_pass(_input: Self::Input, state: &mut crate::CompilerState) -> Result<Self::Output> {
+        let mut ast = std::mem::take(&mut state.ast);
+        let mut visitor = DisambiguateVisitor { state };
+        ast.ast = visitor.reconstruct_program(ast.ast);
+        visitor.state.handler.last_err()?;
+        visitor.state.ast = ast;
+        Ok(())
+    }
+}
+
+pub struct DisambiguateVisitor<'state> {
+    pub state: &'state mut CompilerState,
+}
+
+impl ProgramReconstructor for DisambiguateVisitor<'_> {}
+
+impl AstReconstructor for DisambiguateVisitor<'_> {
+    type AdditionalInput = ();
+    type AdditionalOutput = ();
+
+    fn reconstruct_intrinsic(
+        &mut self,
+        mut input: IntrinsicExpression,
+        _additional: &Self::AdditionalInput,
+    ) -> (Expression, Self::AdditionalOutput) {
+        input.arguments = input.arguments.into_iter().map(|arg| self.reconstruct_expression(arg, &()).0).collect();
+
+        if input.name == Symbol::intern("__unresolved_get") {
+            match self.state.type_table.get(&input.arguments[0].id()) {
+                Some(Type::Vector(..)) => {
+                    input.name = sym::_vector_get;
+                }
+                Some(Type::Mapping(..)) => {
+                    input.name = sym::_mapping_get;
+                }
+                _ => {
+                    panic!("type checking should guarantee that no other type is expected here.")
+                }
+            }
+        } else if input.name == Symbol::intern("__unresolved_set") {
+            match self.state.type_table.get(&input.arguments[0].id()) {
+                Some(Type::Vector(..)) => {
+                    input.name = sym::_vector_set;
+                }
+                Some(Type::Mapping(..)) => {
+                    input.name = sym::_mapping_set;
+                }
+                _ => {
+                    panic!("type checking should guarantee that no other type is expected here.")
+                }
+            }
+        }
+
+        (input.into(), ())
+    }
+}

--- a/compiler/passes/src/lib.rs
+++ b/compiler/passes/src/lib.rs
@@ -41,6 +41,9 @@ pub use dead_code_elimination::*;
 mod destructuring;
 pub use destructuring::*;
 
+mod disambiguate;
+pub use disambiguate::*;
+
 mod flattening;
 pub use flattening::*;
 

--- a/compiler/passes/src/test_passes.rs
+++ b/compiler/passes/src/test_passes.rs
@@ -119,72 +119,84 @@ macro_rules! compiler_passes {
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (CommonSubexpressionEliminating, ())
             ]),
             (const_prop_unroll_and_morphing_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (ConstPropUnrollAndMorphing, (TypeCheckingInput::new(NetworkName::TestnetV0)))
             ]),
             (destructuring_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (Destructuring, ())
             ]),
             (dead_code_elimination_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (DeadCodeEliminating, ())
             ]),
             (flattening_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (Flattening, ())
             ]),
             (function_inlining_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (FunctionInlining, ())
             ]),
             (option_lowering_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (OptionLowering, (TypeCheckingInput::new(NetworkName::TestnetV0)))
             ]),
             (processing_async_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (ProcessingAsync, (TypeCheckingInput::new(NetworkName::TestnetV0)))
             ]),
             (processing_script_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (ProcessingScript, ())
             ]),
             (ssa_forming_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (SsaForming, (SsaFormingInput { rename_defs: true }))
             ]),
             (storage_lowering_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (StorageLowering, (TypeCheckingInput::new(NetworkName::TestnetV0)))
             ]),
             (write_transforming_runner, [
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (WriteTransforming, ())
             ]),
             (remove_unreachable_runner, [
@@ -194,8 +206,15 @@ macro_rules! compiler_passes {
                 (PathResolution, ()),
                 (SymbolTableCreation, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
                 (SsaForming, (SsaFormingInput { rename_defs: true })),
                 (SsaConstPropagation, ()),
+            ]),
+            (disambiguate_runner, [
+                (PathResolution, ()),
+                (SymbolTableCreation, ()),
+                (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
+                (Disambiguate, ()),
             ]),
         }
     };

--- a/interpreter/src/cursor.rs
+++ b/interpreter/src/cursor.rs
@@ -1009,18 +1009,24 @@ impl Cursor {
                 )))
             }
             Expression::Intrinsic(intr) if step == 0 => {
-                let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) else {
-                    halt!(intr.span(), "Unkown intrinsic {}", intr.name);
+                let intrinsic = if intr.name == Symbol::intern("__unresolved_get") {
+                    Intrinsic::MappingGet
+                } else if intr.name == Symbol::intern("__unresolved_set") {
+                    Intrinsic::MappingSet
+                } else if let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) {
+                    intrinsic
+                } else {
+                    halt!(intr.span(), "Unknown intrinsic {}", intr.name);
                 };
 
                 // We want to push expressions for each of the arguments... except for mappings,
                 // because we don't look them up as Values.
                 match intrinsic {
-                    Intrinsic::Get | Intrinsic::MappingRemove | Intrinsic::MappingContains => {
+                    Intrinsic::MappingGet | Intrinsic::MappingRemove | Intrinsic::MappingContains => {
                         push!()(&intr.arguments[1], &None);
                         None
                     }
-                    Intrinsic::MappingGetOrUse | Intrinsic::Set => {
+                    Intrinsic::MappingGetOrUse | Intrinsic::MappingSet => {
                         push!()(&intr.arguments[2], &None);
                         push!()(&intr.arguments[1], &None);
                         None
@@ -1072,8 +1078,14 @@ impl Cursor {
                 }
             }
             Expression::Intrinsic(intr) if step == 1 => {
-                let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) else {
-                    halt!(intr.span(), "Unkown intrinsic {}", intr.name);
+                let intrinsic = if intr.name == Symbol::intern("__unresolved_get") {
+                    Intrinsic::MappingGet
+                } else if intr.name == Symbol::intern("__unresolved_set") {
+                    Intrinsic::MappingSet
+                } else if let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) {
+                    intrinsic
+                } else {
+                    halt!(intr.span(), "Unknown intrinsic {}", intr.name);
                 };
 
                 let span = intr.span();
@@ -1117,8 +1129,14 @@ impl Cursor {
                 }
             }
             Expression::Intrinsic(intr) if step == 2 => {
-                let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) else {
-                    halt!(intr.span(), "Unkown intrinsic {}", intr.name);
+                let intrinsic = if intr.name == Symbol::intern("__unresolved_get") {
+                    Intrinsic::MappingGet
+                } else if intr.name == Symbol::intern("__unresolved_set") {
+                    Intrinsic::MappingSet
+                } else if let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) {
+                    intrinsic
+                } else {
+                    halt!(intr.span(), "Unknown intrinsic {}", intr.name);
                 };
                 assert!(intrinsic == Intrinsic::FutureAwait);
                 Some(Value::make_unit())

--- a/tests/expectations/parser/program/async_basic.out
+++ b/tests/expectations/parser/program/async_basic.out
@@ -307,7 +307,7 @@
                   "Expression": {
                     "expression": {
                       "Intrinsic": {
-                        "name": "__unresolved_set",
+                        "name": "_mapping_set",
                         "type_parameters": [],
                         "arguments": [
                           {

--- a/tests/expectations/parser/program/external_mapping.out
+++ b/tests/expectations/parser/program/external_mapping.out
@@ -143,7 +143,7 @@
                   "Expression": {
                     "expression": {
                       "Intrinsic": {
-                        "name": "__unresolved_set",
+                        "name": "_mapping_set",
                         "type_parameters": [],
                         "arguments": [
                           {
@@ -341,7 +341,7 @@
                     },
                     "value": {
                       "Intrinsic": {
-                        "name": "__unresolved_get",
+                        "name": "_mapping_get",
                         "type_parameters": [],
                         "arguments": [
                           {

--- a/tests/expectations/passes/disambiguate/simple_async.out
+++ b/tests/expectations/passes/disambiguate/simple_async.out
@@ -1,0 +1,9 @@
+program test.aleo {
+    mapping foo: u32 => u32;
+    async transition main(x: u32, y: u32) -> Future<Fn()> {
+        return async {
+            let a = _mapping_get(foo, x);
+            _mapping_set(foo, x, y);
+        };
+    }
+}

--- a/tests/expectations/passes/disambiguate/vector_ops.out
+++ b/tests/expectations/passes/disambiguate/vector_ops.out
@@ -1,0 +1,35 @@
+program singleton_storage.aleo {
+    async transition push() -> Future<Fn()> {
+        return async {
+            _vector_push(vec, 42u8);
+        };
+    }
+    async transition pop() -> Future<Fn()> {
+        return async {
+            let x = _vector_pop(vec);
+            assert(x != none);
+        };
+    }
+    async transition get() -> Future<Fn()> {
+        return async {
+            let x = _vector_get(vec, 3u32);
+            assert(x != none);
+        };
+    }
+    async transition clear() -> Future<Fn()> {
+        return async {
+            _vector_clear(vec);
+        };
+    }
+    async transition swap_remove() -> Future<Fn()> {
+        return async {
+            let x = _vector_swap_remove(vec, 3u32);
+            assert(x >= 0);
+        };
+    }
+    async transition set() -> Future<Fn()> {
+        return async {
+            _vector_set(vec, 3u32, 42u8);
+        };
+    }
+}

--- a/tests/expectations/passes/processing_async/simple_async.out
+++ b/tests/expectations/passes/processing_async/simple_async.out
@@ -4,6 +4,6 @@ program test.aleo {
         return ::main$0(::x, ::y);
     }
     async function main$0(x: u32, y: u32) {
-        __unresolved_set(foo, ::x, ::y);
+        _mapping_set(foo, ::x, ::y);
     }
 }

--- a/tests/tests/passes/disambiguate/simple_async.leo
+++ b/tests/tests/passes/disambiguate/simple_async.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    mapping foo: u32 => u32;
+    async transition main(x: u32, y: u32) -> Future {
+        return async {
+            let a = foo.get(x);
+            foo.set(x, y);
+        };
+    }
+}

--- a/tests/tests/passes/disambiguate/vector_ops.leo
+++ b/tests/tests/passes/disambiguate/vector_ops.leo
@@ -1,0 +1,44 @@
+program singleton_storage.aleo {
+    storage counter: u8;
+    
+    storage vec: [u8];
+
+    async transition push() -> Future {
+        return async {
+            vec.push(42u8);
+        };
+    }
+
+    async transition pop() -> Future {
+        return async {
+            let x = vec.pop();
+            assert(x != none);
+        };
+    }
+
+    async transition get() -> Future {
+        return async {
+            let x = vec.get(3u32);
+            assert(x != none);
+        };
+    }
+
+    async transition clear() -> Future {
+        return async {
+            vec.clear();
+        };
+    }
+
+    async transition swap_remove() -> Future {
+        return async {
+            let x = vec.swap_remove(3u32);
+            assert(x >= 0);
+        };
+    }
+
+    async transition set() -> Future {
+        return async {
+            vec.set(3u32, 42u8);
+        };
+    }
+}


### PR DESCRIPTION
Add an explicit step to disambiguate `.get` and `.set` instrinsics after the first type checking simplifying intrinsic processing and making it more accurate in further steps.

Closes #29045