### PR TITLE
Some fixes from `master` and move to canary 4.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3953,7 +3953,7 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -3973,7 +3973,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4000,7 +4000,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4014,7 +4014,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-account"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -4034,7 +4034,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-collections"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -4044,7 +4044,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "indexmap",
  "itertools",
@@ -4062,12 +4062,12 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-environment-witness"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 
 [[package]]
 name = "snarkvm-circuit-network"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -4078,7 +4078,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -4092,7 +4092,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -4107,7 +4107,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-address"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4120,7 +4120,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-boolean"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -4129,7 +4129,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-field"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4139,7 +4139,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-group"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4151,7 +4151,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-integers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4163,7 +4163,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-scalar"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4174,7 +4174,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-circuit-types-string"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -4186,7 +4186,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -4199,7 +4199,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-account"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-algorithms"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -4226,7 +4226,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-collections"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "rayon",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-network-environment"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "anyhow",
  "bech32",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -4297,7 +4297,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -4312,7 +4312,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-address"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4323,7 +4323,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-boolean"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
@@ -4331,7 +4331,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-field"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4341,7 +4341,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-group"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4352,7 +4352,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-integers"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4363,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-scalar"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4374,7 +4374,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-console-types-string"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -4385,7 +4385,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-curves"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "rand 0.8.5",
  "rustc_version",
@@ -4398,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-fields"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4415,7 +4415,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4443,7 +4443,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-authority"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "anyhow",
  "rand 0.8.5",
@@ -4455,7 +4455,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-block"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -4477,7 +4477,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-committee"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "indexmap",
  "rayon",
@@ -4489,7 +4489,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -4502,7 +4502,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "indexmap",
  "rayon",
@@ -4515,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "indexmap",
  "rayon",
@@ -4527,7 +4527,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4538,7 +4538,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "indexmap",
  "rayon",
@@ -4553,7 +4553,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "bytes",
  "serde_json",
@@ -4566,7 +4566,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -4575,7 +4575,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4594,7 +4594,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-query"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4633,7 +4633,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-ledger-store"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -4658,7 +4658,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-parameters"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4680,7 +4680,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4712,7 +4712,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-process"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "colored",
@@ -4736,7 +4736,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-program"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -4755,7 +4755,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-synthesizer-snark"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "bincode",
  "serde_json",
@@ -4768,7 +4768,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -4791,7 +4791,7 @@ dependencies = [
 [[package]]
 name = "snarkvm-utilities-derives"
 version = "4.4.0"
-source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=testnet-v4.5.1#d30cca62582106ccaab0de03a7713049dfa85a04"
+source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "proc-macro2",
  "quote 1.0.44",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,7 +132,7 @@ serial_test        = "3.1"
 sha2               = "0.10"
 # We enable "test_consensus_heights" to give developers freedom to set custom consensus version upgrade heights and "test_targets" because the devnode's genesis block was created with the same feature flag.
 # TODO: update `rev` to an actual snarkVM tag when available.
-snarkvm            = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "testnet-v4.5.1", features = [ "test_consensus_heights", "dev_skip_checks", "test_targets" ] }
+snarkvm            = { git = "https://github.com/ProvableHQ/snarkVM.git", tag = "canary-v4.5.3", features = [ "test_consensus_heights", "dev_skip_checks", "test_targets" ] }
 sys-info           = "0.9"
 tempfile           = "3.20"
 thiserror          = "2.0"

--- a/compiler/passes/src/static_single_assignment/expression.rs
+++ b/compiler/passes/src/static_single_assignment/expression.rs
@@ -211,9 +211,13 @@ impl ExpressionConsumer for SsaFormingVisitor<'_> {
     /// Note that this shouldn't be used for `Identifier`s on the lhs of definitions or
     /// assignments.
     fn consume_path(&mut self, path: Path) -> Self::Output {
-        // If lookup fails, either it's the name of a mapping or we didn't rename it.
-        let name = *self.rename_table.lookup(path.identifier().name).unwrap_or(&path.identifier().name);
-        (path.with_updated_last_symbol(name).into(), Default::default())
+        if let Some(name) = path.try_local_symbol() {
+            // If lookup fails, then we didn't rename it.
+            let name = *self.rename_table.lookup(name).unwrap_or(&name);
+            (path.with_updated_last_symbol(name).into(), Default::default())
+        } else {
+            (path.into(), Default::default())
+        }
     }
 
     /// Consumes and returns the literal without making any modifications.

--- a/tests/expectations/compiler/statements/b29134.out
+++ b/tests/expectations/compiler/statements/b29134.out
@@ -1,0 +1,46 @@
+program child.aleo;
+
+mapping foo:
+    key as u32.public;
+    value as u32.public;
+
+function bar:
+// --- Next Program --- //
+import child.aleo;
+program parent.aleo;
+
+mapping f:
+    key as u32.public;
+    value as u32.public;
+
+function set_test:
+    async set_test into r0;
+    output r0 as parent.aleo/set_test.future;
+
+finalize set_test:
+    set 0u32 into f[0u32];
+    set 0u32 into f[1u32];
+
+function get_test:
+    async get_test into r0;
+    output r0 as parent.aleo/get_test.future;
+
+finalize get_test:
+    get child.aleo/foo[0u32] into r0;
+    is.eq r0 42u32 into r1;
+    assert.eq r1 true;
+    get child.aleo/foo[1u32] into r2;
+    is.eq r2 42u32 into r3;
+    assert.eq r3 true;
+
+function get_or_use_test:
+    async get_or_use_test into r0;
+    output r0 as parent.aleo/get_or_use_test.future;
+
+finalize get_or_use_test:
+    get.or_use child.aleo/foo[0u32] 42u32 into r0;
+    is.eq r0 42u32 into r1;
+    assert.eq r1 true;
+    get.or_use child.aleo/foo[1u32] 42u32 into r2;
+    is.eq r2 42u32 into r3;
+    assert.eq r3 true;

--- a/tests/tests/compiler/statements/b29134.leo
+++ b/tests/tests/compiler/statements/b29134.leo
@@ -1,0 +1,39 @@
+program child.aleo {
+    mapping foo: u32 => u32; 
+
+    transition bar() { }
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+program parent.aleo {
+    mapping f: u32 => u32;
+
+    async transition set_test() -> Future {
+        return async {
+            for i in 0u32..2u32 {
+                f.set(i, 0);
+            }
+        };
+    }
+
+    async transition get_test() -> Future {
+        return async {
+            for i in 0u32..2u32 {
+                let foo = child.aleo/foo.get(i);
+                assert(foo == 42);
+            }
+        };
+    }
+
+    async transition get_or_use_test() -> Future {
+        return async {
+            for i in 0u32..2u32 {
+                let foo = child.aleo/foo.get_or_use(i, 42);
+                assert(foo == 42);
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
- Fix an issue with SSA trying to replace global vars.
- Port a few fixes from `master` (mostly from https://github.com/ProvableHQ/leo/pull/29135)
- Target `canary-4.5.3`
- Keep the v1/v2 prefix in endpoints since the VM no longer expect them.
