### PR TITLE
fix(cli): remove duplicate `EnvOptions` flatten in `devnode` subcommands

### DIFF
--- a/leo/cli/commands/devnode/advance.rs
+++ b/leo/cli/commands/devnode/advance.rs
@@ -24,8 +24,6 @@ pub struct Advance {
     pub num_blocks: u32,
     #[clap(long, help = "devnode REST API server address", default_value = "127.0.0.1:3030")]
     pub(crate) socket_addr: String,
-    #[clap(flatten)]
-    pub(crate) env_override: EnvOptions,
 }
 
 impl Command for Advance {

--- a/leo/cli/commands/devnode/mod.rs
+++ b/leo/cli/commands/devnode/mod.rs
@@ -69,10 +69,11 @@ impl Command for LeoDevnode {
 
 // A helper function to handle the Devnode command based on the subcommand provided.
 fn handle_devnode(devnode_command: LeoDevnode, context: Context) -> Result<<LeoDevnode as Command>::Output> {
+    let private_key = devnode_command.env_override.private_key;
     match devnode_command.command {
         DevnodeCommands::Start { command } => {
             tracing::info!("Starting the Devnode server...");
-            command.apply(context, ())
+            command.apply(context, private_key)
         }
         DevnodeCommands::Advance { command } => command.apply(context, ()),
     }

--- a/leo/cli/commands/devnode/start.rs
+++ b/leo/cli/commands/devnode/start.rs
@@ -41,13 +41,11 @@ pub struct Start {
     /// Enable manual block creation mode.
     #[clap(long, help = "disables automatic block creation after broadcast", default_value = "false")]
     pub(crate) manual_block_creation: bool,
-    /// Environment override options.
-    #[clap(flatten)]
-    pub(crate) env_override: EnvOptions,
 }
 
 impl Command for Start {
-    type Input = ();
+    /// The private key, resolved from the parent command's `EnvOptions`.
+    type Input = Option<String>;
     type Output = ();
 
     fn log_span(&self) -> Span {
@@ -55,17 +53,17 @@ impl Command for Start {
     }
 
     fn prelude(&self, _context: Context) -> Result<Self::Input> {
-        Ok(())
+        Ok(None)
     }
 
-    fn apply(self, _context: Context, _: Self::Input) -> Result<Self::Output> {
+    fn apply(self, _context: Context, private_key: Self::Input) -> Result<Self::Output> {
         let rt = tokio::runtime::Runtime::new().unwrap();
-        rt.block_on(async { start_devnode(self).await })
+        rt.block_on(async { start_devnode(self, private_key).await })
     }
 }
 
 // This command initializes a local development node that is pre-populated with test accounts.
-pub(crate) async fn start_devnode(command: Start) -> Result<<Start as Command>::Output> {
+async fn start_devnode(command: Start, private_key: Option<String>) -> Result<()> {
     // Initialize the logger.
     println!("Starting the Devnode server...");
     initialize_terminal_logger(command.verbosity).expect("Failed to initialize logger");
@@ -87,7 +85,7 @@ pub(crate) async fn start_devnode(command: Start) -> Result<<Start as Command>::
     // Initialize the storage mode.
     let storage_mode = StorageMode::new_test(None);
     // Fetch the private key from the command line or an environment variable.
-    let private_key = match command.env_override.private_key {
+    let private_key = match private_key {
         Some(key) => key,
         None => std::env::var("PRIVATE_KEY").map_err(|e| {
             CliError::custom(format!(


### PR DESCRIPTION
`EnvOptions` fields use `global = true`, so flattening at both `LeoDevnode` (parent) and `Start`/`Advance` (subcommands) caused clap's debug assertions to detect duplicate global arg registration, crashing `leo devnode start` in debug builds.

Remove the `EnvOptions` flatten from `Start` and `Advance`. Pass the private key from the parent's `EnvOptions` through `Start::apply` via `type Input = Option<String>`, matching the pattern used by `LeoQuery`.

Closes #29125 