### PR TITLE
Cleanup Cargo.toml files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ebd144c81671193ed85aa2db9bb5e183421843e0485de8fffc07e5cf50e18a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "syn 1.0.109",
 ]
 
@@ -81,7 +81,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f6ff9e4c36858fa2c29e5284b77527b5a7466743976e1ba1f5824e16683545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "syn 1.0.109",
 ]
 
@@ -211,8 +211,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -262,9 +262,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
@@ -319,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90f7deecfac93095eb874a40febd69427776e24e1bd7f87f33ac62d6f0174df"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -390,9 +390,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -412,9 +412,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -425,9 +425,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -435,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -453,15 +453,15 @@ checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "color-backtrace"
@@ -491,11 +491,11 @@ dependencies = [
 
 [[package]]
 name = "colored"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -533,9 +533,9 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
@@ -654,7 +654,7 @@ dependencies = [
  "mio",
  "parking_lot",
  "rustix 0.38.44",
- "signal-hook",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -671,8 +671,8 @@ dependencies = [
  "document-features",
  "mio",
  "parking_lot",
- "rustix 1.1.2",
- "signal-hook",
+ "rustix 1.1.3",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.85+curl-8.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
 dependencies = [
  "cc",
  "libc",
@@ -778,15 +778,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -794,27 +794,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "strsim",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -843,7 +842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "syn 1.0.109",
 ]
 
@@ -854,30 +853,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "derive_more"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -944,8 +943,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1071,8 +1070,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1131,9 +1130,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fixedbitset"
@@ -1143,9 +1142,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1191,21 +1190,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
 ]
 
 [[package]]
@@ -1259,7 +1243,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -1281,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1292,9 +1275,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1332,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1660,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -1695,15 +1678,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1714,9 +1697,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -1748,15 +1731,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1795,6 +1778,7 @@ dependencies = [
  "itertools 0.14.0",
  "lalrpop-util 0.22.2",
  "petgraph",
+ "pico-args",
  "regex",
  "regex-syntax",
  "sha3",
@@ -1819,6 +1803,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
+ "regex-automata",
  "rustversion",
 ]
 
@@ -1861,6 +1846,7 @@ dependencies = [
  "leo-span",
  "leo-test-framework",
  "rand_chacha",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
@@ -1900,7 +1886,7 @@ version = "3.4.0"
 dependencies = [
  "chrono",
  "colored 2.2.0",
- "crossterm 0.28.1",
+ "crossterm 0.29.0",
  "dialoguer",
  "indexmap",
  "itertools 0.13.0",
@@ -1948,7 +1934,6 @@ dependencies = [
  "leo-package",
  "leo-span",
  "libc",
- "nix",
  "num-format",
  "once_cell",
  "parking_lot",
@@ -1962,7 +1947,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
- "signal-hook",
+ "signal-hook 0.4.1",
  "snarkvm",
  "sys-info",
  "tempfile",
@@ -1972,7 +1957,7 @@ dependencies = [
  "walkdir",
  "which",
  "winapi",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2064,15 +2049,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df15f6eac291ed1cf25865b1ee60399f57e7c227e7f51bdbd4c5270396a9ed50"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
@@ -2148,10 +2133,10 @@ dependencies = [
  "fnv",
  "lazy_static",
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2174,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.2"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96051b46fc183dc9cd4a223960ef37b9af631b55191852a8274bfef064cda20f"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -2298,8 +2283,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2404,8 +2389,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2481,6 +2466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,9 +2501,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "potential_utf"
@@ -2546,9 +2537,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -2570,9 +2561,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -2610,7 +2601,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2678,7 +2669,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -2714,9 +2705,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "reqwest"
-version = "0.12.26"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4c14b2d9afca6a60277086b0cc6a6ae0b568f6f7916c943a8cdc79f8be240f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -2772,7 +2763,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2801,9 +2792,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
@@ -2829,9 +2820,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -2842,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "log",
  "once_cell",
@@ -2857,18 +2848,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2883,9 +2874,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "same-file"
@@ -3038,22 +3029,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3070,11 +3061,12 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
 dependencies = [
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
@@ -3084,13 +3076,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3146,6 +3138,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a37d01603c37b5466f808de79f845c7116049b0579adb70a6b7d47c1fa3a952"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-mio"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,15 +3155,16 @@ checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
- "signal-hook",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -3252,7 +3255,7 @@ dependencies = [
  "snarkvm-fields",
  "snarkvm-parameters",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3650,7 +3653,7 @@ dependencies = [
  "serde",
  "snarkvm-fields",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3666,7 +3669,7 @@ dependencies = [
  "rayon",
  "serde",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -3678,7 +3681,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap",
- "lru 0.16.2",
+ "lru 0.16.3",
  "parking_lot",
  "rand",
  "rand_chacha",
@@ -3693,7 +3696,7 @@ dependencies = [
  "snarkvm-ledger-store",
  "snarkvm-synthesizer",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tracing",
 ]
@@ -3839,7 +3842,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "indexmap",
- "lru 0.16.2",
+ "lru 0.16.3",
  "parking_lot",
  "rand",
  "rand_chacha",
@@ -3856,9 +3859,9 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.0#990f61
 dependencies = [
  "aleo-std",
  "anyhow",
- "colored 3.0.0",
+ "colored 3.1.1",
  "indexmap",
- "lru 0.16.2",
+ "lru 0.16.3",
  "parking_lot",
  "rand",
  "rand_chacha",
@@ -3921,7 +3924,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "cfg-if",
- "colored 3.0.0",
+ "colored 3.1.1",
  "curl",
  "hex",
  "lazy_static",
@@ -3932,7 +3935,7 @@ dependencies = [
  "sha2",
  "snarkvm-curves",
  "snarkvm-utilities",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3944,7 +3947,7 @@ dependencies = [
  "anyhow",
  "indexmap",
  "itertools 0.14.0",
- "lru 0.16.2",
+ "lru 0.16.3",
  "parking_lot",
  "rand",
  "rayon",
@@ -3973,7 +3976,7 @@ version = "4.4.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.0#990f618ad12d85ade7d05dd3595173396751f52c"
 dependencies = [
  "aleo-std",
- "colored 3.0.0",
+ "colored 3.1.1",
  "indexmap",
  "parking_lot",
  "rand",
@@ -4031,7 +4034,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "colored 3.0.0",
+ "colored 3.1.1",
  "num-bigint",
  "num_cpus",
  "rand",
@@ -4041,7 +4044,7 @@ dependencies = [
  "serde_json",
  "smol_str",
  "snarkvm-utilities-derives",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "zeroize",
 ]
@@ -4052,8 +4055,8 @@ version = "4.4.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.0#990f618ad12d85ade7d05dd3595173396751f52c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4123,9 +4126,9 @@ checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "rustversion",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4152,18 +4155,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "unicode-ident",
 ]
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
+ "quote 1.0.43",
  "unicode-ident",
 ]
 
@@ -4192,8 +4195,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4229,14 +4232,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -4269,11 +4272,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -4283,19 +4286,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4309,30 +4312,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4374,9 +4377,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -4408,9 +4411,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4421,9 +4424,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4466,9 +4469,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -4482,15 +4485,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4620,9 +4623,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4699,18 +4702,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4721,11 +4724,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4734,41 +4738,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
- "quote 1.0.42",
+ "quote 1.0.43",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4786,9 +4790,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4856,8 +4860,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4867,8 +4871,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5073,9 +5077,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -5101,29 +5105,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5142,8 +5146,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -5158,13 +5162,13 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5196,8 +5200,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.42",
- "syn 2.0.111",
+ "quote 1.0.43",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -5213,7 +5217,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "zopfli",
 ]
@@ -5225,8 +5229,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dba6063ff82cdbd9a765add16d369abe81e520f836054e997c2db217ceca40c0"
 dependencies = [
  "ed25519-dalek",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,125 +44,6 @@ members = [
   "utils/disassembler"
 ]
 
-[workspace.dependencies.leo-ast]
-path = "./compiler/ast"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-compiler]
-path = "./compiler/compiler"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-disassembler]
-path = "./utils/disassembler"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-errors]
-path = "./errors"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-interpreter]
-path = "./interpreter"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-package]
-path = "./leo/package"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-parser]
-path = "./compiler/parser"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-parser-lossless]
-path = "./compiler/parser-lossless"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-passes]
-path = "./compiler/passes"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-span]
-path = "./compiler/span"
-version = "=3.4.0"
-
-[workspace.dependencies.leo-test-framework]
-path = "./test-framework"
-version = "=3.4.0"
-
-[workspace.dependencies.aleo-std]
-version = "1.0.1"
-default-features = false
-
-[workspace.dependencies.anyhow]
-version = "1.0"
-
-[workspace.dependencies.base62]
-version = "2.2.1"
-
-[workspace.dependencies.colored]
-version = "2.0"
-
-[workspace.dependencies.indexmap]
-version = "2.6"
-features = [ "serde" ]
-
-[workspace.dependencies.itertools]
-version = "0.13.0"
-
-[workspace.dependencies.paste]
-version = "1.0"
-
-[workspace.dependencies.rand]
-version = "0.8"
-default-features = false
-
-[workspace.dependencies.rand_chacha]
-version = "0.3.0"
-default-features = false
-
-[workspace.dependencies.rayon]
-version = "1.11.0"
-
-[workspace.dependencies.regex]
-version = "1.11.1"
-
-[workspace.dependencies.self_update]
-version = "0.41.0"
-features = [ "archive-zip", "compression-zip-deflate" ]
-
-[workspace.dependencies.serde]
-version = "1.0.214"
-features = [ "derive", "rc" ]
-
-[workspace.dependencies.serde_json]
-version = "1.0"
-features = [ "preserve_order" ]
-
-[workspace.dependencies.serial_test]
-version = "3.1.1"
-
-[workspace.dependencies.sha2]
-version = "0.10.9"
-
-[workspace.dependencies.snarkvm]
-git = "https://github.com/ProvableHQ/snarkVM.git"
-tag = "canary-v4.5.0"
-features = [ "test_consensus_heights" ]
-
-[workspace.dependencies.tempfile]
-version = "3.13"
-
-[workspace.dependencies.tracing]
-version = "0.1"
-
-[workspace.dependencies.ureq]
-version = "3.0.12"
-
-[workspace.dependencies.walkdir]
-version = "2.5"
-
-[workspace.dependencies.which]
-version = "4.4"
-
 [lib]
 path = "leo/lib.rs"
 
@@ -180,166 +61,130 @@ ci_skip = [ "leo-compiler/ci_skip" ]
 noconfig = [ ]
 only_testnet = [ ]
 
-[dependencies.leo-ast]
-workspace = true
+[workspace.dependencies]
+# leo dependencies
+leo-ast             = { path = "./compiler/ast",              version = "=3.4.0" }
+leo-compiler        = { path = "./compiler/compiler",         version = "=3.4.0" }
+leo-disassembler    = { path = "./utils/disassembler",        version = "=3.4.0" }
+leo-errors          = { path = "./errors",                    version = "=3.4.0" }
+leo-interpreter     = { path = "./interpreter",               version = "=3.4.0" }
+leo-package         = { path = "./leo/package",               version = "=3.4.0" }
+leo-parser          = { path = "./compiler/parser",           version = "=3.4.0" }
+leo-parser-lossless = { path = "./compiler/parser-lossless",  version = "=3.4.0" }
+leo-passes          = { path = "./compiler/passes",           version = "=3.4.0" }
+leo-span            = { path = "./compiler/span",             version = "=3.4.0" }
+leo-test-framework  = { path = "./test-framework",            version = "=3.4.0" }
+# third party dependencies
+aleo-std           = { version = "1.0", default-features = false }
+aleo-std-storage   = "1.0"
+anyhow             = "1.0"
+backtrace          = "0.3"
+base62             = "2.2"
+chrono             = "0.4"
+clap               = { version = "4.5", features = [ "derive", "env", "color", "unstable-styles" ] }
+color-backtrace    = "0.6"
+colored            = "2.0"
+crossbeam-channel  = "0.5"
+crossterm          = "0.29"
+ctrlc              = "3.4"
+derivative         = "2.2"
+dialoguer          = "0.11"
+dotenvy            = "0.15"
+dunce              = "1.0"
+fxhash             = "0.2.1"
+indexmap           = { version = "2.6", features = [ "serde" ] }
+itertools          = "0.13"
+lalrpop            = "0.22"
+lalrpop-util       = { version = "0.21", features = [ "unicode" ] }
+logos              = "0.15"
+num-format         = "0.4"
+num-traits         = "0.2.19"
+once_cell          = "1.21"
+parking_lot        = "0.12"
+paste              = "1.0"
+rand               = { version = "0.8", default-features = false }
+rand_chacha        = { version = "0.3", default-features = false }
+ratatui            = "0.29"
+rayon              = "1.11"
+regex              = "1.11"
+rpassword          = "7.4"
+scoped-tls         = "1.0"
+self_update        = { version = "0.41", features = [ "archive-zip", "compression-zip-deflate" ] }
+serde              = { version = "1.0", features = [ "derive", "rc" ] }
+serde_json         = { version = "1.0", features = [ "preserve_order" ] }
+serial_test        = "3.1"
+sha2               = "0.10"
+snarkvm            = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.0", features = [ "test_consensus_heights" ] }
+sys-info           = "0.9"
+tempfile           = "3.20"
+thiserror          = "1.0"
+tracing            = "0.1"
+tracing-subscriber = { version = "0.3", features = [ "fmt" ] }
+ureq               = { version = "3.0", features = [ "json" ] }
+walkdir            = "2.5"
+which              = "4.4"
 
-[dependencies.leo-compiler]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-ast           = { workspace = true }
+leo-compiler      = { workspace = true }
+leo-disassembler  = { workspace = true }
+leo-errors        = { workspace = true }
+leo-interpreter   = { workspace = true }
+leo-package       = { workspace = true }
+leo-span          = { workspace = true }
+# third party dependencies
+aleo-std           = { workspace = true }
+anyhow             = { workspace = true }
+backtrace          = { workspace = true }
+chrono             = { workspace = true }
+clap               = { workspace = true }
+colored            = { workspace = true }
+crossbeam-channel  = { workspace = true }
+crossterm          = { workspace = true }
+ctrlc              = { workspace = true }
+dialoguer          = { workspace = true }
+dotenvy            = { workspace = true }
+dunce              = { workspace = true }
+indexmap           = { workspace = true }
+itertools          = { workspace = true }
+num-format         = { workspace = true }
+once_cell          = { workspace = true }
+parking_lot        = { workspace = true }
+rand               = { workspace = true }
+rand_chacha        = { workspace = true }
+rayon              = { workspace = true }
+regex              = { workspace = true }
+rpassword          = { workspace = true }
+self_update        = { workspace = true }
+serde              = { workspace = true }
+serde_json         = { workspace = true }
+serial_test        = { workspace = true }
+sha2               = { workspace = true }
+snarkvm            = { workspace = true }
+sys-info           = { workspace = true }
+tempfile           = { workspace = true }
+tracing            = { workspace = true }
+tracing-subscriber = { workspace = true }
+ureq               = { workspace = true }
+walkdir            = { workspace = true }
+which              = { workspace = true }
 
-[dependencies.leo-disassembler]
-workspace = true
+[dev-dependencies]
+regex = { workspace = true }
+which = { workspace = true }
 
-[dependencies.leo-errors]
-workspace = true
+[build-dependencies]
+walkdir = { workspace = true }
 
-[dependencies.leo-interpreter]
-workspace = true
+[target."cfg(unix)".dependencies]
+libc        = "0.2"
+signal-hook = { version = "0.4", features = [ "iterator" ] }
 
-[dependencies.leo-package]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.anyhow]
-workspace = true
-
-[dependencies.aleo-std]
-workspace = true
-
-[dependencies.backtrace]
-version = "0.3.74"
-
-[dependencies.chrono]
-version = "0.4.41"
-
-[dependencies.clap]
-version = "4.5"
-features = [ "derive", "env", "color", "unstable-styles" ]
-
-[dependencies.colored]
-workspace = true
-
-[dependencies.crossterm]
-version = "0.29.0"
-
-[dependencies.crossbeam-channel]
-version = "0.5.15"
-
-[dependencies.ctrlc]
-version = "3.4.7"
-
-[dependencies.dialoguer]
-version = "0.11.0"
-
-[dependencies.dotenvy]
-version = "0.15.7"
-
-[dependencies.dunce]
-version = "1.0.5"
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.itertools]
-workspace = true
-
-[dependencies.num-format]
-version = "0.4.4"
-
-[dependencies.once_cell]
-version = "1.21.3"
-
-[dependencies.parking_lot]
-version = "0.12.1"
-
-[dependencies.rand]
-workspace = true
-
-[dependencies.rayon]
-workspace = true
-
-[dependencies.rand_chacha]
-workspace = true
-
-[dependencies.regex]
-workspace = true
-
-[dependencies.rpassword]
-version = "7.4.0"
-
-[dependencies.self_update]
-workspace = true
-
-[dependencies.serde]
-workspace = true
-
-[dependencies.serde_json]
-workspace = true
-
-[dependencies.serial_test]
-workspace = true
-
-[dependencies.sha2]
-workspace = true
-
-[dependencies.snarkvm]
-workspace = true
-features = [ "circuit", "console" ]
-
-[dependencies.sys-info]
-version = "0.9.1"
-
-[dependencies.tempfile]
-version = "3.20.0"
-
-[dependencies.tracing]
-workspace = true
-
-[dependencies.tracing-subscriber]
-version = "0.3.18"
-features = [ "fmt" ]
-
-[dependencies.ureq]
-workspace = true
-features = [ "json" ]
-
-[dependencies.walkdir]
-workspace = true
-
-[dev-dependencies.regex]
-workspace = true
-
-[dev-dependencies.which]
-workspace = true
-
-[target."cfg(unix)".dependencies.nix]
-version = "0.30.1"
-features = [ "process", "term", "fs", "poll" ]
-
-[target."cfg(unix)".dependencies.libc]
-version = "0.2.174"
-
-[target."cfg(unix)".dependencies.signal-hook]
-version = "0.3.17"
-features = [ "iterator" ]
-
-[target."cfg(windows)".dependencies.winapi]
-version = "0.3.9"
-
-[target."cfg(windows)".dependencies.ansi_term]
-version = "0.12.1"
-
-[target."cfg(windows)".dependencies.windows-sys]
-version = "0.59"
-features = [
-  "Win32_Foundation",
-  "Win32_System_Threading",
-  "Win32_System_JobObjects"
-]
-
-[build-dependencies.walkdir]
-workspace = true
+[target."cfg(windows)".dependencies]
+winapi      = "0.3"
+ansi_term   = "0.12"
+windows-sys = { version = "0.61", features = [ "Win32_Foundation", "Win32_System_Threading", "Win32_System_JobObjects" ] }
 
 [profile.release]
 opt-level = 3

--- a/compiler/ast/Cargo.toml
+++ b/compiler/ast/Cargo.toml
@@ -17,36 +17,20 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.snarkvm]
-workspace = true
-
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.anyhow]
-workspace = true
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.itertools]
-workspace = true
-
-[dependencies.rand]
-workspace = true
-
-[dependencies.rand_chacha]
-workspace = true
-
-[dependencies.serde]
-workspace = true
-
-[dependencies.serde_json]
-workspace = true
-
 [features]
 default = [ ]
 ci_skip = [ ]
+
+[dependencies]
+# leo dependencies
+leo-errors      = { workspace = true }
+leo-span        = { workspace = true }
+# third party dependencies
+anyhow          = { workspace = true }
+indexmap        = { workspace = true }
+itertools       = { workspace = true }
+rand            = { workspace = true }
+rand_chacha     = { workspace = true }
+serde           = { workspace = true }
+serde_json      = { workspace = true }
+snarkvm         = { workspace = true }

--- a/compiler/compiler/Cargo.toml
+++ b/compiler/compiler/Cargo.toml
@@ -17,69 +17,38 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[build-dependencies.walkdir]
-workspace = true
-
-[dependencies.leo-ast]
-workspace = true
-
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.leo-passes]
-workspace = true
-
-[dependencies.leo-parser]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.anyhow]
-workspace = true
-
-[dependencies.aleo-std]
-workspace = true
-
-[dependencies.aleo-std-storage]
-version = "1.0"
-
-[dependencies.rand_chacha]
-workspace = true
-
-[dependencies.snarkvm]
-workspace = true
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.serde_json]
-workspace = true
-
-[dependencies.walkdir]
-workspace = true
-
-[dev-dependencies.leo-disassembler]
-path = "../../utils/disassembler"
-
-[dev-dependencies.leo-test-framework]
-workspace = true
-
-[dev-dependencies.itertools]
-workspace = true
-
-[dev-dependencies.snarkvm]
-workspace = true
-
-[dev-dependencies.serde]
-workspace = true
-
-[dev-dependencies.regex]
-workspace = true
-
-[dev-dependencies.serial_test]
-workspace = true
-
 [features]
 default = [ ]
 ci_skip = [ "leo-ast/ci_skip" ]
+
+[dependencies]
+# leo dependencies
+leo-ast           = { workspace = true }
+leo-errors        = { workspace = true }
+leo-passes        = { workspace = true }
+leo-parser        = { workspace = true }
+leo-span          = { workspace = true }
+# third party dependencies
+aleo-std          = { workspace = true }
+aleo-std-storage  = { workspace = true }
+anyhow            = { workspace = true }
+indexmap          = { workspace = true }
+rand_chacha       = { workspace = true }
+rayon             = { workspace = true }
+snarkvm           = { workspace = true }
+serde_json        = { workspace = true }
+walkdir           = { workspace = true }
+
+[dev-dependencies]
+# leo dependencies
+leo-disassembler  = { workspace = true }
+leo-test-framework= { workspace = true }
+# third party dependencies
+itertools         = { workspace = true }
+regex             = { workspace = true }
+serde             = { workspace = true }
+serial_test       = { workspace = true }
+snarkvm           = { workspace = true }
+
+[build-dependencies]
+walkdir           = { workspace = true }

--- a/compiler/parser-lossless/Cargo.toml
+++ b/compiler/parser-lossless/Cargo.toml
@@ -17,25 +17,16 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.leo-span]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-errors      = { workspace = true }
+leo-span        = { workspace = true }
+# third party dependencies
+itertools       = { workspace = true }
+lalrpop-util    = { workspace = true }
+logos           = { workspace = true }
+regex           = { workspace = true }
 
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.itertools]
-workspace = true
-
-[dependencies.lalrpop-util]
-version = "0.21.0"
-features = [ "unicode" ]
-
-[dependencies.logos]
-version = "0.15.0"
-
-[dependencies.regex]
-workspace = true
-
-[build-dependencies.lalrpop]
-version = "0.22.2"
-default-features = false
+[build-dependencies]
+# third party dependencies
+lalrpop = { workspace = true }

--- a/compiler/parser/Cargo.toml
+++ b/compiler/parser/Cargo.toml
@@ -17,35 +17,21 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.leo-ast]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-ast             = { workspace = true }
+leo-errors          = { workspace = true }
+leo-parser-lossless = { workspace = true }
+leo-span            = { workspace = true }
+# third party dependencies
+indexmap            = { workspace = true }
+itertools           = { workspace = true }
+snarkvm             = { workspace = true }
 
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.leo-parser-lossless]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.snarkvm]
-workspace = true
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.itertools]
-workspace = true
-
-[dev-dependencies.serde]
-workspace = true
-
-[dev-dependencies.serde_json]
-workspace = true
-
-[dev-dependencies.serial_test]
-workspace = true
-
-[dev-dependencies.leo-test-framework]
-workspace = true
+[dev-dependencies]
+# leo dependencies
+leo-test-framework  = { workspace = true }
+# third party dependencies
+serde               = { workspace = true }
+serde_json          = { workspace = true }
+serial_test         = { workspace = true }

--- a/compiler/passes/Cargo.toml
+++ b/compiler/passes/Cargo.toml
@@ -20,56 +20,28 @@ edition = "2024"
 [lib]
 path = "src/lib.rs"
 
-[dependencies.anyhow]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-ast       = { workspace = true }
+leo-errors    = { workspace = true }
+leo-package   = { workspace = true }
+leo-span      = { workspace = true }
+# third party dependencies
+anyhow        = { workspace = true }
+base62        = { workspace = true }
+indexmap      = { workspace = true }
+itertools     = { workspace = true }
+num-traits    = { workspace = true }
+regex         = { workspace = true }
+sha2          = { workspace = true }
+serde         = { workspace = true }
+serde_json    = { workspace = true }
+snarkvm       = { workspace = true }
 
-[dependencies.base62]
-workspace = true
-
-[dependencies.snarkvm]
-workspace = true
-
-[dependencies.leo-ast]
-workspace = true
-
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.leo-package]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.itertools]
-workspace = true
-
-[dependencies.num-traits]
-version = "0.2.19"
-
-[dependencies.regex]
-workspace = true
-
-[dependencies.sha2]
-workspace = true
-
-[dependencies.serde]
-workspace = true
-
-[dependencies.serde_json]
-workspace = true
-
-[dev-dependencies.leo-test-framework]
-workspace = true
-
-[dev-dependencies.leo-parser]
-workspace = true
-
-[dev-dependencies.paste]
-workspace = true
-
-[dev-dependencies.serial_test]
-workspace = true
+[dev-dependencies]
+# leo dependencies
+leo-parser         = { workspace = true }
+leo-test-framework = { workspace = true }
+# third party dependencies
+paste              = { workspace = true }
+serial_test        = { workspace = true }

--- a/compiler/span/Cargo.toml
+++ b/compiler/span/Cargo.toml
@@ -17,14 +17,9 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.fxhash]
-version = "0.2.1"
-
-[dependencies.scoped-tls]
-version = "1.0.1"
-
-[dependencies.serde]
-workspace = true
+[dependencies]
+# third party dependencies
+fxhash       = { workspace = true }
+indexmap     = { workspace = true }
+scoped-tls   = { workspace = true }
+serde        = { workspace = true }

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -17,29 +17,15 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.anyhow]
-version = "1.0"
-
-[dependencies.backtrace]
-version = "0.3.74"
-
-[dependencies.colored]
-version = "2.0.4"
-
-[dependencies.color-backtrace]
-version = "0.6.1"
-
-[dependencies.derivative]
-version = "2.2.0"
-
-[dependencies.itertools]
-workspace = true
-
-[dependencies.serde]
-workspace = true
-
-[dependencies.thiserror]
-version = "1.0.65"
+[dependencies]
+# leo dependencies
+leo-span         = { workspace = true }
+# third party dependencies
+anyhow           = { workspace = true }
+backtrace        = { workspace = true }
+colored          = { workspace = true }
+color-backtrace  = { workspace = true }
+derivative       = { workspace = true }
+itertools        = { workspace = true }
+serde            = { workspace = true }
+thiserror        = { workspace = true }

--- a/interpreter/Cargo.toml
+++ b/interpreter/Cargo.toml
@@ -17,66 +17,31 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.snarkvm]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-ast       = { workspace = true }
+leo-errors    = { workspace = true }
+leo-parser    = { workspace = true }
+leo-span      = { workspace = true }
+# third party dependencies
+colored       = { workspace = true }
+crossterm     = { workspace = true }
+dialoguer     = { workspace = true, features = [ "history" ] }
+indexmap      = { workspace = true }
+itertools     = { workspace = true }
+rand          = { workspace = true }
+rand_chacha   = { workspace = true }
+ratatui       = { workspace = true }
+snarkvm       = { workspace = true }
 
-[dependencies.leo-ast]
-workspace = true
-
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.leo-parser]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.colored]
-workspace = true
-
-[dependencies.crossterm]
-version = "0.28.1"
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.dialoguer]
-version = "0.11.0"
-features = [ "history" ]
-
-[dependencies.rand]
-workspace = true
-
-[dependencies.rand_chacha]
-workspace = true
-
-[dependencies.ratatui]
-version = "0.29.0"
-
-[dependencies.itertools]
-workspace = true
-
-[dev-dependencies.leo-compiler]
-workspace = true
-
-[dev-dependencies.leo-disassembler]
-workspace = true
-
-[dev-dependencies.leo-test-framework]
-workspace = true
-
-[dev-dependencies.chrono]
-version = "0.4.41"
-
-[dev-dependencies.regex]
-workspace = true
-
-[dev-dependencies.serial_test]
-workspace = true
-
-[dev-dependencies.tempfile]
-workspace = true
-
-[dev-dependencies.walkdir]
-workspace = true
+[dev-dependencies]
+# leo dependencies
+leo-compiler       = { workspace = true }
+leo-disassembler   = { workspace = true }
+leo-test-framework = { workspace = true }
+# third party dependencies
+chrono             = { workspace = true }
+regex              = { workspace = true }
+serial_test        = { workspace = true }
+tempfile           = { workspace = true }
+walkdir            = { workspace = true }

--- a/leo/package/Cargo.toml
+++ b/leo/package/Cargo.toml
@@ -17,29 +17,15 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.leo-ast]
-workspace = true
-
-[dependencies.leo-errors]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.snarkvm]
-workspace = true
-
-[dependencies.indexmap]
-workspace = true
-
-[dependencies.serde]
-workspace = true
-
-[dependencies.serde_json]
-workspace = true
-
-[dependencies.tracing]
-workspace = true
-
-[dependencies.ureq]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-ast     = { workspace = true }
+leo-errors  = { workspace = true }
+leo-span    = { workspace = true }
+# third party dependencies
+indexmap    = { workspace = true }
+serde       = { workspace = true }
+serde_json  = { workspace = true }
+snarkvm     = { workspace = true }
+tracing     = { workspace = true }
+ureq        = { workspace = true }

--- a/test-framework/Cargo.toml
+++ b/test-framework/Cargo.toml
@@ -17,11 +17,10 @@ include = [ "Cargo.toml", "src", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
-[dependencies.rayon]
-workspace = true
-
-[dependencies.walkdir]
-workspace = true
-
 [features]
-no_parallel = [ ]
+no_parallel = []
+
+[dependencies]
+# third party dependencies
+rayon   = { workspace = true }
+walkdir = { workspace = true }

--- a/utils/disassembler/Cargo.toml
+++ b/utils/disassembler/Cargo.toml
@@ -20,14 +20,10 @@ edition = "2024"
 [lib]
 path = "src/lib.rs"
 
-[dependencies.snarkvm]
-workspace = true
-
-[dependencies.leo-ast]
-workspace = true
-
-[dependencies.leo-span]
-workspace = true
-
-[dependencies.leo-errors]
-workspace = true
+[dependencies]
+# leo dependencies
+leo-ast    = { workspace = true }
+leo-errors = { workspace = true }
+leo-span   = { workspace = true }
+# third party dependencies
+snarkvm    = { workspace = true }


### PR DESCRIPTION
- Condense `Cargo.toml` files by merging dependencies in table format.
- Change all dependencies to use `<major.minor>` version only to allow patch release to be retrieved when running `cargo update`.
- Run `cargo update`.
- Make sure all dependencies are workspace dependencies.