### PR TITLE
Implement multiple inheritance

### DIFF
--- a/compiler/ast/src/interface/mod.rs
+++ b/compiler/ast/src/interface/mod.rs
@@ -28,8 +28,8 @@ mod prototypes;
 pub struct Interface {
     /// The interface identifier, e.g., `Foo` in `interface Foo { ... }`.
     pub identifier: Identifier,
-    /// The interface this interface inherits from, if any
-    pub parent: Option<Symbol>,
+    /// The interfaces this interface inherits from (supports multiple inheritance)
+    pub parents: Vec<Symbol>,
     /// The entire span of the interface definition.
     pub span: Span,
     /// The ID of the node.
@@ -66,7 +66,11 @@ impl fmt::Display for Interface {
             f,
             "interface {}{} {{",
             self.identifier,
-            if let Some(parent) = self.parent { format!(" : {parent}") } else { "".into() }
+            if self.parents.is_empty() {
+                String::new()
+            } else {
+                format!(" : {}", self.parents.iter().map(|p| p.to_string()).collect::<Vec<_>>().join(" + "))
+            }
         )?;
         for (_, fun_prot) in &self.functions {
             writeln!(f, "{}", Indent(fun_prot))?;

--- a/compiler/ast/src/passes/reconstructor.rs
+++ b/compiler/ast/src/passes/reconstructor.rs
@@ -582,7 +582,7 @@ pub trait ProgramReconstructor: AstReconstructor {
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             consts: input
                 .consts
                 .into_iter()
@@ -626,7 +626,7 @@ pub trait ProgramReconstructor: AstReconstructor {
     fn reconstruct_interface(&mut self, input: Interface) -> Interface {
         Interface {
             identifier: input.identifier,
-            parent: input.parent,
+            parents: input.parents.clone(),
             span: input.span,
             id: input.id,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function_prototype(f))).collect(),

--- a/compiler/ast/src/program/program_scope.rs
+++ b/compiler/ast/src/program/program_scope.rs
@@ -37,8 +37,8 @@ use std::fmt;
 pub struct ProgramScope {
     /// The program id of the program scope.
     pub program_id: ProgramId,
-    /// The interface this program inherits from, if any
-    pub parent: Option<Symbol>,
+    /// The interfaces this program implements
+    pub parents: Vec<Symbol>,
     /// A vector of const definitions.
     pub consts: Vec<(Symbol, ConstDeclaration)>,
     /// A vector of composite definitions.

--- a/compiler/parser-rowan/src/syntax_kind.rs
+++ b/compiler/parser-rowan/src/syntax_kind.rs
@@ -537,6 +537,8 @@ pub enum SyntaxKind {
     TYPE_FINAL,
     /// Mapping type in storage.
     TYPE_MAPPING,
+    /// Parent list: `Foo + Bar`
+    PARENT_LIST,
 
     // Sentinel for bounds checking (must be last)
     #[doc(hidden)]
@@ -1149,6 +1151,7 @@ const SYNTAX_KIND_TABLE: &[SyntaxKind] = &[
     TYPE_OPTIONAL,
     TYPE_FINAL,
     TYPE_MAPPING,
+    PARENT_LIST,
     __LAST,
 ];
 

--- a/compiler/passes/src/flattening/program.rs
+++ b/compiler/passes/src/flattening/program.rs
@@ -33,7 +33,7 @@ impl ProgramReconstructor for FlatteningVisitor<'_> {
         self.program = input.program_id.name.name;
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             consts: input
                 .consts
                 .into_iter()

--- a/compiler/passes/src/function_inlining/transform.rs
+++ b/compiler/passes/src/function_inlining/transform.rs
@@ -96,7 +96,7 @@ impl ProgramReconstructor for TransformVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             composites: input.composites,
             mappings: input.mappings,
             storage_variables: input.storage_variables,

--- a/compiler/passes/src/monomorphization/program.rs
+++ b/compiler/passes/src/monomorphization/program.rs
@@ -125,7 +125,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
         // Return the fully reconstructed scope with updated functions.
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             composites: self
                 .reconstructed_composites
                 .iter()

--- a/compiler/passes/src/path_resolution/program.rs
+++ b/compiler/passes/src/path_resolution/program.rs
@@ -52,7 +52,7 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
         // This is the default implementation.
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             consts: input
                 .consts
                 .into_iter()

--- a/compiler/passes/src/processing_async/program.rs
+++ b/compiler/passes/src/processing_async/program.rs
@@ -51,7 +51,7 @@ impl ProgramReconstructor for ProcessingAsyncVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             composites: input.composites.into_iter().map(|(id, def)| (id, self.reconstruct_composite(def))).collect(),
             mappings: input.mappings.into_iter().map(|(id, mapping)| (id, self.reconstruct_mapping(mapping))).collect(),
             storage_variables: input

--- a/compiler/passes/src/ssa_const_propagation/program.rs
+++ b/compiler/passes/src/ssa_const_propagation/program.rs
@@ -24,7 +24,7 @@ impl ProgramReconstructor for SsaConstPropagationVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             consts: input
                 .consts
                 .into_iter()

--- a/compiler/passes/src/static_single_assignment/program.rs
+++ b/compiler/passes/src/static_single_assignment/program.rs
@@ -130,7 +130,7 @@ impl ProgramScopeConsumer for SsaFormingVisitor<'_> {
         self.program = input.program_id.name.name;
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             consts: input.consts,
             composites: input.composites.into_iter().map(|(i, s)| (i, self.consume_composite(s))).collect(),
             mappings: input.mappings,

--- a/compiler/passes/src/storage_lowering/program.rs
+++ b/compiler/passes/src/storage_lowering/program.rs
@@ -53,7 +53,7 @@ impl ProgramReconstructor for StorageLoweringVisitor<'_> {
 
         ProgramScope {
             program_id: input.program_id,
-            parent: input.parent,
+            parents: input.parents.clone(),
             consts: input
                 .consts
                 .into_iter()

--- a/tests/expectations/compiler/interfaces/multiple_inheritance.out
+++ b/tests/expectations/compiler/interfaces/multiple_inheritance.out
@@ -1,0 +1,7 @@
+program test.aleo;
+
+function increment:
+    output 1u64 as u64.private;
+
+function reset:
+    output 0u64 as u64.private;

--- a/tests/expectations/compiler/interfaces/multiple_inheritance_missing_fail.out
+++ b/tests/expectations/compiler/interfaces/multiple_inheritance_missing_fail.out
@@ -1,0 +1,17 @@
+Error [ECHI03712002]: Program `test` implements interface `Resettable` but is missing the required function `reset`.
+    --> compiler-test:9:1
+     |
+   9 | program test.aleo : Counter + Resettable {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 |     fn increment() -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^
+  11 |         return 1u64;
+     |         ^^^^^^^^^^^^
+  12 |     }
+     |     ^
+  13 |     // Missing reset from Resettable
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  14 | }
+     | ^
+     |
+     = Add the missing function with the exact signature specified in the interface.

--- a/tests/expectations/passes/check_interfaces/diamond_inheritance_valid.out
+++ b/tests/expectations/passes/check_interfaces/diamond_inheritance_valid.out
@@ -1,0 +1,15 @@
+program test.aleo {
+    fn get_value() -> u64 {
+        return 0u64;
+    }
+    fn left_op() -> u64 {
+        return 1u64;
+    }
+    fn right_op() -> u64 {
+        return 2u64;
+    }
+    fn main(x: u64) -> u64 {
+        return 0;
+    }
+}
+

--- a/tests/expectations/passes/check_interfaces/interface_multiple_inheritance_conflict_fail.out
+++ b/tests/expectations/passes/check_interfaces/interface_multiple_inheritance_conflict_fail.out
@@ -1,0 +1,7 @@
+Error [ECHI03712001]: Interface `C` has a conflicting definition for `process` inherited from `B`. Members with the same name must have identical signatures.
+    --> test:11:1
+     |
+  11 | interface C : A + B {}
+     | ^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Ensure both interfaces define the same signature for this member, or rename one of them.

--- a/tests/expectations/passes/check_interfaces/interface_multiple_inheritance_valid.out
+++ b/tests/expectations/passes/check_interfaces/interface_multiple_inheritance_valid.out
@@ -1,0 +1,15 @@
+program test.aleo {
+    fn foo() -> u64 {
+        return 1u64;
+    }
+    fn bar() -> u64 {
+        return 2u64;
+    }
+    fn baz() -> u64 {
+        return 3u64;
+    }
+    fn main(x: u64) -> u64 {
+        return 0;
+    }
+}
+

--- a/tests/expectations/passes/check_interfaces/multiple_inheritance_conflict_fail.out
+++ b/tests/expectations/passes/check_interfaces/multiple_inheritance_conflict_fail.out
@@ -1,0 +1,15 @@
+Error [ECHI03712004]: Function `get_value` does not match the signature required by interface `BoolChecker`.
+Expected:
+fn get_value() -> bool
+Found:
+fn get_value() -> u64
+    --> test:12:5
+     |
+  12 |     fn get_value() -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^
+  13 |         return 0u64;
+     |         ^^^^^^^^^^^^
+  14 |     }
+     |     ^
+     |
+     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/multiple_inheritance_missing_fail.out
+++ b/tests/expectations/passes/check_interfaces/multiple_inheritance_missing_fail.out
@@ -1,0 +1,24 @@
+Error [ECHI03712002]: Program `test` implements interface `Calculator` but is missing the required function `add`.
+    --> test:11:1
+     |
+  11 | program test.aleo : Counter + Calculator {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  12 |     fn increment() -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^
+  13 |         return 1u64;
+     |         ^^^^^^^^^^^^
+  14 |     }
+     |     ^
+  15 |     // Missing add function from Calculator
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  16 | 
+  17 |     fn main(x: u64) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^
+  18 |         return 0;
+     |         ^^^^^^^^^
+  19 |     }
+     |     ^
+  20 | }
+     | ^
+     |
+     = Add the missing function with the exact signature specified in the interface.

--- a/tests/expectations/passes/check_interfaces/multiple_inheritance_valid.out
+++ b/tests/expectations/passes/check_interfaces/multiple_inheritance_valid.out
@@ -1,0 +1,12 @@
+program test.aleo {
+    fn increment() -> u64 {
+        return 1u64;
+    }
+    fn add(a: u64, b: u64) -> u64 {
+        return a + b;
+    }
+    fn main(x: u64) -> u64 {
+        return test.aleo/increment();
+    }
+}
+

--- a/tests/tests/compiler/interfaces/multiple_inheritance.leo
+++ b/tests/tests/compiler/interfaces/multiple_inheritance.leo
@@ -1,0 +1,17 @@
+interface Counter {
+    fn increment() -> u64;
+}
+
+interface Resettable {
+    fn reset() -> u64;
+}
+
+program test.aleo : Counter + Resettable {
+    fn increment() -> u64 {
+        return 1u64;
+    }
+
+    fn reset() -> u64 {
+        return 0u64;
+    }
+}

--- a/tests/tests/compiler/interfaces/multiple_inheritance_missing_fail.leo
+++ b/tests/tests/compiler/interfaces/multiple_inheritance_missing_fail.leo
@@ -1,0 +1,14 @@
+interface Counter {
+    fn increment() -> u64;
+}
+
+interface Resettable {
+    fn reset() -> u64;
+}
+
+program test.aleo : Counter + Resettable {
+    fn increment() -> u64 {
+        return 1u64;
+    }
+    // Missing reset from Resettable
+}

--- a/tests/tests/passes/check_interfaces/diamond_inheritance_valid.leo
+++ b/tests/tests/passes/check_interfaces/diamond_inheritance_valid.leo
@@ -1,0 +1,33 @@
+// Test: Diamond pattern with compatible signatures
+
+interface Base {
+    fn get_value() -> u64;
+}
+
+interface Left : Base {
+    fn left_op() -> u64;
+}
+
+interface Right : Base {
+    fn right_op() -> u64;
+}
+
+interface Diamond : Left + Right {}
+
+program test.aleo : Diamond {
+    fn get_value() -> u64 {
+        return 0u64;
+    }
+
+    fn left_op() -> u64 {
+        return 1u64;
+    }
+
+    fn right_op() -> u64 {
+        return 2u64;
+    }
+
+    fn main(x: u64) -> u64 {
+        return 0;
+    }
+}

--- a/tests/tests/passes/check_interfaces/interface_multiple_inheritance_conflict_fail.leo
+++ b/tests/tests/passes/check_interfaces/interface_multiple_inheritance_conflict_fail.leo
@@ -1,0 +1,13 @@
+// Test: Interface inheriting conflicting members
+
+interface A {
+    fn process() -> u64;
+}
+
+interface B {
+    fn process() -> u32;
+}
+
+interface C : A + B {}
+
+program test.aleo {}

--- a/tests/tests/passes/check_interfaces/interface_multiple_inheritance_valid.leo
+++ b/tests/tests/passes/check_interfaces/interface_multiple_inheritance_valid.leo
@@ -1,0 +1,31 @@
+// Test: Interface extending multiple interfaces
+
+interface A {
+    fn foo() -> u64;
+}
+
+interface B {
+    fn bar() -> u64;
+}
+
+interface C : A + B {
+    fn baz() -> u64;
+}
+
+program test.aleo : C {
+    fn foo() -> u64 {
+        return 1u64;
+    }
+
+    fn bar() -> u64 {
+        return 2u64;
+    }
+
+    fn baz() -> u64 {
+        return 3u64;
+    }
+
+    fn main(x: u64) -> u64 {
+        return 0;
+    }
+}

--- a/tests/tests/passes/check_interfaces/multiple_inheritance_conflict_fail.leo
+++ b/tests/tests/passes/check_interfaces/multiple_inheritance_conflict_fail.leo
@@ -1,0 +1,19 @@
+// Test: Conflicting signatures from two interfaces
+
+interface IntCounter {
+    fn get_value() -> u64;
+}
+
+interface BoolChecker {
+    fn get_value() -> bool;
+}
+
+program test.aleo : IntCounter + BoolChecker {
+    fn get_value() -> u64 {
+        return 0u64;
+    }
+
+    fn main(x: u64) -> u64 {
+        return 0;
+    }
+}

--- a/tests/tests/passes/check_interfaces/multiple_inheritance_missing_fail.leo
+++ b/tests/tests/passes/check_interfaces/multiple_inheritance_missing_fail.leo
@@ -1,0 +1,20 @@
+// Test: Missing function from second interface
+
+interface Counter {
+    fn increment() -> u64;
+}
+
+interface Calculator {
+    fn add(a: u64, b: u64) -> u64;
+}
+
+program test.aleo : Counter + Calculator {
+    fn increment() -> u64 {
+        return 1u64;
+    }
+    // Missing add function from Calculator
+
+    fn main(x: u64) -> u64 {
+        return 0;
+    }
+}

--- a/tests/tests/passes/check_interfaces/multiple_inheritance_valid.leo
+++ b/tests/tests/passes/check_interfaces/multiple_inheritance_valid.leo
@@ -1,0 +1,23 @@
+// Test: Valid program implementing multiple interfaces
+
+interface Counter {
+    fn increment() -> u64;
+}
+
+interface Calculator {
+    fn add(a: u64, b: u64) -> u64;
+}
+
+program test.aleo : Counter + Calculator {
+    fn increment() -> u64 {
+        return 1u64;
+    }
+
+    fn add(a: u64, b: u64) -> u64 {
+        return a + b;
+    }
+
+    fn main(x: u64) -> u64 {
+        return increment();
+    }
+}


### PR DESCRIPTION
Partially implementing #29144, this change adds multiple inheritance to program and interface declarations using this syntax:

```leo
interface Base {
    fn get_value() -> u64;
}

interface Left : Base {
    fn left_op() -> u64;
}

interface Right : Base {
    fn right_op() -> u64;
}

interface Diamond : Left + Right {}

program test.aleo : Diamond {
    fn get_value() -> u64 {
        return 0u64;
    }

    fn left_op() -> u64 {
        return 1u64;
    }

    fn right_op() -> u64 {
        return 2u64;
    }

    fn main(x: u64) -> u64 {
        return 0;
    }
}
```

