### PR TITLE
refactor(test): Replace `REWRITE_EXPECTATIONS with `UPDATE_EXPECT`

### DIFF
--- a/leo/tests/integration.rs
+++ b/leo/tests/integration.rs
@@ -67,7 +67,7 @@ fn run_single_cli_test(test_directory: &Path) {
         mismatch_directory: mismatch_directory.join(test_directory.file_name().unwrap()),
     };
 
-    let rewrite_expectations = !std::env::var("REWRITE_EXPECTATIONS").unwrap_or_default().trim().is_empty();
+    let rewrite_expectations = !std::env::var("UPDATE_EXPECT").unwrap_or_default().trim().is_empty();
 
     let port = find_free_port();
     let mut devnode_process = run_leo_devnode(port).expect("devnode");

--- a/test-framework/src/lib.rs
+++ b/test-framework/src/lib.rs
@@ -59,7 +59,7 @@ fn print_diff(expected: &str, actual: &str) {
 ///
 ///
 /// If no corresponding `.out` file is found in `expecations/{category}`,
-/// or if the environment variable `REWRITE_EXPECTATIONS` is set, no
+/// or if the environment variable `UPDATE_EXPECT` is set, no
 /// comparison to a previous result is done and the result of the current
 /// run is written to the file.
 pub fn run_tests(category: &str, runner: fn(&str) -> String) {
@@ -79,7 +79,7 @@ pub fn run_tests(category: &str, runner: fn(&str) -> String) {
     let expectations_dir = base_tests_dir.join("expectations").join(category);
 
     let filter_string = std::env::var("TEST_FILTER").unwrap_or_default();
-    let rewrite_expectations = std::env::var("REWRITE_EXPECTATIONS").is_ok();
+    let rewrite_expectations = std::env::var("UPDATE_EXPECT").is_ok();
 
     struct TestResult {
         failure: Option<TestFailure>,
@@ -203,7 +203,7 @@ pub fn run_single_test(category: &str, path: &Path, runner: fn(&str) -> String) 
     let tests_dir = base_tests_dir.join("tests").join(category);
     let expectations_dir = base_tests_dir.join("expectations").join(category);
 
-    let rewrite_expectations = std::env::var("REWRITE_EXPECTATIONS").is_ok();
+    let rewrite_expectations = std::env::var("UPDATE_EXPECT").is_ok();
 
     // Read the test file
     println!("Running: {}", path.display());

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,6 +27,6 @@ don't match actual results, an error will be thrown and the test won't pass. Of 
 
 1. If the test has failed because the logic was changed intentionally, then expectations need to be deleted. New ones will be
 generated instead. A PR should contain changes to expectations as well as to tests or code. You can also regenerate new
-expectation files by setting the environment variable `REWRITE_EXPECTATIONS` while running tests.
+expectation files by setting the environment variable `UPDATE_EXPECT` while running tests.
 2. If the test should pass, then expectations should not be changed or removed.
 


### PR DESCRIPTION
This replaces the custom `REWRITE_EXPECTATIONS` env var with `UPDATE_EXPECT`.

## Motivation

The goal here is to make it easier to update expectations for both the existing compiler and integration tests, as well as the unit tests using `expect-test` crate's `expect![[...]]` macro snapshots (used throughout the new rowan-parser).

Unfortunately, the `expect-test` crate doesn't offer any nice approach for specifying a custom env var, and after doing some digging I couldn't come up with a non-hacky solution for having `REWRITE_EXPECTATIONS=1` imply `UPDATE_EXPECT=1`. As a result, I'm proposing we replace `REWRITE_EXPECTATIONS` with `UPDATE_EXPECT` instead.

## Example

So previously, we'd run:

```console
REWRITE_EXPECTATIONS=1 cargo nextest run --workspace
```

Instead, we now run:

```console
UPDATE_EXPECT=1 cargo nextest run --workspace
```