### PR TITLE
fix: preserve and format HTTP response body in broadcast errors

### DIFF
--- a/errors/src/errors/cli/cli_errors.rs
+++ b/errors/src/errors/cli/cli_errors.rs
@@ -274,7 +274,7 @@ create_messages!(
     @backtraced
     broadcast_error {
         args: (error: impl Display),
-        msg: format!("Failed to broadcast transaction: {error}"),
+        msg: format!("Failed to broadcast transaction:\n{error}"),
         help: None,
     }
 

--- a/tests/expectations/cli/broadcast_error/COMMANDS
+++ b/tests/expectations/cli/broadcast_error/COMMANDS
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Test that broadcast errors include the server's response body.
+# We deploy a program twice - the second deploy should fail with a
+# detailed error message (not just a status code).
+
+LEO_BIN=${1}
+PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
+COMMON_OPTS="--disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+
+# First deploy should succeed
+$LEO_BIN deploy -y $COMMON_OPTS
+
+# Second deploy should fail with a detailed error message
+$LEO_BIN deploy -y $COMMON_OPTS || true

--- a/tests/expectations/cli/broadcast_error/STDERR
+++ b/tests/expectations/cli/broadcast_error/STDERR
@@ -1,0 +1,6 @@
+Error [ECLI0377034]: Failed to broadcast transaction:
+   Failed to deploy 'broadcast_error.aleo'
+   Endpoint: http://localhost:3030/testnet/transaction/broadcast
+   Status:   500 Internal Server Error
+   Response: Invalid transaction — Program ID 'broadcast_error.aleo' is already deployed
+

--- a/tests/expectations/cli/broadcast_error/STDOUT
+++ b/tests/expectations/cli/broadcast_error/STDOUT
@@ -1,0 +1,135 @@
+       Leo     2 statements before dead code elimination.
+       Leo     2 statements after dead code elimination.
+       Leo     The program checksum is: '[65u8, 89u8, 187u8, 94u8, 189u8, 162u8, 9u8, 5u8, 82u8, 113u8, 145u8, 228u8, 159u8, 225u8, 53u8, 52u8, 194u8, 213u8, 69u8, 110u8, 78u8, 244u8, 159u8, 99u8, 80u8, 151u8, 122u8, 38u8, 220u8, 73u8, 200u8, 114u8]'.
+       Leo     Program size: 0.26 KB / 97.66 KB
+       Leo ✅ Compiled 'broadcast_error.aleo' into Aleo instructions.
+       Leo ✅ Generated ABI at 'build/abi.json'.
+
+📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12
+  To override, pass in `--consensus-heights` or override the environment variable `CONSENSUS_VERSION_HEIGHTS`.
+
+Attempting to determine the consensus version from the latest block height at http://localhost:3030...
+
+🛠️  Deployment Plan Summary
+──────────────────────────────────────────────
+🔧 Configuration:
+  Private Key:        APrivateKey1zkp8CZNn3yeC...
+  Address:            aleo1rhgdu77hgyqd3xjj8uc...
+  Endpoint:           http://localhost:3030
+  Network:            testnet
+  Consensus Version:  13
+
+📦 Deployment Tasks:
+  • broadcast_error.aleo  │ priority fee: 0  │ fee record: no (public fee)
+
+⚙️ Actions:
+  • Transaction(s) will NOT be printed to the console.
+  • Transaction(s) will NOT be saved to a file.
+  • Transaction(s) will be broadcast to http://localhost:3030
+──────────────────────────────────────────────
+
+
+🔧 Your program 'broadcast_error.aleo' has the following constructor.
+──────────────────────────────────────────────
+constructor:
+    assert.eq program_owner aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+──────────────────────────────────────────────
+Once it is deployed, it CANNOT be changed.
+
+📦 Creating deployment transaction for 'broadcast_error.aleo'...
+
+
+📊 Deployment Summary for broadcast_error.aleo
+──────────────────────────────────────────────
+  Program Size:         0.26 KB / 97.66 KB
+  Total Variables:      17,191
+  Total Constraints:    12,927
+  Max Variables:        XXXXXX
+  Max Constraints:      XXXXXX
+
+💰 Cost Breakdown (credits)
+  Transaction Storage:  0.914000
+  Program Synthesis:    0.030118
+  Namespace:            1.000000
+  Constructor:          0.002000
+  Priority Fee:         0.000000
+  Total Fee:            1.946118
+──────────────────────────────────────────────
+
+📡 Broadcasting deployment for broadcast_error.aleo...
+💰Your current public balance is XXXXXX credits.
+
+✉️ Broadcasted transaction with:
+  - transaction ID: 'XXXXXX'
+  - fee ID: 'XXXXXX'
+  - fee transaction ID: 'XXXXXX'
+    (use this to check for rejected transactions)
+
+🔄 Searching up to 12 blocks to confirm transaction (this may take several seconds)...
+Explored XXXXXX blocks.
+Transaction accepted.
+✅ Deployment confirmed!
+       Leo     2 statements before dead code elimination.
+       Leo     2 statements after dead code elimination.
+       Leo     The program checksum is: '[65u8, 89u8, 187u8, 94u8, 189u8, 162u8, 9u8, 5u8, 82u8, 113u8, 145u8, 228u8, 159u8, 225u8, 53u8, 52u8, 194u8, 213u8, 69u8, 110u8, 78u8, 244u8, 159u8, 99u8, 80u8, 151u8, 122u8, 38u8, 220u8, 73u8, 200u8, 114u8]'.
+       Leo     Program size: 0.26 KB / 97.66 KB
+       Leo ✅ Compiled 'broadcast_error.aleo' into Aleo instructions.
+       Leo ✅ Generated ABI at 'build/abi.json'.
+
+📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12
+  To override, pass in `--consensus-heights` or override the environment variable `CONSENSUS_VERSION_HEIGHTS`.
+
+Attempting to determine the consensus version from the latest block height at http://localhost:3030...
+
+🛠️  Deployment Plan Summary
+──────────────────────────────────────────────
+🔧 Configuration:
+  Private Key:        APrivateKey1zkp8CZNn3yeC...
+  Address:            aleo1rhgdu77hgyqd3xjj8uc...
+  Endpoint:           http://localhost:3030
+  Network:            testnet
+  Consensus Version:  13
+
+📦 Deployment Tasks:
+  • broadcast_error.aleo  │ priority fee: 0  │ fee record: no (public fee)
+
+⚙️ Actions:
+  • Transaction(s) will NOT be printed to the console.
+  • Transaction(s) will NOT be saved to a file.
+  • Transaction(s) will be broadcast to http://localhost:3030
+
+⚠️ Warnings:
+  • The program 'broadcast_error.aleo' already exists on the network. Please use `leo upgrade` instead.
+──────────────────────────────────────────────
+
+
+🔧 Your program 'broadcast_error.aleo' has the following constructor.
+──────────────────────────────────────────────
+constructor:
+    assert.eq program_owner aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;
+──────────────────────────────────────────────
+Once it is deployed, it CANNOT be changed.
+
+📦 Creating deployment transaction for 'broadcast_error.aleo'...
+
+
+📊 Deployment Summary for broadcast_error.aleo
+──────────────────────────────────────────────
+  Program Size:         0.26 KB / 97.66 KB
+  Total Variables:      17,191
+  Total Constraints:    12,927
+  Max Variables:        XXXXXX
+  Max Constraints:      XXXXXX
+
+💰 Cost Breakdown (credits)
+  Transaction Storage:  0.914000
+  Program Synthesis:    0.030118
+  Namespace:            1.000000
+  Constructor:          0.002000
+  Priority Fee:         0.000000
+  Total Fee:            1.946118
+──────────────────────────────────────────────
+
+📡 Broadcasting deployment for broadcast_error.aleo...
+💰Your current public balance is XXXXXX credits.
+

--- a/tests/expectations/cli/broadcast_error/contents/.gitignore
+++ b/tests/expectations/cli/broadcast_error/contents/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.avm
+*.prover
+*.verifier
+outputs/

--- a/tests/expectations/cli/broadcast_error/contents/build/abi.json
+++ b/tests/expectations/cli/broadcast_error/contents/build/abi.json
@@ -1,0 +1,49 @@
+{
+  "program": "broadcast_error.aleo",
+  "structs": [],
+  "records": [],
+  "mappings": [],
+  "storage_variables": [],
+  "transitions": [
+    {
+      "name": "main",
+      "is_async": false,
+      "inputs": [
+        {
+          "name": "a",
+          "ty": {
+            "Plaintext": {
+              "Primitive": {
+                "UInt": "U32"
+              }
+            }
+          },
+          "mode": "Public"
+        },
+        {
+          "name": "b",
+          "ty": {
+            "Plaintext": {
+              "Primitive": {
+                "UInt": "U32"
+              }
+            }
+          },
+          "mode": "None"
+        }
+      ],
+      "outputs": [
+        {
+          "ty": {
+            "Plaintext": {
+              "Primitive": {
+                "UInt": "U32"
+              }
+            }
+          },
+          "mode": "None"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/expectations/cli/broadcast_error/contents/build/main.aleo
+++ b/tests/expectations/cli/broadcast_error/contents/build/main.aleo
@@ -1,0 +1,10 @@
+program broadcast_error.aleo;
+
+function main:
+    input r0 as u32.public;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq program_owner aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px;

--- a/tests/expectations/cli/broadcast_error/contents/build/program.json
+++ b/tests/expectations/cli/broadcast_error/contents/build/program.json
@@ -1,0 +1,9 @@
+{
+  "program": "broadcast_error.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "",
+  "leo": "3.4.0",
+  "dependencies": null,
+  "dev_dependencies": null
+}

--- a/tests/expectations/cli/broadcast_error/contents/program.json
+++ b/tests/expectations/cli/broadcast_error/contents/program.json
@@ -1,0 +1,8 @@
+{
+  "program": "broadcast_error.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "dependencies": null,
+  "dev_dependencies": null
+}

--- a/tests/expectations/cli/broadcast_error/contents/src/main.leo
+++ b/tests/expectations/cli/broadcast_error/contents/src/main.leo
@@ -1,0 +1,9 @@
+program broadcast_error.aleo {
+    transition main(public a: u32, b: u32) -> u32 {
+        let c: u32 = a + b;
+        return c;
+    }
+
+    @admin(address = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px")
+    async constructor() {}
+}

--- a/tests/tests/cli/broadcast_error/COMMANDS
+++ b/tests/tests/cli/broadcast_error/COMMANDS
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Test that broadcast errors include the server's response body.
+# We deploy a program twice - the second deploy should fail with a
+# detailed error message (not just a status code).
+
+LEO_BIN=${1}
+PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
+COMMON_OPTS="--disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+
+# First deploy should succeed
+$LEO_BIN deploy -y $COMMON_OPTS
+
+# Second deploy should fail with a detailed error message
+$LEO_BIN deploy -y $COMMON_OPTS || true

--- a/tests/tests/cli/broadcast_error/contents/.gitignore
+++ b/tests/tests/cli/broadcast_error/contents/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.avm
+*.prover
+*.verifier
+outputs/

--- a/tests/tests/cli/broadcast_error/contents/program.json
+++ b/tests/tests/cli/broadcast_error/contents/program.json
@@ -1,0 +1,8 @@
+{
+  "program": "broadcast_error.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "dependencies": null,
+  "dev_dependencies": null
+}

--- a/tests/tests/cli/broadcast_error/contents/src/main.leo
+++ b/tests/tests/cli/broadcast_error/contents/src/main.leo
@@ -1,0 +1,9 @@
+program broadcast_error.aleo {
+    transition main(public a: u32, b: u32) -> u32 {
+        let c: u32 = a + b;
+        return c;
+    }
+
+    @admin(address = "aleo1rhgdu77hgyqd3xjj8ucu3jj9r2krwz6mnzyd80gncr5fxcwlh5rsvzp9px")
+    async constructor() {}
+}


### PR DESCRIPTION
## Summary
When broadcasting a transaction fails, users now see the actual error message from the server instead of just a status code.

**Before:**
```
Error [ECLI0377034]: Failed to broadcast transaction: http status: 500
```

**After:**
```
Error [ECLI0377034]: Failed to broadcast transaction:
   Failed to deploy 'broadcast_error.aleo'
   Endpoint: http://localhost:3030/testnet/transaction/broadcast
   Status:   500 Internal Server Error
   Response: Invalid transaction — Program ID 'broadcast_error.aleo' is already deployed
```