### PR TITLE
Traverse stubs when calling `fill` in WriteTransforming

### DIFF
--- a/compiler/passes/src/write_transforming/visitor.rs
+++ b/compiler/passes/src/write_transforming/visitor.rs
@@ -31,6 +31,7 @@ use leo_ast::{
     Path,
     Program,
     Statement,
+    Stub,
     Type,
 };
 use leo_span::Symbol;
@@ -257,6 +258,11 @@ impl AstVisitor for WriteTransformingFiller<'_> {
 
 impl WriteTransformingFiller<'_> {
     fn fill(&mut self, program: &Program) {
+        for stub in program.stubs.iter() {
+            if let (_, Stub::FromLeo { program, .. }) = stub {
+                self.fill(program);
+            }
+        }
         for (_, module) in program.modules.iter() {
             self.0.program = module.program_name;
             for (_, function) in module.functions.iter() {

--- a/tests/expectations/compiler/array/array_assign_in_external.out
+++ b/tests/expectations/compiler/array/array_assign_in_external.out
@@ -1,0 +1,11 @@
+program child.aleo;
+
+function foo:
+    input r0 as u32.private;
+    cast 1u32 2u32 3u32 into r1 as [u32; 3u32];
+    output r1 as [u32; 3u32].private;
+// --- Next Program --- //
+import child.aleo;
+program parent.aleo;
+
+function main:

--- a/tests/expectations/compiler/function/inline_in_external.out
+++ b/tests/expectations/compiler/function/inline_in_external.out
@@ -1,0 +1,19 @@
+program child.aleo;
+
+function foo:
+    async foo into r0;
+    output r0 as child.aleo/foo.future;
+
+finalize foo:
+    assert.eq true true;
+    assert.eq false true;
+// --- Next Program --- //
+import child.aleo;
+program parent.aleo;
+
+function foo:
+    async foo into r0;
+    output r0 as parent.aleo/foo.future;
+
+finalize foo:
+    assert.eq true true;

--- a/tests/tests/compiler/array/array_assign_in_external.leo
+++ b/tests/tests/compiler/array/array_assign_in_external.leo
@@ -1,0 +1,18 @@
+// This test ensures that `WriteTransforming` works on array assignment in Leo stubs
+
+program child.aleo {
+    fn foo(b: u32) -> [u32; 3] {
+        let a = [b; 3];
+        a[0] = 1;
+        a[1] = 2;
+        a[2] = 3;
+        return a;
+    }
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+program parent.aleo {
+    fn main() { }
+}

--- a/tests/tests/compiler/function/inline_in_external.leo
+++ b/tests/tests/compiler/function/inline_in_external.leo
@@ -1,0 +1,25 @@
+// This test ensures that `FunctionInlining` works in Leo stubs
+
+program child.aleo {
+    fn foo() -> Final {
+        return final {
+            assert(f() == 4);
+            assert(f() != 4);
+        };
+    }
+}
+
+fn f() -> u32 { return 4; }
+
+// --- Next Program --- //
+
+import child.aleo;
+program parent.aleo {
+    fn foo() -> Final {
+        return final {
+            assert(f() == 4);
+        };
+    }
+}
+
+fn f() -> u32 { return 4; }


### PR DESCRIPTION
Pretty straightforward change. A partner ran into a crash that this PR fixes.

I ran into another issue related to inlining in on the `release-3.5.0` branch but it looks like it has been fixed on `master`. I added a test anyways.

PR on the release branch: https://github.com/ProvableHQ/leo/pull/29137