### PR TITLE
feat(leo-fmt): implement statement and expression formatting

### DIFF
--- a/leo-fmt/src/format.rs
+++ b/leo-fmt/src/format.rs
@@ -19,31 +19,96 @@
 use crate::output::Output;
 use leo_parser_lossless::{ExpressionKind, IntegerLiteralKind, LiteralKind, StatementKind, SyntaxKind, SyntaxNode};
 
+/// Returns true if this operator token requires surrounding spaces.
+fn is_spaced_operator(text: &str) -> bool {
+    matches!(
+        text,
+        // Binary arithmetic
+        "+" | "-" | "*" | "/" | "%" | "**" |
+        // Binary logical
+        "&&" | "||" |
+        // Binary bitwise
+        "&" | "|" | "^" | "<<" | ">>" |
+        // Binary comparison
+        "<" | ">" | "<=" | ">=" | "==" | "!=" |
+        // Assignment (simple and compound)
+        "=" | "+=" | "-=" | "*=" | "/=" | "%=" | "**=" |
+        "<<=" | ">>=" | "&=" | "|=" | "^=" | "&&=" | "||=" |
+        // Range
+        ".."
+    )
+}
+
 /// Format any syntax node.
 pub fn format_node(node: &SyntaxNode, out: &mut Output) {
     match &node.kind {
+        // Top-level
         SyntaxKind::MainContents => format_main(node, out),
         SyntaxKind::ProgramDeclaration => format_program(node, out),
         SyntaxKind::ModuleContents => format_module_contents(node, out),
-        SyntaxKind::Function => format_function(node, out),
-        SyntaxKind::Constructor => format_function(node, out),
-        SyntaxKind::CompositeDeclaration => format_struct(node, out),
+
+        // Declarations
+        SyntaxKind::Function | SyntaxKind::Constructor => format_function(node, out),
+        SyntaxKind::CompositeDeclaration => format_composite(node, out),
         SyntaxKind::Import => format_import(node, out),
         SyntaxKind::Mapping => format_mapping(node, out),
+        SyntaxKind::Storage => format_storage(node, out),
+        SyntaxKind::GlobalConst => format_global_const(node, out),
         SyntaxKind::Annotation => format_annotation(node, out),
-        SyntaxKind::ParameterList => format_delimited(node, out, "(", ")", ","),
+        SyntaxKind::AnnotationList => format_annotation_list(node, out),
+        SyntaxKind::AnnotationMember => format_annotation_member(node, out),
+        SyntaxKind::ParameterList => format_parameter_list(node, out),
         SyntaxKind::Parameter => format_parameter(node, out),
         SyntaxKind::FunctionOutputs => format_function_outputs(node, out),
         SyntaxKind::FunctionOutput => format_function_output(node, out),
+        SyntaxKind::ConstParameter => format_const_parameter(node, out),
+        SyntaxKind::ConstParameterList => format_const_parameter_list(node, out),
+        SyntaxKind::ConstArgumentList => format_const_argument_list(node, out),
         SyntaxKind::CompositeMemberDeclarationList => format_composite_member_list(node, out),
         SyntaxKind::CompositeMemberDeclaration => format_composite_member(node, out),
+
+        // Statements
         SyntaxKind::Statement(StatementKind::Block) => format_block(node, out),
         SyntaxKind::Statement(StatementKind::Return) => format_return(node, out),
+        SyntaxKind::Statement(StatementKind::Definition) => format_definition(node, out),
+        SyntaxKind::Statement(StatementKind::Const) => format_const_stmt(node, out),
+        SyntaxKind::Statement(StatementKind::Assign) => format_assign(node, out),
+        SyntaxKind::Statement(StatementKind::Conditional) => format_conditional(node, out),
+        SyntaxKind::Statement(StatementKind::Iteration) => format_iteration(node, out),
+        SyntaxKind::Statement(StatementKind::Assert) => format_assert(node, out, "assert"),
+        SyntaxKind::Statement(StatementKind::AssertEq) => format_assert_eq(node, out),
+        SyntaxKind::Statement(StatementKind::AssertNeq) => format_assert_neq(node, out),
+        SyntaxKind::Statement(StatementKind::Expression) => format_expr_stmt(node, out),
+
+        // Expressions
         SyntaxKind::Expression(ExpressionKind::Literal(_)) => format_literal(node, out),
         SyntaxKind::Expression(ExpressionKind::Call) => format_call(node, out),
         SyntaxKind::Expression(ExpressionKind::Binary) => format_binary(node, out),
         SyntaxKind::Expression(ExpressionKind::Path) => format_path(node, out),
+        SyntaxKind::Expression(ExpressionKind::Unary) => format_unary(node, out),
+        SyntaxKind::Expression(ExpressionKind::Ternary) => format_ternary(node, out),
+        SyntaxKind::Expression(ExpressionKind::MethodCall) => format_method_call(node, out),
+        SyntaxKind::Expression(ExpressionKind::AssociatedFunctionCall) => format_assoc_call(node, out),
+        SyntaxKind::Expression(ExpressionKind::AssociatedConstant) => format_assoc_const(node, out),
+        SyntaxKind::Expression(ExpressionKind::Composite) => format_composite_expr(node, out),
+        SyntaxKind::Expression(ExpressionKind::ArrayAccess) => format_array_access(node, out),
+        SyntaxKind::Expression(ExpressionKind::TupleAccess) => format_tuple_access(node, out),
+        SyntaxKind::Expression(ExpressionKind::MemberAccess) => format_member_access(node, out),
+        SyntaxKind::Expression(ExpressionKind::Cast) => format_cast(node, out),
+        SyntaxKind::Expression(ExpressionKind::Array) => format_array_expr(node, out),
+        SyntaxKind::Expression(ExpressionKind::Tuple) => format_tuple_expr(node, out),
+        SyntaxKind::Expression(ExpressionKind::Parenthesized) => format_parenthesized(node, out),
+        SyntaxKind::Expression(ExpressionKind::Repeat) => format_repeat_expr(node, out),
+        SyntaxKind::Expression(ExpressionKind::Async) => format_async_expr(node, out),
+        SyntaxKind::Expression(ExpressionKind::Intrinsic) => format_intrinsic(node, out),
+        SyntaxKind::Expression(ExpressionKind::SpecialAccess) => format_special_access(node, out),
+        SyntaxKind::Expression(ExpressionKind::Unit) => out.write("()"),
+        SyntaxKind::CompositeMemberInitializer => format_composite_member_init(node, out),
+
+        // Types
         SyntaxKind::Type(_) => format_type(node, out),
+
+        // Trivia
         SyntaxKind::Whitespace | SyntaxKind::Linebreak => {}
         SyntaxKind::CommentLine => {
             out.space();
@@ -56,30 +121,43 @@ pub fn format_node(node: &SyntaxNode, out: &mut Output) {
         }
         SyntaxKind::Token => {
             out.write(node.text);
-            emit_comments(&node.children, out);
+            emit_trivia(&node.children, out);
         }
-        // TODO: Handle remaining statement and expression formatting.
-        _ => format_children(node, out),
     }
 }
 
-fn format_children(node: &SyntaxNode, out: &mut Output) {
-    for child in &node.children {
-        format_node(child, out);
-    }
-}
-
-fn emit_comments(children: &[SyntaxNode], out: &mut Output) {
+/// Emit comments from a token's trailing trivia children.
+///
+/// Uses linebreaks in the trivia to distinguish trailing comments (same line)
+/// from standalone comments (own line). Whitespace trivia is ignored since
+/// the formatter controls all spacing.
+fn emit_trivia(children: &[SyntaxNode], out: &mut Output) {
+    let mut saw_linebreak = false;
     for child in children {
         match child.kind {
+            SyntaxKind::Linebreak => {
+                saw_linebreak = true;
+            }
             SyntaxKind::CommentLine => {
-                out.space();
+                if saw_linebreak {
+                    // Standalone comment — goes on its own line
+                    out.ensure_newline();
+                } else {
+                    // Trailing comment — stays on same line
+                    out.space();
+                }
                 out.write(child.text.trim_end());
                 out.newline();
+                saw_linebreak = false;
             }
             SyntaxKind::CommentBlock => {
-                out.space();
+                if saw_linebreak {
+                    out.ensure_newline();
+                } else {
+                    out.space();
+                }
                 out.write(child.text);
+                saw_linebreak = false;
             }
             _ => {}
         }
@@ -98,18 +176,21 @@ fn format_main(node: &SyntaxNode, out: &mut Output) {
     }
 }
 
+fn is_program_item(kind: &SyntaxKind) -> bool {
+    matches!(
+        kind,
+        SyntaxKind::Function
+            | SyntaxKind::Constructor
+            | SyntaxKind::CompositeDeclaration
+            | SyntaxKind::Mapping
+            | SyntaxKind::Storage
+            | SyntaxKind::GlobalConst
+    )
+}
+
 fn format_program(node: &SyntaxNode, out: &mut Output) {
-    // Collect items (functions, structs, mappings)
-    let items: Vec<_> = node
-        .children
-        .iter()
-        .filter(|c| {
-            matches!(
-                c.kind,
-                SyntaxKind::Function | SyntaxKind::Constructor | SyntaxKind::CompositeDeclaration | SyntaxKind::Mapping
-            )
-        })
-        .collect();
+    let item_count = node.children.iter().filter(|c| is_program_item(&c.kind)).count();
+    let mut item_idx = 0;
 
     for child in &node.children {
         match &child.kind {
@@ -120,22 +201,25 @@ fn format_program(node: &SyntaxNode, out: &mut Output) {
             SyntaxKind::Token if child.text == "{" => {
                 out.space();
                 out.write("{");
-                if !items.is_empty() {
+                if item_count > 0 {
                     out.newline();
                 }
+                // Emit comments after opening brace (before first item).
+                out.indented(|out| {
+                    emit_trivia(&child.children, out);
+                });
             }
             SyntaxKind::Token if child.text == "}" => {
                 out.write("}");
                 out.newline();
             }
             SyntaxKind::Token => out.write(child.text),
-            SyntaxKind::Function | SyntaxKind::Constructor | SyntaxKind::CompositeDeclaration | SyntaxKind::Mapping => {
+            kind if is_program_item(kind) => {
                 out.indented(|out| {
                     format_node(child, out);
-                    // Add blank line between items (but not after the last one)
-                    let is_last = items.iter().position(|x| std::ptr::eq(*x, child)) == Some(items.len() - 1);
-                    if !is_last {
-                        out.newline();
+                    item_idx += 1;
+                    if item_idx < item_count {
+                        out.insert_newline_at_mark();
                     }
                 });
             }
@@ -145,24 +229,16 @@ fn format_program(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_module_contents(node: &SyntaxNode, out: &mut Output) {
-    let items: Vec<_> = node
-        .children
-        .iter()
-        .filter(|c| {
-            matches!(
-                c.kind,
-                SyntaxKind::Function | SyntaxKind::Constructor | SyntaxKind::CompositeDeclaration | SyntaxKind::Mapping
-            )
-        })
-        .collect();
+    let item_count = node.children.iter().filter(|c| is_program_item(&c.kind)).count();
+    let mut item_idx = 0;
 
     for child in &node.children {
         match &child.kind {
-            SyntaxKind::Function | SyntaxKind::Constructor | SyntaxKind::CompositeDeclaration | SyntaxKind::Mapping => {
+            kind if is_program_item(kind) => {
                 format_node(child, out);
-                let is_last = items.iter().position(|x| std::ptr::eq(*x, child)) == Some(items.len() - 1);
-                if !is_last {
-                    out.newline();
+                item_idx += 1;
+                if item_idx < item_count {
+                    out.insert_newline_at_mark();
                 }
             }
             _ => {}
@@ -193,7 +269,7 @@ fn format_function(node: &SyntaxNode, out: &mut Output) {
                 }
                 _ => out.write(child.text),
             },
-            SyntaxKind::ParameterList => format_delimited(child, out, "(", ")", ","),
+            SyntaxKind::ParameterList => format_parameter_list(child, out),
             SyntaxKind::FunctionOutputs => format_function_outputs(child, out),
             SyntaxKind::Statement(StatementKind::Block) => {
                 out.space();
@@ -207,14 +283,16 @@ fn format_function(node: &SyntaxNode, out: &mut Output) {
 
 fn format_annotation(node: &SyntaxNode, out: &mut Output) {
     for child in &node.children {
-        if let SyntaxKind::Token = &child.kind {
-            out.write(child.text);
+        match &child.kind {
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::AnnotationList => format_annotation_list(child, out),
+            _ => {}
         }
     }
     out.newline();
 }
 
-fn format_struct(node: &SyntaxNode, out: &mut Output) {
+fn format_composite(node: &SyntaxNode, out: &mut Output) {
     for child in &node.children {
         match &child.kind {
             SyntaxKind::Token if child.text == "struct" || child.text == "record" => {
@@ -236,26 +314,25 @@ fn format_struct(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_composite_member_list(node: &SyntaxNode, out: &mut Output) {
-    for child in &node.children {
-        match &child.kind {
-            SyntaxKind::Token if child.text == "{" => {
-                out.write("{");
-                out.newline();
-            }
-            SyntaxKind::Token if child.text == "}" => {
-                out.write("}");
-            }
-            SyntaxKind::Token if child.text == "," => {
-                out.write(",");
-                out.newline();
-            }
-            SyntaxKind::CompositeMemberDeclaration => {
-                out.indented(|out| {
-                    format_composite_member(child, out);
-                });
-            }
-            _ => {}
-        }
+    let members: Vec<_> =
+        node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::CompositeMemberDeclaration)).collect();
+
+    let close_brace = node.children.iter().find(|c| c.kind == SyntaxKind::Token && c.text == "}");
+
+    out.write("{");
+    out.newline();
+    for member in &members {
+        out.indented(|out| {
+            format_composite_member(member, out);
+            out.write(",");
+        });
+        out.newline();
+    }
+    out.write("}");
+    out.set_mark();
+    // Emit comments that trail after the closing brace (between items).
+    if let Some(brace) = close_brace {
+        emit_trivia(&brace.children, out);
     }
 }
 
@@ -266,7 +343,7 @@ fn format_composite_member(node: &SyntaxNode, out: &mut Output) {
                 out.write(":");
                 out.space();
             }
-            SyntaxKind::Token if child.text == "," => out.write(","),
+            SyntaxKind::Token if child.text == "," => {} // handled by parent
             SyntaxKind::Token => out.write(child.text),
             SyntaxKind::Type(_) => format_type(child, out),
             _ => {}
@@ -281,7 +358,10 @@ fn format_import(node: &SyntaxNode, out: &mut Output) {
                 out.write("import");
                 out.space();
             }
-            SyntaxKind::Token if child.text == ";" => out.write(";"),
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                emit_trivia(&child.children, out);
+            }
             SyntaxKind::Token => out.write(child.text),
             _ => {}
         }
@@ -305,28 +385,17 @@ fn format_mapping(node: &SyntaxNode, out: &mut Output) {
                 out.write("=>");
                 out.space();
             }
-            SyntaxKind::Token if child.text == ";" => out.write(";"),
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                out.set_mark();
+                emit_trivia(&child.children, out);
+            }
             SyntaxKind::Token => out.write(child.text),
             SyntaxKind::Type(_) => format_type(child, out),
             _ => {}
         }
     }
     out.ensure_newline();
-}
-
-fn format_delimited(node: &SyntaxNode, out: &mut Output, open: &str, close: &str, sep: &str) {
-    out.write(open);
-    let items: Vec<_> =
-        node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Parameter | SyntaxKind::FunctionOutput)).collect();
-
-    for (i, child) in items.iter().enumerate() {
-        format_node(child, out);
-        if i < items.len() - 1 {
-            out.write(sep);
-            out.space();
-        }
-    }
-    out.write(close);
 }
 
 fn format_parameter(node: &SyntaxNode, out: &mut Output) {
@@ -350,7 +419,16 @@ fn format_parameter(node: &SyntaxNode, out: &mut Output) {
 fn format_function_outputs(node: &SyntaxNode, out: &mut Output) {
     let has_paren = node.children.iter().any(|c| c.kind == SyntaxKind::Token && c.text == "(");
     if has_paren {
-        format_delimited(node, out, "(", ")", ",");
+        let outputs: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::FunctionOutput)).collect();
+        out.write("(");
+        for (i, child) in outputs.iter().enumerate() {
+            format_function_output(child, out);
+            if i < outputs.len() - 1 {
+                out.write(",");
+                out.space();
+            }
+        }
+        out.write(")");
     } else {
         for child in &node.children {
             if matches!(child.kind, SyntaxKind::FunctionOutput) {
@@ -397,11 +475,20 @@ fn format_type(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_block(node: &SyntaxNode, out: &mut Output) {
-    out.write("{");
+    let open_brace = node.children.iter().find(|c| c.kind == SyntaxKind::Token && c.text == "{");
     let has_stmts = node.children.iter().any(|c| matches!(c.kind, SyntaxKind::Statement(_)));
-    if has_stmts {
+    let has_open_comments = open_brace
+        .map(|b| b.children.iter().any(|c| matches!(c.kind, SyntaxKind::CommentLine | SyntaxKind::CommentBlock)))
+        .unwrap_or(false);
+
+    out.write("{");
+    if has_stmts || has_open_comments {
         out.newline();
         out.indented(|out| {
+            // Emit comments attached as trivia to the opening brace.
+            if let Some(brace) = open_brace {
+                emit_trivia(&brace.children, out);
+            }
             for child in &node.children {
                 if matches!(child.kind, SyntaxKind::Statement(_)) {
                     format_node(child, out);
@@ -411,6 +498,12 @@ fn format_block(node: &SyntaxNode, out: &mut Output) {
         });
     }
     out.write("}");
+    out.set_mark();
+    // Emit comments that trail after the closing brace (between items).
+    let close_brace = node.children.iter().find(|c| c.kind == SyntaxKind::Token && c.text == "}");
+    if let Some(brace) = close_brace {
+        emit_trivia(&brace.children, out);
+    }
 }
 
 fn format_return(node: &SyntaxNode, out: &mut Output) {
@@ -422,7 +515,10 @@ fn format_return(node: &SyntaxNode, out: &mut Output) {
     for child in &node.children {
         match &child.kind {
             SyntaxKind::Token if child.text == "return" => {}
-            SyntaxKind::Token if child.text == ";" => out.write(";"),
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                emit_trivia(&child.children, out);
+            }
             SyntaxKind::Expression(_) => format_node(child, out),
             _ => {}
         }
@@ -469,7 +565,6 @@ fn format_call(node: &SyntaxNode, out: &mut Output) {
                 out.space();
             }
             SyntaxKind::Token => out.write(child.text),
-            // TODO: Handle expression formatting.
             _ => format_node(child, out),
         }
     }
@@ -478,15 +573,11 @@ fn format_call(node: &SyntaxNode, out: &mut Output) {
 /// Binary expressions have the structure: [lhs, operator, rhs].
 fn format_binary(node: &SyntaxNode, out: &mut Output) {
     let children: Vec<_> = node.children.iter().collect();
-    if children.len() >= 3 {
-        format_node(children[0], out);
-        out.space();
-        out.write(children[1].text);
-        out.space();
-        format_node(children[2], out);
-    } else {
-        format_children(node, out);
-    }
+    format_node(children[0], out);
+    out.space();
+    out.write(children[1].text);
+    out.space();
+    format_node(children[2], out);
 }
 
 fn format_path(node: &SyntaxNode, out: &mut Output) {
@@ -495,6 +586,659 @@ fn format_path(node: &SyntaxNode, out: &mut Output) {
     } else {
         for child in &node.children {
             format_node(child, out);
+        }
+    }
+}
+
+// --- Storage and Global Const ---
+
+fn format_storage(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "storage" => {
+                out.write("storage");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ":" => {
+                out.write(":");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                out.set_mark();
+                emit_trivia(&child.children, out);
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Type(_) => format_type(child, out),
+            _ => {}
+        }
+    }
+    out.ensure_newline();
+}
+
+fn format_global_const(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "const" => {
+                out.write("const");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ":" => {
+                out.write(":");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == "=" => {
+                out.space();
+                out.write("=");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                out.set_mark();
+                emit_trivia(&child.children, out);
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Type(_) => format_type(child, out),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+    out.ensure_newline();
+}
+
+// --- Annotations ---
+
+fn format_annotation_list(node: &SyntaxNode, out: &mut Output) {
+    let members: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::AnnotationMember)).collect();
+
+    out.write("(");
+    for (i, child) in members.iter().enumerate() {
+        format_annotation_member(child, out);
+        if i < members.len() - 1 {
+            out.write(",");
+            out.space();
+        }
+    }
+    out.write(")");
+}
+
+fn format_annotation_member(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "=" => {
+                out.space();
+                out.write("=");
+                out.space();
+            }
+            SyntaxKind::Token => out.write(child.text),
+            _ => {}
+        }
+    }
+}
+
+// --- Const Parameters and Arguments ---
+
+fn format_parameter_list(node: &SyntaxNode, out: &mut Output) {
+    let params: Vec<_> =
+        node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Parameter | SyntaxKind::FunctionOutput)).collect();
+
+    out.write("(");
+    for (i, child) in params.iter().enumerate() {
+        format_node(child, out);
+        if i < params.len() - 1 {
+            out.write(",");
+            out.space();
+        }
+    }
+    out.write(")");
+}
+
+fn format_const_parameter(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == ":" => {
+                out.write(":");
+                out.space();
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Type(_) => format_type(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_const_parameter_list(node: &SyntaxNode, out: &mut Output) {
+    let params: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::ConstParameter)).collect();
+
+    out.write("::[");
+    for (i, child) in params.iter().enumerate() {
+        format_const_parameter(child, out);
+        if i < params.len() - 1 {
+            out.write(",");
+            out.space();
+        }
+    }
+    out.write("]");
+}
+
+fn format_const_argument_list(node: &SyntaxNode, out: &mut Output) {
+    let args: Vec<_> =
+        node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Expression(_) | SyntaxKind::Type(_))).collect();
+
+    out.write("::[");
+    for (i, child) in args.iter().enumerate() {
+        format_node(child, out);
+        if i < args.len() - 1 {
+            out.write(",");
+            out.space();
+        }
+    }
+    out.write("]");
+}
+
+// --- Statement Formatters ---
+
+fn format_definition(node: &SyntaxNode, out: &mut Output) {
+    out.write("let");
+    out.space();
+
+    let has_paren = node.children.iter().any(|c| c.kind == SyntaxKind::Token && c.text == "(");
+
+    if has_paren {
+        // Tuple destructuring: let (a, b) = expr;
+        let mut in_parens = false;
+        for child in &node.children {
+            match &child.kind {
+                SyntaxKind::Token if child.text == "let" => {}
+                SyntaxKind::Token if child.text == "(" => {
+                    out.write("(");
+                    in_parens = true;
+                }
+                SyntaxKind::Token if child.text == ")" => {
+                    out.write(")");
+                    in_parens = false;
+                }
+                SyntaxKind::Token if child.text == "," && in_parens => {
+                    out.write(",");
+                    out.space();
+                }
+                SyntaxKind::Token if child.text == ":" => {
+                    out.write(":");
+                    out.space();
+                }
+                SyntaxKind::Token if child.text == "=" => {
+                    out.space();
+                    out.write("=");
+                    out.space();
+                }
+                SyntaxKind::Token if child.text == ";" => {
+                    out.write(";");
+                    emit_trivia(&child.children, out);
+                }
+                SyntaxKind::Token if in_parens => {
+                    out.write(child.text);
+                }
+                SyntaxKind::Token => out.write(child.text),
+                SyntaxKind::Type(_) => format_type(child, out),
+                SyntaxKind::Expression(_) => format_node(child, out),
+                _ => {}
+            }
+        }
+    } else {
+        // Simple: let x = expr; or let x: T = expr;
+        for child in &node.children {
+            match &child.kind {
+                SyntaxKind::Token if child.text == "let" => {}
+                SyntaxKind::Token if child.text == ":" => {
+                    out.write(":");
+                    out.space();
+                }
+                SyntaxKind::Token if child.text == "=" => {
+                    out.space();
+                    out.write("=");
+                    out.space();
+                }
+                SyntaxKind::Token if child.text == ";" => {
+                    out.write(";");
+                    emit_trivia(&child.children, out);
+                }
+                SyntaxKind::Token => out.write(child.text),
+                SyntaxKind::Type(_) => format_type(child, out),
+                SyntaxKind::Expression(_) => format_node(child, out),
+                _ => {}
+            }
+        }
+    }
+}
+
+fn format_const_stmt(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "const" => {
+                out.write("const");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ":" => {
+                out.write(":");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == "=" => {
+                out.space();
+                out.write("=");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                emit_trivia(&child.children, out);
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Type(_) => format_type(child, out),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_assign(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if is_spaced_operator(child.text) => {
+                out.space();
+                out.write(child.text);
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                emit_trivia(&child.children, out);
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_conditional(node: &SyntaxNode, out: &mut Output) {
+    let mut first_block = true;
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "if" => {
+                out.write("if");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == "else" => {
+                out.space();
+                out.write("else");
+                out.space();
+            }
+            SyntaxKind::Expression(_) => format_node(child, out),
+            SyntaxKind::Statement(StatementKind::Block) => {
+                if first_block {
+                    out.space();
+                    first_block = false;
+                }
+                format_block(child, out);
+            }
+            SyntaxKind::Statement(StatementKind::Conditional) => {
+                // else if chain
+                format_conditional(child, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn format_iteration(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "for" => {
+                out.write("for");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ":" => {
+                out.write(":");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == "in" => {
+                out.space();
+                out.write("in");
+                out.space();
+            }
+            SyntaxKind::Token if child.text == ".." => {
+                out.write("..");
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Type(_) => format_type(child, out),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            SyntaxKind::Statement(StatementKind::Block) => {
+                out.space();
+                format_block(child, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn format_assert(node: &SyntaxNode, out: &mut Output, keyword: &str) {
+    out.write(keyword);
+    out.write("(");
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token
+                if child.text == keyword || child.text == "(" || child.text == ")" || child.text == ";" => {}
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+    out.write(");");
+    if let Some(semi) = node.children.iter().find(|c| c.kind == SyntaxKind::Token && c.text == ";") {
+        emit_trivia(&semi.children, out);
+    }
+}
+
+fn format_assert_eq(node: &SyntaxNode, out: &mut Output) {
+    format_assert_pair(node, out, "assert_eq");
+}
+
+fn format_assert_neq(node: &SyntaxNode, out: &mut Output) {
+    format_assert_pair(node, out, "assert_neq");
+}
+
+fn format_assert_pair(node: &SyntaxNode, out: &mut Output, keyword: &str) {
+    out.write(keyword);
+    out.write("(");
+    let mut first = true;
+    for child in &node.children {
+        if matches!(child.kind, SyntaxKind::Expression(_)) {
+            if !first {
+                out.write(",");
+                out.space();
+            }
+            format_node(child, out);
+            first = false;
+        }
+    }
+    out.write(");");
+    if let Some(semi) = node.children.iter().find(|c| c.kind == SyntaxKind::Token && c.text == ";") {
+        emit_trivia(&semi.children, out);
+    }
+}
+
+fn format_expr_stmt(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == ";" => {
+                out.write(";");
+                emit_trivia(&child.children, out);
+            }
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+// --- Expression Formatters ---
+
+fn format_unary(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_ternary(node: &SyntaxNode, out: &mut Output) {
+    let exprs: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Expression(_))).collect();
+    if exprs.len() >= 3 {
+        format_node(exprs[0], out);
+        out.space();
+        out.write("?");
+        out.space();
+        format_node(exprs[1], out);
+        out.space();
+        out.write(":");
+        out.space();
+        format_node(exprs[2], out);
+    }
+}
+
+fn format_method_call(node: &SyntaxNode, out: &mut Output) {
+    let mut after_dot = false;
+    let mut in_args = false;
+
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "." => {
+                out.write(".");
+                after_dot = true;
+            }
+            SyntaxKind::Token if child.text == "(" => {
+                out.write("(");
+                in_args = true;
+            }
+            SyntaxKind::Token if child.text == ")" => {
+                out.write(")");
+                in_args = false;
+            }
+            SyntaxKind::Token if child.text == "," => {
+                out.write(",");
+                out.space();
+            }
+            SyntaxKind::Token if after_dot && !in_args => {
+                out.write(child.text);
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) if !in_args => {
+                format_node(child, out);
+            }
+            SyntaxKind::Expression(_) => {
+                format_node(child, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn format_assoc_call(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "," => {
+                out.write(",");
+                out.space();
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::ConstArgumentList => format_const_argument_list(child, out),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_assoc_const(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        if let SyntaxKind::Token = &child.kind {
+            out.write(child.text);
+        }
+    }
+}
+
+fn format_composite_expr(node: &SyntaxNode, out: &mut Output) {
+    let inits: Vec<_> =
+        node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::CompositeMemberInitializer)).collect();
+
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "{" => {
+                out.space();
+                out.write("{");
+                if !inits.is_empty() {
+                    out.space();
+                    // Format all initializers inline
+                    for (i, init) in inits.iter().enumerate() {
+                        format_composite_member_init(init, out);
+                        if i < inits.len() - 1 {
+                            out.write(",");
+                            out.space();
+                        }
+                    }
+                    out.space();
+                }
+            }
+            SyntaxKind::Token if child.text == "}" => {
+                out.write("}");
+            }
+            SyntaxKind::Token if child.text == "," => {} // handled above with initializers
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::ConstArgumentList => format_const_argument_list(child, out),
+            SyntaxKind::CompositeMemberInitializer => {} // handled above
+            _ => {}
+        }
+    }
+}
+
+fn format_composite_member_init(node: &SyntaxNode, out: &mut Output) {
+    let has_colon = node.children.iter().any(|c| c.kind == SyntaxKind::Token && c.text == ":");
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == ":" => {
+                out.write(":");
+                out.space();
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) if has_colon => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_array_access(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "[" || child.text == "]" => out.write(child.text),
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_tuple_access(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_member_access(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_cast(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "as" => {
+                out.space();
+                out.write("as");
+                out.space();
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            SyntaxKind::Type(_) => format_type(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_array_expr(node: &SyntaxNode, out: &mut Output) {
+    let exprs: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Expression(_))).collect();
+
+    out.write("[");
+    for (i, expr) in exprs.iter().enumerate() {
+        format_node(expr, out);
+        if i < exprs.len() - 1 {
+            out.write(",");
+            out.space();
+        }
+    }
+    out.write("]");
+}
+
+fn format_tuple_expr(node: &SyntaxNode, out: &mut Output) {
+    let exprs: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Expression(_))).collect();
+
+    out.write("(");
+    for (i, expr) in exprs.iter().enumerate() {
+        format_node(expr, out);
+        if i < exprs.len() - 1 {
+            out.write(",");
+            out.space();
+        }
+    }
+    out.write(")");
+}
+
+fn format_parenthesized(node: &SyntaxNode, out: &mut Output) {
+    out.write("(");
+    for child in &node.children {
+        if let SyntaxKind::Expression(_) = &child.kind {
+            format_node(child, out);
+        }
+    }
+    out.write(")");
+}
+
+fn format_repeat_expr(node: &SyntaxNode, out: &mut Output) {
+    let exprs: Vec<_> = node.children.iter().filter(|c| matches!(c.kind, SyntaxKind::Expression(_))).collect();
+
+    out.write("[");
+    if exprs.len() >= 2 {
+        format_node(exprs[0], out);
+        out.write(";");
+        out.space();
+        format_node(exprs[1], out);
+    }
+    out.write("]");
+}
+
+fn format_async_expr(node: &SyntaxNode, out: &mut Output) {
+    out.write("async");
+    out.space();
+    for child in &node.children {
+        if let SyntaxKind::Statement(StatementKind::Block) = &child.kind {
+            format_block(child, out);
+        }
+    }
+}
+
+fn format_intrinsic(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        match &child.kind {
+            SyntaxKind::Token if child.text == "," => {
+                out.write(",");
+                out.space();
+            }
+            SyntaxKind::Token => out.write(child.text),
+            SyntaxKind::Expression(_) => format_node(child, out),
+            _ => {}
+        }
+    }
+}
+
+fn format_special_access(node: &SyntaxNode, out: &mut Output) {
+    for child in &node.children {
+        if let SyntaxKind::Token = &child.kind {
+            out.write(child.text);
         }
     }
 }

--- a/leo-fmt/tests/source/comment_between.leo
+++ b/leo-fmt/tests/source/comment_between.leo
@@ -1,0 +1,12 @@
+program test.aleo{
+        function process(  a  : u64  )  ->  u64  {
+                        // validate input
+        assert(  a  >  0u64  );
+    // compute result
+    let x  :u64=a  *  2u64;
+                    // apply offset
+            let y:   u64  =  x  +  1u64;
+      // return
+    return y;
+        }
+}

--- a/leo-fmt/tests/source/comment_end_of_block.leo
+++ b/leo-fmt/tests/source/comment_end_of_block.leo
@@ -1,0 +1,11 @@
+program test.aleo   {
+    function compute(   a  :  u64  )  ->  u64    {
+  let x  :  u64  =  a  *  2u64  ;
+          return x  ;
+                // end of function
+        }
+
+function empty_with_comment(  )  {
+                            // only a comment here
+}
+}

--- a/leo-fmt/tests/source/comment_mixed.leo
+++ b/leo-fmt/tests/source/comment_mixed.leo
@@ -1,0 +1,10 @@
+                // File-level comment
+    program test.aleo    {
+        function example(   a  :  u64  ,    b  :  u64  )  ->  u64    {
+    let x  :  u64  =    a  +  b  ;         // trailing comment
+            // standalone comment
+            let y  :  u64  =    x  *  2u64  ;
+                                // another standalone
+        return y  ;                 // return value
+        }
+}

--- a/leo-fmt/tests/source/comment_multiline.leo
+++ b/leo-fmt/tests/source/comment_multiline.leo
@@ -1,0 +1,39 @@
+         // The token program.
+// Implements minting and transferring of tokens.
+    import credits.aleo;
+
+program test.aleo {
+// A token record.
+   // - `owner` : The token owner.
+                    // - `amount` : The token amount.
+    record token {
+            owner: address,
+    amount: u64,
+        }
+
+        /* Mint */
+
+        // The function `mint_public` issues the specified token amount
+ // for the token receiver publicly on the network.
+    async transition mint_public(  public receiver:address ,  public amount:u64  )->Future{
+    return finalize_mint(  receiver  ,  amount  );
+    }
+
+/* Transfer */
+
+             // Transfers tokens from one address to another.
+
+
+
+
+    // This function is public and both the sender and receiver
+
+      // are visible on-chain.
+        async transition transfer_public(  public receiver:address  ,  public amount:u64  )->Future{
+        // Compute the change amount.
+    // This `sub` operation is safe, and the proof will fail
+                     // if an overflow occurs.
+    let change:u64=amount-1u64;
+                return finalize_transfer(  self.caller  ,  receiver  ,  amount  );
+    }
+}

--- a/leo-fmt/tests/source/comment_trailing.leo
+++ b/leo-fmt/tests/source/comment_trailing.leo
@@ -1,0 +1,14 @@
+program test.aleo {
+function compute(  a:u64 ,  b:u64   )->u64{
+let x:u64  =   a+b;       // compute sum
+        let y:u64=  x  *2u64;                  // double it
+assert(  y>0u64  );                                // must be positive
+                        return y;     // return result
+    }
+
+transition check(  a:u64  ,  b  :u64)  ->  bool   {
+                let result:bool  =a  >=  b;           // compare values
+            assert_eq(result,true);                         // verify
+return result;                              // done
+        }
+}

--- a/leo-fmt/tests/source/expr_access.leo
+++ b/leo-fmt/tests/source/expr_access.leo
@@ -1,0 +1,24 @@
+program test.aleo{
+struct Point  {  x:u64,
+    y  :  u64  }
+
+	function main(  )  ->  u64   {
+
+                let arr  :[u64;3]  =  [1u64  ,  2u64  ,  3u64];
+    let first  :u64  =  arr  [  0u32  ]  ;
+
+let tup
+    :(u64,u64)  =(  1u64  ,  2u64  );
+
+	    let a:u64  =tup.0;
+            let b:u64
+                =tup.1;
+
+let p:  Point
+    =Point  {  x  :  1u64  ,  y  :  2u64  };
+
+	        let px :u64  =  p.x;
+        return first  ;
+
+    }
+}

--- a/leo-fmt/tests/source/expr_binary.leo
+++ b/leo-fmt/tests/source/expr_binary.leo
@@ -1,0 +1,56 @@
+program test.aleo {
+    function compute(a: u64,b: u64) -> u64 {
+
+        let sum: u64  =a
+        +   b;
+	let diff: u64
+	    =a  -
+	    b;
+
+let prod
+    : u64   =   a
+                *b;
+                            let quot: u64=a   /b;
+        let rem: u64 =a
+            %b
+            ;
+
+let pow: u64=a  **
+    2u64;
+    let lt: bool =  a
+        <b;
+let gt
+    : bool=a   >
+    b;
+
+
+	    let le
+	        : bool  =a
+	             <=b;
+let ge: bool
+    =a
+        >=   b;
+        let eq: bool=a
+            ==b;
+let ne: bool=a  !=
+    b;
+
+let and: bool
+  =true
+      &&false;
+                    let or: bool=true||   false;
+        let band: u64=a
+                    &b;
+
+	let bor: u64  =  a  |
+	    b;
+let bxor: u64=   a^b;
+let shl: u64
+        =a
+            <<2u8;
+                let shr: u64=a  >>  2u8;
+
+        return sum
+            ;
+    }
+}

--- a/leo-fmt/tests/source/expr_call.leo
+++ b/leo-fmt/tests/source/expr_call.leo
@@ -1,0 +1,34 @@
+program test.aleo   {
+	function add(   a  :  u64  ,
+	    b  :  u64  )  ->  u64  {  return   a  +  b  ;  }
+
+    function main(
+            )  ->  u64   {
+
+let x
+    :u64  =add(
+        1u64
+            ,
+            2u64  )  ;
+
+                    let y:u64  =  add(
+                        1u64  ,  2u64  )  ;
+
+
+	    let hash
+	        :field  =  BHP256::hash_to_field(
+	                1u64  )  ;
+
+let mapped
+    :   u64=Mapping::get(
+    balances
+        ,
+                self.caller
+    )  ;
+
+            return
+                x  ;
+    }
+
+	mapping balances  :  address  =>  u64  ;
+}

--- a/leo-fmt/tests/source/expr_cast.leo
+++ b/leo-fmt/tests/source/expr_cast.leo
@@ -1,0 +1,17 @@
+program test.aleo   {
+	function main(   a
+	        :  u64  )  ->  u32  {
+
+let b  :  u32
+    =  a
+    as   u32
+    ;
+
+                let c
+                    :field=  a  as
+                    field  ;
+
+	    return b  ;
+
+    }
+}

--- a/leo-fmt/tests/source/expr_collections.leo
+++ b/leo-fmt/tests/source/expr_collections.leo
@@ -1,0 +1,29 @@
+program test.aleo
+    {
+	function main(  ){
+
+            let arr  :  [u64;  3]  =  [
+                1u64  ,
+                    2u64  ,
+            3u64  ]  ;
+
+let tup  :(u64  ,u64  ,u64)=(
+    1u64  ,
+        2u64,
+                3u64  )
+                ;
+
+	    let nested:[[u64;2];2]  =  [
+            [  1u64
+                ,  2u64  ]  ,
+    [3u64  ,
+            4u64]  ];
+
+
+let parens  :u64  =(  1u64  +  2u64  )
+    *  3u64;
+                    let repeat  :  [u64;4]=[   0u64
+                        ;  4u64   ];
+
+	}
+}

--- a/leo-fmt/tests/source/expr_literals.leo
+++ b/leo-fmt/tests/source/expr_literals.leo
@@ -1,0 +1,31 @@
+program test.aleo{
+	function main(  ){
+
+let a  :u8  =  1u8;
+                    let b:u16=2u16;
+  let c :u32  =
+      3u32;
+
+        let d:   u64   =4u64;
+	    let e  :  u128  =  5u128;
+
+let f:i8=  -1i8;
+            let g:i16  =-2i16;
+        let h  :  i32=
+            -3i32;
+
+
+	let i:i64
+        =-4i64;
+                let j  :i128  =  -5i128;
+
+    let k :  field  =  1field;
+let l  :scalar=1scalar;
+        let m:bool
+      =true;
+                    let n  :  bool  =  false;
+
+let o:address  =aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8s7pyjh9;
+
+	}
+}

--- a/leo-fmt/tests/source/expr_method_chain.leo
+++ b/leo-fmt/tests/source/expr_method_chain.leo
@@ -1,0 +1,66 @@
+program test.aleo
+  {
+	mapping balances  :  address
+	    =>  u64;
+
+    struct Wrapper   {
+                inner  :  u64,
+	}
+
+  async transition deposit(
+            public sender
+                :  address  ,
+    public amount
+        :  u64  )  ->  Future  {
+	    let bal  :  u64  =  balances.get(
+                            sender
+                                );
+        let check  :  bool  =  balances.contains(
+    sender  )
+        ;
+            balances.set(  sender  ,
+	    amount  )
+	        ;
+balances.remove(
+                sender  )  ;
+    let val  :  u64  =  balances.get_or_use(  sender  ,
+	        0u64  )
+	            ;
+            return finalize_deposit(
+    sender  ,
+        amount  )
+            ;
+        }
+
+	function use_special(
+	        )  ->  address  {
+let caller  :  address  =  self.caller
+    ;
+                let signer  :  address
+    =  self.signer;
+	    let h  :  u32  =  block.height
+	        ;
+            let t  :  u128  =
+        block.timestamp
+            ;
+    let n  :  u16  =  network.id;
+	                return
+	                    caller  ;
+}
+
+      function access_chain(
+            w  :  Wrapper  ,
+	    arr  :  [u64;  3]  ,
+    tup  :  (u64,  u64)
+        )  ->  u64   {
+        let a  :  u64  =  w.inner
+            ;
+let b  :  u64
+                =  arr[  0u32  ]  ;
+	    let c  :  u64  =  tup.0
+	        ;
+            let d  :  u64  =  tup.1;
+    return
+        a  ;
+  }
+}

--- a/leo-fmt/tests/source/expr_struct.leo
+++ b/leo-fmt/tests/source/expr_struct.leo
@@ -1,0 +1,17 @@
+program test.aleo   {
+	struct Point  {
+  x  :u64  ,
+            y  :  u64  }
+
+    function main(  )  ->  Point   {
+
+let p  :Point  =  Point  {   x  :  1u64  ,
+        y  :  2u64   }  ;
+
+                let q  :  Point  =  Point  {
+	    x  :  p.x  ,  y  :  p.y  };
+
+            return p  ;
+
+    }
+}

--- a/leo-fmt/tests/source/expr_ternary.leo
+++ b/leo-fmt/tests/source/expr_ternary.leo
@@ -1,0 +1,20 @@
+program test.aleo
+{
+	function main(  a  :  u64  ,
+	        b
+	            :  u64  )  ->  u64  {
+
+let result  :u64  =  a  >  b
+    ?  a
+        :  b
+        ;
+
+            let nested:u64  =a  >b  ?  a  >  10u64
+                ?  a  :
+                    10u64  :  b;
+
+	    return
+	        result  ;
+
+    }
+}

--- a/leo-fmt/tests/source/expr_unary.leo
+++ b/leo-fmt/tests/source/expr_unary.leo
@@ -1,0 +1,13 @@
+program test.aleo{
+	function main(  a  :  u64  )  ->  u64  {
+
+            let neg  :  u64  =  -  a;
+
+    let not  :  bool  =  !  true;
+
+let double_neg  :  u64  =
+        -  -  a;
+
+	    return neg  ;
+    }
+}

--- a/leo-fmt/tests/source/function_simple.leo
+++ b/leo-fmt/tests/source/function_simple.leo
@@ -1,4 +1,4 @@
-program test.aleo {
+program test.aleo{
   function add( a :u64,  b:u64 )  ->  u64 {
       return a+b;
    }

--- a/leo-fmt/tests/source/stmt_assert.leo
+++ b/leo-fmt/tests/source/stmt_assert.leo
@@ -1,0 +1,26 @@
+program test.aleo{
+	function main(   a  :  u64  ,
+	        b  :  u64   )  {
+
+            assert(  a  >  0u64  )
+                ;
+    assert(
+        b  >0u64)  ;
+
+assert_eq(  a  ,
+                b  )
+                    ;
+
+	    assert_eq(
+	        a,
+	            b)  ;
+
+        assert_neq(
+            a  ,
+                0u64  )  ;
+                assert_neq(a
+    ,0u64)
+        ;
+
+	}
+}

--- a/leo-fmt/tests/source/stmt_assign.leo
+++ b/leo-fmt/tests/source/stmt_assign.leo
@@ -1,0 +1,29 @@
+program test.aleo
+  {
+	function main(  ){
+
+let x  :  u64  =
+        5u64
+            ;
+
+                x  =
+                    10u64  ;
+
+    x  +=
+        5u64
+            ;
+	    x  -=  2u64
+	        ;
+
+            x  *=
+                3u64;
+
+x  /=
+                    2u64
+                        ;
+        x%=  3u64  ;
+
+	x  **=  2u64  ;
+
+}
+}

--- a/leo-fmt/tests/source/stmt_const.leo
+++ b/leo-fmt/tests/source/stmt_const.leo
@@ -1,0 +1,17 @@
+program test.aleo
+        {
+	function main(
+	    )  ->  u64   {
+const X  :u64
+        =  100u64
+            ;
+            const Y  :  field
+                =  1field  ;
+    const Z
+        :  bool  =
+	    true
+	        ;
+                    return
+                        X  ;
+    }
+}

--- a/leo-fmt/tests/source/stmt_expression.leo
+++ b/leo-fmt/tests/source/stmt_expression.leo
@@ -1,0 +1,15 @@
+program test.aleo
+    {
+	transition main(
+            item
+                :  u64
+    )  {
+    Mapping::set(  balances  ,
+                    self.caller  ,
+                        item  )
+                            ;
+	    Mapping::get(  balances  ,
+        self.caller  )
+            ;
+    }
+}

--- a/leo-fmt/tests/source/stmt_for.leo
+++ b/leo-fmt/tests/source/stmt_for.leo
@@ -1,0 +1,20 @@
+program test.aleo{
+	function main(  )  ->  u64  {
+            let sum  :  u64
+                =  0u64
+                    ;
+    for i in
+            0u64  ..  10u64  {
+	    sum  +=
+	        i
+	            ;
+                    }
+for j  :  u64 in 0u64  ..
+    5u64
+        {
+sum  +=  j  ;
+	    }
+        return
+            sum  ;
+}
+}

--- a/leo-fmt/tests/source/stmt_if.leo
+++ b/leo-fmt/tests/source/stmt_if.leo
@@ -1,0 +1,25 @@
+program test.aleo{
+	function main(  a
+	        :  u64  )  ->  u64   {
+            if  a  >  5u64  {  return
+                1u64  ;  }
+    if a  <  3u64
+	{
+                    return
+                        2u64  ;
+        }
+if a  ==  4u64  {  return 3u64  ;  }  else  {  return
+        4u64  ;  }
+	    if a  >10u64{
+            return 5u64
+                ;
+    }  else
+                if a  >  7u64
+	{  return
+	    6u64  ;  }
+            else  {
+    return 7u64
+        ;
+        }
+    }
+}

--- a/leo-fmt/tests/source/stmt_let_destructure.leo
+++ b/leo-fmt/tests/source/stmt_let_destructure.leo
@@ -1,0 +1,22 @@
+program test.aleo
+  {
+	function main(  )   {
+            let (  a  ,
+                b  )  =  (  1u64  ,
+                    2u64  )  ;
+    let (  x  ,
+	    y  )  =  get_pair(
+                    )
+                        ;
+let (  p  ,  q  )  :  (  u64  ,  u64  )  =  (
+        3u64  ,
+        4u64  )  ;
+    }
+
+	function get_pair(
+	        )  ->  (  u64  ,  u64  )   {
+            return (  1u64  ,
+    2u64  )
+        ;
+    }
+}

--- a/leo-fmt/tests/source/stmt_let_simple.leo
+++ b/leo-fmt/tests/source/stmt_let_simple.leo
@@ -1,0 +1,8 @@
+program test.aleo   {
+	function main(  )  {
+            let x  =  5u64;
+    let    y
+            =  10u64;
+	let		z  =  x  ;
+    }
+}

--- a/leo-fmt/tests/source/stmt_let_typed.leo
+++ b/leo-fmt/tests/source/stmt_let_typed.leo
@@ -1,0 +1,15 @@
+program test.aleo
+    {
+	function main(  )   {
+let x  :  u64
+        =  5u64
+            ;
+            let y
+                :field  =
+	    1field
+	        ;
+    let z  :
+                bool  =
+        true  ;
+}
+}

--- a/leo-fmt/tests/source/stmt_return.leo
+++ b/leo-fmt/tests/source/stmt_return.leo
@@ -1,0 +1,22 @@
+program test.aleo
+            {
+	function with_expr(  a  :  u64  )  ->  u64  {
+    return   a  *
+                    2u64
+                        ;
+        }
+
+	function bare_return(
+	        )  ->  (  )  {
+            return
+                ;
+    }
+
+        function with_tuple(  a  :  u64  ,
+	    b
+	        :  u64  )  ->  (  u64  ,  u64  )  {
+return    (  a  +  b  ,
+            a  *  b  )
+                ;
+    }
+}

--- a/leo-fmt/tests/source/struct_simple.leo
+++ b/leo-fmt/tests/source/struct_simple.leo
@@ -1,6 +1,5 @@
-program test.aleo  {
-    struct Point  {
+program test.aleo{
+struct Point{
   x :  u64,
-        y:u64,
-    }
+        y:u64}
 }

--- a/leo-fmt/tests/target/comment_between.leo
+++ b/leo-fmt/tests/target/comment_between.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    function process(a: u64) -> u64 {
+        // validate input
+        assert(a > 0u64);
+        // compute result
+        let x: u64 = a * 2u64;
+        // apply offset
+        let y: u64 = x + 1u64;
+        // return
+        return y;
+    }
+}

--- a/leo-fmt/tests/target/comment_end_of_block.leo
+++ b/leo-fmt/tests/target/comment_end_of_block.leo
@@ -1,0 +1,11 @@
+program test.aleo {
+    function compute(a: u64) -> u64 {
+        let x: u64 = a * 2u64;
+        return x;
+        // end of function
+    }
+
+    function empty_with_comment() {
+        // only a comment here
+    }
+}

--- a/leo-fmt/tests/target/comment_mixed.leo
+++ b/leo-fmt/tests/target/comment_mixed.leo
@@ -1,0 +1,10 @@
+// File-level comment
+program test.aleo {
+    function example(a: u64, b: u64) -> u64 {
+        let x: u64 = a + b; // trailing comment
+        // standalone comment
+        let y: u64 = x * 2u64;
+        // another standalone
+        return y; // return value
+    }
+}

--- a/leo-fmt/tests/target/comment_multiline.leo
+++ b/leo-fmt/tests/target/comment_multiline.leo
@@ -1,0 +1,32 @@
+// The token program.
+// Implements minting and transferring of tokens.
+import credits.aleo;
+
+program test.aleo {
+    // A token record.
+    // - `owner` : The token owner.
+    // - `amount` : The token amount.
+    record token {
+        owner: address,
+        amount: u64,
+    }
+
+    /* Mint */
+    // The function `mint_public` issues the specified token amount
+    // for the token receiver publicly on the network.
+    async transition mint_public(public receiver: address, public amount: u64) -> Future {
+        return finalize_mint(receiver, amount);
+    }
+
+    /* Transfer */
+    // Transfers tokens from one address to another.
+    // This function is public and both the sender and receiver
+    // are visible on-chain.
+    async transition transfer_public(public receiver: address, public amount: u64) -> Future {
+        // Compute the change amount.
+        // This `sub` operation is safe, and the proof will fail
+        // if an overflow occurs.
+        let change: u64 = amount - 1u64;
+        return finalize_transfer(self.caller, receiver, amount);
+    }
+}

--- a/leo-fmt/tests/target/comment_trailing.leo
+++ b/leo-fmt/tests/target/comment_trailing.leo
@@ -1,0 +1,14 @@
+program test.aleo {
+    function compute(a: u64, b: u64) -> u64 {
+        let x: u64 = a + b; // compute sum
+        let y: u64 = x * 2u64; // double it
+        assert(y > 0u64); // must be positive
+        return y; // return result
+    }
+
+    transition check(a: u64, b: u64) -> bool {
+        let result: bool = a >= b; // compare values
+        assert_eq(result, true); // verify
+        return result; // done
+    }
+}

--- a/leo-fmt/tests/target/expr_access.leo
+++ b/leo-fmt/tests/target/expr_access.leo
@@ -1,0 +1,17 @@
+program test.aleo {
+    struct Point {
+        x: u64,
+        y: u64,
+    }
+
+    function main() -> u64 {
+        let arr: [u64; 3] = [1u64, 2u64, 3u64];
+        let first: u64 = arr[0u32];
+        let tup: (u64, u64) = (1u64, 2u64);
+        let a: u64 = tup.0;
+        let b: u64 = tup.1;
+        let p: Point = Point { x: 1u64, y: 2u64 };
+        let px: u64 = p.x;
+        return first;
+    }
+}

--- a/leo-fmt/tests/target/expr_binary.leo
+++ b/leo-fmt/tests/target/expr_binary.leo
@@ -1,0 +1,24 @@
+program test.aleo {
+    function compute(a: u64, b: u64) -> u64 {
+        let sum: u64 = a + b;
+        let diff: u64 = a - b;
+        let prod: u64 = a * b;
+        let quot: u64 = a / b;
+        let rem: u64 = a % b;
+        let pow: u64 = a ** 2u64;
+        let lt: bool = a < b;
+        let gt: bool = a > b;
+        let le: bool = a <= b;
+        let ge: bool = a >= b;
+        let eq: bool = a == b;
+        let ne: bool = a != b;
+        let and: bool = true && false;
+        let or: bool = true || false;
+        let band: u64 = a & b;
+        let bor: u64 = a | b;
+        let bxor: u64 = a ^ b;
+        let shl: u64 = a << 2u8;
+        let shr: u64 = a >> 2u8;
+        return sum;
+    }
+}

--- a/leo-fmt/tests/target/expr_call.leo
+++ b/leo-fmt/tests/target/expr_call.leo
@@ -1,0 +1,15 @@
+program test.aleo {
+    function add(a: u64, b: u64) -> u64 {
+        return a + b;
+    }
+
+    function main() -> u64 {
+        let x: u64 = add(1u64, 2u64);
+        let y: u64 = add(1u64, 2u64);
+        let hash: field = BHP256::hash_to_field(1u64);
+        let mapped: u64 = Mapping::get(balances, self.caller);
+        return x;
+    }
+
+    mapping balances: address => u64;
+}

--- a/leo-fmt/tests/target/expr_cast.leo
+++ b/leo-fmt/tests/target/expr_cast.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    function main(a: u64) -> u32 {
+        let b: u32 = a as u32;
+        let c: field = a as field;
+        return b;
+    }
+}

--- a/leo-fmt/tests/target/expr_collections.leo
+++ b/leo-fmt/tests/target/expr_collections.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    function main() {
+        let arr: [u64; 3] = [1u64, 2u64, 3u64];
+        let tup: (u64, u64, u64) = (1u64, 2u64, 3u64);
+        let nested: [[u64; 2]; 2] = [[1u64, 2u64], [3u64, 4u64]];
+        let parens: u64 = (1u64 + 2u64) * 3u64;
+        let repeat: [u64; 4] = [0u64; 4u64];
+    }
+}

--- a/leo-fmt/tests/target/expr_literals.leo
+++ b/leo-fmt/tests/target/expr_literals.leo
@@ -1,0 +1,19 @@
+program test.aleo {
+    function main() {
+        let a: u8 = 1u8;
+        let b: u16 = 2u16;
+        let c: u32 = 3u32;
+        let d: u64 = 4u64;
+        let e: u128 = 5u128;
+        let f: i8 = -1i8;
+        let g: i16 = -2i16;
+        let h: i32 = -3i32;
+        let i: i64 = -4i64;
+        let j: i128 = -5i128;
+        let k: field = 1field;
+        let l: scalar = 1scalar;
+        let m: bool = true;
+        let n: bool = false;
+        let o: address = aleo1qnr4dkkvkgfqph0vzc3y6z2eu975wnpz2925ntjccd5cfqxtyu8s7pyjh9;
+    }
+}

--- a/leo-fmt/tests/target/expr_method_chain.leo
+++ b/leo-fmt/tests/target/expr_method_chain.leo
@@ -1,0 +1,33 @@
+program test.aleo {
+    mapping balances: address => u64;
+
+    struct Wrapper {
+        inner: u64,
+    }
+
+    async transition deposit(public sender: address, public amount: u64) -> Future {
+        let bal: u64 = balances.get(sender);
+        let check: bool = balances.contains(sender);
+        balances.set(sender, amount);
+        balances.remove(sender);
+        let val: u64 = balances.get_or_use(sender, 0u64);
+        return finalize_deposit(sender, amount);
+    }
+
+    function use_special() -> address {
+        let caller: address = self.caller;
+        let signer: address = self.signer;
+        let h: u32 = block.height;
+        let t: u128 = block.timestamp;
+        let n: u16 = network.id;
+        return caller;
+    }
+
+    function access_chain(w: Wrapper, arr: [u64; 3], tup: (u64, u64)) -> u64 {
+        let a: u64 = w.inner;
+        let b: u64 = arr[0u32];
+        let c: u64 = tup.0;
+        let d: u64 = tup.1;
+        return a;
+    }
+}

--- a/leo-fmt/tests/target/expr_struct.leo
+++ b/leo-fmt/tests/target/expr_struct.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    struct Point {
+        x: u64,
+        y: u64,
+    }
+
+    function main() -> Point {
+        let p: Point = Point { x: 1u64, y: 2u64 };
+        let q: Point = Point { x: p.x, y: p.y };
+        return p;
+    }
+}

--- a/leo-fmt/tests/target/expr_ternary.leo
+++ b/leo-fmt/tests/target/expr_ternary.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    function main(a: u64, b: u64) -> u64 {
+        let result: u64 = a > b ? a : b;
+        let nested: u64 = a > b ? a > 10u64 ? a : 10u64 : b;
+        return result;
+    }
+}

--- a/leo-fmt/tests/target/expr_unary.leo
+++ b/leo-fmt/tests/target/expr_unary.leo
@@ -1,0 +1,8 @@
+program test.aleo {
+    function main(a: u64) -> u64 {
+        let neg: u64 = -a;
+        let not: bool = !true;
+        let double_neg: u64 = --a;
+        return neg;
+    }
+}

--- a/leo-fmt/tests/target/stmt_assert.leo
+++ b/leo-fmt/tests/target/stmt_assert.leo
@@ -1,0 +1,10 @@
+program test.aleo {
+    function main(a: u64, b: u64) {
+        assert(a > 0u64);
+        assert(b > 0u64);
+        assert_eq(a, b);
+        assert_eq(a, b);
+        assert_neq(a, 0u64);
+        assert_neq(a, 0u64);
+    }
+}

--- a/leo-fmt/tests/target/stmt_assign.leo
+++ b/leo-fmt/tests/target/stmt_assign.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    function main() {
+        let x: u64 = 5u64;
+        x = 10u64;
+        x += 5u64;
+        x -= 2u64;
+        x *= 3u64;
+        x /= 2u64;
+        x %= 3u64;
+        x **= 2u64;
+    }
+}

--- a/leo-fmt/tests/target/stmt_const.leo
+++ b/leo-fmt/tests/target/stmt_const.leo
@@ -1,0 +1,8 @@
+program test.aleo {
+    function main() -> u64 {
+        const X: u64 = 100u64;
+        const Y: field = 1field;
+        const Z: bool = true;
+        return X;
+    }
+}

--- a/leo-fmt/tests/target/stmt_expression.leo
+++ b/leo-fmt/tests/target/stmt_expression.leo
@@ -1,0 +1,6 @@
+program test.aleo {
+    transition main(item: u64) {
+        Mapping::set(balances, self.caller, item);
+        Mapping::get(balances, self.caller);
+    }
+}

--- a/leo-fmt/tests/target/stmt_for.leo
+++ b/leo-fmt/tests/target/stmt_for.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    function main() -> u64 {
+        let sum: u64 = 0u64;
+        for i in 0u64..10u64 {
+            sum += i;
+        }
+        for j: u64 in 0u64..5u64 {
+            sum += j;
+        }
+        return sum;
+    }
+}

--- a/leo-fmt/tests/target/stmt_if.leo
+++ b/leo-fmt/tests/target/stmt_if.leo
@@ -1,0 +1,22 @@
+program test.aleo {
+    function main(a: u64) -> u64 {
+        if a > 5u64 {
+            return 1u64;
+        }
+        if a < 3u64 {
+            return 2u64;
+        }
+        if a == 4u64 {
+            return 3u64;
+        } else {
+            return 4u64;
+        }
+        if a > 10u64 {
+            return 5u64;
+        } else if a > 7u64 {
+            return 6u64;
+        } else {
+            return 7u64;
+        }
+    }
+}

--- a/leo-fmt/tests/target/stmt_let_destructure.leo
+++ b/leo-fmt/tests/target/stmt_let_destructure.leo
@@ -1,0 +1,11 @@
+program test.aleo {
+    function main() {
+        let (a, b) = (1u64, 2u64);
+        let (x, y) = get_pair();
+        let (p, q): (u64, u64) = (3u64, 4u64);
+    }
+
+    function get_pair() -> (u64, u64) {
+        return (1u64, 2u64);
+    }
+}

--- a/leo-fmt/tests/target/stmt_let_simple.leo
+++ b/leo-fmt/tests/target/stmt_let_simple.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    function main() {
+        let x = 5u64;
+        let y = 10u64;
+        let z = x;
+    }
+}

--- a/leo-fmt/tests/target/stmt_let_typed.leo
+++ b/leo-fmt/tests/target/stmt_let_typed.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    function main() {
+        let x: u64 = 5u64;
+        let y: field = 1field;
+        let z: bool = true;
+    }
+}

--- a/leo-fmt/tests/target/stmt_return.leo
+++ b/leo-fmt/tests/target/stmt_return.leo
@@ -1,0 +1,13 @@
+program test.aleo {
+    function with_expr(a: u64) -> u64 {
+        return a * 2u64;
+    }
+
+    function bare_return() -> () {
+        return;
+    }
+
+    function with_tuple(a: u64, b: u64) -> (u64, u64) {
+        return (a + b, a * b);
+    }
+}


### PR DESCRIPTION
Completes the core formatting logic. All statements, expressions, and types now produce correct output.

Adds:
- Statement formatting: let/const bindings, assignment, return, if/else, for loops, assert, expression statements
- Expression formatting: binary/unary/ternary ops, function/method/associated calls, struct literals, access expressions, casts, literals, collections
- Comment preservation: trailing vs standalone comment detection via trivia linebreak tracking, inter-item blank line placement that keeps doc comments attached to the item they describe
- Fixes `Storage` and `GlobalConst` items being silently dropped

Note: Line-width wrapping for long lines is deferred for a follow up PR.

Part of #28579