### PR TITLE
Add mapping and storage definitions to interfaces

### DIFF
--- a/crates/ast/src/interface/mod.rs
+++ b/crates/ast/src/interface/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Identifier, Node, NodeID, Type, indent_display::Indent};
+use crate::{Identifier, Mapping, Node, NodeID, StorageVariable, Type, indent_display::Indent};
 use leo_span::{Span, Symbol};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -38,6 +38,10 @@ pub struct Interface {
     pub functions: Vec<(Symbol, FunctionPrototype)>,
     /// A vector of record prototypes.
     pub records: Vec<(Symbol, RecordPrototype)>,
+    /// A vector of mapping declarations.
+    pub mappings: Vec<Mapping>,
+    /// A vector of storage declarations.
+    pub storages: Vec<StorageVariable>,
 }
 
 impl Interface {

--- a/crates/ast/src/passes/reconstructor.rs
+++ b/crates/ast/src/passes/reconstructor.rs
@@ -631,6 +631,8 @@ pub trait ProgramReconstructor: AstReconstructor {
             id: input.id,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function_prototype(f))).collect(),
             records: input.records.into_iter().map(|(i, f)| (i, self.reconstruct_record_prototype(f))).collect(),
+            mappings: input.mappings.into_iter().map(|f| self.reconstruct_mapping(f)).collect(),
+            storages: input.storages.into_iter().map(|f| self.reconstruct_storage_variable(f)).collect(),
         }
     }
 

--- a/crates/errors/src/errors/check_interfaces.rs
+++ b/crates/errors/src/errors/check_interfaces.rs
@@ -75,4 +75,44 @@ create_messages!(
         msg: format!("`{name}` is not an interface."),
         help: Some("Only interface declarations can be inherited from.".to_string()),
     }
+
+    @formatted
+    missing_interface_mapping {
+        args: (mapping_name: impl Display, interface_name: impl Display, program_name: impl Display),
+        msg: format!(
+            "Program `{program_name}` implements interface `{interface_name}` but is missing the required mapping `{mapping_name}`."
+        ),
+        help: Some("Add a mapping definition with the specified name.".to_string()),
+    }
+
+    @formatted
+    missing_interface_storage {
+        args: (storage_name: impl Display, interface_name: impl Display, program_name: impl Display),
+        msg: format!(
+            "Program `{program_name}` implements interface `{interface_name}` but is missing the required storage variable `{storage_name}`."
+        ),
+        help: Some("Add a storage variable definition with the specified name.".to_string()),
+    }
+
+    @formatted
+    mapping_type_mismatch {
+        args: (mapping_name: impl Display, interface_name: impl Display, expected_key: impl Display, expected_value: impl Display, found_key: impl Display, found_value: impl Display),
+        msg: format!(
+            "Mapping `{mapping_name}` does not match the type required by interface `{interface_name}`.\n\
+             Expected: {expected_key} => {expected_value}\n\
+             Found: {found_key} => {found_value}"
+        ),
+        help: Some("Mapping key and value types must match exactly.".to_string()),
+    }
+
+    @formatted
+    storage_type_mismatch {
+        args: (storage_name: impl Display, interface_name: impl Display, expected: impl Display, found: impl Display),
+        msg: format!(
+            "Storage variable `{storage_name}` does not match the type required by interface `{interface_name}`.\n\
+             Expected: {expected}\n\
+             Found: {found}"
+        ),
+        help: Some("Storage variable types must match exactly.".to_string()),
+    }
 );

--- a/crates/parser-rowan/src/parser/items.rs
+++ b/crates/parser-rowan/src/parser/items.rs
@@ -725,6 +725,14 @@ impl Parser<'_, '_> {
                 self.parse_record_prototype();
                 true
             }
+            KW_MAPPING => {
+                self.parse_mapping_def();
+                true
+            }
+            KW_STORAGE => {
+                self.parse_storage_def();
+                true
+            }
             _ => false,
         }
     }

--- a/crates/parser/src/rowan.rs
+++ b/crates/parser/src/rowan.rs
@@ -2305,6 +2305,8 @@ impl<'a> ConversionContext<'a> {
 
         let mut functions = Vec::new();
         let mut records = Vec::new();
+        let mut mappings = Vec::new();
+        let mut storages = Vec::new();
 
         for child in children(node) {
             match child.kind() {
@@ -2316,11 +2318,28 @@ impl<'a> ConversionContext<'a> {
                     let proto = self.to_record_prototype(&child)?;
                     records.push((proto.identifier.name, proto));
                 }
+                MAPPING_DEF => {
+                    let mapping = self.to_mapping(&child)?;
+                    mappings.push(mapping);
+                }
+                STORAGE_DEF => {
+                    let storage = self.to_storage(&child)?;
+                    storages.push(storage);
+                }
                 _ => {}
             }
         }
 
-        Ok(leo_ast::Interface { identifier, parents, span, id: self.builder.next_id(), functions, records })
+        Ok(leo_ast::Interface {
+            identifier,
+            parents,
+            span,
+            id: self.builder.next_id(),
+            functions,
+            records,
+            mappings,
+            storages,
+        })
     }
 
     /// Convert an FN_PROTOTYPE_DEF node to a FunctionPrototype.

--- a/tests/expectations/compiler/interfaces/inherited_mapping_conflict_fail.out
+++ b/tests/expectations/compiler/interfaces/inherited_mapping_conflict_fail.out
@@ -1,0 +1,14 @@
+Error [ECHI03712001]: Interface `Combined` has a conflicting definition for `counter` inherited from `Counter2`. Members with the same name must have identical signatures.
+    --> compiler-test:9:1
+     |
+   9 | interface Combined : Counter1 + Counter2 {}
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Ensure both interfaces define the same signature for this member, or rename one of them.
+Error [ECHI03712001]: Interface `Combined` has a conflicting definition for `counter` inherited from `Counter2`. Members with the same name must have identical signatures.
+    --> compiler-test:9:1
+     |
+   9 | interface Combined : Counter1 + Counter2 {}
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Ensure both interfaces define the same signature for this member, or rename one of them.

--- a/tests/expectations/compiler/interfaces/inherited_storage_conflict_fail.out
+++ b/tests/expectations/compiler/interfaces/inherited_storage_conflict_fail.out
@@ -1,0 +1,14 @@
+Error [ECHI03712001]: Interface `Combined` has a conflicting definition for `value` inherited from `Storage2`. Members with the same name must have identical signatures.
+    --> compiler-test:9:1
+     |
+   9 | interface Combined : Storage1 + Storage2 {}
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Ensure both interfaces define the same signature for this member, or rename one of them.
+Error [ECHI03712001]: Interface `Combined` has a conflicting definition for `value` inherited from `Storage2`. Members with the same name must have identical signatures.
+    --> compiler-test:9:1
+     |
+   9 | interface Combined : Storage1 + Storage2 {}
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Ensure both interfaces define the same signature for this member, or rename one of them.

--- a/tests/expectations/compiler/interfaces/mapping_missing_fail.out
+++ b/tests/expectations/compiler/interfaces/mapping_missing_fail.out
@@ -1,0 +1,11 @@
+Error [ECHI03712006]: Program `test` implements interface `CounterInterface` but is missing the required mapping `counter`.
+    --> compiler-test:5:1
+     |
+   5 | program test.aleo : CounterInterface {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   6 |     fn main() {}
+     |     ^^^^^^^^^^^^
+   7 | }
+     | ^
+     |
+     = Add a mapping definition with the specified name.

--- a/tests/expectations/compiler/interfaces/mapping_type_mismatch_fail.out
+++ b/tests/expectations/compiler/interfaces/mapping_type_mismatch_fail.out
@@ -1,0 +1,9 @@
+Error [ECHI03712008]: Mapping `counter` does not match the type required by interface `CounterInterface`.
+Expected: address => u64
+Found: u32 => u64
+    --> compiler-test:6:5
+     |
+   6 |     mapping counter: u32 => u64;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Mapping key and value types must match exactly.

--- a/tests/expectations/compiler/interfaces/mapping_valid.out
+++ b/tests/expectations/compiler/interfaces/mapping_valid.out
@@ -1,0 +1,7 @@
+program test.aleo;
+
+mapping counter:
+    key as address.public;
+    value as u64.public;
+
+function main:

--- a/tests/expectations/compiler/interfaces/storage_missing_fail.out
+++ b/tests/expectations/compiler/interfaces/storage_missing_fail.out
@@ -1,0 +1,11 @@
+Error [ECHI03712007]: Program `test` implements interface `StorageInterface` but is missing the required storage variable `counter`.
+    --> compiler-test:5:1
+     |
+   5 | program test.aleo : StorageInterface {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   6 |     fn main() {}
+     |     ^^^^^^^^^^^^
+   7 | }
+     | ^
+     |
+     = Add a storage variable definition with the specified name.

--- a/tests/expectations/compiler/interfaces/storage_type_mismatch_fail.out
+++ b/tests/expectations/compiler/interfaces/storage_type_mismatch_fail.out
@@ -1,0 +1,9 @@
+Error [ECHI03712009]: Storage variable `counter` does not match the type required by interface `StorageInterface`.
+Expected: u32
+Found: u64
+    --> compiler-test:6:5
+     |
+   6 |     storage counter: u64;
+     |     ^^^^^^^^^^^^^^^^^^^^^
+     |
+     = Storage variable types must match exactly.

--- a/tests/expectations/compiler/interfaces/storage_valid.out
+++ b/tests/expectations/compiler/interfaces/storage_valid.out
@@ -1,0 +1,7 @@
+program test.aleo;
+
+mapping counter__:
+    key as boolean.public;
+    value as u32.public;
+
+function main:

--- a/tests/tests/compiler/interfaces/inherited_mapping_conflict_fail.leo
+++ b/tests/tests/compiler/interfaces/inherited_mapping_conflict_fail.leo
@@ -1,0 +1,13 @@
+interface Counter1 {
+    mapping counter: address => u64;
+}
+
+interface Counter2 {
+    mapping counter: address => u32;
+}
+
+interface Combined : Counter1 + Counter2 {}
+
+program test.aleo : Combined {
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/inherited_storage_conflict_fail.leo
+++ b/tests/tests/compiler/interfaces/inherited_storage_conflict_fail.leo
@@ -1,0 +1,13 @@
+interface Storage1 {
+    storage value: u64;
+}
+
+interface Storage2 {
+    storage value: u32;
+}
+
+interface Combined : Storage1 + Storage2 {}
+
+program test.aleo : Combined {
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/mapping_missing_fail.leo
+++ b/tests/tests/compiler/interfaces/mapping_missing_fail.leo
@@ -1,0 +1,7 @@
+interface CounterInterface {
+    mapping counter: address => u64;
+}
+
+program test.aleo : CounterInterface {
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/mapping_type_mismatch_fail.leo
+++ b/tests/tests/compiler/interfaces/mapping_type_mismatch_fail.leo
@@ -1,0 +1,8 @@
+interface CounterInterface {
+    mapping counter: address => u64;
+}
+
+program test.aleo : CounterInterface {
+    mapping counter: u32 => u64;
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/mapping_valid.leo
+++ b/tests/tests/compiler/interfaces/mapping_valid.leo
@@ -1,0 +1,8 @@
+interface CounterInterface {
+    mapping counter: address => u64;
+}
+
+program test.aleo : CounterInterface {
+    mapping counter: address => u64;
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/storage_missing_fail.leo
+++ b/tests/tests/compiler/interfaces/storage_missing_fail.leo
@@ -1,0 +1,7 @@
+interface StorageInterface {
+    storage counter: u32;
+}
+
+program test.aleo : StorageInterface {
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/storage_type_mismatch_fail.leo
+++ b/tests/tests/compiler/interfaces/storage_type_mismatch_fail.leo
@@ -1,0 +1,8 @@
+interface StorageInterface {
+    storage counter: u32;
+}
+
+program test.aleo : StorageInterface {
+    storage counter: u64;
+    fn main() {}
+}

--- a/tests/tests/compiler/interfaces/storage_valid.leo
+++ b/tests/tests/compiler/interfaces/storage_valid.leo
@@ -1,0 +1,8 @@
+interface StorageInterface {
+    storage counter: u32;
+}
+
+program test.aleo : StorageInterface {
+    storage counter: u32;
+    fn main() {}
+}


### PR DESCRIPTION
Part of #29144

Interface declaratins can now name mappings and storage variables requirements such as:

```leo
interface Foo {
    storage a: u64;
    mapping b: u64 => u64;
    fn bar();
}
```
