### PR TITLE
perf: avoid Vec allocation in async finalize lookup

### DIFF
--- a/compiler/passes/src/code_generation/program.rs
+++ b/compiler/passes/src/code_generation/program.rs
@@ -106,15 +106,13 @@ impl<'a> CodeGeneratingVisitor<'a> {
                             .finalizer
                             .unwrap();
                         // Write the finalize string.
+                        let [finalize_name] = &finalize.location.path[..] else {
+                            panic!("finalize location must have a single-segment path at this stage of compilation");
+                        };
                         if let Some(caller) = &mut aleo_function {
                             caller.as_function_ref_mut().finalize = Some(
                                 self.visit_function_with(
-                                    &program_scope
-                                        .functions
-                                        .iter()
-                                        .find(|(name, _f)| vec![*name] == finalize.location.path)
-                                        .unwrap()
-                                        .1,
+                                    &program_scope.functions.iter().find(|(name, _f)| name == finalize_name).unwrap().1,
                                     &finalize.future_inputs,
                                 )
                                 .unwrap()


### PR DESCRIPTION
Before this change, attaching finalize logic to async transitions compared function names by constructing a temporary Vec<Symbol> on each iteration (`vec![*name] == finalize.location.path`). That caused unnecessary allocations during code generation without providing any semantic benefit.

Extracted the async function name from `finalize.location.path` once and compares `Symbol`s directly in the `program_scope.functions` iterator. Behavior stays the same (still enforcing a single-segment finalize location), but we avoid per-iteration Vec allocations and keep the lookup logic simpler and cheaper.