### PR TITLE
 Refactor the CLI testing framework + `leo devnode` enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,5 @@
 version: 2.1
 
-parameters:
-  snarkos-rev:
-    type: string
-    default: "c0b9a20d2a8aa6811e3ce93826ed489b59ab9bf3" # testnet-v4.5.1
-
 # Notes
 # - `sccache` was removed because it doesn't actually provide much benefit in CI. Lots of cache misses.
 # - https://github.com/Swatinem/rust-cache?tab=readme-ov-file#cache-details provides guidance on which directories to cache.
@@ -18,7 +13,6 @@ parameters:
 # TODO:
 #  - The cache size can accumulate as the dependencies get upgraded. Ideally you want some pruning before the cache gets persisted.
 #    See swatinem/rust-cache for a sensible approach. Unfortunately, we'd have to build this for CircleCI.
-
 
 orbs:
   windows: circleci/windows@5.1.0
@@ -78,43 +72,6 @@ commands:
                 cargo generate-lockfile
             }
             cargo install cargo-mtime
-
-  install-snarkos:
-    description: "Install snarkOS (Linux/macOS)"
-    steps:
-      - restore_cache:
-          keys:
-            - snarkos-install-{{ arch }}-<< pipeline.parameters.snarkos-rev >>
-
-      - run:
-          name: Install snarkOS
-          command: |
-            set -euo pipefail
-            BIN="$HOME/.cargo/snarkos-<< pipeline.parameters.snarkos-rev >>/bin/snarkos"
-
-            if [ -f "$BIN" ] && [ -x "$BIN" ]; then
-                echo "Using cached snarkOS"
-                mkdir -p "$HOME/.cargo/bin"
-                ln -sf "$BIN" "$HOME/.cargo/bin/snarkos"
-                snarkos --version
-                exit 0
-            fi
-
-            rm -f "$HOME/.cargo/bin/snarkos"
-            git clone https://github.com/ProvableHQ/snarkOS.git
-            cd snarkOS
-            git checkout << pipeline.parameters.snarkos-rev >>
-            cargo install --path . --features test_network --locked --force \
-              --root "$HOME/.cargo/snarkos-<< pipeline.parameters.snarkos-rev >>"
-            cd ..
-            rm -rf snarkOS
-            ln -sf "$BIN" "$HOME/.cargo/bin/snarkos"
-            snarkos --version
-
-      - save_cache:
-          key: snarkos-install-{{ arch }}-<< pipeline.parameters.snarkos-rev >>
-          paths:
-            - ~/.cargo/snarkos-<< pipeline.parameters.snarkos-rev >>
 
   build-and-test:
     description: "Build and run tests"
@@ -219,11 +176,6 @@ jobs:
             - cargo-v1-{{ arch }}-{{ checksum "Cargo.toml" }}
             - cargo-v1-{{ arch }}
       - install-rust
-      - install-snarkos
-      - run:
-          name: Verify SnarkOS installation
-          command: |
-            snarkos --version
       - run:
           name: Update Submodules
           command: git submodule update --init --recursive
@@ -244,22 +196,6 @@ jobs:
             - cargo-v1-{{ arch }}-{{ checksum "Cargo.toml" }}
             - cargo-v1-{{ arch }}
       - install-rust
-      - run:
-          name: Install snarkos dependencies
-          command: |
-            sudo apt-get update
-            sudo apt-get install -y \
-              build-essential \
-              clang \
-              libssl-dev \
-              llvm \
-              lld \
-              pkg-config
-      - install-snarkos
-      - run:
-          name: Verify SnarkOS installation
-          command: |
-            snarkos --version
       - run:
             name: Update Submodules
             command: git submodule update --init --recursive

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,7 @@
+[test-groups]
+serial-integration = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(cli_tests::)'
+platform = 'cfg(unix)'
+test-group = 'serial-integration'

--- a/leo/cli/commands/devnode/rest/routes.rs
+++ b/leo/cli/commands/devnode/rest/routes.rs
@@ -74,22 +74,22 @@ pub(crate) struct CreateBlockRequest {
 impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
     /// Get /<network>/consensus_version
     pub(crate) async fn get_consensus_version(State(rest): State<Self>) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(N::CONSENSUS_VERSION(rest.ledger.latest_height())? as u16))
+        Ok(ErasedJson::new(N::CONSENSUS_VERSION(rest.ledger.latest_height())? as u16))
     }
 
     /// GET /<network>/block/height/latest
     pub(crate) async fn get_block_height_latest(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_height())
+        ErasedJson::new(rest.ledger.latest_height())
     }
 
     /// GET /<network>/block/hash/latest
     pub(crate) async fn get_block_hash_latest(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_hash())
+        ErasedJson::new(rest.ledger.latest_hash())
     }
 
     /// GET /<network>/block/latest
     pub(crate) async fn get_block_latest(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_block())
+        ErasedJson::new(rest.ledger.latest_block())
     }
 
     /// GET /<network>/block/{height}
@@ -110,7 +110,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             )));
         };
 
-        Ok(ErasedJson::pretty(block))
+        Ok(ErasedJson::new(block))
     }
 
     /// GET /<network>/blocks?start={start_height}&end={end_height}
@@ -143,7 +143,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
                 .map(|height| rest.ledger.get_block(height))
                 .collect::<Result<Vec<_>, _>>()?;
 
-            Ok(ErasedJson::pretty(blocks))
+            Ok(ErasedJson::new(blocks))
         };
 
         // Fetch the blocks from ledger and serialize to json.
@@ -164,7 +164,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(hash): Path<N::BlockHash>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_height(&hash)?))
+        Ok(ErasedJson::new(rest.ledger.get_height(&hash)?))
     }
 
     /// GET /<network>/block/{height}/header
@@ -172,7 +172,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(height): Path<u32>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_header(height)?))
+        Ok(ErasedJson::new(rest.ledger.get_header(height)?))
     }
 
     /// GET /<network>/block/{height}/transactions
@@ -180,7 +180,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(height): Path<u32>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_transactions(height)?))
+        Ok(ErasedJson::new(rest.ledger.get_transactions(height)?))
     }
 
     /// GET /<network>/transaction/{transactionID}
@@ -189,7 +189,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
         // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
-        Ok(ErasedJson::pretty(rest.ledger.get_transaction(tx_id).map_err(|err| {
+        Ok(ErasedJson::new(rest.ledger.get_transaction(tx_id).map_err(|err| {
             if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
         })?))
     }
@@ -200,7 +200,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
         // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
-        Ok(ErasedJson::pretty(rest.ledger.get_confirmed_transaction(tx_id).map_err(|err| {
+        Ok(ErasedJson::new(rest.ledger.get_confirmed_transaction(tx_id).map_err(|err| {
             if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
         })?))
     }
@@ -211,7 +211,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
         // Ledger returns a generic anyhow::Error, so checking the message is the only way to parse it.
-        Ok(ErasedJson::pretty(rest.ledger.get_unconfirmed_transaction(&tx_id).map_err(|err| {
+        Ok(ErasedJson::new(rest.ledger.get_unconfirmed_transaction(&tx_id).map_err(|err| {
             if err.to_string().contains("Missing") { RestError::not_found(err) } else { RestError::from(err) }
         })?))
     }
@@ -232,7 +232,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             return rest.return_program_with_metadata(program, edition);
         }
         // Return the program without metadata.
-        Ok(ErasedJson::pretty(program))
+        Ok(ErasedJson::new(program))
     }
 
     /// GET /<network>/program/{programID}/{edition}
@@ -253,7 +253,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
                 if metadata.metadata.unwrap_or(false) {
                     rest.return_program_with_metadata(program, edition)
                 } else {
-                    Ok(ErasedJson::pretty(program))
+                    Ok(ErasedJson::new(program))
                 }
             }
             None => Err(RestError::not_found(anyhow!("No program `{id}` exists for edition {edition}"))),
@@ -279,7 +279,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
                 .and_then(|deployment| deployment.program_owner()),
             None => None,
         };
-        Ok(ErasedJson::pretty(json!({
+        Ok(ErasedJson::new(json!({
             "program": program,
             "edition": edition,
             "transaction_id": tx_id,
@@ -292,7 +292,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(id): Path<ProgramID<N>>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_latest_edition_for_program(&id)?))
+        Ok(ErasedJson::new(rest.ledger.get_latest_edition_for_program(&id)?))
     }
 
     /// GET /<network>/program/{programID}/mappings
@@ -300,7 +300,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(id): Path<ProgramID<N>>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.vm().finalize_store().get_mapping_names_confirmed(&id)?))
+        Ok(ErasedJson::new(rest.ledger.vm().finalize_store().get_mapping_names_confirmed(&id)?))
     }
 
     /// GET /<network>/program/{programID}/mapping/{mappingName}/{mappingKey}
@@ -315,14 +315,14 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
 
         // Check if metadata is requested and return the value with metadata if so.
         if metadata.metadata.unwrap_or(false) {
-            return Ok(ErasedJson::pretty(json!({
+            return Ok(ErasedJson::new(json!({
                 "data": mapping_value,
                 "height": rest.ledger.latest_height(),
             })));
         }
 
         // Return the value without metadata.
-        Ok(ErasedJson::pretty(mapping_value))
+        Ok(ErasedJson::new(mapping_value))
     }
 
     /// GET /<network>/program/{programID}/mapping/{mappingName}?all={true}&metadata={true}
@@ -348,14 +348,14 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             Ok(Ok(mapping_values)) => {
                 // Check if metadata is requested and return the mapping with metadata if so.
                 if metadata.metadata.unwrap_or(false) {
-                    return Ok(ErasedJson::pretty(json!({
+                    return Ok(ErasedJson::new(json!({
                         "data": mapping_values,
                         "height": height,
                     })));
                 }
 
                 // Return the full mapping without metadata.
-                Ok(ErasedJson::pretty(mapping_values))
+                Ok(ErasedJson::new(mapping_values))
             }
             Ok(Err(err)) => Err(RestError::internal_server_error(err.context("Unable to read mapping"))),
             Err(err) => Err(RestError::internal_server_error(anyhow!("Tokio error: {err}"))),
@@ -367,7 +367,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(commitment): Path<Field<N>>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_state_path_for_commitment(&commitment)?))
+        Ok(ErasedJson::new(rest.ledger.get_state_path_for_commitment(&commitment)?))
     }
 
     /// GET /<network>/statePaths?commitments=cm1,cm2,...
@@ -400,12 +400,12 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        Ok(ErasedJson::pretty(rest.ledger.get_state_paths_for_commitments(&commitments)?))
+        Ok(ErasedJson::new(rest.ledger.get_state_paths_for_commitments(&commitments)?))
     }
 
     /// GET /<network>/stateRoot/latest
     pub(crate) async fn get_state_root_latest(State(rest): State<Self>) -> ErasedJson {
-        ErasedJson::pretty(rest.ledger.latest_state_root())
+        ErasedJson::new(rest.ledger.latest_state_root())
     }
 
     /// GET /<network>/stateRoot/{height}
@@ -413,7 +413,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(height): Path<u32>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.get_state_root(height)?))
+        Ok(ErasedJson::new(rest.ledger.get_state_root(height)?))
     }
 
     /// GET /<network>/find/blockHash/{transactionID}
@@ -421,7 +421,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(tx_id): Path<N::TransactionID>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_block_hash(&tx_id)?))
+        Ok(ErasedJson::new(rest.ledger.find_block_hash(&tx_id)?))
     }
 
     /// GET /<network>/find/blockHeight/{stateRoot}
@@ -429,7 +429,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(state_root): Path<N::StateRoot>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_block_height_from_state_root(state_root)?))
+        Ok(ErasedJson::new(rest.ledger.find_block_height_from_state_root(state_root)?))
     }
 
     /// GET /<network>/find/transactionID/deployment/{programID}
@@ -437,7 +437,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(program_id): Path<ProgramID<N>>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_latest_transaction_id_from_program_id(&program_id)?))
+        Ok(ErasedJson::new(rest.ledger.find_latest_transaction_id_from_program_id(&program_id)?))
     }
 
     /// GET /<network>/find/transactionID/deployment/{programID}/{edition}
@@ -445,7 +445,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path((program_id, edition)): Path<(ProgramID<N>, u16)>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_transaction_id_from_program_id_and_edition(&program_id, edition)?))
+        Ok(ErasedJson::new(rest.ledger.find_transaction_id_from_program_id_and_edition(&program_id, edition)?))
     }
 
     /// GET /<network>/find/transactionID/{transitionID}
@@ -453,7 +453,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(transition_id): Path<N::TransitionID>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_transaction_id_from_transition_id(&transition_id)?))
+        Ok(ErasedJson::new(rest.ledger.find_transaction_id_from_transition_id(&transition_id)?))
     }
 
     /// GET /<network>/find/transitionID/{inputOrOutputID}
@@ -461,7 +461,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
         State(rest): State<Self>,
         Path(input_or_output_id): Path<Field<N>>,
     ) -> Result<ErasedJson, RestError> {
-        Ok(ErasedJson::pretty(rest.ledger.find_transition_id(&input_or_output_id)?))
+        Ok(ErasedJson::new(rest.ledger.find_transition_id(&input_or_output_id)?))
     }
 
     // /// POST /<network>/transaction/broadcast
@@ -556,7 +556,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             tokio::task::spawn_blocking(move || rest.ledger.advance_to_next_block(&new_block))
                 .await
                 .map_err(|e| RestError::internal_server_error(anyhow!("Task panicked: {}", e)))??;
-            return Ok((StatusCode::OK, ErasedJson::pretty(tx_id)));
+            return Ok((StatusCode::OK, ErasedJson::new(tx_id)));
         }
 
         // Add the transaction to the Rest buffer.
@@ -565,7 +565,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             buffer.push(tx);
         }
 
-        Ok((StatusCode::OK, ErasedJson::pretty(tx_id)))
+        Ok((StatusCode::OK, ErasedJson::new(tx_id)))
     }
 
     /// POST /{network}/create_block
@@ -608,7 +608,7 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
                 last_block = Some(new_block);
             }
 
-            Ok(ErasedJson::pretty(last_block.unwrap()))
+            Ok(ErasedJson::new(last_block.unwrap()))
         })
         .await
         .map_err(|e| RestError::internal_server_error(anyhow!("Task panicked: {}", e)))??;

--- a/tests/expectations/cli/broadcast_error/COMMANDS
+++ b/tests/expectations/cli/broadcast_error/COMMANDS
@@ -6,7 +6,7 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-COMMON_OPTS="--disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 # First deploy should succeed
 $LEO_BIN deploy -y $COMMON_OPTS

--- a/tests/expectations/cli/network_dependency/COMMANDS
+++ b/tests/expectations/cli/network_dependency/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-COMMON_OPTS="-y --blocks-to-check 20 --disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="-y --disable-update-check --broadcast --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 cd test_program1 || exit 1
 echo "DEPLOYMENT 1"

--- a/tests/expectations/cli/network_dependency/STDOUT
+++ b/tests/expectations/cli/network_dependency/STDOUT
@@ -66,7 +66,7 @@ Once it is deployed, it CANNOT be changed.
   - fee transaction ID: 'XXXXXX'
     (use this to check for rejected transactions)
 
-🔄 Searching up to 20 blocks to confirm transaction (this may take several seconds)...
+🔄 Searching up to 12 blocks to confirm transaction (this may take several seconds)...
 Explored XXXXXX blocks.
 Transaction accepted.
 ✅ Deployment confirmed!
@@ -142,7 +142,7 @@ Once it is deployed, it CANNOT be changed.
   - fee transaction ID: 'XXXXXX'
     (use this to check for rejected transactions)
 
-🔄 Searching up to 20 blocks to confirm transaction (this may take several seconds)...
+🔄 Searching up to 12 blocks to confirm transaction (this may take several seconds)...
 Explored XXXXXX blocks.
 Transaction accepted.
 ✅ Deployment confirmed!
@@ -212,7 +212,7 @@ Attempting to determine the consensus version from the latest block height at ht
   - fee transaction ID: 'XXXXXX'
     (use this to check for rejected transactions)
 
-🔄 Searching up to 20 blocks to confirm transaction (this may take several seconds)...
+🔄 Searching up to 12 blocks to confirm transaction (this may take several seconds)...
 Explored XXXXXX blocks.
 Transaction accepted.
 ✅ Execution confirmed!

--- a/tests/expectations/cli/test_deploy/COMMANDS
+++ b/tests/expectations/cli/test_deploy/COMMANDS
@@ -2,6 +2,6 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-COMMON_OPTS="--disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 $LEO_BIN deploy -y $COMMON_OPTS

--- a/tests/expectations/cli/test_json/COMMANDS
+++ b/tests/expectations/cli/test_json/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh"
-COMMON_OPTS="--disable-update-check --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="--disable-update-check --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 $LEO_BIN run --json-output main 1u32 2u32
 

--- a/tests/tests/cli/broadcast_error/COMMANDS
+++ b/tests/tests/cli/broadcast_error/COMMANDS
@@ -6,7 +6,7 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-COMMON_OPTS="--disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 # First deploy should succeed
 $LEO_BIN deploy -y $COMMON_OPTS

--- a/tests/tests/cli/network_dependency/COMMANDS
+++ b/tests/tests/cli/network_dependency/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-COMMON_OPTS="-y --blocks-to-check 20 --disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="-y --disable-update-check --broadcast --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 cd test_program1 || exit 1
 echo "DEPLOYMENT 1"

--- a/tests/tests/cli/test_deploy/COMMANDS
+++ b/tests/tests/cli/test_deploy/COMMANDS
@@ -2,6 +2,6 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH"
-COMMON_OPTS="--disable-update-check --broadcast --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="--disable-update-check --broadcast --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 $LEO_BIN deploy -y $COMMON_OPTS

--- a/tests/tests/cli/test_json/COMMANDS
+++ b/tests/tests/cli/test_json/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 PRIVATE_KEY="APrivateKey1zkp2RWGDcde3efb89rjhME1VYA8QMxcxep5DShNBR6n8Yjh"
-COMMON_OPTS="--disable-update-check --devnet --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
+COMMON_OPTS="--disable-update-check --network testnet --endpoint http://localhost:3030 --private-key $PRIVATE_KEY --consensus-heights 0,1,2,3,4,5,6,7,8,9,10,11,12"
 
 $LEO_BIN run --json-output main 1u32 2u32
 


### PR DESCRIPTION
**Summary:**  
This PR introduces several improvements to the Leo CLI testing infrastructure:

**Changes:**

1. Fix `leo devnode` to use `ErasedJson::new` instead of `ErasedJson::pretty` since the latter was adding an extra `\n` causing all the query methods from other Leo tools to break.

2. **Switch from `leo devnet` to `leo devnode`**  
   - Replaced `leo devnet` with `leo devnode` for starting local development nodes in integration tests.  
   - `leo devnode` is faster, simpler, and requires fewer dependencies/configuration (no SnarkOS dependency).  
   - Removed devnet-specific parameters such as validators, consensus heights, and snarkOS paths.

3. **Remove `snarkOS` installation steps from CI**.

4. **Refactor CLI Tests**  
   - Each CLI test now runs as its own Rust unit test.  
   - Improves test isolation and reduces test flakiness (hopefully!).  
   - Makes it easier to run individual tests in CI or locally. `REWRITE_EXPECTATIONS` still works.
 
<img width="687" height="313" alt="image" src="https://github.com/user-attachments/assets/8cf415d2-4f2e-4dae-bf4c-00fedae89658" />
