### PR TITLE
feat(leo-fmt): add line wrapping at 100-char width

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,7 +2176,11 @@ dependencies = [
 name = "leo-fmt"
 version = "3.4.0"
 dependencies = [
+ "leo-ast",
+ "leo-compiler",
+ "leo-errors",
  "leo-parser-rowan",
+ "leo-span",
  "similar",
  "walkdir",
 ]

--- a/leo-fmt/Cargo.toml
+++ b/leo-fmt/Cargo.toml
@@ -16,8 +16,21 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
+[features]
+default = []
+validate = [
+  "dep:leo-compiler",
+  "dep:leo-ast",
+  "dep:leo-errors",
+  "dep:leo-span",
+]
+
 [dependencies]
 leo-parser-rowan    = { workspace = true }
+leo-compiler        = { workspace = true, optional = true }
+leo-ast             = { workspace = true, optional = true }
+leo-errors          = { workspace = true, optional = true }
+leo-span            = { workspace = true, optional = true }
 
 [dev-dependencies]
 similar             = { version = "2.6" }

--- a/leo-fmt/src/lib.rs
+++ b/leo-fmt/src/lib.rs
@@ -42,6 +42,9 @@ pub const INDENT: &str = "    ";
 /// Newline character.
 pub const NEWLINE: &str = "\n";
 
+/// Maximum line width before wrapping.
+pub const LINE_WIDTH: usize = 100;
+
 /// Format Leo source code.
 ///
 /// Takes Leo source code as input and returns formatted source code.

--- a/leo-fmt/tests/source/comment_between.leo
+++ b/leo-fmt/tests/source/comment_between.leo
@@ -1,5 +1,5 @@
 program test.aleo{
-        function process(  a  : u64  )  ->  u64  {
+        transition process(  a  : u64  )  ->  u64  {
                         // validate input
         assert(  a  >  0u64  );
     // compute result

--- a/leo-fmt/tests/source/comment_end_of_block.leo
+++ b/leo-fmt/tests/source/comment_end_of_block.leo
@@ -1,11 +1,11 @@
 program test.aleo   {
-    function compute(   a  :  u64  )  ->  u64    {
+    transition compute(   a  :  u64  )  ->  u64    {
   let x  :  u64  =  a  *  2u64  ;
           return x  ;
                 // end of function
         }
 
-function empty_with_comment(  )  {
+transition empty_with_comment(  )  {
                             // only a comment here
 }
 }

--- a/leo-fmt/tests/source/comment_mixed.leo
+++ b/leo-fmt/tests/source/comment_mixed.leo
@@ -1,6 +1,6 @@
                 // File-level comment
     program test.aleo    {
-        function example(   a  :  u64  ,    b  :  u64  )  ->  u64    {
+        transition example(   a  :  u64  ,    b  :  u64  )  ->  u64    {
     let x  :  u64  =    a  +  b  ;         // trailing comment
             // standalone comment
             let y  :  u64  =    x  *  2u64  ;

--- a/leo-fmt/tests/source/comment_multiline.leo
+++ b/leo-fmt/tests/source/comment_multiline.leo
@@ -1,6 +1,5 @@
          // The token program.
 // Implements minting and transferring of tokens.
-    import credits.aleo;
 
 program test.aleo {
 // A token record.
@@ -15,8 +14,8 @@ program test.aleo {
 
         // The function `mint_public` issues the specified token amount
  // for the token receiver publicly on the network.
-    async transition mint_public(  public receiver:address ,  public amount:u64  )->Future{
-    return finalize_mint(  receiver  ,  amount  );
+    transition mint_public(  public receiver:address ,  public amount:u64  ){
+    return;
     }
 
 /* Transfer */
@@ -29,11 +28,11 @@ program test.aleo {
     // This function is public and both the sender and receiver
 
       // are visible on-chain.
-        async transition transfer_public(  public receiver:address  ,  public amount:u64  )->Future{
+        transition transfer_public(  public receiver:address  ,  public amount:u64  ){
         // Compute the change amount.
     // This `sub` operation is safe, and the proof will fail
                      // if an overflow occurs.
     let change:u64=amount-1u64;
-                return finalize_transfer(  self.caller  ,  receiver  ,  amount  );
+                return;
     }
 }

--- a/leo-fmt/tests/source/comment_struct_members.leo
+++ b/leo-fmt/tests/source/comment_struct_members.leo
@@ -1,0 +1,17 @@
+program test.aleo {
+    struct Foo {
+        // leading comment on x
+        x:    u32, // trailing comment on x
+        y: u32,   /* block comment on y */
+    }
+
+    struct Bar {
+        // comment before first
+        a: u32,
+        b: bool,  // inline comment
+    } // after struct
+
+    transition main(f: Foo, b: Bar) -> u32 {
+        return f.x + b.a;
+    }
+}

--- a/leo-fmt/tests/source/comment_trailing_inline.leo
+++ b/leo-fmt/tests/source/comment_trailing_inline.leo
@@ -1,0 +1,15 @@
+program test.aleo {
+    const X: u32 = 4u32; // trailing on const
+
+    struct Foo {
+        x: u32,
+    }
+
+    mapping balances: address => u64; // trailing on mapping
+
+    const Y: bool = true; /* block trailing */
+
+    transition main(f: Foo) -> u32 {
+        return f.x + X;
+    } // after function
+}

--- a/leo-fmt/tests/source/expr_access.leo
+++ b/leo-fmt/tests/source/expr_access.leo
@@ -2,7 +2,7 @@ program test.aleo{
 struct Point  {  x:u64,
     y  :  u64  }
 
-	function main(  )  ->  u64   {
+	transition main(  )  ->  u64   {
 
                 let arr  :[u64;3]  =  [1u64  ,  2u64  ,  3u64];
     let first  :u64  =  arr  [  0u32  ]  ;

--- a/leo-fmt/tests/source/expr_binary.leo
+++ b/leo-fmt/tests/source/expr_binary.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function compute(a: u64,b: u64) -> u64 {
+    transition compute(a: u64,b: u64) -> u64 {
 
         let sum: u64  =a
         +   b;
@@ -16,7 +16,7 @@ let prod
             ;
 
 let pow: u64=a  **
-    2u64;
+    2u32;
     let lt: bool =  a
         <b;
 let gt

--- a/leo-fmt/tests/source/expr_call.leo
+++ b/leo-fmt/tests/source/expr_call.leo
@@ -2,7 +2,10 @@ program test.aleo   {
 	function add(   a  :  u64  ,
 	    b  :  u64  )  ->  u64  {  return   a  +  b  ;  }
 
-    function main(
+    function to_field(
+	    a  :  u64  )  ->  field  {  return  a  as  field  ;  }
+
+    transition main(
             )  ->  u64   {
 
 let x
@@ -16,19 +19,10 @@ let x
 
 
 	    let hash
-	        :field  =  BHP256::hash_to_field(
+	        :field  =  to_field(
 	                1u64  )  ;
-
-let mapped
-    :   u64=Mapping::get(
-    balances
-        ,
-                self.caller
-    )  ;
 
             return
                 x  ;
     }
-
-	mapping balances  :  address  =>  u64  ;
 }

--- a/leo-fmt/tests/source/expr_cast.leo
+++ b/leo-fmt/tests/source/expr_cast.leo
@@ -1,5 +1,5 @@
 program test.aleo   {
-	function main(   a
+	transition main(   a
 	        :  u64  )  ->  u32  {
 
 let b  :  u32

--- a/leo-fmt/tests/source/expr_collections.leo
+++ b/leo-fmt/tests/source/expr_collections.leo
@@ -1,6 +1,6 @@
 program test.aleo
     {
-	function main(  ){
+	transition main(  ){
 
             let arr  :  [u64;  3]  =  [
                 1u64  ,

--- a/leo-fmt/tests/source/expr_const_arg_list.leo
+++ b/leo-fmt/tests/source/expr_const_arg_list.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    transition main(  bits  :  [bool  ;  256]  )  ->  [u8  ;  32] {
+        return Deserialize  ::  from_bits_raw  ::  [  [u8  ;  32]  ](  bits  )  ;
+    }
+}

--- a/leo-fmt/tests/source/expr_literals.leo
+++ b/leo-fmt/tests/source/expr_literals.leo
@@ -1,5 +1,5 @@
 program test.aleo{
-	function main(  ){
+	transition main(  ){
 
 let a  :u8  =  1u8;
                     let b:u16=2u16;

--- a/leo-fmt/tests/source/expr_method_chain.leo
+++ b/leo-fmt/tests/source/expr_method_chain.leo
@@ -8,10 +8,21 @@ program test.aleo
 	}
 
   async transition deposit(
-            public sender
-                :  address  ,
-    public amount
-        :  u64  )  ->  Future  {
+            public amount
+                :  u64  )  ->  Future  {
+	    let caller  :  address  =  self.caller
+	        ;
+        let signer  :  address
+    =  self.signer;
+            return finalize_deposit(
+    caller  ,
+        amount  )
+            ;
+        }
+
+  async function finalize_deposit(
+    sender  :  address  ,
+        amount  :  u64  )  {
 	    let bal  :  u64  =  balances.get(
                             sender
                                 );
@@ -26,37 +37,32 @@ balances.remove(
     let val  :  u64  =  balances.get_or_use(  sender  ,
 	        0u64  )
 	            ;
-            return finalize_deposit(
-    sender  ,
-        amount  )
-            ;
-        }
-
-	function use_special(
-	        )  ->  address  {
-let caller  :  address  =  self.caller
-    ;
-                let signer  :  address
-    =  self.signer;
+        let bal2  :  u64  =  Mapping  ::  get(  balances  ,
+                sender  )  ;
+    Mapping  ::  set(  balances  ,  sender  ,
+            amount  )  ;
+        Mapping  ::  remove(  balances  ,
+    sender  )  ;
+            let val2  :  u64  =  Mapping  ::  get_or_use(  balances  ,
+        sender  ,  0u64  )  ;
 	    let h  :  u32  =  block.height
 	        ;
-            let t  :  u128  =
+            let t  :  i64  =
         block.timestamp
             ;
-    let n  :  u16  =  network.id;
-	                return
-	                    caller  ;
-}
+    }
 
       function access_chain(
             w  :  Wrapper  ,
 	    arr  :  [u64;  3]  ,
-    tup  :  (u64,  u64)
+    x  :  u64  ,
+        y  :  u64
         )  ->  u64   {
         let a  :  u64  =  w.inner
             ;
 let b  :  u64
                 =  arr[  0u32  ]  ;
+        let tup  :  (u64,  u64)  =  (  x  ,  y  )  ;
 	    let c  :  u64  =  tup.0
 	        ;
             let d  :  u64  =  tup.1;

--- a/leo-fmt/tests/source/expr_struct.leo
+++ b/leo-fmt/tests/source/expr_struct.leo
@@ -3,7 +3,7 @@ program test.aleo   {
   x  :u64  ,
             y  :  u64  }
 
-    function main(  )  ->  Point   {
+    transition main(  )  ->  Point   {
 
 let p  :Point  =  Point  {   x  :  1u64  ,
         y  :  2u64   }  ;

--- a/leo-fmt/tests/source/expr_ternary.leo
+++ b/leo-fmt/tests/source/expr_ternary.leo
@@ -1,6 +1,6 @@
 program test.aleo
 {
-	function main(  a  :  u64  ,
+	transition main(  a  :  u64  ,
 	        b
 	            :  u64  )  ->  u64  {
 

--- a/leo-fmt/tests/source/expr_unary.leo
+++ b/leo-fmt/tests/source/expr_unary.leo
@@ -1,11 +1,11 @@
 program test.aleo{
-	function main(  a  :  u64  )  ->  u64  {
+	transition main(  a  :  i64  )  ->  i64  {
 
-            let neg  :  u64  =  -  a;
+            let neg  :  i64  =  -  a;
 
     let not  :  bool  =  !  true;
 
-let double_neg  :  u64  =
+let double_neg  :  i64  =
         -  -  a;
 
 	    return neg  ;

--- a/leo-fmt/tests/source/function_simple.leo
+++ b/leo-fmt/tests/source/function_simple.leo
@@ -1,5 +1,5 @@
 program test.aleo{
-  function add( a :u64,  b:u64 )  ->  u64 {
+  transition add( a :u64,  b:u64 )  ->  u64 {
       return a+b;
    }
 }

--- a/leo-fmt/tests/source/mapping_simple.leo
+++ b/leo-fmt/tests/source/mapping_simple.leo
@@ -1,4 +1,14 @@
 program test.aleo{
   mapping   balances :  address   =>u64
 ;
+
+    async   transition deposit(  amount  :  u64  )  ->  Future  {
+	    return finalize_deposit(
+	        self.caller  ,  amount  )  ;
+    }
+
+  async function finalize_deposit(  caller  :  address  ,
+        amount  :  u64  )  {
+            balances.set(  caller  ,
+                amount  )  ;  }
 }

--- a/leo-fmt/tests/source/program_mixed.leo
+++ b/leo-fmt/tests/source/program_mixed.leo
@@ -1,13 +1,20 @@
 program test.aleo
   {
 struct Data{
-value:u64,
+amount:u64,
 }
     mapping store:field  =>Data;
 
 
-  transition save(d:Data){
+  async transition save(d:Data)  ->  Future{
 
-return;
+return finalize_save(
+    1field  ,  d  )  ;
 }
+
+    async function finalize_save(  key  :  field  ,
+        d  :  Data  )  {
+            store.set(  key  ,
+                d  )  ;
+    }
 }

--- a/leo-fmt/tests/source/record_basic.leo
+++ b/leo-fmt/tests/source/record_basic.leo
@@ -7,4 +7,9 @@ owner:address,
 
   amount :  u64 ,
     }
+
+  transition mint(  owner  :  address  ,
+        amount  :  u64  )  ->  Token  {
+    return Token  {  owner  :  owner  ,  amount  :  amount  }  ;
+    }
 }

--- a/leo-fmt/tests/source/stmt_assert.leo
+++ b/leo-fmt/tests/source/stmt_assert.leo
@@ -1,5 +1,5 @@
 program test.aleo{
-	function main(   a  :  u64  ,
+	transition main(   a  :  u64  ,
 	        b  :  u64   )  {
 
             assert(  a  >  0u64  )

--- a/leo-fmt/tests/source/stmt_assign.leo
+++ b/leo-fmt/tests/source/stmt_assign.leo
@@ -1,6 +1,6 @@
 program test.aleo
   {
-	function main(  ){
+	transition main(  ){
 
 let x  :  u64  =
         5u64
@@ -23,7 +23,7 @@ x  /=
                         ;
         x%=  3u64  ;
 
-	x  **=  2u64  ;
+	x  **=  2u32  ;
 
 }
 }

--- a/leo-fmt/tests/source/stmt_const.leo
+++ b/leo-fmt/tests/source/stmt_const.leo
@@ -1,6 +1,6 @@
 program test.aleo
         {
-	function main(
+	transition main(
 	    )  ->  u64   {
 const X  :u64
         =  100u64

--- a/leo-fmt/tests/source/stmt_expression.leo
+++ b/leo-fmt/tests/source/stmt_expression.leo
@@ -1,15 +1,23 @@
 program test.aleo
     {
+    function process(  a  :  u64  ,
+                    b  :  u64  ,
+                        c  :  u64  )
+                            {
+    assert(  a  >
+        0u64  )  ;  }
+
 	transition main(
             item
                 :  u64
     )  {
-    Mapping::set(  balances  ,
-                    self.caller  ,
+    process(  item  ,
+                    item  ,
                         item  )
                             ;
-	    Mapping::get(  balances  ,
-        self.caller  )
+	    process(  item  ,
+        1u64  ,
+            2u64  )
             ;
     }
 }

--- a/leo-fmt/tests/source/stmt_for.leo
+++ b/leo-fmt/tests/source/stmt_for.leo
@@ -1,5 +1,5 @@
 program test.aleo{
-	function main(  )  ->  u64  {
+	transition main(  )  ->  u64  {
             let sum  :  u64
                 =  0u64
                     ;

--- a/leo-fmt/tests/source/stmt_if.leo
+++ b/leo-fmt/tests/source/stmt_if.leo
@@ -1,15 +1,17 @@
 program test.aleo{
-	function main(  a
+	transition main(  a
 	        :  u64  )  ->  u64   {
-            if  a  >  5u64  {  return
-                1u64  ;  }
+        let result  :  u64  =
+                0u64  ;
+            if  a  >  5u64  {  result
+                =  1u64  ;  }
     if a  <  3u64
 	{
-                    return
+                    result  =
                         2u64  ;
-        }
-if a  ==  4u64  {  return 3u64  ;  }  else  {  return
-        4u64  ;  }
+        }  else  {
+    result  =  3u64
+        ;  }
 	    if a  >10u64{
             return 5u64
                 ;
@@ -18,7 +20,7 @@ if a  ==  4u64  {  return 3u64  ;  }  else  {  return
 	{  return
 	    6u64  ;  }
             else  {
-    return 7u64
+    return result
         ;
         }
     }

--- a/leo-fmt/tests/source/stmt_let_destructure.leo
+++ b/leo-fmt/tests/source/stmt_let_destructure.leo
@@ -1,12 +1,12 @@
 program test.aleo
   {
-	function main(  )   {
+	transition main(  )   {
             let (  a  ,
                 b  )  =  (  1u64  ,
                     2u64  )  ;
     let (  x  ,
 	    y  )  =  get_pair(
-                    )
+                    1u64  )
                         ;
 let (  p  ,  q  )  :  (  u64  ,  u64  )  =  (
         3u64  ,
@@ -14,9 +14,9 @@ let (  p  ,  q  )  :  (  u64  ,  u64  )  =  (
     }
 
 	function get_pair(
-	        )  ->  (  u64  ,  u64  )   {
-            return (  1u64  ,
-    2u64  )
+	        n  :  u64  )  ->  (  u64  ,  u64  )   {
+            return (  n  ,
+    n  )
         ;
     }
 }

--- a/leo-fmt/tests/source/stmt_let_simple.leo
+++ b/leo-fmt/tests/source/stmt_let_simple.leo
@@ -1,5 +1,5 @@
 program test.aleo   {
-	function main(  )  {
+	transition main(  )  {
             let x  =  5u64;
     let    y
             =  10u64;

--- a/leo-fmt/tests/source/stmt_let_typed.leo
+++ b/leo-fmt/tests/source/stmt_let_typed.leo
@@ -1,6 +1,6 @@
 program test.aleo
     {
-	function main(  )   {
+	transition main(  )   {
 let x  :  u64
         =  5u64
             ;

--- a/leo-fmt/tests/source/stmt_return.leo
+++ b/leo-fmt/tests/source/stmt_return.leo
@@ -1,18 +1,18 @@
 program test.aleo
             {
-	function with_expr(  a  :  u64  )  ->  u64  {
+	transition with_expr(  a  :  u64  )  ->  u64  {
     return   a  *
                     2u64
                         ;
         }
 
-	function bare_return(
+	transition bare_return(
 	        )  ->  (  )  {
             return
                 ;
     }
 
-        function with_tuple(  a  :  u64  ,
+        transition with_tuple(  a  :  u64  ,
 	    b
 	        :  u64  )  ->  (  u64  ,  u64  )  {
 return    (  a  +  b  ,

--- a/leo-fmt/tests/source/struct_simple.leo
+++ b/leo-fmt/tests/source/struct_simple.leo
@@ -2,4 +2,8 @@ program test.aleo{
 struct Point{
   x :  u64,
         y:u64}
+
+  transition main(  )  ->  Point  {
+    return Point  {  x  :  1u64  ,  y  :  2u64  }  ;
+    }
 }

--- a/leo-fmt/tests/source/wrap_array_tuple.leo
+++ b/leo-fmt/tests/source/wrap_array_tuple.leo
@@ -1,0 +1,25 @@
+program test.aleo
+{
+	    transition main(  public  a  :  u64  ,
+	        public  b  :  u64  )  ->  u64  {
+
+    let short_arr  :  [u64  ;  3]  =  [
+        1u64  ,
+            2u64  ,
+                3u64  ]  ;
+let first_amount  :u64  =a  +  1u64  ;
+            let second_amount  :  u64  =b  +2u64  ;
+	let third_amount  :  u64  =  a  +  3u64  ;
+                    let fourth_amount  :  u64=b  +  4u64  ;
+    let fifth_amount  :u64  =  a  +  5u64  ;
+let long_arr  :  [u64;5]  =  [  first_amount  ,  second_amount  ,  third_amount  ,  fourth_amount  ,  fifth_amount  ]  ;
+	    let repeat  :  [u64  ;  4]  =  [   0u64
+	        ;  4u64  ]  ;
+    let short_tup  :  (u64  ,  u64)  =(
+            a  ,
+        b  )  ;
+let long_tup  :(u64  ,u64  ,u64  ,u64  ,u64)  =(  first_amount  ,  second_amount  ,  third_amount  ,  fourth_amount  ,  fifth_amount  )  ;
+                return short_arr[  0u32  ]  +
+                    long_arr[  0u32  ]  ;
+    }
+}

--- a/leo-fmt/tests/source/wrap_assert_pair.leo
+++ b/leo-fmt/tests/source/wrap_assert_pair.leo
@@ -1,0 +1,17 @@
+program test.aleo  {
+    transition main(
+	    public  a  :  u64  ,
+	        public  b  :  u64  )  {
+
+assert_eq(
+    a  ,
+            b  )  ;
+    let expected_first_balance  :u64
+        =  a  +  b  ;
+            let computed_second_balance
+                :  u64  =  a  *  2u64  ;
+assert_eq(  expected_first_balance  +  computed_second_balance  ,  computed_second_balance  +  expected_first_balance  )  ;
+	    assert_neq(  a  ,
+	        0u64  )  ;
+                assert_neq(  expected_first_balance  *  computed_second_balance  ,  computed_second_balance  *  expected_first_balance  )  ;
+}  }

--- a/leo-fmt/tests/source/wrap_call_args.leo
+++ b/leo-fmt/tests/source/wrap_call_args.leo
@@ -1,0 +1,26 @@
+program test.aleo
+    {
+	function compute_sum(  first  :  u64  ,  second  :u64  ,  third  :  u64  )  ->  u64  {
+        return  first  +
+            second  +  third
+                ;  }
+
+    transition main(   public   a  :  u64  ,
+                public  b  :  u64  )  ->  u64  {
+
+let short  :u64  =  compute_sum(
+    a  ,
+        b  ,
+            a  )  ;
+	    let first_value
+	        :  u64  =  a  *  2u64  ;
+            let second_value  :u64  =b  *
+                3u64  ;
+    let third_value  :  u64
+        =a  +  b  ;
+let long  :  u64  =  compute_sum(  first_value  +  second_value  ,  second_value  +  third_value  ,  third_value  +  first_value  )
+    ;
+                    return short  +
+                        long  ;
+    }
+}

--- a/leo-fmt/tests/source/wrap_comprehensive.leo
+++ b/leo-fmt/tests/source/wrap_comprehensive.leo
@@ -1,0 +1,27 @@
+program test.aleo
+    {
+	struct TransferInfo  {
+    sender_amount  :u64  ,
+                receiver_amount  :  u64  ,
+        transfer_fee  :  u64  ,  }
+
+function compute_remaining(  sender_amount  :  u64  ,  receiver_amount  :u64  ,  transfer_fee  :  u64  ,  bonus_amount  :  u64  )  ->  u64  {
+return sender_amount  -  receiver_amount  -
+    transfer_fee  +  bonus_amount
+        ;  }
+
+    transition transfer(  public  sender_amount  :  u64  ,  public  receiver_amount  :  u64  ,  private  transfer_fee  :  u64  ,  private  is_valid  :  bool  )  ->  u64  {
+let bonus_amount
+    :  u64  =  sender_amount  +
+        1u64  ;
+            let remaining  :  u64  =  compute_remaining(  sender_amount  ,  receiver_amount  ,  transfer_fee  ,  bonus_amount  )  ;
+    let info  :TransferInfo  =  TransferInfo  {  sender_amount  :  sender_amount  ,  receiver_amount  :  receiver_amount  ,  transfer_fee  :  transfer_fee  }
+        ;
+	assert_eq(  info.sender_amount  ,
+	    sender_amount  )  ;
+                assert_eq(  info.sender_amount  +  info.receiver_amount  +  info.transfer_fee  ,  sender_amount  +  receiver_amount  +  transfer_fee  )  ;
+    let amounts  :  [u64  ;  5]  =  [  sender_amount  ,  receiver_amount  ,  transfer_fee  ,  remaining  ,  sender_amount  +  receiver_amount  ]  ;
+        return
+            remaining  ;
+}
+}

--- a/leo-fmt/tests/source/wrap_function_params.leo
+++ b/leo-fmt/tests/source/wrap_function_params.leo
@@ -1,0 +1,10 @@
+program test.aleo  {  function add(   a  :u64  ,
+	    b  :  u64  )  ->  u64  {  return   a  +  b  ;  }
+
+	transition transfer_tokens(  public   sender_balance  :  u64  ,  public  receiver_balance  :u64  ,  private   transfer_amount  :u64  )  ->  u64  {
+        let remaining
+            :u64  =sender_balance   -  transfer_amount
+                ;
+                return
+	        remaining  ;  }
+}

--- a/leo-fmt/tests/source/wrap_struct_expr.leo
+++ b/leo-fmt/tests/source/wrap_struct_expr.leo
@@ -1,0 +1,20 @@
+program test.aleo{
+	struct Point  {
+            x  :  u64  ,
+        y  :u64  }
+
+    struct TransferInfo  {
+        sender_amount  :  u64  ,receiver_amount  :  u64  ,   transfer_fee  :  u64  ,
+    }
+
+transition main(  public  a  :  u64  ,
+            public  b  :  u64  )  ->  u64  {
+
+    let p  :  Point  =  Point  {
+        x  :  1u64  ,
+                y  :  2u64  }  ;
+	let info  :TransferInfo  =  TransferInfo  {  sender_amount  :  a  ,  receiver_amount  :  b  ,  transfer_fee  :  10u64  }
+	    ;
+        return  p.x  +
+            info.sender_amount  ;
+}  }

--- a/leo-fmt/tests/target/comment_between.leo
+++ b/leo-fmt/tests/target/comment_between.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function process(a: u64) -> u64 {
+    transition process(a: u64) -> u64 {
         // validate input
         assert(a > 0u64);
         // compute result

--- a/leo-fmt/tests/target/comment_end_of_block.leo
+++ b/leo-fmt/tests/target/comment_end_of_block.leo
@@ -1,11 +1,11 @@
 program test.aleo {
-    function compute(a: u64) -> u64 {
+    transition compute(a: u64) -> u64 {
         let x: u64 = a * 2u64;
         return x;
         // end of function
     }
 
-    function empty_with_comment() {
+    transition empty_with_comment() {
         // only a comment here
     }
 }

--- a/leo-fmt/tests/target/comment_mixed.leo
+++ b/leo-fmt/tests/target/comment_mixed.leo
@@ -1,6 +1,6 @@
 // File-level comment
 program test.aleo {
-    function example(a: u64, b: u64) -> u64 {
+    transition example(a: u64, b: u64) -> u64 {
         let x: u64 = a + b; // trailing comment
         // standalone comment
         let y: u64 = x * 2u64;

--- a/leo-fmt/tests/target/comment_multiline.leo
+++ b/leo-fmt/tests/target/comment_multiline.leo
@@ -1,7 +1,5 @@
 // The token program.
 // Implements minting and transferring of tokens.
-import credits.aleo;
-
 program test.aleo {
     // A token record.
     // - `owner` : The token owner.
@@ -14,19 +12,19 @@ program test.aleo {
     /* Mint */
     // The function `mint_public` issues the specified token amount
     // for the token receiver publicly on the network.
-    async transition mint_public(public receiver: address, public amount: u64) -> Future {
-        return finalize_mint(receiver, amount);
+    transition mint_public(public receiver: address, public amount: u64) {
+        return;
     }
 
     /* Transfer */
     // Transfers tokens from one address to another.
     // This function is public and both the sender and receiver
     // are visible on-chain.
-    async transition transfer_public(public receiver: address, public amount: u64) -> Future {
+    transition transfer_public(public receiver: address, public amount: u64) {
         // Compute the change amount.
         // This `sub` operation is safe, and the proof will fail
         // if an overflow occurs.
         let change: u64 = amount - 1u64;
-        return finalize_transfer(self.caller, receiver, amount);
+        return;
     }
 }

--- a/leo-fmt/tests/target/comment_struct_members.leo
+++ b/leo-fmt/tests/target/comment_struct_members.leo
@@ -1,0 +1,19 @@
+program test.aleo {
+    struct Foo {
+        // leading comment on x
+        x: u32, // trailing comment on x
+        y: u32,
+        /* block comment on y */
+    }
+
+    struct Bar {
+        // comment before first
+        a: u32,
+        b: bool,
+        // inline comment
+    } // after struct
+
+    transition main(f: Foo, b: Bar) -> u32 {
+        return f.x + b.a;
+    }
+}

--- a/leo-fmt/tests/target/comment_trailing_inline.leo
+++ b/leo-fmt/tests/target/comment_trailing_inline.leo
@@ -1,0 +1,16 @@
+program test.aleo {
+    const X: u32 = 4u32; // trailing on const
+
+    struct Foo {
+        x: u32,
+    }
+
+    mapping balances: address => u64; // trailing on mapping
+
+    const Y: bool = true; /* block trailing */
+
+    transition main(f: Foo) -> u32 {
+        return f.x + X;
+    }
+    // after function
+}

--- a/leo-fmt/tests/target/expr_access.leo
+++ b/leo-fmt/tests/target/expr_access.leo
@@ -4,7 +4,7 @@ program test.aleo {
         y: u64,
     }
 
-    function main() -> u64 {
+    transition main() -> u64 {
         let arr: [u64; 3] = [1u64, 2u64, 3u64];
         let first: u64 = arr[0u32];
         let tup: (u64, u64) = (1u64, 2u64);

--- a/leo-fmt/tests/target/expr_binary.leo
+++ b/leo-fmt/tests/target/expr_binary.leo
@@ -1,11 +1,11 @@
 program test.aleo {
-    function compute(a: u64, b: u64) -> u64 {
+    transition compute(a: u64, b: u64) -> u64 {
         let sum: u64 = a + b;
         let diff: u64 = a - b;
         let prod: u64 = a * b;
         let quot: u64 = a / b;
         let rem: u64 = a % b;
-        let pow: u64 = a ** 2u64;
+        let pow: u64 = a ** 2u32;
         let lt: bool = a < b;
         let gt: bool = a > b;
         let le: bool = a <= b;

--- a/leo-fmt/tests/target/expr_call.leo
+++ b/leo-fmt/tests/target/expr_call.leo
@@ -3,13 +3,14 @@ program test.aleo {
         return a + b;
     }
 
-    function main() -> u64 {
-        let x: u64 = add(1u64, 2u64);
-        let y: u64 = add(1u64, 2u64);
-        let hash: field = BHP256::hash_to_field(1u64);
-        let mapped: u64 = Mapping::get(balances, self.caller);
-        return x;
+    function to_field(a: u64) -> field {
+        return a as field;
     }
 
-    mapping balances: address => u64;
+    transition main() -> u64 {
+        let x: u64 = add(1u64, 2u64);
+        let y: u64 = add(1u64, 2u64);
+        let hash: field = to_field(1u64);
+        return x;
+    }
 }

--- a/leo-fmt/tests/target/expr_cast.leo
+++ b/leo-fmt/tests/target/expr_cast.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main(a: u64) -> u32 {
+    transition main(a: u64) -> u32 {
         let b: u32 = a as u32;
         let c: field = a as field;
         return b;

--- a/leo-fmt/tests/target/expr_collections.leo
+++ b/leo-fmt/tests/target/expr_collections.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() {
+    transition main() {
         let arr: [u64; 3] = [1u64, 2u64, 3u64];
         let tup: (u64, u64, u64) = (1u64, 2u64, 3u64);
         let nested: [[u64; 2]; 2] = [[1u64, 2u64], [3u64, 4u64]];

--- a/leo-fmt/tests/target/expr_const_arg_list.leo
+++ b/leo-fmt/tests/target/expr_const_arg_list.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    transition main(bits: [bool; 256]) -> [u8; 32] {
+        return Deserialize::from_bits_raw::[[u8; 32]](bits);
+    }
+}

--- a/leo-fmt/tests/target/expr_literals.leo
+++ b/leo-fmt/tests/target/expr_literals.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() {
+    transition main() {
         let a: u8 = 1u8;
         let b: u16 = 2u16;
         let c: u32 = 3u32;

--- a/leo-fmt/tests/target/expr_method_chain.leo
+++ b/leo-fmt/tests/target/expr_method_chain.leo
@@ -5,27 +5,30 @@ program test.aleo {
         inner: u64,
     }
 
-    async transition deposit(public sender: address, public amount: u64) -> Future {
+    async transition deposit(public amount: u64) -> Future {
+        let caller: address = self.caller;
+        let signer: address = self.signer;
+        return finalize_deposit(caller, amount);
+    }
+
+    async function finalize_deposit(sender: address, amount: u64) {
         let bal: u64 = balances.get(sender);
         let check: bool = balances.contains(sender);
         balances.set(sender, amount);
         balances.remove(sender);
         let val: u64 = balances.get_or_use(sender, 0u64);
-        return finalize_deposit(sender, amount);
-    }
-
-    function use_special() -> address {
-        let caller: address = self.caller;
-        let signer: address = self.signer;
+        let bal2: u64 = Mapping::get(balances, sender);
+        Mapping::set(balances, sender, amount);
+        Mapping::remove(balances, sender);
+        let val2: u64 = Mapping::get_or_use(balances, sender, 0u64);
         let h: u32 = block.height;
-        let t: u128 = block.timestamp;
-        let n: u16 = network.id;
-        return caller;
+        let t: i64 = block.timestamp;
     }
 
-    function access_chain(w: Wrapper, arr: [u64; 3], tup: (u64, u64)) -> u64 {
+    function access_chain(w: Wrapper, arr: [u64; 3], x: u64, y: u64) -> u64 {
         let a: u64 = w.inner;
         let b: u64 = arr[0u32];
+        let tup: (u64, u64) = (x, y);
         let c: u64 = tup.0;
         let d: u64 = tup.1;
         return a;

--- a/leo-fmt/tests/target/expr_struct.leo
+++ b/leo-fmt/tests/target/expr_struct.leo
@@ -4,7 +4,7 @@ program test.aleo {
         y: u64,
     }
 
-    function main() -> Point {
+    transition main() -> Point {
         let p: Point = Point { x: 1u64, y: 2u64 };
         let q: Point = Point { x: p.x, y: p.y };
         return p;

--- a/leo-fmt/tests/target/expr_ternary.leo
+++ b/leo-fmt/tests/target/expr_ternary.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main(a: u64, b: u64) -> u64 {
+    transition main(a: u64, b: u64) -> u64 {
         let result: u64 = a > b ? a : b;
         let nested: u64 = a > b ? a > 10u64 ? a : 10u64 : b;
         return result;

--- a/leo-fmt/tests/target/expr_unary.leo
+++ b/leo-fmt/tests/target/expr_unary.leo
@@ -1,8 +1,8 @@
 program test.aleo {
-    function main(a: u64) -> u64 {
-        let neg: u64 = -a;
+    transition main(a: i64) -> i64 {
+        let neg: i64 = -a;
         let not: bool = !true;
-        let double_neg: u64 = --a;
+        let double_neg: i64 = --a;
         return neg;
     }
 }

--- a/leo-fmt/tests/target/function_simple.leo
+++ b/leo-fmt/tests/target/function_simple.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function add(a: u64, b: u64) -> u64 {
+    transition add(a: u64, b: u64) -> u64 {
         return a + b;
     }
 }

--- a/leo-fmt/tests/target/mapping_simple.leo
+++ b/leo-fmt/tests/target/mapping_simple.leo
@@ -1,3 +1,11 @@
 program test.aleo {
     mapping balances: address => u64;
+
+    async transition deposit(amount: u64) -> Future {
+        return finalize_deposit(self.caller, amount);
+    }
+
+    async function finalize_deposit(caller: address, amount: u64) {
+        balances.set(caller, amount);
+    }
 }

--- a/leo-fmt/tests/target/program_mixed.leo
+++ b/leo-fmt/tests/target/program_mixed.leo
@@ -1,11 +1,15 @@
 program test.aleo {
     struct Data {
-        value: u64,
+        amount: u64,
     }
 
     mapping store: field => Data;
 
-    transition save(d: Data) {
-        return;
+    async transition save(d: Data) -> Future {
+        return finalize_save(1field, d);
+    }
+
+    async function finalize_save(key: field, d: Data) {
+        store.set(key, d);
     }
 }

--- a/leo-fmt/tests/target/record_basic.leo
+++ b/leo-fmt/tests/target/record_basic.leo
@@ -3,4 +3,8 @@ program test.aleo {
         owner: address,
         amount: u64,
     }
+
+    transition mint(owner: address, amount: u64) -> Token {
+        return Token { owner: owner, amount: amount };
+    }
 }

--- a/leo-fmt/tests/target/stmt_assert.leo
+++ b/leo-fmt/tests/target/stmt_assert.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main(a: u64, b: u64) {
+    transition main(a: u64, b: u64) {
         assert(a > 0u64);
         assert(b > 0u64);
         assert_eq(a, b);

--- a/leo-fmt/tests/target/stmt_assign.leo
+++ b/leo-fmt/tests/target/stmt_assign.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() {
+    transition main() {
         let x: u64 = 5u64;
         x = 10u64;
         x += 5u64;
@@ -7,6 +7,6 @@ program test.aleo {
         x *= 3u64;
         x /= 2u64;
         x %= 3u64;
-        x **= 2u64;
+        x **= 2u32;
     }
 }

--- a/leo-fmt/tests/target/stmt_const.leo
+++ b/leo-fmt/tests/target/stmt_const.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() -> u64 {
+    transition main() -> u64 {
         const X: u64 = 100u64;
         const Y: field = 1field;
         const Z: bool = true;

--- a/leo-fmt/tests/target/stmt_expression.leo
+++ b/leo-fmt/tests/target/stmt_expression.leo
@@ -1,6 +1,10 @@
 program test.aleo {
+    function process(a: u64, b: u64, c: u64) {
+        assert(a > 0u64);
+    }
+
     transition main(item: u64) {
-        Mapping::set(balances, self.caller, item);
-        Mapping::get(balances, self.caller);
+        process(item, item, item);
+        process(item, 1u64, 2u64);
     }
 }

--- a/leo-fmt/tests/target/stmt_for.leo
+++ b/leo-fmt/tests/target/stmt_for.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() -> u64 {
+    transition main() -> u64 {
         let sum: u64 = 0u64;
         for i in 0u64..10u64 {
             sum += i;

--- a/leo-fmt/tests/target/stmt_if.leo
+++ b/leo-fmt/tests/target/stmt_if.leo
@@ -1,22 +1,20 @@
 program test.aleo {
-    function main(a: u64) -> u64 {
+    transition main(a: u64) -> u64 {
+        let result: u64 = 0u64;
         if a > 5u64 {
-            return 1u64;
+            result = 1u64;
         }
         if a < 3u64 {
-            return 2u64;
-        }
-        if a == 4u64 {
-            return 3u64;
+            result = 2u64;
         } else {
-            return 4u64;
+            result = 3u64;
         }
         if a > 10u64 {
             return 5u64;
         } else if a > 7u64 {
             return 6u64;
         } else {
-            return 7u64;
+            return result;
         }
     }
 }

--- a/leo-fmt/tests/target/stmt_let_destructure.leo
+++ b/leo-fmt/tests/target/stmt_let_destructure.leo
@@ -1,11 +1,11 @@
 program test.aleo {
-    function main() {
+    transition main() {
         let (a, b) = (1u64, 2u64);
-        let (x, y) = get_pair();
+        let (x, y) = get_pair(1u64);
         let (p, q): (u64, u64) = (3u64, 4u64);
     }
 
-    function get_pair() -> (u64, u64) {
-        return (1u64, 2u64);
+    function get_pair(n: u64) -> (u64, u64) {
+        return (n, n);
     }
 }

--- a/leo-fmt/tests/target/stmt_let_simple.leo
+++ b/leo-fmt/tests/target/stmt_let_simple.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() {
+    transition main() {
         let x = 5u64;
         let y = 10u64;
         let z = x;

--- a/leo-fmt/tests/target/stmt_let_typed.leo
+++ b/leo-fmt/tests/target/stmt_let_typed.leo
@@ -1,5 +1,5 @@
 program test.aleo {
-    function main() {
+    transition main() {
         let x: u64 = 5u64;
         let y: field = 1field;
         let z: bool = true;

--- a/leo-fmt/tests/target/stmt_return.leo
+++ b/leo-fmt/tests/target/stmt_return.leo
@@ -1,13 +1,13 @@
 program test.aleo {
-    function with_expr(a: u64) -> u64 {
+    transition with_expr(a: u64) -> u64 {
         return a * 2u64;
     }
 
-    function bare_return() -> () {
+    transition bare_return() -> () {
         return;
     }
 
-    function with_tuple(a: u64, b: u64) -> (u64, u64) {
+    transition with_tuple(a: u64, b: u64) -> (u64, u64) {
         return (a + b, a * b);
     }
 }

--- a/leo-fmt/tests/target/struct_simple.leo
+++ b/leo-fmt/tests/target/struct_simple.leo
@@ -3,4 +3,8 @@ program test.aleo {
         x: u64,
         y: u64,
     }
+
+    transition main() -> Point {
+        return Point { x: 1u64, y: 2u64 };
+    }
 }

--- a/leo-fmt/tests/target/wrap_array_tuple.leo
+++ b/leo-fmt/tests/target/wrap_array_tuple.leo
@@ -1,0 +1,27 @@
+program test.aleo {
+    transition main(public a: u64, public b: u64) -> u64 {
+        let short_arr: [u64; 3] = [1u64, 2u64, 3u64];
+        let first_amount: u64 = a + 1u64;
+        let second_amount: u64 = b + 2u64;
+        let third_amount: u64 = a + 3u64;
+        let fourth_amount: u64 = b + 4u64;
+        let fifth_amount: u64 = a + 5u64;
+        let long_arr: [u64; 5] = [
+            first_amount,
+            second_amount,
+            third_amount,
+            fourth_amount,
+            fifth_amount,
+        ];
+        let repeat: [u64; 4] = [0u64; 4u64];
+        let short_tup: (u64, u64) = (a, b);
+        let long_tup: (u64, u64, u64, u64, u64) = (
+            first_amount,
+            second_amount,
+            third_amount,
+            fourth_amount,
+            fifth_amount,
+        );
+        return short_arr[0u32] + long_arr[0u32];
+    }
+}

--- a/leo-fmt/tests/target/wrap_assert_pair.leo
+++ b/leo-fmt/tests/target/wrap_assert_pair.leo
@@ -1,0 +1,16 @@
+program test.aleo {
+    transition main(public a: u64, public b: u64) {
+        assert_eq(a, b);
+        let expected_first_balance: u64 = a + b;
+        let computed_second_balance: u64 = a * 2u64;
+        assert_eq(
+            expected_first_balance + computed_second_balance,
+            computed_second_balance + expected_first_balance
+        );
+        assert_neq(a, 0u64);
+        assert_neq(
+            expected_first_balance * computed_second_balance,
+            computed_second_balance * expected_first_balance
+        );
+    }
+}

--- a/leo-fmt/tests/target/wrap_call_args.leo
+++ b/leo-fmt/tests/target/wrap_call_args.leo
@@ -1,0 +1,18 @@
+program test.aleo {
+    function compute_sum(first: u64, second: u64, third: u64) -> u64 {
+        return first + second + third;
+    }
+
+    transition main(public a: u64, public b: u64) -> u64 {
+        let short: u64 = compute_sum(a, b, a);
+        let first_value: u64 = a * 2u64;
+        let second_value: u64 = b * 3u64;
+        let third_value: u64 = a + b;
+        let long: u64 = compute_sum(
+            first_value + second_value,
+            second_value + third_value,
+            third_value + first_value,
+        );
+        return short + long;
+    }
+}

--- a/leo-fmt/tests/target/wrap_comprehensive.leo
+++ b/leo-fmt/tests/target/wrap_comprehensive.leo
@@ -1,0 +1,49 @@
+program test.aleo {
+    struct TransferInfo {
+        sender_amount: u64,
+        receiver_amount: u64,
+        transfer_fee: u64,
+    }
+
+    function compute_remaining(
+        sender_amount: u64,
+        receiver_amount: u64,
+        transfer_fee: u64,
+        bonus_amount: u64,
+    ) -> u64 {
+        return sender_amount - receiver_amount - transfer_fee + bonus_amount;
+    }
+
+    transition transfer(
+        public sender_amount: u64,
+        public receiver_amount: u64,
+        private transfer_fee: u64,
+        private is_valid: bool,
+    ) -> u64 {
+        let bonus_amount: u64 = sender_amount + 1u64;
+        let remaining: u64 = compute_remaining(
+            sender_amount,
+            receiver_amount,
+            transfer_fee,
+            bonus_amount,
+        );
+        let info: TransferInfo = TransferInfo {
+            sender_amount: sender_amount,
+            receiver_amount: receiver_amount,
+            transfer_fee: transfer_fee,
+        };
+        assert_eq(info.sender_amount, sender_amount);
+        assert_eq(
+            info.sender_amount + info.receiver_amount + info.transfer_fee,
+            sender_amount + receiver_amount + transfer_fee
+        );
+        let amounts: [u64; 5] = [
+            sender_amount,
+            receiver_amount,
+            transfer_fee,
+            remaining,
+            sender_amount + receiver_amount,
+        ];
+        return remaining;
+    }
+}

--- a/leo-fmt/tests/target/wrap_function_params.leo
+++ b/leo-fmt/tests/target/wrap_function_params.leo
@@ -1,0 +1,14 @@
+program test.aleo {
+    function add(a: u64, b: u64) -> u64 {
+        return a + b;
+    }
+
+    transition transfer_tokens(
+        public sender_balance: u64,
+        public receiver_balance: u64,
+        private transfer_amount: u64,
+    ) -> u64 {
+        let remaining: u64 = sender_balance - transfer_amount;
+        return remaining;
+    }
+}

--- a/leo-fmt/tests/target/wrap_struct_expr.leo
+++ b/leo-fmt/tests/target/wrap_struct_expr.leo
@@ -1,0 +1,22 @@
+program test.aleo {
+    struct Point {
+        x: u64,
+        y: u64,
+    }
+
+    struct TransferInfo {
+        sender_amount: u64,
+        receiver_amount: u64,
+        transfer_fee: u64,
+    }
+
+    transition main(public a: u64, public b: u64) -> u64 {
+        let p: Point = Point { x: 1u64, y: 2u64 };
+        let info: TransferInfo = TransferInfo {
+            sender_amount: a,
+            receiver_amount: b,
+            transfer_fee: 10u64,
+        };
+        return p.x + info.sender_amount;
+    }
+}


### PR DESCRIPTION
Adds line wrapping to `leo-fmt`, breaking long lines at a 100-character width. Function parameters, call arguments, assert arguments, array/tuple literals, and struct expressions all wrap to multi-line
form when they exceed the limit.

Also:
- Updates the test corpus so that most source/target examples pass Leo type checking
  (`cargo test -p leo-fmt --features validate`), ensuring the formatter's test programs are valid Leo.
- Fixes `::` doubling before const arg lists (`from_bits_raw::[[u8; 32]]`).
- Fixes struct comment mangling and trailing comment drift.

Closes #29128
Partially addresses #29127 (fixes 2a and 2d; items 1, 2b, 2c, 3 remain)

Part of #28579