### PR TITLE
feat(leo-fmt): add formatter crate scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,6 +1881,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "leo-fmt"
+version = "3.4.0"
+dependencies = [
+ "anyhow",
+ "leo-errors",
+ "leo-parser-lossless",
+ "similar",
+ "walkdir",
+]
+
+[[package]]
 name = "leo-interpreter"
 version = "3.4.0"
 dependencies = [
@@ -3183,6 +3194,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
   "compiler/passes",
   "compiler/span",
   "errors",
+  "leo-fmt",
   "interpreter",
   "leo/package",
   "test-framework",
@@ -67,6 +68,7 @@ leo-ast             = { path = "./compiler/ast",              version = "=3.4.0"
 leo-compiler        = { path = "./compiler/compiler",         version = "=3.4.0" }
 leo-disassembler    = { path = "./utils/disassembler",        version = "=3.4.0" }
 leo-errors          = { path = "./errors",                    version = "=3.4.0" }
+leo-fmt             = { path = "./leo-fmt",                   version = "=3.4.0" }
 leo-interpreter     = { path = "./interpreter",               version = "=3.4.0" }
 leo-package         = { path = "./leo/package",               version = "=3.4.0" }
 leo-parser          = { path = "./compiler/parser",           version = "=3.4.0" }

--- a/leo-fmt/Cargo.toml
+++ b/leo-fmt/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "leo-fmt"
+version = "3.4.0"
+authors = [ "The Leo Team <leo@provable.com>" ]
+description = "Source code formatter for the Leo programming language"
+homepage = "https://leo-lang.org"
+repository = "https://github.com/ProvableHQ/leo"
+keywords = [
+  "formatter",
+  "code-formatter",
+  "leo",
+  "aleo"
+]
+categories = [ "development-tools", "command-line-utilities" ]
+include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
+license = "GPL-3.0"
+edition = "2024"
+rust-version = "1.92.0"
+
+[dependencies]
+leo-errors          = { workspace = true }
+leo-parser-lossless = { workspace = true }
+anyhow              = { workspace = true }
+
+[dev-dependencies]
+similar             = { version = "2.6" }
+walkdir             = { workspace = true }

--- a/leo-fmt/src/lib.rs
+++ b/leo-fmt/src/lib.rs
@@ -1,0 +1,103 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Leo source code formatter.
+//!
+//! This crate provides an opinionated, zero-configuration formatter for Leo source code.
+//! The formatter operates on the lossless syntax tree from `leo-parser-lossless` and
+//! produces consistently formatted code.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use leo_fmt::format_source;
+//!
+//! let source = "program test.aleo{transition main()->u64{return 1u64;}}";
+//! let formatted = format_source(source)?;
+//! ```
+
+mod output;
+
+use anyhow::{Context, Result};
+use leo_errors::Handler;
+use leo_parser_lossless::parse_main;
+
+/// Indentation string: 4 spaces.
+pub const INDENT: &str = "    ";
+
+/// Newline character.
+pub const NEWLINE: &str = "\n";
+
+/// Format Leo source code.
+///
+/// Takes Leo source code as input and returns formatted source code.
+/// Returns an error if the source code cannot be parsed.
+///
+/// # Guarantees
+///
+/// - **Idempotent**: `format_source(format_source(x)?) == format_source(x)?`
+/// - **Deterministic**: Same input always produces same output
+/// - **Parse-safe**: Formatted output always parses successfully
+/// - **Comment-preserving**: All comments are retained
+pub fn format_source(source: &str) -> Result<String> {
+    let handler = Handler::default();
+
+    // Verify the source parses successfully.
+    let _tree = parse_main(handler, source, 0).context("parse failed")?;
+
+    // TODO: Implement actual formatting in follow up PRs.
+    // For now, return the input unchanged (stub implementation).
+    let mut result = source.trim_end().to_string();
+    if !result.is_empty() {
+        result.push('\n');
+    }
+
+    Ok(result)
+}
+
+/// Check if source code is already formatted.
+///
+/// Returns `true` if the source code matches what the formatter would produce,
+/// `false` otherwise. Returns an error if the source code cannot be parsed.
+pub fn check_formatted(source: &str) -> Result<bool> {
+    let formatted = format_source(source)?;
+    Ok(source == formatted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "program test.aleo {}\n";
+
+    #[test]
+    fn valid_code_ok() {
+        assert!(format_source(VALID).is_ok());
+    }
+
+    #[test]
+    fn invalid_code_err() {
+        assert!(format_source("not valid leo").is_err());
+    }
+
+    #[test]
+    fn normalizes_trailing_newline() {
+        // Adds missing newline
+        assert!(format_source("program test.aleo {}").unwrap().ends_with('\n'));
+        // Removes extra newlines
+        assert!(format_source("program test.aleo {}\n\n\n").unwrap().ends_with("}\n"));
+    }
+}

--- a/leo-fmt/src/output.rs
+++ b/leo-fmt/src/output.rs
@@ -1,0 +1,209 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+
+//! Output buffer for building formatted source code.
+//!
+//! The `Output` struct manages indentation and newline handling automatically,
+//! allowing formatting code to focus on structure rather than whitespace details.
+
+use crate::{INDENT, NEWLINE};
+
+/// Output buffer for building formatted source code.
+///
+/// Handles indentation automatically when writing after a newline.
+/// Tracks whether we're at the start of a line to manage spacing correctly.
+pub struct Output {
+    /// The accumulated output string.
+    buf: String,
+    /// Current indentation depth (number of indentation levels).
+    depth: usize,
+    /// Whether we're at the start of a line (for auto-indentation).
+    at_line_start: bool,
+}
+
+impl Output {
+    /// Create a new empty output buffer.
+    pub fn new() -> Self {
+        Self { buf: String::new(), depth: 0, at_line_start: true }
+    }
+
+    /// Write text to the buffer.
+    ///
+    /// If we're at the start of a line, automatically inserts indentation first.
+    /// Empty strings are ignored.
+    pub fn write(&mut self, s: &str) {
+        if s.is_empty() {
+            return;
+        }
+        if self.at_line_start {
+            self.buf.push_str(&INDENT.repeat(self.depth));
+            self.at_line_start = false;
+        }
+        self.buf.push_str(s);
+    }
+
+    /// Write a single space (unless at line start).
+    ///
+    /// Spaces at the start of a line would be redundant since indentation
+    /// is handled automatically.
+    pub fn space(&mut self) {
+        if !self.at_line_start {
+            self.buf.push(' ');
+        }
+    }
+
+    /// Write a newline.
+    pub fn newline(&mut self) {
+        self.buf.push_str(NEWLINE);
+        self.at_line_start = true;
+    }
+
+    /// Ensure we're on a fresh line.
+    ///
+    /// If the buffer doesn't end with a newline, adds one.
+    /// If it already ends with a newline, does nothing.
+    pub fn ensure_newline(&mut self) {
+        if !self.buf.ends_with('\n') {
+            self.newline();
+        }
+    }
+
+    /// Increase the indentation level.
+    pub fn indent(&mut self) {
+        self.depth += 1;
+    }
+
+    /// Decrease the indentation level.
+    ///
+    /// Uses saturating subtraction to prevent underflow.
+    pub fn dedent(&mut self) {
+        self.depth = self.depth.saturating_sub(1);
+    }
+
+    /// Execute a closure with increased indentation.
+    ///
+    /// Automatically indents before calling the closure and dedents after,
+    /// even if the closure panics.
+    pub fn indented<F: FnOnce(&mut Self)>(&mut self, f: F) {
+        self.indent();
+        f(self);
+        self.dedent();
+    }
+
+    /// Consume the buffer and return the final formatted string.
+    ///
+    /// Ensures the output ends with exactly one trailing newline.
+    pub fn finish(mut self) -> String {
+        // Remove extra trailing newlines.
+        while self.buf.ends_with("\n\n") {
+            self.buf.pop();
+        }
+        // Ensure at least one trailing newline (if non-empty).
+        if !self.buf.ends_with('\n') && !self.buf.is_empty() {
+            self.buf.push('\n');
+        }
+        self.buf
+    }
+}
+
+impl Default for Output {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_and_space() {
+        assert_eq!(Output::new().finish(), "");
+
+        let mut out = Output::new();
+        out.write("");
+        out.write("a");
+        out.space();
+        out.write("b");
+        out.write("");
+        assert_eq!(out.finish(), "a b\n");
+
+        // Space at line start is ignored
+        let mut out = Output::new();
+        out.space();
+        out.write("x");
+        assert_eq!(out.finish(), "x\n");
+    }
+
+    #[test]
+    fn newlines() {
+        let mut out = Output::new();
+        out.write("a");
+        out.newline();
+        out.write("b");
+        assert_eq!(out.finish(), "a\nb\n");
+
+        // ensure_newline is idempotent
+        let mut out = Output::new();
+        out.write("x");
+        out.ensure_newline();
+        out.ensure_newline();
+        out.write("y");
+        assert_eq!(out.finish(), "x\ny\n");
+    }
+
+    #[test]
+    fn indentation() {
+        let mut out = Output::new();
+        out.write("L0");
+        out.newline();
+        out.indented(|out| {
+            out.write("L1");
+            out.newline();
+            out.indented(|out| {
+                out.write("L2");
+                out.newline();
+            });
+        });
+        out.write("L0");
+        assert_eq!(out.finish(), "L0\n    L1\n        L2\nL0\n");
+
+        // Dedent saturates at zero
+        let mut out = Output::new();
+        out.dedent();
+        out.dedent();
+        out.write("x");
+        assert_eq!(out.finish(), "x\n");
+    }
+
+    #[test]
+    fn finish_normalizes_trailing_newlines() {
+        // Adds missing newline
+        let mut out = Output::new();
+        out.write("x");
+        assert_eq!(out.finish(), "x\n");
+
+        // Removes extra newlines
+        let mut out = Output::new();
+        out.write("x");
+        out.newline();
+        out.newline();
+        out.newline();
+        assert_eq!(out.finish(), "x\n");
+    }
+}

--- a/leo-fmt/tests/harness.rs
+++ b/leo-fmt/tests/harness.rs
@@ -1,0 +1,167 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Test harness for the Leo formatter.
+//!
+//! Uses source/target file pairs (rustfmt-style) to test formatting:
+//! - `tests/source/*.leo` — unformatted input files
+//! - `tests/target/*.leo` — expected formatted output files
+//!
+//! Tests verify:
+//! 1. Source files format to match target files
+//! 2. Target files are idempotent (format to themselves)
+//! 3. Target files parse successfully
+
+use leo_errors::Handler;
+use leo_fmt::format_source;
+use similar::{ChangeTag, TextDiff};
+use std::path::{Path, PathBuf};
+use walkdir::WalkDir;
+
+/// Get the path to the tests directory.
+fn tests_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests")
+}
+
+/// Collect all .leo files in a directory.
+fn collect_leo_files(dir: &Path) -> Vec<PathBuf> {
+    if !dir.exists() {
+        return Vec::new();
+    }
+
+    WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|x| x == "leo"))
+        .map(|e| e.path().to_path_buf())
+        .collect()
+}
+
+/// Print a unified diff between expected and actual content.
+fn print_diff(expected: &str, actual: &str, file: &Path) {
+    let diff = TextDiff::from_lines(expected, actual);
+    println!("\n=== MISMATCH: {} ===", file.display());
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        print!("{sign}{change}");
+    }
+    println!("=== END ===\n");
+}
+
+/// Test that formatting source files produces the expected target files.
+///
+/// For each file in `tests/source/`, formats it and compares the result
+/// to the corresponding file in `tests/target/`.
+#[test]
+fn test_source_to_target() {
+    let source_dir = tests_dir().join("source");
+    let source_files = collect_leo_files(&source_dir);
+
+    let mut failures = Vec::new();
+
+    for source_path in source_files {
+        // Compute the corresponding target path.
+        let relative = source_path.strip_prefix(&source_dir).unwrap();
+        let target_path = tests_dir().join("target").join(relative);
+
+        // Read source (unformatted input).
+        let source = std::fs::read_to_string(&source_path)
+            .unwrap_or_else(|_| panic!("Failed to read source: {}", source_path.display()));
+
+        // Read target (expected output).
+        let expected = std::fs::read_to_string(&target_path)
+            .unwrap_or_else(|_| panic!("Missing target file: {}", target_path.display()));
+
+        // Format the source.
+        let actual = match format_source(&source) {
+            Ok(formatted) => formatted,
+            Err(e) => {
+                println!("Format failed for {}: {e}", source_path.display());
+                failures.push(source_path.clone());
+                continue;
+            }
+        };
+
+        // Compare.
+        if actual != expected {
+            print_diff(&expected, &actual, &source_path);
+            failures.push(source_path.clone());
+        }
+    }
+
+    assert!(failures.is_empty(), "{} test(s) failed: {failures:?}", failures.len());
+}
+
+/// Test that formatted files are idempotent.
+///
+/// Formatting a target file should produce identical output.
+/// This ensures the formatter's output is stable.
+#[test]
+fn test_idempotency() {
+    let target_dir = tests_dir().join("target");
+    let target_files = collect_leo_files(&target_dir);
+
+    let mut failures = Vec::new();
+
+    for target_path in target_files {
+        let input = std::fs::read_to_string(&target_path)
+            .unwrap_or_else(|_| panic!("Failed to read: {}", target_path.display()));
+
+        let output = match format_source(&input) {
+            Ok(formatted) => formatted,
+            Err(e) => {
+                println!("Format failed for {}: {e}", target_path.display());
+                failures.push(target_path.clone());
+                continue;
+            }
+        };
+
+        if input != output {
+            print_diff(&input, &output, &target_path);
+            failures.push(target_path.clone());
+        }
+    }
+
+    assert!(failures.is_empty(), "{} file(s) not idempotent: {failures:?}", failures.len());
+}
+
+/// Test that all target files parse successfully.
+///
+/// This ensures the formatter never produces invalid Leo code.
+#[test]
+fn test_parse_safety() {
+    let target_dir = tests_dir().join("target");
+    let target_files = collect_leo_files(&target_dir);
+
+    let mut failures = Vec::new();
+
+    for target_path in target_files {
+        let content = std::fs::read_to_string(&target_path)
+            .unwrap_or_else(|_| panic!("Failed to read: {}", target_path.display()));
+
+        let handler = Handler::default();
+        if leo_parser_lossless::parse_main(handler, &content, 0).is_err() {
+            println!("Parse failed for target file: {}", target_path.display());
+            failures.push(target_path.clone());
+        }
+    }
+
+    assert!(failures.is_empty(), "{} target file(s) don't parse: {failures:?}", failures.len());
+}

--- a/leo-fmt/tests/source/empty_program.leo
+++ b/leo-fmt/tests/source/empty_program.leo
@@ -1,0 +1,1 @@
+program test.aleo {}

--- a/leo-fmt/tests/source/minimal.leo
+++ b/leo-fmt/tests/source/minimal.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    transition main() -> u64 {
+        return 1u64;
+    }
+}

--- a/leo-fmt/tests/target/empty_program.leo
+++ b/leo-fmt/tests/target/empty_program.leo
@@ -1,0 +1,1 @@
+program test.aleo {}

--- a/leo-fmt/tests/target/minimal.leo
+++ b/leo-fmt/tests/target/minimal.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    transition main() -> u64 {
+        return 1u64;
+    }
+}


### PR DESCRIPTION
This PR introduces the `leo-fmt` crate, the foundation for `leo fmt` command support.

Adds:
- `Output` struct for managing indented output with automatic whitespace handling
- `format_source()` and `check_formatted()` public API (stub implementation for now)
- Test harness using rustfmt-style source/target file pairs
- Initial test fixtures (`empty_program.leo`, `minimal.leo`)

The formatter will be built incrementally in follow-up PRs, starting with declaration formatting.

Testing:
```
cargo test -p leo-fmt
```

Part of #28579