### PR TITLE
Fix an issue with SSA trying to replace global vars.

### DIFF
--- a/compiler/passes/src/static_single_assignment/expression.rs
+++ b/compiler/passes/src/static_single_assignment/expression.rs
@@ -211,9 +211,13 @@ impl ExpressionConsumer for SsaFormingVisitor<'_> {
     /// Note that this shouldn't be used for `Identifier`s on the lhs of definitions or
     /// assignments.
     fn consume_path(&mut self, path: Path) -> Self::Output {
-        // If lookup fails, either it's the name of a mapping or we didn't rename it.
-        let name = *self.rename_table.lookup(path.identifier().name).unwrap_or(&path.identifier().name);
-        (path.with_updated_last_symbol(name).into(), Default::default())
+        if let Some(name) = path.try_local_symbol() {
+            // If lookup fails, then we didn't rename it.
+            let name = *self.rename_table.lookup(name).unwrap_or(&name);
+            (path.with_updated_last_symbol(name).into(), Default::default())
+        } else {
+            (path.into(), Default::default())
+        }
     }
 
     /// Consumes and returns the literal without making any modifications.

--- a/tests/expectations/compiler/statements/b29134.out
+++ b/tests/expectations/compiler/statements/b29134.out
@@ -1,0 +1,46 @@
+program child.aleo;
+
+mapping foo:
+    key as u32.public;
+    value as u32.public;
+
+function bar:
+// --- Next Program --- //
+import child.aleo;
+program parent.aleo;
+
+mapping f:
+    key as u32.public;
+    value as u32.public;
+
+function set_test:
+    async set_test into r0;
+    output r0 as parent.aleo/set_test.future;
+
+finalize set_test:
+    set 0u32 into f[0u32];
+    set 0u32 into f[1u32];
+
+function get_test:
+    async get_test into r0;
+    output r0 as parent.aleo/get_test.future;
+
+finalize get_test:
+    get child.aleo/foo[0u32] into r0;
+    is.eq r0 42u32 into r1;
+    assert.eq r1 true;
+    get child.aleo/foo[1u32] into r2;
+    is.eq r2 42u32 into r3;
+    assert.eq r3 true;
+
+function get_or_use_test:
+    async get_or_use_test into r0;
+    output r0 as parent.aleo/get_or_use_test.future;
+
+finalize get_or_use_test:
+    get.or_use child.aleo/foo[0u32] 42u32 into r0;
+    is.eq r0 42u32 into r1;
+    assert.eq r1 true;
+    get.or_use child.aleo/foo[1u32] 42u32 into r2;
+    is.eq r2 42u32 into r3;
+    assert.eq r3 true;

--- a/tests/tests/compiler/statements/b29134.leo
+++ b/tests/tests/compiler/statements/b29134.leo
@@ -1,0 +1,39 @@
+program child.aleo {
+    mapping foo: u32 => u32; 
+
+    fn bar() { }
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+program parent.aleo {
+    mapping f: u32 => u32;
+
+    fn set_test() -> Final {
+        return final {
+            for i in 0u32..2u32 {
+                f.set(i, 0);
+            }
+        };
+    }
+
+    fn get_test() -> Final {
+        return final {
+            for i in 0u32..2u32 {
+                let foo = child.aleo/foo.get(i);
+                assert(foo == 42);
+            }
+        };
+    }
+
+    fn get_or_use_test() -> Final {
+        return final {
+            for i in 0u32..2u32 {
+                let foo = child.aleo/foo.get_or_use(i, 42);
+                assert(foo == 42);
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
- Fix to SSA where in some cases, it was trying to SSA paths to external global variables when they have the same name as a local variable.
  - The issue was especially apparent for external mapping accesses inside loops such as:
  ```leo
  for i in 0u32..2u32 {
      let foo = child.aleo/foo.get_or_use(i, 42);
      assert(foo == 42);
  }
  ```
  where the name `foo` of a local variable matches the global name `foo` from `child.aleo`.
- Fix type inference for `get_or_use` so that unsuffixed numerics work.
- Tidy up how intrinsics are type checked in general. For vector and mapping ops specifically, make all of those intrinsics follow the same pattern.
- The test I added stresses both cases.

Closes #29134