### PR TITLE
fix: remove redundant member assignment in `reconstruct_composite_init`

### DIFF
--- a/compiler/passes/src/monomorphization/ast.rs
+++ b/compiler/passes/src/monomorphization/ast.rs
@@ -247,7 +247,6 @@ impl AstReconstructor for MonomorphizationVisitor<'_> {
         // The types of the const arguments are already checked in the type checking pass.
         let Some(evaluated_const_args) = self.try_evaluate_const_args(&input.const_arguments) else {
             self.unresolved_composite_exprs.push(input.clone());
-            input.members = members;
             return (input.into(), Default::default());
         };
 


### PR DESCRIPTION
The assignment `input.members = members` in the unresolved composite expression branch was dead code. After `input.clone()` preserves the original state for the unresolved tracking, the mutated `input` is immediately consumed by `input.into()` and returned. The mutation had no observable effect since the value was moved right after.

This aligns with the pattern in [reconstruct_composite_type]https://github.com/ProvableHQ/leo/blob/15ce644631285d35b3d8b56f767c553ae8278bf3/compiler/passes/src/monomorphization/ast.rs#L59-L84 which doesn't perform such unnecessary mutation before returning.