### PR TITLE
Add base support for interfaces

### DIFF
--- a/compiler/ast/src/interface/mod.rs
+++ b/compiler/ast/src/interface/mod.rs
@@ -1,0 +1,81 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Identifier, Node, NodeID, indent_display::Indent};
+use leo_span::{Span, Symbol};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+pub use prototypes::{FunctionPrototype, RecordPrototype};
+
+mod prototypes;
+
+/// An interface definition.
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct Interface {
+    /// The interface identifier, e.g., `Foo` in `interface Foo { ... }`.
+    pub identifier: Identifier,
+    /// The interface this interface inherits from, if any
+    pub parent: Option<Symbol>,
+    /// The entire span of the interface definition.
+    pub span: Span,
+    /// The ID of the node.
+    pub id: NodeID,
+    /// A vector of function prototypes.
+    pub functions: Vec<(Symbol, FunctionPrototype)>,
+    /// A vector of record prototypes.
+    pub records: Vec<(Symbol, RecordPrototype)>,
+}
+
+impl Interface {
+    pub fn name(&self) -> Symbol {
+        self.identifier.name
+    }
+}
+
+impl PartialEq for Interface {
+    fn eq(&self, other: &Self) -> bool {
+        self.identifier == other.identifier
+    }
+}
+
+impl Eq for Interface {}
+
+impl fmt::Debug for Interface {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl fmt::Display for Interface {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(
+            f,
+            "interface {}{} {{",
+            self.identifier,
+            if let Some(parent) = self.parent { format!(" : {parent}") } else { "".into() }
+        )?;
+        for (_, fun_prot) in &self.functions {
+            writeln!(f, "{}", Indent(fun_prot))?;
+        }
+        for (_, rec_prot) in &self.records {
+            writeln!(f, "{}", Indent(rec_prot))?;
+        }
+        write!(f, "}}")
+    }
+}
+
+crate::simple_node_impl!(Interface);

--- a/compiler/ast/src/interface/prototypes.rs
+++ b/compiler/ast/src/interface/prototypes.rs
@@ -1,0 +1,136 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::fmt;
+
+use crate::{Annotation, ConstParameter, Identifier, Input, Node, NodeID, Output, TupleType, Type};
+use itertools::Itertools;
+use leo_span::Span;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct FunctionPrototype {
+    /// Annotations on the function.
+    pub annotations: Vec<Annotation>,
+    /// The function identifier, e.g., `foo` in `function foo(...) { ... }`.
+    pub identifier: Identifier,
+    /// The function's const parameters.
+    pub const_parameters: Vec<ConstParameter>,
+    /// The function's input parameters.
+    pub input: Vec<Input>,
+    /// The function's output declarations.
+    pub output: Vec<Output>,
+    /// The function's output type.
+    pub output_type: Type,
+    /// The entire span of the function definition.
+    pub span: Span,
+    /// The ID of the node.
+    pub id: NodeID,
+}
+
+impl FunctionPrototype {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        annotations: Vec<Annotation>,
+        identifier: Identifier,
+        const_parameters: Vec<ConstParameter>,
+        input: Vec<Input>,
+        output: Vec<Output>,
+        span: Span,
+        id: NodeID,
+    ) -> Self {
+        let output_type = match output.len() {
+            0 => Type::Unit,
+            1 => output[0].type_.clone(),
+            _ => Type::Tuple(TupleType::new(output.iter().map(|o| o.type_.clone()).collect())),
+        };
+
+        Self { annotations, identifier, const_parameters, input, output, output_type, span, id }
+    }
+}
+
+impl PartialEq for FunctionPrototype {
+    fn eq(&self, other: &Self) -> bool {
+        self.identifier == other.identifier
+    }
+}
+
+impl Eq for FunctionPrototype {}
+
+impl fmt::Debug for FunctionPrototype {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl fmt::Display for FunctionPrototype {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for annotation in &self.annotations {
+            writeln!(f, "{annotation}")?;
+        }
+        write!(f, "fn {}", self.identifier)?;
+        if !self.const_parameters.is_empty() {
+            write!(f, "::[{}]", self.const_parameters.iter().format(", "))?;
+        }
+        write!(f, "({})", self.input.iter().format(", "))?;
+        match self.output.len() {
+            0 => {}
+            1 => {
+                if !matches!(self.output[0].type_, Type::Unit) {
+                    write!(f, " -> {}", self.output[0])?;
+                }
+            }
+            _ => {
+                write!(f, " -> ({})", self.output.iter().format(", "))?;
+            }
+        }
+        write!(f, ";")
+    }
+}
+
+crate::simple_node_impl!(FunctionPrototype);
+
+#[derive(Clone, Default, Serialize, Deserialize)]
+pub struct RecordPrototype {
+    /// The record identifier
+    pub identifier: Identifier,
+    /// The entire span of the composite definition.
+    pub span: Span,
+    /// The ID of the node.
+    pub id: NodeID,
+}
+
+impl PartialEq for RecordPrototype {
+    fn eq(&self, other: &Self) -> bool {
+        self.identifier == other.identifier
+    }
+}
+
+impl Eq for RecordPrototype {}
+
+impl fmt::Debug for RecordPrototype {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{self}")
+    }
+}
+
+impl fmt::Display for RecordPrototype {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "record {};", self.identifier)
+    }
+}
+
+crate::simple_node_impl!(RecordPrototype);

--- a/compiler/ast/src/lib.rs
+++ b/compiler/ast/src/lib.rs
@@ -37,6 +37,9 @@ pub use self::expressions::*;
 mod functions;
 pub use self::functions::*;
 
+mod interface;
+pub use self::interface::*;
+
 mod indent_display;
 use indent_display::*;
 

--- a/compiler/ast/src/module/mod.rs
+++ b/compiler/ast/src/module/mod.rs
@@ -23,8 +23,9 @@
 //! - A list of constant declarations (`consts`)
 //! - A list of composite type definitions (`composites`)
 //! - A list of function definitions (`functions`)
+//! - A list of interface definitions (`interfaces`)
 
-use crate::{Composite, ConstDeclaration, Function, Indent};
+use crate::{Composite, ConstDeclaration, Function, Indent, Interface};
 
 use leo_span::Symbol;
 
@@ -46,6 +47,8 @@ pub struct Module {
     pub composites: Vec<(Symbol, Composite)>,
     /// A vector of function definitions.
     pub functions: Vec<(Symbol, Function)>,
+    /// A vector of interface definitions.
+    pub interfaces: Vec<(Symbol, Interface)>,
 }
 
 impl fmt::Display for Module {

--- a/compiler/ast/src/passes/consumer.rs
+++ b/compiler/ast/src/passes/consumer.rs
@@ -129,6 +129,13 @@ pub trait FunctionConsumer {
     fn consume_function(&mut self, input: Function) -> Self::Output;
 }
 
+/// A Consumer trait for interfaces in the AST.
+pub trait InterfaceConsumer {
+    type Output;
+
+    fn consume_interface(&mut self, input: Interface) -> Self::Output;
+}
+
 /// A Consumer trait for constructors in the AST.
 pub trait ConstructorConsumer {
     type Output;

--- a/compiler/ast/src/passes/reconstructor.rs
+++ b/compiler/ast/src/passes/reconstructor.rs
@@ -582,6 +582,7 @@ pub trait ProgramReconstructor: AstReconstructor {
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             consts: input
                 .consts
                 .into_iter()
@@ -598,6 +599,7 @@ pub trait ProgramReconstructor: AstReconstructor {
                 .map(|(id, storage_variable)| (id, self.reconstruct_storage_variable(storage_variable)))
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }
@@ -617,7 +619,60 @@ pub trait ProgramReconstructor: AstReconstructor {
                 .collect(),
             composites: input.composites.into_iter().map(|(i, c)| (i, self.reconstruct_composite(c))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
         }
+    }
+
+    fn reconstruct_interface(&mut self, input: Interface) -> Interface {
+        Interface {
+            identifier: input.identifier,
+            parent: input.parent,
+            span: input.span,
+            id: input.id,
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function_prototype(f))).collect(),
+            records: input.records.into_iter().map(|(i, f)| (i, self.reconstruct_record_prototype(f))).collect(),
+        }
+    }
+
+    fn reconstruct_function_prototype(&mut self, input: FunctionPrototype) -> FunctionPrototype {
+        FunctionPrototype {
+            annotations: input.annotations,
+            identifier: input.identifier,
+            const_parameters: input
+                .const_parameters
+                .iter()
+                .map(|param| {
+                    let mut param = param.clone();
+                    param.type_ = self.reconstruct_type(param.type_).0;
+                    param
+                })
+                .collect(),
+            input: input
+                .input
+                .iter()
+                .map(|input| {
+                    let mut input = input.clone();
+                    input.type_ = self.reconstruct_type(input.type_).0;
+                    input
+                })
+                .collect(),
+            output: input
+                .output
+                .iter()
+                .map(|output| {
+                    let mut output = output.clone();
+                    output.type_ = self.reconstruct_type(output.type_).0;
+                    output
+                })
+                .collect(),
+            output_type: self.reconstruct_type(input.output_type).0,
+            span: input.span,
+            id: input.id,
+        }
+    }
+
+    fn reconstruct_record_prototype(&mut self, input: RecordPrototype) -> RecordPrototype {
+        RecordPrototype { identifier: input.identifier, span: input.span, id: input.id }
     }
 
     fn reconstruct_function(&mut self, input: Function) -> Function {

--- a/compiler/ast/src/passes/visitor.rs
+++ b/compiler/ast/src/passes/visitor.rs
@@ -369,6 +369,20 @@ pub trait ProgramVisitor: AstVisitor {
         self.visit_block(&input.block);
     }
 
+    fn visit_interface(&mut self, input: &Interface) {
+        input.functions.iter().for_each(|(_, f)| self.visit_function_prototype(f));
+        input.records.iter().for_each(|(_, r)| self.visit_record_prototype(r));
+    }
+
+    fn visit_function_prototype(&mut self, input: &FunctionPrototype) {
+        input.const_parameters.iter().for_each(|input| self.visit_type(&input.type_));
+        input.input.iter().for_each(|input| self.visit_type(&input.type_));
+        input.output.iter().for_each(|output| self.visit_type(&output.type_));
+        self.visit_type(&input.output_type);
+    }
+
+    fn visit_record_prototype(&mut self, _input: &RecordPrototype) {}
+
     fn visit_constructor(&mut self, input: &Constructor) {
         self.visit_block(&input.block);
     }

--- a/compiler/ast/src/program/program_scope.rs
+++ b/compiler/ast/src/program/program_scope.rs
@@ -16,7 +16,17 @@
 
 //! A Leo program scope consists of const, composite, function, and mapping definitions.
 
-use crate::{Composite, ConstDeclaration, Constructor, Function, Indent, Mapping, ProgramId, StorageVariable};
+use crate::{
+    Composite,
+    ConstDeclaration,
+    Constructor,
+    Function,
+    Indent,
+    Interface,
+    Mapping,
+    ProgramId,
+    StorageVariable,
+};
 
 use leo_span::{Span, Symbol};
 use serde::{Deserialize, Serialize};
@@ -27,6 +37,8 @@ use std::fmt;
 pub struct ProgramScope {
     /// The program id of the program scope.
     pub program_id: ProgramId,
+    /// The interface this program inherits from, if any
+    pub parent: Option<Symbol>,
     /// A vector of const definitions.
     pub consts: Vec<(Symbol, ConstDeclaration)>,
     /// A vector of composite definitions.
@@ -37,6 +49,8 @@ pub struct ProgramScope {
     pub storage_variables: Vec<(Symbol, StorageVariable)>,
     /// A vector of function definitions.
     pub functions: Vec<(Symbol, Function)>,
+    /// A vector of interface definitions.
+    pub interfaces: Vec<(Symbol, Interface)>,
     /// An optional constructor.
     pub constructor: Option<Constructor>,
     /// The span associated with the program scope.

--- a/compiler/compiler/src/compiler.rs
+++ b/compiler/compiler/src/compiler.rs
@@ -196,6 +196,8 @@ impl Compiler {
 
         self.do_pass::<GlobalItemsCollection>(())?;
 
+        self.do_pass::<CheckInterfaces>(())?;
+
         self.do_pass::<TypeChecking>(type_checking_config.clone())?;
 
         self.do_pass::<Disambiguate>(())?;

--- a/compiler/parser-rowan/src/lexer.rs
+++ b/compiler/parser-rowan/src/lexer.rs
@@ -315,6 +315,7 @@ fn ident_to_kind(s: &str) -> SyntaxKind {
         "Fn" => KW_FN_UPPER,
         "struct" => KW_STRUCT,
         "constructor" => KW_CONSTRUCTOR,
+        "interface" => KW_INTERFACE,
         // Program structure keywords
         "program" => KW_PROGRAM,
         "import" => KW_IMPORT,

--- a/compiler/parser-rowan/src/syntax_kind.rs
+++ b/compiler/parser-rowan/src/syntax_kind.rs
@@ -157,6 +157,8 @@ pub enum SyntaxKind {
     KW_STRUCT,
     /// `constructor`
     KW_CONSTRUCTOR,
+    /// `interface`
+    KW_INTERFACE,
 
     // ==========================================================================
     // Keywords - Program Structure
@@ -371,6 +373,12 @@ pub enum SyntaxKind {
     STORAGE_DEF,
     /// Global constant definition.
     GLOBAL_CONST,
+    /// Interface declaration.
+    INTERFACE_DEF,
+    /// Function prototype (in interface).
+    FN_PROTOTYPE_DEF,
+    /// Record prototype (in interface).
+    RECORD_PROTOTYPE_DEF,
 
     // ==========================================================================
     // Composite Nodes - Function Parts
@@ -580,6 +588,7 @@ impl SyntaxKind {
                 | KW_FN_UPPER
                 | KW_STRUCT
                 | KW_CONSTRUCTOR
+                | KW_INTERFACE
                 | KW_PROGRAM
                 | KW_IMPORT
                 | KW_MAPPING
@@ -835,6 +844,7 @@ impl SyntaxKind {
             KW_FN_UPPER => "'Fn'",
             KW_STRUCT => "'struct'",
             KW_CONSTRUCTOR => "'constructor'",
+            KW_INTERFACE => "'interface'",
 
             // Program structure keywords
             KW_PROGRAM => "'program'",
@@ -981,6 +991,7 @@ const SYNTAX_KIND_TABLE: &[SyntaxKind] = &[
     KW_FN_UPPER,
     KW_STRUCT,
     KW_CONSTRUCTOR,
+    KW_INTERFACE,
     KW_PROGRAM,
     KW_IMPORT,
     KW_MAPPING,
@@ -1066,6 +1077,9 @@ const SYNTAX_KIND_TABLE: &[SyntaxKind] = &[
     MAPPING_DEF,
     STORAGE_DEF,
     GLOBAL_CONST,
+    INTERFACE_DEF,
+    FN_PROTOTYPE_DEF,
+    RECORD_PROTOTYPE_DEF,
     ANNOTATION,
     ANNOTATION_PAIR,
     PARAM,

--- a/compiler/passes/src/check_interfaces/mod.rs
+++ b/compiler/passes/src/check_interfaces/mod.rs
@@ -1,0 +1,47 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+mod visitor;
+use visitor::*;
+
+use crate::{CompilerState, Pass};
+
+use leo_ast::ProgramVisitor;
+use leo_errors::Result;
+
+/// A pass to validate interface inheritance soundness.
+///
+/// Validates:
+/// 1. Interface-to-interface inheritance has no conflicting members
+/// 2. Programs implement all required interface members
+/// 3. Signature matching is exact
+pub struct CheckInterfaces;
+
+impl Pass for CheckInterfaces {
+    type Input = ();
+    type Output = ();
+
+    const NAME: &'static str = "CheckInterfaces";
+
+    fn do_pass(_: Self::Input, state: &mut CompilerState) -> Result<Self::Output> {
+        let ast = std::mem::take(&mut state.ast);
+        let mut visitor = CheckInterfacesVisitor::new(state);
+        visitor.visit_program(ast.as_repr());
+        visitor.state.handler.last_err()?;
+        visitor.state.ast = ast;
+        Ok(())
+    }
+}

--- a/compiler/passes/src/check_interfaces/visitor.rs
+++ b/compiler/passes/src/check_interfaces/visitor.rs
@@ -1,0 +1,292 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::CompilerState;
+
+use leo_ast::{
+    AstVisitor,
+    Function,
+    FunctionPrototype,
+    Interface,
+    Location,
+    ProgramScope,
+    ProgramVisitor,
+    RecordPrototype,
+};
+use leo_errors::CheckInterfacesError;
+use leo_span::Symbol;
+
+use indexmap::IndexMap;
+
+/// A flattened interface with all inherited members collected.
+#[derive(Clone, Debug)]
+struct FlattenedInterface {
+    functions: Vec<(Symbol, FunctionPrototype)>,
+    records: Vec<(Symbol, RecordPrototype)>,
+}
+
+pub struct CheckInterfacesVisitor<'a> {
+    pub state: &'a mut CompilerState,
+    /// Current program name being processed.
+    current_program: Symbol,
+    /// Cache of flattened interfaces (with all inherited members).
+    flattened_interfaces: IndexMap<Location, FlattenedInterface>,
+}
+
+impl<'a> CheckInterfacesVisitor<'a> {
+    pub fn new(state: &'a mut CompilerState) -> Self {
+        Self { state, current_program: Symbol::intern(""), flattened_interfaces: IndexMap::new() }
+    }
+
+    /// Flatten an interface by collecting all inherited members.
+    /// Detects conflicts during flattening.
+    fn flatten_interface(&mut self, interface: &Interface, location: &Location) -> Option<FlattenedInterface> {
+        // Check cache first.
+        if let Some(flattened) = self.flattened_interfaces.get(location) {
+            return Some(flattened.clone());
+        }
+
+        // Start with the interface's own members.
+        let mut flattened =
+            FlattenedInterface { functions: interface.functions.clone(), records: interface.records.clone() };
+
+        // If there's a parent, merge parent's members.
+        if let Some(parent_name) = interface.parent {
+            let parent_location = Location::new(location.program, vec![parent_name]);
+
+            // Lookup parent interface.
+            let parent_interface =
+                match self.state.symbol_table.lookup_interface(self.current_program, &parent_location) {
+                    Some(p) => p.clone(),
+                    None => {
+                        self.state
+                            .handler
+                            .emit_err(CheckInterfacesError::interface_not_found(parent_name, interface.span));
+                        return None;
+                    }
+                };
+
+            // Recursively flatten parent.
+            // FIXME: handle cycles
+            let parent_flattened = self.flatten_interface(&parent_interface, &parent_location)?;
+
+            // Merge parent functions, checking for conflicts.
+            for (name, parent_func) in &parent_flattened.functions {
+                if let Some((_, existing_func)) = flattened.functions.iter().find(|(n, _)| n == name) {
+                    // Same name exists - check if compatible.
+                    if !Self::prototypes_match(existing_func, parent_func) {
+                        self.state.handler.emit_err(CheckInterfacesError::conflicting_interface_member(
+                            name,
+                            interface.identifier.name,
+                            parent_interface.identifier.name,
+                            interface.span,
+                        ));
+                        return None;
+                    }
+                    // Compatible - no action needed, child's version takes precedence.
+                } else {
+                    // Add parent's function.
+                    flattened.functions.push((*name, parent_func.clone()));
+                }
+            }
+
+            // Merge parent records.
+            for (name, parent_record) in &parent_flattened.records {
+                if !flattened.records.iter().any(|(n, _)| n == name) {
+                    flattened.records.push((*name, parent_record.clone()));
+                }
+            }
+        }
+
+        // Cache the result.
+        self.flattened_interfaces.insert(location.clone(), flattened.clone());
+        Some(flattened)
+    }
+
+    /// Validate that a program implements all interface requirements.
+    fn check_program_implements_interface(&mut self, program_scope: &ProgramScope, interface_name: Symbol) {
+        let program_name = program_scope.program_id.name.name;
+        let interface_location = Location::new(program_name, vec![interface_name]);
+
+        // Look up the interface.
+        let interface = match self.state.symbol_table.lookup_interface(program_name, &interface_location) {
+            Some(i) => i.clone(),
+            None => {
+                self.state
+                    .handler
+                    .emit_err(CheckInterfacesError::interface_not_found(interface_name, program_scope.span));
+                return;
+            }
+        };
+
+        // Get the flattened interface (with all inherited members).
+        let flattened = match self.flatten_interface(&interface, &interface_location) {
+            Some(f) => f,
+            None => return, // Error already emitted.
+        };
+
+        // Check all required functions are implemented.
+        for (func_name, required_proto) in &flattened.functions {
+            let func_location = Location::new(program_name, vec![*func_name]);
+
+            match self.state.symbol_table.lookup_function(program_name, &func_location) {
+                Some(func_symbol) => {
+                    // Function exists - check signature matches exactly.
+                    if !Self::function_matches_prototype(&func_symbol.function, required_proto) {
+                        self.state.handler.emit_err(CheckInterfacesError::signature_mismatch(
+                            func_name,
+                            interface_name,
+                            Self::format_prototype_signature(required_proto),
+                            Self::format_function_signature(&func_symbol.function),
+                            func_symbol.function.span,
+                        ));
+                    }
+                }
+                None => {
+                    self.state.handler.emit_err(CheckInterfacesError::missing_interface_function(
+                        func_name,
+                        interface_name,
+                        program_name,
+                        program_scope.span,
+                    ));
+                }
+            }
+        }
+
+        // Check all required records are declared.
+        for (record_name, _) in &flattened.records {
+            let record_location = Location::new(program_name, vec![*record_name]);
+
+            if self.state.symbol_table.lookup_record(program_name, &record_location).is_none() {
+                self.state.handler.emit_err(CheckInterfacesError::missing_interface_record(
+                    record_name,
+                    interface_name,
+                    program_name,
+                    program_scope.span,
+                ));
+            }
+        }
+    }
+
+    /// Check if two FunctionPrototypes have matching signatures.
+    fn prototypes_match(a: &FunctionPrototype, b: &FunctionPrototype) -> bool {
+        // Input parameters must match exactly.
+        a.input.len() != b.input.len() &&
+        a.input.iter().zip(b.input.iter()).all(|(input_a, input_b)| {
+            // Parameter names must match.
+            input_a.identifier.name == input_b.identifier.name &&
+            // Parameter types must match.
+            input_a.type_.eq_user(&input_b.type_) &&
+            // Parameter modes must match.
+            input_a.mode == input_b.mode
+        }) &&
+
+        // Output must match.
+        a.output.len() == b.output.len() &&
+        a.output.iter().zip(b.output.iter()).all(|(output_a, output_b)| output_a.type_.eq_user(&output_b.type_) && output_a.mode == output_b.mode) &&
+
+        // Const parameters must match.
+        a.const_parameters.len() == b.const_parameters.len() &&
+        a.const_parameters.iter().zip(b.const_parameters.iter()).all(|(const_a, const_b)| const_a.type_.eq_user(&const_b.type_)) &&
+
+
+        //TODO: we may want to check certain annotations, but they are not significant yet
+        // // Annotations must match.
+        // a.annotations.len() == b.annotations.len() &&
+        // a.annotations.iter().zip(b.annotations.iter()).all(|(ann_a, ann_b)| ann_a == ann_b) &&
+
+        // Output type must match (including Final).
+        a.output_type.eq_user(&b.output_type)
+    }
+
+    /// Check if a Function matches a FunctionPrototype exactly.
+    fn function_matches_prototype(func: &Function, proto: &FunctionPrototype) -> bool {
+        // Input parameters must match exactly.
+        func.input.len() == proto.input.len() &&
+
+        func.input.iter().zip(proto.input.iter()).all(|(func_input, proto_input)| {
+            // Parameter names must match.
+            func_input.identifier.name == proto_input.identifier.name &&
+            // Parameter types must match.
+            func_input.type_.eq_user(&proto_input.type_) &&
+            // Parameter modes must match.
+            func_input.mode == proto_input.mode
+        }) &&
+
+        // Output must match.
+        func.output.len() == proto.output.len() &&
+
+        func.output.iter().zip(proto.output.iter()).all(
+            |(func_output, proto_output)| func_output.type_.eq_user(&proto_output.type_) && func_output.mode == proto_output.mode) &&
+
+        // Const parameters must match.
+        func.const_parameters.len() == proto.const_parameters.len() &&
+        func.const_parameters.iter().zip(proto.const_parameters.iter()).all(|(func_const, proto_const)| func_const.type_.eq_user(&proto_const.type_)) &&
+
+        //TODO: we may want to check certain annotations, but they are not significant yet
+        // // Annotations must match.
+        // func.annotations.len() == proto.annotations.len() &&
+        // func.annotations.iter().zip(proto.annotations.iter()).all(|(ann_func, ann_proto)| ann_func == ann_proto) &&
+
+        // Output type must match (including Final).
+        func.output_type.eq_user(&proto.output_type)
+    }
+
+    fn format_prototype_signature(proto: &FunctionPrototype) -> String {
+        let inputs: Vec<String> = proto.input.iter().map(|i| format!("{}: {}", i.identifier.name, i.type_)).collect();
+        format!(
+            "{}fn {}({}) -> {}",
+            proto.annotations.iter().map(|ann| format!("{ann}\n")).collect::<Vec<String>>().join(""),
+            proto.identifier.name,
+            inputs.join(", "),
+            proto.output_type
+        )
+    }
+
+    fn format_function_signature(func: &Function) -> String {
+        let inputs: Vec<String> = func.input.iter().map(|i| format!("{}: {}", i.identifier.name, i.type_)).collect();
+        format!(
+            "{}fn {}({}) -> {}",
+            func.annotations.iter().map(|ann| format!("{ann}\n")).collect::<Vec<String>>().join(""),
+            func.identifier.name,
+            inputs.join(", "),
+            func.output_type
+        )
+    }
+}
+
+impl AstVisitor for CheckInterfacesVisitor<'_> {
+    type AdditionalInput = ();
+    type Output = ();
+}
+
+impl ProgramVisitor for CheckInterfacesVisitor<'_> {
+    fn visit_program_scope(&mut self, input: &ProgramScope) {
+        self.current_program = input.program_id.name.name;
+
+        // First, validate all interfaces in this program scope.
+        for (_, interface) in &input.interfaces {
+            let location = Location::new(self.current_program, vec![interface.identifier.name]);
+            // This will validate inheritance and cache the result.
+            self.flatten_interface(interface, &location);
+        }
+
+        // Then, check if the program implements an interface.
+        if let Some(parent_interface) = input.parent {
+            self.check_program_implements_interface(input, parent_interface);
+        }
+    }
+}

--- a/compiler/passes/src/const_propagation/program.rs
+++ b/compiler/passes/src/const_propagation/program.rs
@@ -75,6 +75,7 @@ impl ProgramReconstructor for ConstPropagationVisitor<'_> {
                 path: input.path,
                 composites: input.composites.into_iter().map(|(i, c)| (i, slf.reconstruct_composite(c))).collect(),
                 functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),
+                interfaces: input.interfaces.into_iter().map(|(i, int)| (i, slf.reconstruct_interface(int))).collect(),
             }
         })
     }

--- a/compiler/passes/src/flattening/program.rs
+++ b/compiler/passes/src/flattening/program.rs
@@ -33,6 +33,7 @@ impl ProgramReconstructor for FlatteningVisitor<'_> {
         self.program = input.program_id.name.name;
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             consts: input
                 .consts
                 .into_iter()
@@ -49,6 +50,7 @@ impl ProgramReconstructor for FlatteningVisitor<'_> {
                 .map(|(id, storage_variable)| (id, self.reconstruct_storage_variable(storage_variable)))
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }

--- a/compiler/passes/src/function_inlining/transform.rs
+++ b/compiler/passes/src/function_inlining/transform.rs
@@ -96,11 +96,13 @@ impl ProgramReconstructor for TransformVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             composites: input.composites,
             mappings: input.mappings,
             storage_variables: input.storage_variables,
             constructor,
             functions,
+            interfaces: input.interfaces,
             consts: input.consts,
             span: input.span,
         }

--- a/compiler/passes/src/global_items_collection.rs
+++ b/compiler/passes/src/global_items_collection.rs
@@ -41,6 +41,7 @@ use leo_ast::{
     ConstDeclaration,
     Function,
     FunctionStub,
+    Interface,
     Location,
     Mapping,
     MappingType,
@@ -117,6 +118,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
         input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
         input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
+        input.interfaces.iter().for_each(|(_, c)| self.visit_interface(c));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }
@@ -176,6 +178,15 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
         let full_name = self.module.iter().cloned().chain(std::iter::once(input.name())).collect::<Vec<Symbol>>();
         if let Err(err) =
             self.state.symbol_table.insert_function(Location::new(self.program_name, full_name), input.clone())
+        {
+            self.state.handler.emit_err(err);
+        }
+    }
+
+    fn visit_interface(&mut self, input: &Interface) {
+        let full_name = self.module.iter().cloned().chain(std::iter::once(input.name())).collect::<Vec<Symbol>>();
+        if let Err(err) =
+            self.state.symbol_table.insert_interface(Location::new(self.program_name, full_name), input.clone())
         {
             self.state.handler.emit_err(err);
         }

--- a/compiler/passes/src/lib.rs
+++ b/compiler/passes/src/lib.rs
@@ -95,6 +95,9 @@ pub use type_checking::*;
 mod name_validation;
 pub use name_validation::*;
 
+mod check_interfaces;
+pub use check_interfaces::*;
+
 mod write_transforming;
 pub use write_transforming::*;
 

--- a/compiler/passes/src/monomorphization/program.rs
+++ b/compiler/passes/src/monomorphization/program.rs
@@ -125,6 +125,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
         // Return the fully reconstructed scope with updated functions.
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             composites: self
                 .reconstructed_composites
                 .iter()
@@ -148,6 +149,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                         .map(|(last, _)| (*last, f.clone()))
                 })
                 .collect(),
+            interfaces: input.interfaces,
             constructor,
             consts,
             span: input.span,

--- a/compiler/passes/src/path_resolution/program.rs
+++ b/compiler/passes/src/path_resolution/program.rs
@@ -52,6 +52,7 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
         // This is the default implementation.
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             consts: input
                 .consts
                 .into_iter()
@@ -68,6 +69,7 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
                 .map(|(id, storage_variable)| (id, self.reconstruct_storage_variable(storage_variable)))
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }
@@ -80,6 +82,7 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
             path: input.path,
             composites: input.composites.into_iter().map(|(i, c)| (i, slf.reconstruct_composite(c))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, slf.reconstruct_interface(int))).collect(),
             consts: input
                 .consts
                 .into_iter()

--- a/compiler/passes/src/processing_async/program.rs
+++ b/compiler/passes/src/processing_async/program.rs
@@ -51,6 +51,7 @@ impl ProgramReconstructor for ProcessingAsyncVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             composites: input.composites.into_iter().map(|(id, def)| (id, self.reconstruct_composite(def))).collect(),
             mappings: input.mappings.into_iter().map(|(id, mapping)| (id, self.reconstruct_mapping(mapping))).collect(),
             storage_variables: input
@@ -59,6 +60,7 @@ impl ProgramReconstructor for ProcessingAsyncVisitor<'_> {
                 .map(|(id, storage_variable)| (id, self.reconstruct_storage_variable(storage_variable)))
                 .collect(),
             functions: reconstructed_functions,
+            interfaces: input.interfaces.into_iter().map(|(id, int)| (id, self.reconstruct_interface(int))).collect(),
             constructor: input.constructor,
             consts: input
                 .consts

--- a/compiler/passes/src/ssa_const_propagation/program.rs
+++ b/compiler/passes/src/ssa_const_propagation/program.rs
@@ -24,6 +24,7 @@ impl ProgramReconstructor for SsaConstPropagationVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             consts: input
                 .consts
                 .into_iter()
@@ -40,6 +41,7 @@ impl ProgramReconstructor for SsaConstPropagationVisitor<'_> {
                 .map(|(id, storage_variable)| (id, self.reconstruct_storage_variable(storage_variable)))
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }

--- a/compiler/passes/src/static_single_assignment/program.rs
+++ b/compiler/passes/src/static_single_assignment/program.rs
@@ -130,11 +130,13 @@ impl ProgramScopeConsumer for SsaFormingVisitor<'_> {
         self.program = input.program_id.name.name;
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             consts: input.consts,
             composites: input.composites.into_iter().map(|(i, s)| (i, self.consume_composite(s))).collect(),
             mappings: input.mappings,
             storage_variables: input.storage_variables,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
+            interfaces: input.interfaces,
             constructor: input.constructor.map(|c| self.consume_constructor(c)),
             span: input.span,
         }
@@ -179,6 +181,7 @@ impl ModuleConsumer for SsaFormingVisitor<'_> {
             program_name: self.program,
             composites: input.composites.into_iter().map(|(i, s)| (i, self.consume_composite(s))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
+            interfaces: input.interfaces,
             consts: input.consts,
         }
     }

--- a/compiler/passes/src/storage_lowering/program.rs
+++ b/compiler/passes/src/storage_lowering/program.rs
@@ -53,6 +53,7 @@ impl ProgramReconstructor for StorageLoweringVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
+            parent: input.parent,
             consts: input
                 .consts
                 .into_iter()
@@ -65,6 +66,7 @@ impl ProgramReconstructor for StorageLoweringVisitor<'_> {
             mappings,
             storage_variables,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }

--- a/compiler/passes/src/test_passes.rs
+++ b/compiler/passes/src/test_passes.rs
@@ -235,6 +235,12 @@ macro_rules! compiler_passes {
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
                 (Disambiguate, ()),
             ]),
+            (check_interfaces_runner, [
+                (GlobalVarsCollection, ()),
+                (PathResolution, ()),
+                (GlobalItemsCollection, ()),
+                (CheckInterfaces, ()),
+            ]),
         }
     };
 }

--- a/errors/src/errors/check_interfaces.rs
+++ b/errors/src/errors/check_interfaces.rs
@@ -1,0 +1,71 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use std::fmt::{Debug, Display};
+
+create_messages!(
+    CheckInterfacesError,
+    code_mask: 12000i32,
+    code_prefix: "CHI",
+
+    @formatted
+    interface_not_found {
+        args: (name: impl Display),
+        msg: format!("Interface `{name}` not found."),
+        help: Some("Make sure the interface is defined in the current program or an imported program.".to_string()),
+    }
+
+    @formatted
+    conflicting_interface_member {
+        args: (member_name: impl Display, interface_name: impl Display, parent_name: impl Display),
+        msg: format!(
+            "Interface `{interface_name}` has a conflicting definition for `{member_name}` inherited from `{parent_name}`. \
+             Members with the same name must have identical signatures."
+        ),
+        help: Some("Ensure both interfaces define the same signature for this member, or rename one of them.".to_string()),
+    }
+
+    @formatted
+    missing_interface_function {
+        args: (func_name: impl Display, interface_name: impl Display, program_name: impl Display),
+        msg: format!(
+            "Program `{program_name}` implements interface `{interface_name}` but is missing the required function `{func_name}`."
+        ),
+        help: Some("Add the missing function with the exact signature specified in the interface.".to_string()),
+    }
+
+    @formatted
+    missing_interface_record {
+        args: (record_name: impl Display, interface_name: impl Display, program_name: impl Display),
+        msg: format!(
+            "Program `{program_name}` implements interface `{interface_name}` but is missing the required record `{record_name}`."
+        ),
+        help: Some("Add a record definition with the specified name.".to_string()),
+    }
+
+    @formatted
+    signature_mismatch {
+        args: (func_name: impl Display, interface_name: impl Display, expected: impl Display, found: impl Display),
+        msg: format!(
+            "Function `{func_name}` does not match the signature required by interface `{interface_name}`.\n\
+             Expected:\n\
+             {expected}\n\
+             Found:\n\
+             {found}"
+        ),
+        help: Some("Function signatures must match exactly: same parameter names, types, modes, order, and return type.".to_string()),
+    }
+);

--- a/errors/src/errors/mod.rs
+++ b/errors/src/errors/mod.rs
@@ -60,6 +60,10 @@ pub use self::type_checker::*;
 mod name_validation;
 pub use self::name_validation::*;
 
+/// Contains the Check Interfaces error definitions.
+mod check_interfaces;
+pub use self::check_interfaces::*;
+
 /// Contains the Utils error definitions.
 mod utils;
 pub use self::utils::*;
@@ -94,6 +98,9 @@ pub enum LeoError {
     /// Represents a Name Validation Error in a Leo Error.
     #[error(transparent)]
     NameValidationError(#[from] NameValidationError),
+    /// Represents a Check Interfaces Error in a Leo Error.
+    #[error(transparent)]
+    CheckInterfacesError(#[from] CheckInterfacesError),
     /// Represents a Loop Unroller Error in a Leo Error.
     #[error(transparent)]
     LoopUnrollerError(#[from] LoopUnrollerError),
@@ -126,6 +133,7 @@ impl LeoError {
             StaticAnalyzerError(error) => error.error_code(),
             TypeCheckerError(error) => error.error_code(),
             NameValidationError(error) => error.error_code(),
+            CheckInterfacesError(error) => error.error_code(),
             LoopUnrollerError(error) => error.error_code(),
             FlattenError(error) => error.error_code(),
             UtilError(error) => error.error_code(),
@@ -148,6 +156,7 @@ impl LeoError {
             StaticAnalyzerError(error) => error.exit_code(),
             TypeCheckerError(error) => error.exit_code(),
             NameValidationError(error) => error.exit_code(),
+            CheckInterfacesError(error) => error.exit_code(),
             LoopUnrollerError(error) => error.exit_code(),
             FlattenError(error) => error.exit_code(),
             UtilError(error) => error.exit_code(),

--- a/tests/expectations/compiler/interfaces/extend.out
+++ b/tests/expectations/compiler/interfaces/extend.out
@@ -1,0 +1,5 @@
+program bar.aleo;
+
+function foo:
+
+function bar:

--- a/tests/expectations/compiler/interfaces/mismatch_fail.out
+++ b/tests/expectations/compiler/interfaces/mismatch_fail.out
@@ -1,0 +1,41 @@
+Error [ECHI03712004]: Function `foo` does not match the signature required by interface `AbstractProgram`.
+Expected:
+fn foo() -> u64
+Found:
+fn foo() -> u32
+    --> compiler-test:11:5
+     |
+  11 |     fn foo() -> u32 {
+     |     ^^^^^^^^^^^^^^^^^
+  12 |         return 0;
+     |         ^^^^^^^^^
+  13 |     }
+     |     ^
+     |
+     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+Error [ECHI03712004]: Function `bar` does not match the signature required by interface `AbstractProgram`.
+Expected:
+fn bar(a: u64) -> ()
+Found:
+fn bar(b: u64) -> ()
+    --> compiler-test:14:5
+     |
+  14 |     fn bar(b: u64) {
+     |     ^^^^^^^^^^^^^^^^
+  15 |         return 0;
+     |         ^^^^^^^^^
+  16 |     }
+     |     ^
+     |
+     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+Error [ECHI03712004]: Function `baz` does not match the signature required by interface `AbstractProgram`.
+Expected:
+fn baz(a: u64, b: u8, c: u32) -> Final<Fn()>
+Found:
+fn baz(a: u32, b: u8, c: u32) -> ()
+    --> compiler-test:17:5
+     |
+  17 |     fn baz(a: u32, b: u8, c: u32) {}
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.

--- a/tests/expectations/compiler/interfaces/missing_fail.out
+++ b/tests/expectations/compiler/interfaces/missing_fail.out
@@ -1,0 +1,14 @@
+Error [ECHI03712002]: Program `scratch` implements interface `AbstractFoo` but is missing the required function `foobar`.
+    --> compiler-test:13:1
+     |
+  13 | program scratch.aleo : AbstractFoo {}
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Add the missing function with the exact signature specified in the interface.
+Error [ECHI03712003]: Program `scratch` implements interface `AbstractFoo` but is missing the required record `Foo`.
+    --> compiler-test:13:1
+     |
+  13 | program scratch.aleo : AbstractFoo {}
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Add a record definition with the specified name.

--- a/tests/expectations/compiler/interfaces/simple.out
+++ b/tests/expectations/compiler/interfaces/simple.out
@@ -1,0 +1,9 @@
+program scratch.aleo;
+
+record Foo:
+    owner as address.private;
+    num as u32.private;
+
+function foobar:
+    cast self.signer 42u32 into r0 as Foo.record;
+    output r0 as Foo.record;

--- a/tests/expectations/parser/finalize/mapping_fail.out
+++ b/tests/expectations/parser/finalize/mapping_fail.out
@@ -13,7 +13,7 @@ Error [EPAR0370005]: expected ')' -- found '=>'
      |
    7 |     mapping foo: (bar => baz);
      |                       ^^
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found ')'
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found ')'
     --> test:7:29
      |
    7 |     mapping foo: (bar => baz);

--- a/tests/expectations/parser/program/circuit_deprecated_fail.out
+++ b/tests/expectations/parser/program/circuit_deprecated_fail.out
@@ -1,4 +1,4 @@
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found 'circuit'
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found 'circuit'
     --> test:4:5
      |
    4 |     circuit Foo {

--- a/tests/expectations/parser/program/illegal_import_fail.out
+++ b/tests/expectations/parser/program/illegal_import_fail.out
@@ -3,7 +3,7 @@ Error [EPAR0370047]: expected `import`, `program`, or module item at top level
      |
    2 | stub credits.aleo {
      | ^^^^
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found 'import'
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found 'import'
     --> test:7:5
      |
    7 |     import hello.aleo;

--- a/tests/expectations/parser/program/mapping_fail.out
+++ b/tests/expectations/parser/program/mapping_fail.out
@@ -1,4 +1,4 @@
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found 'mappin'
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found 'mappin'
     --> test:3:5
      |
    3 |     mappin balances: address => u128;

--- a/tests/expectations/parser/program/pipe_eof.out
+++ b/tests/expectations/parser/program/pipe_eof.out
@@ -1,4 +1,4 @@
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found '|'
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found '|'
     --> test:6:5
      |
    6 |     |}

--- a/tests/expectations/parser/type_/signature_verify_bad_syntax_fail.out
+++ b/tests/expectations/parser/type_/signature_verify_bad_syntax_fail.out
@@ -18,7 +18,7 @@ Error [EPAR0370047]: expected parameter name
      |
   13 |     fn foo(signature: field) -> u8 {
      |            ^^^^^^^^^
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found ':'
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found ':'
     --> test:13:21
      |
   13 |     fn foo(signature: field) -> u8 {
@@ -28,7 +28,7 @@ Error [EPAR0370047]: expected function name
      |
   17 |     fn signature(foo: field) -> u8 {
      |        ^^^^^^^^^
-Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script' -- found '('
+Error [EPAR0370005]: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface' -- found '('
     --> test:17:17
      |
   17 |     fn signature(foo: field) -> u8 {

--- a/tests/expectations/passes/check_interfaces/interface_inheritance_conflict_fail.out
+++ b/tests/expectations/passes/check_interfaces/interface_inheritance_conflict_fail.out
@@ -1,0 +1,13 @@
+Error [ECHI03712001]: Interface `Derived` has a conflicting definition for `process` inherited from `Base`. Members with the same name must have identical signatures.
+    --> test:7:1
+     |
+   7 | interface Derived : Base {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   8 |     // Conflicting: same name, different return type
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   9 |     fn process(x: u64) -> u32;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 | }
+     | ^
+     |
+     = Ensure both interfaces define the same signature for this member, or rename one of them.

--- a/tests/expectations/passes/check_interfaces/interface_inheritance_valid.out
+++ b/tests/expectations/passes/check_interfaces/interface_inheritance_valid.out
@@ -1,0 +1,12 @@
+program test.aleo {
+    fn get_value() -> u64 {
+        return 0u64;
+    }
+    fn set_value(v: u64) -> u64 {
+        return v;
+    }
+    fn main(x: u64) -> u64 {
+        return test.aleo/set_value(x);
+    }
+}
+

--- a/tests/expectations/passes/check_interfaces/missing_function_fail.out
+++ b/tests/expectations/passes/check_interfaces/missing_function_fail.out
@@ -1,0 +1,24 @@
+Error [ECHI03712002]: Program `test` implements interface `Calculator` but is missing the required function `subtract`.
+    --> test:8:1
+     |
+   8 | program test.aleo : Calculator {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   9 |     // Missing subtract function
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 |     fn add(a: u64, b: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  11 |         return a + b;
+     |         ^^^^^^^^^^^^^
+  12 |     }
+     |     ^
+  13 | 
+  14 |     fn main(x: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^
+  15 |         return add(x, 1u64);
+     |         ^^^^^^^^^^^^^^^^^^^^
+  16 |     }
+     |     ^
+  17 | }
+     | ^
+     |
+     = Add the missing function with the exact signature specified in the interface.

--- a/tests/expectations/passes/check_interfaces/missing_record_fail.out
+++ b/tests/expectations/passes/check_interfaces/missing_record_fail.out
@@ -1,0 +1,24 @@
+Error [ECHI03712003]: Program `test` implements interface `TokenStandard` but is missing the required record `Token`.
+    --> test:8:1
+     |
+   8 | program test.aleo : TokenStandard {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   9 |     // Missing Token record
+     |     ^^^^^^^^^^^^^^^^^^^^^^^
+  10 |     fn transfer(amount: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  11 |         return amount;
+     |         ^^^^^^^^^^^^^^
+  12 |     }
+     |     ^
+  13 | 
+  14 |     fn main(x: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^
+  15 |         return transfer(x);
+     |         ^^^^^^^^^^^^^^^^^^^
+  16 |     }
+     |     ^
+  17 | }
+     | ^
+     |
+     = Add a record definition with the specified name.

--- a/tests/expectations/passes/check_interfaces/signature_mismatch_fail.out
+++ b/tests/expectations/passes/check_interfaces/signature_mismatch_fail.out
@@ -1,0 +1,15 @@
+Error [ECHI03712004]: Function `process` does not match the signature required by interface `Processor`.
+Expected:
+fn process(value: u64, multiplier: u64) -> u64
+Found:
+fn process(value: u64, mult: u64) -> u64
+    --> test:9:5
+     |
+   9 |     fn process(value: u64, mult: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 |         return value * mult;
+     |         ^^^^^^^^^^^^^^^^^^^^
+  11 |     }
+     |     ^
+     |
+     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/signature_mismatch_return_fail.out
+++ b/tests/expectations/passes/check_interfaces/signature_mismatch_return_fail.out
@@ -1,0 +1,15 @@
+Error [ECHI03712004]: Function `convert` does not match the signature required by interface `Converter`.
+Expected:
+fn convert(value: u64) -> u32
+Found:
+fn convert(value: u64) -> u64
+    --> test:9:5
+     |
+   9 |     fn convert(value: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 |         return value;
+     |         ^^^^^^^^^^^^^
+  11 |     }
+     |     ^
+     |
+     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/valid_implementation.out
+++ b/tests/expectations/passes/check_interfaces/valid_implementation.out
@@ -1,0 +1,9 @@
+program test.aleo {
+    fn increment(amount: u64) -> u64 {
+        return amount + 1u64;
+    }
+    fn main(x: u64) -> u64 {
+        return test.aleo/increment(x);
+    }
+}
+

--- a/tests/tests/compiler/interfaces/extend.leo
+++ b/tests/tests/compiler/interfaces/extend.leo
@@ -1,0 +1,8 @@
+interface Foo {
+    fn foo();
+}
+
+program bar.aleo {
+    fn foo() {}
+    fn bar() {}
+}

--- a/tests/tests/compiler/interfaces/mismatch_fail.leo
+++ b/tests/tests/compiler/interfaces/mismatch_fail.leo
@@ -1,0 +1,18 @@
+
+interface AbstractProgram {
+    fn foo() -> u64;
+    fn bar(a: u64);
+    fn baz(a: u64, b: u8, c: u32) -> Final;
+
+}
+
+
+program test.aleo : AbstractProgram {
+    fn foo() -> u32 {
+        return 0;
+    }
+    fn bar(b: u64) {
+        return 0;
+    }
+    fn baz(a: u32, b: u8, c: u32) {}
+}

--- a/tests/tests/compiler/interfaces/missing_fail.leo
+++ b/tests/tests/compiler/interfaces/missing_fail.leo
@@ -1,0 +1,13 @@
+interface Bar{
+    record Foo;
+}
+
+interface Baz : Bar {}
+
+interface AbstractFoo : Baz {
+    record Foo;
+    fn foobar() -> Foo;
+}
+
+
+program scratch.aleo : AbstractFoo {}

--- a/tests/tests/compiler/interfaces/simple.leo
+++ b/tests/tests/compiler/interfaces/simple.leo
@@ -1,0 +1,21 @@
+interface Bar{
+    record Foo;
+}
+
+interface Baz : Bar {}
+
+interface AbstractFoo : Baz {
+    record Foo;
+    fn foobar() -> Foo;
+}
+
+
+program scratch.aleo : AbstractFoo {
+    record Foo {
+        owner: address,
+        num: u32,
+    }
+    fn foobar() -> Foo {
+        return Foo { owner: self.signer, num: 42 };
+    }
+}

--- a/tests/tests/passes/check_interfaces/interface_inheritance_conflict_fail.leo
+++ b/tests/tests/passes/check_interfaces/interface_inheritance_conflict_fail.leo
@@ -1,0 +1,16 @@
+// Test: Interface inheritance with conflicting member signatures (should fail)
+
+interface Base {
+    fn process(x: u64) -> u64;
+}
+
+interface Derived : Base {
+    // Conflicting: same name, different return type
+    fn process(x: u64) -> u32;
+}
+
+program test.aleo {
+    fn main(x: u64) -> u64 {
+        return x;
+    }
+}

--- a/tests/tests/passes/check_interfaces/interface_inheritance_valid.leo
+++ b/tests/tests/passes/check_interfaces/interface_inheritance_valid.leo
@@ -1,0 +1,23 @@
+// Test: Valid interface inheritance with compatible members
+
+interface Base {
+    fn get_value() -> u64;
+}
+
+interface Extended : Base {
+    fn set_value(v: u64) -> u64;
+}
+
+program test.aleo : Extended {
+    fn get_value() -> u64 {
+        return 0u64;
+    }
+
+    fn set_value(v: u64) -> u64 {
+        return v;
+    }
+
+    fn main(x: u64) -> u64 {
+        return set_value(x);
+    }
+}

--- a/tests/tests/passes/check_interfaces/missing_function_fail.leo
+++ b/tests/tests/passes/check_interfaces/missing_function_fail.leo
@@ -1,0 +1,17 @@
+// Test: Program missing a required interface function (should fail)
+
+interface Calculator {
+    fn add(a: u64, b: u64) -> u64;
+    fn subtract(a: u64, b: u64) -> u64;
+}
+
+program test.aleo : Calculator {
+    // Missing subtract function
+    fn add(a: u64, b: u64) -> u64 {
+        return a + b;
+    }
+
+    fn main(x: u64) -> u64 {
+        return add(x, 1u64);
+    }
+}

--- a/tests/tests/passes/check_interfaces/missing_record_fail.leo
+++ b/tests/tests/passes/check_interfaces/missing_record_fail.leo
@@ -1,0 +1,17 @@
+// Test: Program missing a required interface record (should fail)
+
+interface TokenStandard {
+    record Token;
+    fn transfer(amount: u64) -> u64;
+}
+
+program test.aleo : TokenStandard {
+    // Missing Token record
+    fn transfer(amount: u64) -> u64 {
+        return amount;
+    }
+
+    fn main(x: u64) -> u64 {
+        return transfer(x);
+    }
+}

--- a/tests/tests/passes/check_interfaces/signature_mismatch_fail.leo
+++ b/tests/tests/passes/check_interfaces/signature_mismatch_fail.leo
@@ -1,0 +1,16 @@
+// Test: Function signature doesn't match interface requirement (should fail)
+
+interface Processor {
+    fn process(value: u64, multiplier: u64) -> u64;
+}
+
+program test.aleo : Processor {
+    // Wrong parameter name: 'mult' instead of 'multiplier'
+    fn process(value: u64, mult: u64) -> u64 {
+        return value * mult;
+    }
+
+    fn main(x: u64) -> u64 {
+        return process(x, 2u64);
+    }
+}

--- a/tests/tests/passes/check_interfaces/signature_mismatch_return_fail.leo
+++ b/tests/tests/passes/check_interfaces/signature_mismatch_return_fail.leo
@@ -1,0 +1,16 @@
+// Test: Function return type doesn't match interface requirement (should fail)
+
+interface Converter {
+    fn convert(value: u64) -> u32;
+}
+
+program test.aleo : Converter {
+    // Wrong return type: u64 instead of u32
+    fn convert(value: u64) -> u64 {
+        return value;
+    }
+
+    fn main(x: u64) -> u64 {
+        return convert(x);
+    }
+}

--- a/tests/tests/passes/check_interfaces/valid_implementation.leo
+++ b/tests/tests/passes/check_interfaces/valid_implementation.leo
@@ -1,0 +1,15 @@
+// Test: Program correctly implements an interface
+
+interface Counter {
+    fn increment(amount: u64) -> u64;
+}
+
+program test.aleo : Counter {
+    fn increment(amount: u64) -> u64 {
+        return amount + 1u64;
+    }
+
+    fn main(x: u64) -> u64 {
+        return increment(x);
+    }
+}


### PR DESCRIPTION
This change adds interface syntax to Leo partially implementing #29144.

You can now use the `interface` keyword to write top level declarations that include constraints on the presence of entry-points and record names, and inherit these constraints in an interface or a program declaration.

For instance, this is a valid program:

```leo
interface Bar{
    record Foo;
}

interface Baz : Bar {}

interface AbstractFoo : Baz {
    record Foo;
    fn foobar() -> Foo;
}

program test.aleo : AbstractFoo {
    record Foo {
        owner: address,
        foo: u64,
    }

    fn foobar() -> Foo {
        return Foo {
            owner: self.signer,
            foo: 42u64,
        };
    }
}
```

and it is enforced that `test.aleo` contains a `fn foobar() -> Foo` and a `record Foo`.

There are still some limitations, which will be addressed in later changes:
* Multiple inheritance isn't yet supported
* Interfaces can only be declared in the top-level context of a program, not in a module
* Inheritance can only happen within a program scope, as parent definitions are mere symbols and not paths
* Inheritance cycles are not yet handled and result in a stack overflow