### PR TITLE
feat(parser-rowan): implement comprehensive error recovery

### DIFF
--- a/compiler/parser-rowan/src/parser/grammar.rs
+++ b/compiler/parser-rowan/src/parser/grammar.rs
@@ -117,7 +117,7 @@ mod tests {
         let parse = parse_module_entry(input);
         if !parse.errors().is_empty() {
             for err in parse.errors() {
-                eprintln!("error at {}: {}", err.offset, err.message);
+                eprintln!("error at {:?}: {}", err.range, err.message);
             }
             eprintln!("tree:\n{:#?}", parse.syntax());
             panic!("module parse had {} error(s)", parse.errors().len());
@@ -186,7 +186,7 @@ const Y: u32 = 64u32;";
         let parse = parse_file(source);
         if !parse.errors().is_empty() {
             for err in parse.errors() {
-                eprintln!("error at {}: {}", err.offset, err.message);
+                eprintln!("error at {:?}: {}", err.range, err.message);
             }
             eprintln!("tree:\n{:#?}", parse.syntax());
             panic!("file parse had {} error(s)", parse.errors().len());

--- a/compiler/parser-rowan/src/parser/types.rs
+++ b/compiler/parser-rowan/src/parser/types.rs
@@ -869,7 +869,7 @@ mod tests {
         let parse: Parse = parser.finish();
         if !parse.errors().is_empty() {
             for err in parse.errors() {
-                eprintln!("error at {}: {}", err.offset, err.message);
+                eprintln!("error at {:?}: {}", err.range, err.message);
             }
             eprintln!("tree:\n{:#?}", parse.syntax());
             panic!("type parse had {} error(s)", parse.errors().len());


### PR DESCRIPTION
This adds error recovery infrastructure to ensure the new rowan-based parser always produces a syntax tree, even for malformed input. This is essential for IDE tooling where partial/incomplete code must still be analyzed.

Closes #29087 

- #29087 

## Recovery Improvements

- Add recovery token sets (`EXPR_RECOVERY`, `TYPE_RECOVERY`, `PARAM_RECOVERY`).
- Expression recovery: handle missing operands in unary, binary, and ternary expressions. Recover from malformed call arguments and array elements.
- Statement recovery: handle missing types/expressions in `let`/`const`, missing conditions/blocks in `if`/`for`, malformed assert statements.
- Item recovery: handle malformed struct fields, missing types in mappings/storage/params, incomplete function definitions.
- Add delimiter balance tracking (paren/brace/bracket depth) with `skip_to_balanced()` helper for smarter recovery in nested contexts.

### Tests

- Missing semicolons, types, expressions.
- Missing operands and unclosed delimiters.
- Malformed functions, structs, mappings.
- Multiple errors in a single file.
- Garbage input never causes panics.

## Follow-up

- #29088 