### PR TITLE
feat: add Criterion-based compiler benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,47 @@
+name: Benchmarks
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    paths:
+      - crates/compiler/**
+      - crates/passes/**
+      - crates/parser/**
+      - crates/parser-rowan/**
+      - crates/ast/**
+      - crates/span/**
+      - .github/workflows/benchmarks.yml
+  # `workflow_dispatch` allows CodSpeed to trigger backtest
+  # performance analysis in order to generate initial data.
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed
+      - name: Ensure Aleo home exists
+        run: mkdir -p ~/.aleo
+
+      - name: Build the benchmark targets
+        run: cargo codspeed build -p leo-benchmarks
+
+      - name: Run the benchmarks
+        uses: CodSpeedHQ/action@v3
+        with:
+          run: cargo codspeed run -p leo-benchmarks
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +176,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "arbitrary"
@@ -440,6 +455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +501,33 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -532,6 +580,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "codspeed"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c2eb3388ebe26b5a0ab6bf4969d9c4840143d7f6df07caa3cc851b0606cef6"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored 2.2.0",
+ "getrandom 0.2.17",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e270597a1d1e183f86d1cc9f94f0133654ee3daf201c17903ee29363555dd7"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored 2.2.0",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c2613d2fac930fe34456be76f9124ee0800bb9db2e7fd2d6c65b9ebe98a292"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "color-backtrace"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +652,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "colored"
@@ -690,6 +806,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1394,6 +1520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1576,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1857,6 +2000,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1959,12 +2111,31 @@ version = "3.4.0"
 dependencies = [
  "anyhow",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "leo-errors",
  "leo-span",
  "serde",
  "serde_json",
  "snarkvm",
+]
+
+[[package]]
+name = "leo-benchmarks"
+version = "0.1.0"
+dependencies = [
+ "aleo-std",
+ "codspeed-criterion-compat",
+ "indexmap",
+ "leo-ast",
+ "leo-compiler",
+ "leo-disassembler",
+ "leo-errors",
+ "leo-package",
+ "leo-parser",
+ "leo-passes",
+ "leo-span",
+ "snarkvm",
+ "walkdir",
 ]
 
 [[package]]
@@ -1975,7 +2146,7 @@ dependencies = [
  "aleo-std-storage",
  "anyhow",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "leo-abi",
  "leo-ast",
  "leo-disassembler",
@@ -2011,9 +2182,9 @@ dependencies = [
  "anyhow",
  "backtrace",
  "color-backtrace",
- "colored",
+ "colored 3.1.1",
  "derivative",
- "itertools",
+ "itertools 0.14.0",
  "leo-span",
  "serde",
  "thiserror 2.0.18",
@@ -2024,7 +2195,7 @@ name = "leo-fmt"
 version = "3.4.0"
 dependencies = [
  "clap",
- "colored",
+ "colored 3.1.1",
  "leo-ast",
  "leo-compiler",
  "leo-errors",
@@ -2048,7 +2219,7 @@ dependencies = [
  "backtrace",
  "chrono",
  "clap",
- "colored",
+ "colored 3.1.1",
  "crossbeam-channel",
  "crossterm",
  "ctrlc",
@@ -2057,7 +2228,7 @@ dependencies = [
  "dunce",
  "indexmap",
  "is-terminal",
- "itertools",
+ "itertools 0.14.0",
  "leo-abi",
  "leo-ast",
  "leo-compiler",
@@ -2119,7 +2290,7 @@ name = "leo-parser"
 version = "3.4.0"
 dependencies = [
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "leo-ast",
  "leo-errors",
  "leo-parser-rowan",
@@ -2147,7 +2318,7 @@ dependencies = [
  "anyhow",
  "base62",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "leo-abi-types",
  "leo-ast",
  "leo-errors",
@@ -2515,6 +2686,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "openssl"
 version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2823,34 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -3595,7 +3800,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "hex",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
  "rayon",
@@ -3659,7 +3864,7 @@ version = "4.4.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "nom",
  "num-traits",
  "smallvec",
@@ -3874,7 +4079,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f
 dependencies = [
  "anyhow",
  "bech32",
- "itertools",
+ "itertools 0.14.0",
  "nom",
  "num-traits",
  "rand 0.8.5",
@@ -4014,7 +4219,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f
 dependencies = [
  "aleo-std",
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "num-traits",
  "rand 0.8.5",
  "rayon",
@@ -4210,7 +4415,7 @@ source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f
 dependencies = [
  "aleo-std",
  "anyhow",
- "colored",
+ "colored 3.1.1",
  "indexmap",
  "lru",
  "parking_lot",
@@ -4275,7 +4480,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "cfg-if",
- "colored",
+ "colored 3.1.1",
  "curl",
  "hex",
  "lazy_static",
@@ -4297,7 +4502,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "lru",
  "parking_lot",
  "rand 0.8.5",
@@ -4327,7 +4532,7 @@ version = "4.4.0"
 source = "git+https://github.com/ProvableHQ/snarkVM.git?tag=canary-v4.5.3#d67f3f031ecdac287cd7df6637a425112df1c343"
 dependencies = [
  "aleo-std",
- "colored",
+ "colored 3.1.1",
  "indexmap",
  "parking_lot",
  "rand 0.8.5",
@@ -4385,7 +4590,7 @@ dependencies = [
  "aleo-std",
  "anyhow",
  "bincode",
- "colored",
+ "colored 3.1.1",
  "num-bigint",
  "num_cpus",
  "rand 0.8.5",
@@ -4444,6 +4649,16 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "strsim"
@@ -4675,6 +4890,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/*"]
+members = ["crates/*", "crates/compiler/benchmarks"]
 resolver = "3"
 
 [workspace.dependencies]

--- a/crates/compiler/benchmarks/Cargo.toml
+++ b/crates/compiler/benchmarks/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "leo-benchmarks"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+aleo-std = { workspace = true }
+indexmap = { workspace = true }
+leo-ast = { workspace = true }
+leo-compiler = { workspace = true }
+leo-disassembler = { workspace = true }
+leo-errors = { workspace = true }
+leo-package = { workspace = true }
+leo-parser = { workspace = true }
+leo-passes = { workspace = true }
+leo-span = { workspace = true }
+snarkvm = { workspace = true }
+walkdir = { workspace = true }
+
+[dev-dependencies]
+criterion = { package = "codspeed-criterion-compat", version = "4.1.0" }
+
+[[bench]]
+name = "compiler_benchmarks"
+harness = false

--- a/crates/compiler/benchmarks/benches/compiler_benchmarks.rs
+++ b/crates/compiler/benchmarks/benches/compiler_benchmarks.rs
@@ -1,0 +1,295 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use leo_benchmarks::{FixtureData, create_compiler, create_parse_only_compiler, load_fixture, load_source_fixture};
+use leo_compiler::Compiler;
+use leo_passes::*;
+use leo_span::create_session_if_not_set_then;
+
+use std::path::PathBuf;
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+
+// ---------------------------------------------------------------------------
+// Fixture loading
+// ---------------------------------------------------------------------------
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures")
+}
+
+/// Loads a committed contrived package. Panics on failure since these fixtures
+/// are checked into the repo and must always be loadable.
+fn contrived_package(name: &str) -> FixtureData {
+    let package_dir = fixtures_root().join("contrived").join(name);
+    load_fixture(&package_dir).unwrap_or_else(|err| panic!("failed to load committed fixture contrived/{name}: {err}"))
+}
+
+/// Loads a committed single-source fixture. Panics on failure.
+fn single_source(name: &str) -> FixtureData {
+    let path = fixtures_root().join("single").join(name);
+    load_source_fixture(&path).unwrap_or_else(|err| panic!("failed to load committed fixture single/{name}: {err}"))
+}
+
+// ---------------------------------------------------------------------------
+// Compiler setup helpers
+// ---------------------------------------------------------------------------
+
+fn prepare_compiler(fixture: &FixtureData) -> Compiler {
+    let module_refs = fixture.module_refs();
+    let mut compiler = create_compiler(fixture);
+    compiler.parse(&fixture.source, fixture.filename.clone(), &module_refs).expect("parse");
+    compiler.add_import_stubs().expect("add_import_stubs");
+    compiler
+}
+
+/// How far through the frontend pipeline to advance the compiler before the
+/// timed routine begins.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Through {
+    Parsed,
+    NameValidation,
+    GlobalVarsCollection,
+    PathResolution,
+    GlobalItemsCollection,
+    CheckInterfaces,
+    TypeChecking,
+    Disambiguate,
+    ProcessingAsync,
+}
+
+impl Through {
+    const fn rank(self) -> u8 {
+        match self {
+            Self::Parsed => 0,
+            Self::NameValidation => 1,
+            Self::GlobalVarsCollection => 2,
+            Self::PathResolution => 3,
+            Self::GlobalItemsCollection => 4,
+            Self::CheckInterfaces => 5,
+            Self::TypeChecking => 6,
+            Self::Disambiguate => 7,
+            Self::ProcessingAsync => 8,
+        }
+    }
+
+    const fn includes(self, stage: Self) -> bool {
+        self.rank() >= stage.rank()
+    }
+}
+
+/// Builds a fresh compiler advanced through the given stage.
+fn prepare_through(fixture: &FixtureData, through: Through) -> Compiler {
+    let mut compiler = prepare_compiler(fixture);
+
+    if through.includes(Through::NameValidation) {
+        compiler.do_pass::<NameValidation>(()).expect("name_validation");
+    }
+    if through.includes(Through::GlobalVarsCollection) {
+        compiler.do_pass::<GlobalVarsCollection>(()).expect("global_vars_collection");
+    }
+    if through.includes(Through::PathResolution) {
+        compiler.do_pass::<PathResolution>(()).expect("path_resolution");
+    }
+    if through.includes(Through::GlobalItemsCollection) {
+        compiler.do_pass::<GlobalItemsCollection>(()).expect("global_items_collection");
+    }
+    if through.includes(Through::CheckInterfaces) {
+        compiler.do_pass::<CheckInterfaces>(()).expect("check_interfaces");
+    }
+    if through.includes(Through::TypeChecking) {
+        compiler.do_pass::<TypeChecking>(TypeCheckingInput::new(compiler.network())).expect("type_checking");
+    }
+    if through.includes(Through::Disambiguate) {
+        compiler.do_pass::<Disambiguate>(()).expect("disambiguate");
+    }
+    if through.includes(Through::ProcessingAsync) {
+        compiler.do_pass::<ProcessingAsync>(TypeCheckingInput::new(compiler.network())).expect("processing_async");
+    }
+
+    compiler
+}
+
+// ---------------------------------------------------------------------------
+// Shared benchmark patterns
+// ---------------------------------------------------------------------------
+
+fn bench_frontend_case(c: &mut Criterion, bench_name: &str, fixture: &FixtureData) {
+    let filename = fixture.filename.clone();
+    let module_refs = fixture.module_refs();
+
+    c.bench_function(bench_name, |b| {
+        b.iter(|| {
+            let mut compiler = create_compiler(fixture);
+            compiler.parse(&fixture.source, filename.clone(), &module_refs).expect("parse");
+            compiler.add_import_stubs().expect("add_import_stubs");
+            compiler.frontend_passes().expect("frontend_passes");
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark groups
+// ---------------------------------------------------------------------------
+
+fn bench_frontend_with_deps(c: &mut Criterion) {
+    create_session_if_not_set_then(|_| {
+        let settlement = contrived_package("settlement");
+
+        bench_frontend_case(c, "frontend_with_deps/contrived_settlement", &settlement);
+    });
+}
+
+fn bench_dependency_chain(c: &mut Criterion) {
+    create_session_if_not_set_then(|_| {
+        let chain: &[(u8, &str)] =
+            &[(1, "primitives"), (2, "registry"), (3, "policy"), (4, "router"), (5, "settlement")];
+
+        let mut group = c.benchmark_group("dependency_chain");
+
+        for &(depth, package_name) in chain {
+            let fixture = contrived_package(package_name);
+            let filename = fixture.filename.clone();
+            let module_refs = fixture.module_refs();
+
+            group.bench_function(BenchmarkId::from_parameter(format!("{depth:02}_{package_name}")), |b| {
+                b.iter(|| {
+                    let mut compiler = create_compiler(&fixture);
+                    compiler.parse(&fixture.source, filename.clone(), &module_refs).expect("parse");
+                    compiler.add_import_stubs().expect("add_import_stubs");
+                    compiler.frontend_passes().expect("frontend_passes");
+                });
+            });
+        }
+
+        group.finish();
+    });
+}
+
+fn bench_frontend_single_file(c: &mut Criterion) {
+    create_session_if_not_set_then(|_| {
+        let control_flow_matrix = single_source("control_flow_matrix.leo");
+
+        bench_frontend_case(c, "frontend_single_file/control_flow_matrix", &control_flow_matrix);
+    });
+}
+
+fn bench_individual_passes(c: &mut Criterion) {
+    create_session_if_not_set_then(|_| {
+        let fixture = contrived_package("settlement");
+        let target = "contrived_settlement";
+
+        let mut group = c.benchmark_group("individual_passes");
+
+        group.bench_function(BenchmarkId::new("01_parsing", target), |b| {
+            let filename = fixture.filename.clone();
+            let module_refs = fixture.module_refs();
+            b.iter(|| {
+                let mut compiler = create_parse_only_compiler(&fixture);
+                compiler.parse(&fixture.source, filename.clone(), &module_refs).expect("parse");
+            });
+        });
+
+        group.bench_function(BenchmarkId::new("02_name_validation", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::Parsed),
+                |mut c| c.do_pass::<NameValidation>(()).expect("name_validation"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("03_global_vars_collection", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::NameValidation),
+                |mut c| c.do_pass::<GlobalVarsCollection>(()).expect("global_vars_collection"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("04_path_resolution", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::GlobalVarsCollection),
+                |mut c| c.do_pass::<PathResolution>(()).expect("path_resolution"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("05_global_items_collection", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::PathResolution),
+                |mut c| c.do_pass::<GlobalItemsCollection>(()).expect("global_items_collection"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("06_check_interfaces", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::GlobalItemsCollection),
+                |mut c| c.do_pass::<CheckInterfaces>(()).expect("check_interfaces"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("07_type_checking", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::CheckInterfaces),
+                |mut c| {
+                    let network = c.network();
+                    c.do_pass::<TypeChecking>(TypeCheckingInput::new(network)).expect("type_checking")
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("08_disambiguate", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::TypeChecking),
+                |mut c| c.do_pass::<Disambiguate>(()).expect("disambiguate"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("09_processing_async", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::Disambiguate),
+                |mut c| {
+                    let network = c.network();
+                    c.do_pass::<ProcessingAsync>(TypeCheckingInput::new(network)).expect("processing_async")
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.bench_function(BenchmarkId::new("10_static_analyzing", target), |b| {
+            b.iter_batched(
+                || prepare_through(&fixture, Through::ProcessingAsync),
+                |mut c| c.do_pass::<StaticAnalyzing>(()).expect("static_analyzing"),
+                BatchSize::SmallInput,
+            );
+        });
+
+        group.finish();
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_frontend_with_deps,
+    bench_dependency_chain,
+    bench_frontend_single_file,
+    bench_individual_passes
+);
+criterion_main!(benches);

--- a/crates/compiler/benchmarks/fixtures/contrived/policy/program.json
+++ b/crates/compiler/benchmarks/fixtures/contrived/policy/program.json
@@ -1,0 +1,18 @@
+{
+    "program": "bench_policy.aleo",
+    "version": "0.1.0",
+    "description": "",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name": "bench_primitives.aleo",
+            "location": "local",
+            "path": "../primitives"
+        },
+        {
+            "name": "bench_registry.aleo",
+            "location": "local",
+            "path": "../registry"
+        }
+    ]
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/policy/src/main.leo
+++ b/crates/compiler/benchmarks/fixtures/contrived/policy/src/main.leo
@@ -1,0 +1,2069 @@
+import bench_primitives.aleo;
+import bench_registry.aleo;
+
+program bench_policy.aleo {
+    struct PlItem000 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem001 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem002 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem003 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem004 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem005 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem006 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem007 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem008 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem009 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem010 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem011 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem012 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem013 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem014 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem015 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem016 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem017 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem018 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem019 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem020 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem021 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem022 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem023 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem024 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem025 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem026 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem027 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem028 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem029 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem030 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem031 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem032 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem033 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem034 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem035 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem036 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem037 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem038 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem039 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem040 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem041 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem042 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem043 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem044 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem045 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem046 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem047 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem048 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem049 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem050 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem051 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem052 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem053 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem054 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem055 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem056 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem057 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem058 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem059 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem060 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem061 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem062 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem063 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem064 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem065 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem066 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem067 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem068 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem069 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem070 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem071 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem072 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem073 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem074 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem075 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem076 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem077 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem078 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem079 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem080 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem081 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem082 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem083 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem084 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem085 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem086 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem087 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem088 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem089 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem090 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem091 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem092 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem093 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem094 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem095 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem096 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem097 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem098 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem099 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem100 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem101 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem102 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem103 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem104 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem105 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem106 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem107 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem108 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem109 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem110 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem111 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem112 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem113 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem114 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem115 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem116 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem117 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem118 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PlItem119 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    mapping ledger: address => u64;
+    mapping scores: u32 => u64;
+
+    @noupgrade
+    constructor() {}
+
+    fn compute_pl_000(seed: u64) -> u64 {
+        let pl00_v0 = seed + 0u64;
+        let pl00_v1 = seed + 1u64;
+        let pl00_v2 = seed + 2u64;
+        let pl00_v3 = seed + 3u64;
+        let pl00_v4 = seed + 4u64;
+        let pl00_v5 = seed + 5u64;
+        let pl00_v6 = seed + 6u64;
+        let pl00_v7 = seed + 7u64;
+        let pl00_v8 = seed + 8u64;
+        let pl00_v9 = seed + 9u64;
+        let pl00_v10 = seed + 10u64;
+        let pl00_v11 = seed + 11u64;
+        let pl00_v12 = seed + 12u64;
+        let pl00_v13 = seed + 13u64;
+        let pl00_v14 = seed + 14u64;
+        let pl00_v15 = seed + 15u64;
+        let pl00_v16 = seed + 16u64;
+        let pl00_v17 = seed + 17u64;
+        let pl00_v18 = seed + 18u64;
+        let pl00_v19 = seed + 19u64;
+        let pl00_v20 = seed + 20u64;
+        let pl00_v21 = seed + 21u64;
+        let pl00_v22 = seed + 22u64;
+        let pl00_v23 = seed + 23u64;
+        let pl00_v24 = seed + 24u64;
+        let arr_a = [pl00_v0, pl00_v1, pl00_v2, pl00_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl00_v4 {
+            if acc > pl00_v5 + pl00_v6 {
+                acc = acc + pl00_v7 + pl00_v8 + pl00_v9;
+            } else {
+                acc = acc + pl00_v10 + pl00_v11;
+            }
+        } else {
+            if pl00_v12 > pl00_v13 {
+                acc = acc + pl00_v14 + pl00_v15;
+            } else {
+                acc = acc + pl00_v16 + pl00_v17;
+            }
+        }
+        acc += pl00_v18 / (19u64);
+        acc += pl00_v19 / (20u64);
+        acc += pl00_v20 / (21u64);
+        acc += pl00_v21 / (22u64);
+        acc += pl00_v22 / (23u64);
+        acc += pl00_v23 / (24u64);
+        acc += pl00_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_001(seed: u64) -> u64 {
+        let pl01_v0 = seed + 25u64;
+        let pl01_v1 = seed + 26u64;
+        let pl01_v2 = seed + 27u64;
+        let pl01_v3 = seed + 28u64;
+        let pl01_v4 = seed + 29u64;
+        let pl01_v5 = seed + 30u64;
+        let pl01_v6 = seed + 31u64;
+        let pl01_v7 = seed + 32u64;
+        let pl01_v8 = seed + 33u64;
+        let pl01_v9 = seed + 34u64;
+        let pl01_v10 = seed + 35u64;
+        let pl01_v11 = seed + 36u64;
+        let pl01_v12 = seed + 37u64;
+        let pl01_v13 = seed + 38u64;
+        let pl01_v14 = seed + 39u64;
+        let pl01_v15 = seed + 40u64;
+        let pl01_v16 = seed + 41u64;
+        let pl01_v17 = seed + 42u64;
+        let pl01_v18 = seed + 43u64;
+        let pl01_v19 = seed + 44u64;
+        let pl01_v20 = seed + 45u64;
+        let pl01_v21 = seed + 46u64;
+        let pl01_v22 = seed + 47u64;
+        let pl01_v23 = seed + 48u64;
+        let pl01_v24 = seed + 49u64;
+        let arr_a = [pl01_v0, pl01_v1, pl01_v2, pl01_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl01_v4 {
+            if acc > pl01_v5 + pl01_v6 {
+                acc = acc + pl01_v7 + pl01_v8 + pl01_v9;
+            } else {
+                acc = acc + pl01_v10 + pl01_v11;
+            }
+        } else {
+            if pl01_v12 > pl01_v13 {
+                acc = acc + pl01_v14 + pl01_v15;
+            } else {
+                acc = acc + pl01_v16 + pl01_v17;
+            }
+        }
+        acc += pl01_v18 / (19u64);
+        acc += pl01_v19 / (20u64);
+        acc += pl01_v20 / (21u64);
+        acc += pl01_v21 / (22u64);
+        acc += pl01_v22 / (23u64);
+        acc += pl01_v23 / (24u64);
+        acc += pl01_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_002(seed: u64) -> u64 {
+        let pl02_v0 = seed + 50u64;
+        let pl02_v1 = seed + 51u64;
+        let pl02_v2 = seed + 52u64;
+        let pl02_v3 = seed + 53u64;
+        let pl02_v4 = seed + 54u64;
+        let pl02_v5 = seed + 55u64;
+        let pl02_v6 = seed + 56u64;
+        let pl02_v7 = seed + 57u64;
+        let pl02_v8 = seed + 58u64;
+        let pl02_v9 = seed + 59u64;
+        let pl02_v10 = seed + 60u64;
+        let pl02_v11 = seed + 61u64;
+        let pl02_v12 = seed + 62u64;
+        let pl02_v13 = seed + 63u64;
+        let pl02_v14 = seed + 64u64;
+        let pl02_v15 = seed + 65u64;
+        let pl02_v16 = seed + 66u64;
+        let pl02_v17 = seed + 67u64;
+        let pl02_v18 = seed + 68u64;
+        let pl02_v19 = seed + 69u64;
+        let pl02_v20 = seed + 70u64;
+        let pl02_v21 = seed + 71u64;
+        let pl02_v22 = seed + 72u64;
+        let pl02_v23 = seed + 73u64;
+        let pl02_v24 = seed + 74u64;
+        let arr_a = [pl02_v0, pl02_v1, pl02_v2, pl02_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl02_v4 {
+            if acc > pl02_v5 + pl02_v6 {
+                acc = acc + pl02_v7 + pl02_v8 + pl02_v9;
+            } else {
+                acc = acc + pl02_v10 + pl02_v11;
+            }
+        } else {
+            if pl02_v12 > pl02_v13 {
+                acc = acc + pl02_v14 + pl02_v15;
+            } else {
+                acc = acc + pl02_v16 + pl02_v17;
+            }
+        }
+        acc += pl02_v18 / (19u64);
+        acc += pl02_v19 / (20u64);
+        acc += pl02_v20 / (21u64);
+        acc += pl02_v21 / (22u64);
+        acc += pl02_v22 / (23u64);
+        acc += pl02_v23 / (24u64);
+        acc += pl02_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_003(seed: u64) -> u64 {
+        let pl03_v0 = seed + 75u64;
+        let pl03_v1 = seed + 76u64;
+        let pl03_v2 = seed + 77u64;
+        let pl03_v3 = seed + 78u64;
+        let pl03_v4 = seed + 79u64;
+        let pl03_v5 = seed + 80u64;
+        let pl03_v6 = seed + 81u64;
+        let pl03_v7 = seed + 82u64;
+        let pl03_v8 = seed + 83u64;
+        let pl03_v9 = seed + 84u64;
+        let pl03_v10 = seed + 85u64;
+        let pl03_v11 = seed + 86u64;
+        let pl03_v12 = seed + 87u64;
+        let pl03_v13 = seed + 88u64;
+        let pl03_v14 = seed + 89u64;
+        let pl03_v15 = seed + 90u64;
+        let pl03_v16 = seed + 91u64;
+        let pl03_v17 = seed + 92u64;
+        let pl03_v18 = seed + 93u64;
+        let pl03_v19 = seed + 94u64;
+        let pl03_v20 = seed + 95u64;
+        let pl03_v21 = seed + 96u64;
+        let pl03_v22 = seed + 97u64;
+        let pl03_v23 = seed + 98u64;
+        let pl03_v24 = seed + 99u64;
+        let arr_a = [pl03_v0, pl03_v1, pl03_v2, pl03_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl03_v4 {
+            if acc > pl03_v5 + pl03_v6 {
+                acc = acc + pl03_v7 + pl03_v8 + pl03_v9;
+            } else {
+                acc = acc + pl03_v10 + pl03_v11;
+            }
+        } else {
+            if pl03_v12 > pl03_v13 {
+                acc = acc + pl03_v14 + pl03_v15;
+            } else {
+                acc = acc + pl03_v16 + pl03_v17;
+            }
+        }
+        acc += pl03_v18 / (19u64);
+        acc += pl03_v19 / (20u64);
+        acc += pl03_v20 / (21u64);
+        acc += pl03_v21 / (22u64);
+        acc += pl03_v22 / (23u64);
+        acc += pl03_v23 / (24u64);
+        acc += pl03_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_004(seed: u64) -> u64 {
+        let pl04_v0 = seed + 100u64;
+        let pl04_v1 = seed + 101u64;
+        let pl04_v2 = seed + 102u64;
+        let pl04_v3 = seed + 103u64;
+        let pl04_v4 = seed + 104u64;
+        let pl04_v5 = seed + 105u64;
+        let pl04_v6 = seed + 106u64;
+        let pl04_v7 = seed + 107u64;
+        let pl04_v8 = seed + 108u64;
+        let pl04_v9 = seed + 109u64;
+        let pl04_v10 = seed + 110u64;
+        let pl04_v11 = seed + 111u64;
+        let pl04_v12 = seed + 112u64;
+        let pl04_v13 = seed + 113u64;
+        let pl04_v14 = seed + 114u64;
+        let pl04_v15 = seed + 115u64;
+        let pl04_v16 = seed + 116u64;
+        let pl04_v17 = seed + 117u64;
+        let pl04_v18 = seed + 118u64;
+        let pl04_v19 = seed + 119u64;
+        let pl04_v20 = seed + 120u64;
+        let pl04_v21 = seed + 121u64;
+        let pl04_v22 = seed + 122u64;
+        let pl04_v23 = seed + 123u64;
+        let pl04_v24 = seed + 124u64;
+        let arr_a = [pl04_v0, pl04_v1, pl04_v2, pl04_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl04_v4 {
+            if acc > pl04_v5 + pl04_v6 {
+                acc = acc + pl04_v7 + pl04_v8 + pl04_v9;
+            } else {
+                acc = acc + pl04_v10 + pl04_v11;
+            }
+        } else {
+            if pl04_v12 > pl04_v13 {
+                acc = acc + pl04_v14 + pl04_v15;
+            } else {
+                acc = acc + pl04_v16 + pl04_v17;
+            }
+        }
+        acc += pl04_v18 / (19u64);
+        acc += pl04_v19 / (20u64);
+        acc += pl04_v20 / (21u64);
+        acc += pl04_v21 / (22u64);
+        acc += pl04_v22 / (23u64);
+        acc += pl04_v23 / (24u64);
+        acc += pl04_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_005(seed: u64) -> u64 {
+        let pl05_v0 = seed + 125u64;
+        let pl05_v1 = seed + 126u64;
+        let pl05_v2 = seed + 127u64;
+        let pl05_v3 = seed + 128u64;
+        let pl05_v4 = seed + 129u64;
+        let pl05_v5 = seed + 130u64;
+        let pl05_v6 = seed + 131u64;
+        let pl05_v7 = seed + 132u64;
+        let pl05_v8 = seed + 133u64;
+        let pl05_v9 = seed + 134u64;
+        let pl05_v10 = seed + 135u64;
+        let pl05_v11 = seed + 136u64;
+        let pl05_v12 = seed + 137u64;
+        let pl05_v13 = seed + 138u64;
+        let pl05_v14 = seed + 139u64;
+        let pl05_v15 = seed + 140u64;
+        let pl05_v16 = seed + 141u64;
+        let pl05_v17 = seed + 142u64;
+        let pl05_v18 = seed + 143u64;
+        let pl05_v19 = seed + 144u64;
+        let pl05_v20 = seed + 145u64;
+        let pl05_v21 = seed + 146u64;
+        let pl05_v22 = seed + 147u64;
+        let pl05_v23 = seed + 148u64;
+        let pl05_v24 = seed + 149u64;
+        let arr_a = [pl05_v0, pl05_v1, pl05_v2, pl05_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl05_v4 {
+            if acc > pl05_v5 + pl05_v6 {
+                acc = acc + pl05_v7 + pl05_v8 + pl05_v9;
+            } else {
+                acc = acc + pl05_v10 + pl05_v11;
+            }
+        } else {
+            if pl05_v12 > pl05_v13 {
+                acc = acc + pl05_v14 + pl05_v15;
+            } else {
+                acc = acc + pl05_v16 + pl05_v17;
+            }
+        }
+        acc += pl05_v18 / (19u64);
+        acc += pl05_v19 / (20u64);
+        acc += pl05_v20 / (21u64);
+        acc += pl05_v21 / (22u64);
+        acc += pl05_v22 / (23u64);
+        acc += pl05_v23 / (24u64);
+        acc += pl05_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_006(seed: u64) -> u64 {
+        let pl06_v0 = seed + 150u64;
+        let pl06_v1 = seed + 151u64;
+        let pl06_v2 = seed + 152u64;
+        let pl06_v3 = seed + 153u64;
+        let pl06_v4 = seed + 154u64;
+        let pl06_v5 = seed + 155u64;
+        let pl06_v6 = seed + 156u64;
+        let pl06_v7 = seed + 157u64;
+        let pl06_v8 = seed + 158u64;
+        let pl06_v9 = seed + 159u64;
+        let pl06_v10 = seed + 160u64;
+        let pl06_v11 = seed + 161u64;
+        let pl06_v12 = seed + 162u64;
+        let pl06_v13 = seed + 163u64;
+        let pl06_v14 = seed + 164u64;
+        let pl06_v15 = seed + 165u64;
+        let pl06_v16 = seed + 166u64;
+        let pl06_v17 = seed + 167u64;
+        let pl06_v18 = seed + 168u64;
+        let pl06_v19 = seed + 169u64;
+        let pl06_v20 = seed + 170u64;
+        let pl06_v21 = seed + 171u64;
+        let pl06_v22 = seed + 172u64;
+        let pl06_v23 = seed + 173u64;
+        let pl06_v24 = seed + 174u64;
+        let arr_a = [pl06_v0, pl06_v1, pl06_v2, pl06_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl06_v4 {
+            if acc > pl06_v5 + pl06_v6 {
+                acc = acc + pl06_v7 + pl06_v8 + pl06_v9;
+            } else {
+                acc = acc + pl06_v10 + pl06_v11;
+            }
+        } else {
+            if pl06_v12 > pl06_v13 {
+                acc = acc + pl06_v14 + pl06_v15;
+            } else {
+                acc = acc + pl06_v16 + pl06_v17;
+            }
+        }
+        acc += pl06_v18 / (19u64);
+        acc += pl06_v19 / (20u64);
+        acc += pl06_v20 / (21u64);
+        acc += pl06_v21 / (22u64);
+        acc += pl06_v22 / (23u64);
+        acc += pl06_v23 / (24u64);
+        acc += pl06_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_007(seed: u64) -> u64 {
+        let pl07_v0 = seed + 175u64;
+        let pl07_v1 = seed + 176u64;
+        let pl07_v2 = seed + 177u64;
+        let pl07_v3 = seed + 178u64;
+        let pl07_v4 = seed + 179u64;
+        let pl07_v5 = seed + 180u64;
+        let pl07_v6 = seed + 181u64;
+        let pl07_v7 = seed + 182u64;
+        let pl07_v8 = seed + 183u64;
+        let pl07_v9 = seed + 184u64;
+        let pl07_v10 = seed + 185u64;
+        let pl07_v11 = seed + 186u64;
+        let pl07_v12 = seed + 187u64;
+        let pl07_v13 = seed + 188u64;
+        let pl07_v14 = seed + 189u64;
+        let pl07_v15 = seed + 190u64;
+        let pl07_v16 = seed + 191u64;
+        let pl07_v17 = seed + 192u64;
+        let pl07_v18 = seed + 193u64;
+        let pl07_v19 = seed + 194u64;
+        let pl07_v20 = seed + 195u64;
+        let pl07_v21 = seed + 196u64;
+        let pl07_v22 = seed + 197u64;
+        let pl07_v23 = seed + 198u64;
+        let pl07_v24 = seed + 199u64;
+        let arr_a = [pl07_v0, pl07_v1, pl07_v2, pl07_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl07_v4 {
+            if acc > pl07_v5 + pl07_v6 {
+                acc = acc + pl07_v7 + pl07_v8 + pl07_v9;
+            } else {
+                acc = acc + pl07_v10 + pl07_v11;
+            }
+        } else {
+            if pl07_v12 > pl07_v13 {
+                acc = acc + pl07_v14 + pl07_v15;
+            } else {
+                acc = acc + pl07_v16 + pl07_v17;
+            }
+        }
+        acc += pl07_v18 / (19u64);
+        acc += pl07_v19 / (20u64);
+        acc += pl07_v20 / (21u64);
+        acc += pl07_v21 / (22u64);
+        acc += pl07_v22 / (23u64);
+        acc += pl07_v23 / (24u64);
+        acc += pl07_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_008(seed: u64) -> u64 {
+        let pl08_v0 = seed + 200u64;
+        let pl08_v1 = seed + 201u64;
+        let pl08_v2 = seed + 202u64;
+        let pl08_v3 = seed + 203u64;
+        let pl08_v4 = seed + 204u64;
+        let pl08_v5 = seed + 205u64;
+        let pl08_v6 = seed + 206u64;
+        let pl08_v7 = seed + 207u64;
+        let pl08_v8 = seed + 208u64;
+        let pl08_v9 = seed + 209u64;
+        let pl08_v10 = seed + 210u64;
+        let pl08_v11 = seed + 211u64;
+        let pl08_v12 = seed + 212u64;
+        let pl08_v13 = seed + 213u64;
+        let pl08_v14 = seed + 214u64;
+        let pl08_v15 = seed + 215u64;
+        let pl08_v16 = seed + 216u64;
+        let pl08_v17 = seed + 217u64;
+        let pl08_v18 = seed + 218u64;
+        let pl08_v19 = seed + 219u64;
+        let pl08_v20 = seed + 220u64;
+        let pl08_v21 = seed + 221u64;
+        let pl08_v22 = seed + 222u64;
+        let pl08_v23 = seed + 223u64;
+        let pl08_v24 = seed + 224u64;
+        let arr_a = [pl08_v0, pl08_v1, pl08_v2, pl08_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl08_v4 {
+            if acc > pl08_v5 + pl08_v6 {
+                acc = acc + pl08_v7 + pl08_v8 + pl08_v9;
+            } else {
+                acc = acc + pl08_v10 + pl08_v11;
+            }
+        } else {
+            if pl08_v12 > pl08_v13 {
+                acc = acc + pl08_v14 + pl08_v15;
+            } else {
+                acc = acc + pl08_v16 + pl08_v17;
+            }
+        }
+        acc += pl08_v18 / (19u64);
+        acc += pl08_v19 / (20u64);
+        acc += pl08_v20 / (21u64);
+        acc += pl08_v21 / (22u64);
+        acc += pl08_v22 / (23u64);
+        acc += pl08_v23 / (24u64);
+        acc += pl08_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_009(seed: u64) -> u64 {
+        let pl09_v0 = seed + 225u64;
+        let pl09_v1 = seed + 226u64;
+        let pl09_v2 = seed + 227u64;
+        let pl09_v3 = seed + 228u64;
+        let pl09_v4 = seed + 229u64;
+        let pl09_v5 = seed + 230u64;
+        let pl09_v6 = seed + 231u64;
+        let pl09_v7 = seed + 232u64;
+        let pl09_v8 = seed + 233u64;
+        let pl09_v9 = seed + 234u64;
+        let pl09_v10 = seed + 235u64;
+        let pl09_v11 = seed + 236u64;
+        let pl09_v12 = seed + 237u64;
+        let pl09_v13 = seed + 238u64;
+        let pl09_v14 = seed + 239u64;
+        let pl09_v15 = seed + 240u64;
+        let pl09_v16 = seed + 241u64;
+        let pl09_v17 = seed + 242u64;
+        let pl09_v18 = seed + 243u64;
+        let pl09_v19 = seed + 244u64;
+        let pl09_v20 = seed + 245u64;
+        let pl09_v21 = seed + 246u64;
+        let pl09_v22 = seed + 247u64;
+        let pl09_v23 = seed + 248u64;
+        let pl09_v24 = seed + 249u64;
+        let arr_a = [pl09_v0, pl09_v1, pl09_v2, pl09_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl09_v4 {
+            if acc > pl09_v5 + pl09_v6 {
+                acc = acc + pl09_v7 + pl09_v8 + pl09_v9;
+            } else {
+                acc = acc + pl09_v10 + pl09_v11;
+            }
+        } else {
+            if pl09_v12 > pl09_v13 {
+                acc = acc + pl09_v14 + pl09_v15;
+            } else {
+                acc = acc + pl09_v16 + pl09_v17;
+            }
+        }
+        acc += pl09_v18 / (19u64);
+        acc += pl09_v19 / (20u64);
+        acc += pl09_v20 / (21u64);
+        acc += pl09_v21 / (22u64);
+        acc += pl09_v22 / (23u64);
+        acc += pl09_v23 / (24u64);
+        acc += pl09_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_010(seed: u64) -> u64 {
+        let pl10_v0 = seed + 250u64;
+        let pl10_v1 = seed + 251u64;
+        let pl10_v2 = seed + 252u64;
+        let pl10_v3 = seed + 253u64;
+        let pl10_v4 = seed + 254u64;
+        let pl10_v5 = seed + 255u64;
+        let pl10_v6 = seed + 256u64;
+        let pl10_v7 = seed + 257u64;
+        let pl10_v8 = seed + 258u64;
+        let pl10_v9 = seed + 259u64;
+        let pl10_v10 = seed + 260u64;
+        let pl10_v11 = seed + 261u64;
+        let pl10_v12 = seed + 262u64;
+        let pl10_v13 = seed + 263u64;
+        let pl10_v14 = seed + 264u64;
+        let pl10_v15 = seed + 265u64;
+        let pl10_v16 = seed + 266u64;
+        let pl10_v17 = seed + 267u64;
+        let pl10_v18 = seed + 268u64;
+        let pl10_v19 = seed + 269u64;
+        let pl10_v20 = seed + 270u64;
+        let pl10_v21 = seed + 271u64;
+        let pl10_v22 = seed + 272u64;
+        let pl10_v23 = seed + 273u64;
+        let pl10_v24 = seed + 274u64;
+        let arr_a = [pl10_v0, pl10_v1, pl10_v2, pl10_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl10_v4 {
+            if acc > pl10_v5 + pl10_v6 {
+                acc = acc + pl10_v7 + pl10_v8 + pl10_v9;
+            } else {
+                acc = acc + pl10_v10 + pl10_v11;
+            }
+        } else {
+            if pl10_v12 > pl10_v13 {
+                acc = acc + pl10_v14 + pl10_v15;
+            } else {
+                acc = acc + pl10_v16 + pl10_v17;
+            }
+        }
+        acc += pl10_v18 / (19u64);
+        acc += pl10_v19 / (20u64);
+        acc += pl10_v20 / (21u64);
+        acc += pl10_v21 / (22u64);
+        acc += pl10_v22 / (23u64);
+        acc += pl10_v23 / (24u64);
+        acc += pl10_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_011(seed: u64) -> u64 {
+        let pl11_v0 = seed + 275u64;
+        let pl11_v1 = seed + 276u64;
+        let pl11_v2 = seed + 277u64;
+        let pl11_v3 = seed + 278u64;
+        let pl11_v4 = seed + 279u64;
+        let pl11_v5 = seed + 280u64;
+        let pl11_v6 = seed + 281u64;
+        let pl11_v7 = seed + 282u64;
+        let pl11_v8 = seed + 283u64;
+        let pl11_v9 = seed + 284u64;
+        let pl11_v10 = seed + 285u64;
+        let pl11_v11 = seed + 286u64;
+        let pl11_v12 = seed + 287u64;
+        let pl11_v13 = seed + 288u64;
+        let pl11_v14 = seed + 289u64;
+        let pl11_v15 = seed + 290u64;
+        let pl11_v16 = seed + 291u64;
+        let pl11_v17 = seed + 292u64;
+        let pl11_v18 = seed + 293u64;
+        let pl11_v19 = seed + 294u64;
+        let pl11_v20 = seed + 295u64;
+        let pl11_v21 = seed + 296u64;
+        let pl11_v22 = seed + 297u64;
+        let pl11_v23 = seed + 298u64;
+        let pl11_v24 = seed + 299u64;
+        let arr_a = [pl11_v0, pl11_v1, pl11_v2, pl11_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl11_v4 {
+            if acc > pl11_v5 + pl11_v6 {
+                acc = acc + pl11_v7 + pl11_v8 + pl11_v9;
+            } else {
+                acc = acc + pl11_v10 + pl11_v11;
+            }
+        } else {
+            if pl11_v12 > pl11_v13 {
+                acc = acc + pl11_v14 + pl11_v15;
+            } else {
+                acc = acc + pl11_v16 + pl11_v17;
+            }
+        }
+        acc += pl11_v18 / (19u64);
+        acc += pl11_v19 / (20u64);
+        acc += pl11_v20 / (21u64);
+        acc += pl11_v21 / (22u64);
+        acc += pl11_v22 / (23u64);
+        acc += pl11_v23 / (24u64);
+        acc += pl11_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_012(seed: u64) -> u64 {
+        let pl12_v0 = seed + 300u64;
+        let pl12_v1 = seed + 301u64;
+        let pl12_v2 = seed + 302u64;
+        let pl12_v3 = seed + 303u64;
+        let pl12_v4 = seed + 304u64;
+        let pl12_v5 = seed + 305u64;
+        let pl12_v6 = seed + 306u64;
+        let pl12_v7 = seed + 307u64;
+        let pl12_v8 = seed + 308u64;
+        let pl12_v9 = seed + 309u64;
+        let pl12_v10 = seed + 310u64;
+        let pl12_v11 = seed + 311u64;
+        let pl12_v12 = seed + 312u64;
+        let pl12_v13 = seed + 313u64;
+        let pl12_v14 = seed + 314u64;
+        let pl12_v15 = seed + 315u64;
+        let pl12_v16 = seed + 316u64;
+        let pl12_v17 = seed + 317u64;
+        let pl12_v18 = seed + 318u64;
+        let pl12_v19 = seed + 319u64;
+        let pl12_v20 = seed + 320u64;
+        let pl12_v21 = seed + 321u64;
+        let pl12_v22 = seed + 322u64;
+        let pl12_v23 = seed + 323u64;
+        let pl12_v24 = seed + 324u64;
+        let arr_a = [pl12_v0, pl12_v1, pl12_v2, pl12_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl12_v4 {
+            if acc > pl12_v5 + pl12_v6 {
+                acc = acc + pl12_v7 + pl12_v8 + pl12_v9;
+            } else {
+                acc = acc + pl12_v10 + pl12_v11;
+            }
+        } else {
+            if pl12_v12 > pl12_v13 {
+                acc = acc + pl12_v14 + pl12_v15;
+            } else {
+                acc = acc + pl12_v16 + pl12_v17;
+            }
+        }
+        acc += pl12_v18 / (19u64);
+        acc += pl12_v19 / (20u64);
+        acc += pl12_v20 / (21u64);
+        acc += pl12_v21 / (22u64);
+        acc += pl12_v22 / (23u64);
+        acc += pl12_v23 / (24u64);
+        acc += pl12_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_013(seed: u64) -> u64 {
+        let pl13_v0 = seed + 325u64;
+        let pl13_v1 = seed + 326u64;
+        let pl13_v2 = seed + 327u64;
+        let pl13_v3 = seed + 328u64;
+        let pl13_v4 = seed + 329u64;
+        let pl13_v5 = seed + 330u64;
+        let pl13_v6 = seed + 331u64;
+        let pl13_v7 = seed + 332u64;
+        let pl13_v8 = seed + 333u64;
+        let pl13_v9 = seed + 334u64;
+        let pl13_v10 = seed + 335u64;
+        let pl13_v11 = seed + 336u64;
+        let pl13_v12 = seed + 337u64;
+        let pl13_v13 = seed + 338u64;
+        let pl13_v14 = seed + 339u64;
+        let pl13_v15 = seed + 340u64;
+        let pl13_v16 = seed + 341u64;
+        let pl13_v17 = seed + 342u64;
+        let pl13_v18 = seed + 343u64;
+        let pl13_v19 = seed + 344u64;
+        let pl13_v20 = seed + 345u64;
+        let pl13_v21 = seed + 346u64;
+        let pl13_v22 = seed + 347u64;
+        let pl13_v23 = seed + 348u64;
+        let pl13_v24 = seed + 349u64;
+        let arr_a = [pl13_v0, pl13_v1, pl13_v2, pl13_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl13_v4 {
+            if acc > pl13_v5 + pl13_v6 {
+                acc = acc + pl13_v7 + pl13_v8 + pl13_v9;
+            } else {
+                acc = acc + pl13_v10 + pl13_v11;
+            }
+        } else {
+            if pl13_v12 > pl13_v13 {
+                acc = acc + pl13_v14 + pl13_v15;
+            } else {
+                acc = acc + pl13_v16 + pl13_v17;
+            }
+        }
+        acc += pl13_v18 / (19u64);
+        acc += pl13_v19 / (20u64);
+        acc += pl13_v20 / (21u64);
+        acc += pl13_v21 / (22u64);
+        acc += pl13_v22 / (23u64);
+        acc += pl13_v23 / (24u64);
+        acc += pl13_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_014(seed: u64) -> u64 {
+        let pl14_v0 = seed + 350u64;
+        let pl14_v1 = seed + 351u64;
+        let pl14_v2 = seed + 352u64;
+        let pl14_v3 = seed + 353u64;
+        let pl14_v4 = seed + 354u64;
+        let pl14_v5 = seed + 355u64;
+        let pl14_v6 = seed + 356u64;
+        let pl14_v7 = seed + 357u64;
+        let pl14_v8 = seed + 358u64;
+        let pl14_v9 = seed + 359u64;
+        let pl14_v10 = seed + 360u64;
+        let pl14_v11 = seed + 361u64;
+        let pl14_v12 = seed + 362u64;
+        let pl14_v13 = seed + 363u64;
+        let pl14_v14 = seed + 364u64;
+        let pl14_v15 = seed + 365u64;
+        let pl14_v16 = seed + 366u64;
+        let pl14_v17 = seed + 367u64;
+        let pl14_v18 = seed + 368u64;
+        let pl14_v19 = seed + 369u64;
+        let pl14_v20 = seed + 370u64;
+        let pl14_v21 = seed + 371u64;
+        let pl14_v22 = seed + 372u64;
+        let pl14_v23 = seed + 373u64;
+        let pl14_v24 = seed + 374u64;
+        let arr_a = [pl14_v0, pl14_v1, pl14_v2, pl14_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl14_v4 {
+            if acc > pl14_v5 + pl14_v6 {
+                acc = acc + pl14_v7 + pl14_v8 + pl14_v9;
+            } else {
+                acc = acc + pl14_v10 + pl14_v11;
+            }
+        } else {
+            if pl14_v12 > pl14_v13 {
+                acc = acc + pl14_v14 + pl14_v15;
+            } else {
+                acc = acc + pl14_v16 + pl14_v17;
+            }
+        }
+        acc += pl14_v18 / (19u64);
+        acc += pl14_v19 / (20u64);
+        acc += pl14_v20 / (21u64);
+        acc += pl14_v21 / (22u64);
+        acc += pl14_v22 / (23u64);
+        acc += pl14_v23 / (24u64);
+        acc += pl14_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_015(seed: u64) -> u64 {
+        let pl15_v0 = seed + 375u64;
+        let pl15_v1 = seed + 376u64;
+        let pl15_v2 = seed + 377u64;
+        let pl15_v3 = seed + 378u64;
+        let pl15_v4 = seed + 379u64;
+        let pl15_v5 = seed + 380u64;
+        let pl15_v6 = seed + 381u64;
+        let pl15_v7 = seed + 382u64;
+        let pl15_v8 = seed + 383u64;
+        let pl15_v9 = seed + 384u64;
+        let pl15_v10 = seed + 385u64;
+        let pl15_v11 = seed + 386u64;
+        let pl15_v12 = seed + 387u64;
+        let pl15_v13 = seed + 388u64;
+        let pl15_v14 = seed + 389u64;
+        let pl15_v15 = seed + 390u64;
+        let pl15_v16 = seed + 391u64;
+        let pl15_v17 = seed + 392u64;
+        let pl15_v18 = seed + 393u64;
+        let pl15_v19 = seed + 394u64;
+        let pl15_v20 = seed + 395u64;
+        let pl15_v21 = seed + 396u64;
+        let pl15_v22 = seed + 397u64;
+        let pl15_v23 = seed + 398u64;
+        let pl15_v24 = seed + 399u64;
+        let arr_a = [pl15_v0, pl15_v1, pl15_v2, pl15_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl15_v4 {
+            if acc > pl15_v5 + pl15_v6 {
+                acc = acc + pl15_v7 + pl15_v8 + pl15_v9;
+            } else {
+                acc = acc + pl15_v10 + pl15_v11;
+            }
+        } else {
+            if pl15_v12 > pl15_v13 {
+                acc = acc + pl15_v14 + pl15_v15;
+            } else {
+                acc = acc + pl15_v16 + pl15_v17;
+            }
+        }
+        acc += pl15_v18 / (19u64);
+        acc += pl15_v19 / (20u64);
+        acc += pl15_v20 / (21u64);
+        acc += pl15_v21 / (22u64);
+        acc += pl15_v22 / (23u64);
+        acc += pl15_v23 / (24u64);
+        acc += pl15_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_016(seed: u64) -> u64 {
+        let pl16_v0 = seed + 400u64;
+        let pl16_v1 = seed + 401u64;
+        let pl16_v2 = seed + 402u64;
+        let pl16_v3 = seed + 403u64;
+        let pl16_v4 = seed + 404u64;
+        let pl16_v5 = seed + 405u64;
+        let pl16_v6 = seed + 406u64;
+        let pl16_v7 = seed + 407u64;
+        let pl16_v8 = seed + 408u64;
+        let pl16_v9 = seed + 409u64;
+        let pl16_v10 = seed + 410u64;
+        let pl16_v11 = seed + 411u64;
+        let pl16_v12 = seed + 412u64;
+        let pl16_v13 = seed + 413u64;
+        let pl16_v14 = seed + 414u64;
+        let pl16_v15 = seed + 415u64;
+        let pl16_v16 = seed + 416u64;
+        let pl16_v17 = seed + 417u64;
+        let pl16_v18 = seed + 418u64;
+        let pl16_v19 = seed + 419u64;
+        let pl16_v20 = seed + 420u64;
+        let pl16_v21 = seed + 421u64;
+        let pl16_v22 = seed + 422u64;
+        let pl16_v23 = seed + 423u64;
+        let pl16_v24 = seed + 424u64;
+        let arr_a = [pl16_v0, pl16_v1, pl16_v2, pl16_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl16_v4 {
+            if acc > pl16_v5 + pl16_v6 {
+                acc = acc + pl16_v7 + pl16_v8 + pl16_v9;
+            } else {
+                acc = acc + pl16_v10 + pl16_v11;
+            }
+        } else {
+            if pl16_v12 > pl16_v13 {
+                acc = acc + pl16_v14 + pl16_v15;
+            } else {
+                acc = acc + pl16_v16 + pl16_v17;
+            }
+        }
+        acc += pl16_v18 / (19u64);
+        acc += pl16_v19 / (20u64);
+        acc += pl16_v20 / (21u64);
+        acc += pl16_v21 / (22u64);
+        acc += pl16_v22 / (23u64);
+        acc += pl16_v23 / (24u64);
+        acc += pl16_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pl_017(seed: u64) -> u64 {
+        let pl17_v0 = seed + 425u64;
+        let pl17_v1 = seed + 426u64;
+        let pl17_v2 = seed + 427u64;
+        let pl17_v3 = seed + 428u64;
+        let pl17_v4 = seed + 429u64;
+        let pl17_v5 = seed + 430u64;
+        let pl17_v6 = seed + 431u64;
+        let pl17_v7 = seed + 432u64;
+        let pl17_v8 = seed + 433u64;
+        let pl17_v9 = seed + 434u64;
+        let pl17_v10 = seed + 435u64;
+        let pl17_v11 = seed + 436u64;
+        let pl17_v12 = seed + 437u64;
+        let pl17_v13 = seed + 438u64;
+        let pl17_v14 = seed + 439u64;
+        let pl17_v15 = seed + 440u64;
+        let pl17_v16 = seed + 441u64;
+        let pl17_v17 = seed + 442u64;
+        let pl17_v18 = seed + 443u64;
+        let pl17_v19 = seed + 444u64;
+        let pl17_v20 = seed + 445u64;
+        let pl17_v21 = seed + 446u64;
+        let pl17_v22 = seed + 447u64;
+        let pl17_v23 = seed + 448u64;
+        let pl17_v24 = seed + 449u64;
+        let arr_a = [pl17_v0, pl17_v1, pl17_v2, pl17_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pl17_v4 {
+            if acc > pl17_v5 + pl17_v6 {
+                acc = acc + pl17_v7 + pl17_v8 + pl17_v9;
+            } else {
+                acc = acc + pl17_v10 + pl17_v11;
+            }
+        } else {
+            if pl17_v12 > pl17_v13 {
+                acc = acc + pl17_v14 + pl17_v15;
+            } else {
+                acc = acc + pl17_v16 + pl17_v17;
+            }
+        }
+        acc += pl17_v18 / (19u64);
+        acc += pl17_v19 / (20u64);
+        acc += pl17_v20 / (21u64);
+        acc += pl17_v21 / (22u64);
+        acc += pl17_v22 / (23u64);
+        acc += pl17_v23 / (24u64);
+        acc += pl17_v24 / (25u64);
+        return acc;
+    }
+
+    fn aggregate_policy(seed: u64) -> u64 {
+        let acc = seed;
+        acc = bench_primitives.aleo/aggregate_primitives(acc);
+        acc = bench_registry.aleo/aggregate_registry(acc);
+        return acc + 1u64;
+    }
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/primitives/program.json
+++ b/crates/compiler/benchmarks/fixtures/contrived/primitives/program.json
@@ -1,0 +1,7 @@
+{
+    "program": "bench_primitives.aleo",
+    "version": "0.1.0",
+    "description": "",
+    "license": "MIT",
+    "dependencies": []
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/primitives/src/main.leo
+++ b/crates/compiler/benchmarks/fixtures/contrived/primitives/src/main.leo
@@ -1,0 +1,1991 @@
+program bench_primitives.aleo {
+    struct PrItem000 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem001 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem002 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem003 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem004 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem005 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem006 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem007 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem008 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem009 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem010 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem011 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem012 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem013 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem014 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem015 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem016 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem017 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem018 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem019 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem020 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem021 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem022 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem023 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem024 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem025 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem026 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem027 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem028 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem029 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem030 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem031 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem032 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem033 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem034 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem035 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem036 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem037 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem038 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem039 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem040 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem041 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem042 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem043 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem044 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem045 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem046 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem047 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem048 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem049 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem050 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem051 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem052 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem053 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem054 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem055 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem056 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem057 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem058 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem059 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem060 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem061 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem062 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem063 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem064 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem065 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem066 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem067 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem068 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem069 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem070 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem071 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem072 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem073 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem074 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem075 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem076 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem077 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem078 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem079 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem080 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem081 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem082 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem083 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem084 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem085 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem086 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem087 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem088 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem089 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem090 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem091 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem092 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem093 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem094 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem095 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem096 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem097 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem098 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct PrItem099 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    mapping ledger: address => u64;
+    mapping scores: u32 => u64;
+
+    @noupgrade
+    constructor() {}
+
+    fn compute_pr_000(seed: u64) -> u64 {
+        let pr00_v0 = seed + 0u64;
+        let pr00_v1 = seed + 1u64;
+        let pr00_v2 = seed + 2u64;
+        let pr00_v3 = seed + 3u64;
+        let pr00_v4 = seed + 4u64;
+        let pr00_v5 = seed + 5u64;
+        let pr00_v6 = seed + 6u64;
+        let pr00_v7 = seed + 7u64;
+        let pr00_v8 = seed + 8u64;
+        let pr00_v9 = seed + 9u64;
+        let pr00_v10 = seed + 10u64;
+        let pr00_v11 = seed + 11u64;
+        let pr00_v12 = seed + 12u64;
+        let pr00_v13 = seed + 13u64;
+        let pr00_v14 = seed + 14u64;
+        let pr00_v15 = seed + 15u64;
+        let pr00_v16 = seed + 16u64;
+        let pr00_v17 = seed + 17u64;
+        let pr00_v18 = seed + 18u64;
+        let pr00_v19 = seed + 19u64;
+        let pr00_v20 = seed + 20u64;
+        let pr00_v21 = seed + 21u64;
+        let pr00_v22 = seed + 22u64;
+        let pr00_v23 = seed + 23u64;
+        let pr00_v24 = seed + 24u64;
+        let arr_a = [pr00_v0, pr00_v1, pr00_v2, pr00_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr00_v4 {
+            if acc > pr00_v5 + pr00_v6 {
+                acc = acc + pr00_v7 + pr00_v8 + pr00_v9;
+            } else {
+                acc = acc + pr00_v10 + pr00_v11;
+            }
+        } else {
+            if pr00_v12 > pr00_v13 {
+                acc = acc + pr00_v14 + pr00_v15;
+            } else {
+                acc = acc + pr00_v16 + pr00_v17;
+            }
+        }
+        acc += pr00_v18 / (19u64);
+        acc += pr00_v19 / (20u64);
+        acc += pr00_v20 / (21u64);
+        acc += pr00_v21 / (22u64);
+        acc += pr00_v22 / (23u64);
+        acc += pr00_v23 / (24u64);
+        acc += pr00_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_001(seed: u64) -> u64 {
+        let pr01_v0 = seed + 25u64;
+        let pr01_v1 = seed + 26u64;
+        let pr01_v2 = seed + 27u64;
+        let pr01_v3 = seed + 28u64;
+        let pr01_v4 = seed + 29u64;
+        let pr01_v5 = seed + 30u64;
+        let pr01_v6 = seed + 31u64;
+        let pr01_v7 = seed + 32u64;
+        let pr01_v8 = seed + 33u64;
+        let pr01_v9 = seed + 34u64;
+        let pr01_v10 = seed + 35u64;
+        let pr01_v11 = seed + 36u64;
+        let pr01_v12 = seed + 37u64;
+        let pr01_v13 = seed + 38u64;
+        let pr01_v14 = seed + 39u64;
+        let pr01_v15 = seed + 40u64;
+        let pr01_v16 = seed + 41u64;
+        let pr01_v17 = seed + 42u64;
+        let pr01_v18 = seed + 43u64;
+        let pr01_v19 = seed + 44u64;
+        let pr01_v20 = seed + 45u64;
+        let pr01_v21 = seed + 46u64;
+        let pr01_v22 = seed + 47u64;
+        let pr01_v23 = seed + 48u64;
+        let pr01_v24 = seed + 49u64;
+        let arr_a = [pr01_v0, pr01_v1, pr01_v2, pr01_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr01_v4 {
+            if acc > pr01_v5 + pr01_v6 {
+                acc = acc + pr01_v7 + pr01_v8 + pr01_v9;
+            } else {
+                acc = acc + pr01_v10 + pr01_v11;
+            }
+        } else {
+            if pr01_v12 > pr01_v13 {
+                acc = acc + pr01_v14 + pr01_v15;
+            } else {
+                acc = acc + pr01_v16 + pr01_v17;
+            }
+        }
+        acc += pr01_v18 / (19u64);
+        acc += pr01_v19 / (20u64);
+        acc += pr01_v20 / (21u64);
+        acc += pr01_v21 / (22u64);
+        acc += pr01_v22 / (23u64);
+        acc += pr01_v23 / (24u64);
+        acc += pr01_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_002(seed: u64) -> u64 {
+        let pr02_v0 = seed + 50u64;
+        let pr02_v1 = seed + 51u64;
+        let pr02_v2 = seed + 52u64;
+        let pr02_v3 = seed + 53u64;
+        let pr02_v4 = seed + 54u64;
+        let pr02_v5 = seed + 55u64;
+        let pr02_v6 = seed + 56u64;
+        let pr02_v7 = seed + 57u64;
+        let pr02_v8 = seed + 58u64;
+        let pr02_v9 = seed + 59u64;
+        let pr02_v10 = seed + 60u64;
+        let pr02_v11 = seed + 61u64;
+        let pr02_v12 = seed + 62u64;
+        let pr02_v13 = seed + 63u64;
+        let pr02_v14 = seed + 64u64;
+        let pr02_v15 = seed + 65u64;
+        let pr02_v16 = seed + 66u64;
+        let pr02_v17 = seed + 67u64;
+        let pr02_v18 = seed + 68u64;
+        let pr02_v19 = seed + 69u64;
+        let pr02_v20 = seed + 70u64;
+        let pr02_v21 = seed + 71u64;
+        let pr02_v22 = seed + 72u64;
+        let pr02_v23 = seed + 73u64;
+        let pr02_v24 = seed + 74u64;
+        let arr_a = [pr02_v0, pr02_v1, pr02_v2, pr02_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr02_v4 {
+            if acc > pr02_v5 + pr02_v6 {
+                acc = acc + pr02_v7 + pr02_v8 + pr02_v9;
+            } else {
+                acc = acc + pr02_v10 + pr02_v11;
+            }
+        } else {
+            if pr02_v12 > pr02_v13 {
+                acc = acc + pr02_v14 + pr02_v15;
+            } else {
+                acc = acc + pr02_v16 + pr02_v17;
+            }
+        }
+        acc += pr02_v18 / (19u64);
+        acc += pr02_v19 / (20u64);
+        acc += pr02_v20 / (21u64);
+        acc += pr02_v21 / (22u64);
+        acc += pr02_v22 / (23u64);
+        acc += pr02_v23 / (24u64);
+        acc += pr02_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_003(seed: u64) -> u64 {
+        let pr03_v0 = seed + 75u64;
+        let pr03_v1 = seed + 76u64;
+        let pr03_v2 = seed + 77u64;
+        let pr03_v3 = seed + 78u64;
+        let pr03_v4 = seed + 79u64;
+        let pr03_v5 = seed + 80u64;
+        let pr03_v6 = seed + 81u64;
+        let pr03_v7 = seed + 82u64;
+        let pr03_v8 = seed + 83u64;
+        let pr03_v9 = seed + 84u64;
+        let pr03_v10 = seed + 85u64;
+        let pr03_v11 = seed + 86u64;
+        let pr03_v12 = seed + 87u64;
+        let pr03_v13 = seed + 88u64;
+        let pr03_v14 = seed + 89u64;
+        let pr03_v15 = seed + 90u64;
+        let pr03_v16 = seed + 91u64;
+        let pr03_v17 = seed + 92u64;
+        let pr03_v18 = seed + 93u64;
+        let pr03_v19 = seed + 94u64;
+        let pr03_v20 = seed + 95u64;
+        let pr03_v21 = seed + 96u64;
+        let pr03_v22 = seed + 97u64;
+        let pr03_v23 = seed + 98u64;
+        let pr03_v24 = seed + 99u64;
+        let arr_a = [pr03_v0, pr03_v1, pr03_v2, pr03_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr03_v4 {
+            if acc > pr03_v5 + pr03_v6 {
+                acc = acc + pr03_v7 + pr03_v8 + pr03_v9;
+            } else {
+                acc = acc + pr03_v10 + pr03_v11;
+            }
+        } else {
+            if pr03_v12 > pr03_v13 {
+                acc = acc + pr03_v14 + pr03_v15;
+            } else {
+                acc = acc + pr03_v16 + pr03_v17;
+            }
+        }
+        acc += pr03_v18 / (19u64);
+        acc += pr03_v19 / (20u64);
+        acc += pr03_v20 / (21u64);
+        acc += pr03_v21 / (22u64);
+        acc += pr03_v22 / (23u64);
+        acc += pr03_v23 / (24u64);
+        acc += pr03_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_004(seed: u64) -> u64 {
+        let pr04_v0 = seed + 100u64;
+        let pr04_v1 = seed + 101u64;
+        let pr04_v2 = seed + 102u64;
+        let pr04_v3 = seed + 103u64;
+        let pr04_v4 = seed + 104u64;
+        let pr04_v5 = seed + 105u64;
+        let pr04_v6 = seed + 106u64;
+        let pr04_v7 = seed + 107u64;
+        let pr04_v8 = seed + 108u64;
+        let pr04_v9 = seed + 109u64;
+        let pr04_v10 = seed + 110u64;
+        let pr04_v11 = seed + 111u64;
+        let pr04_v12 = seed + 112u64;
+        let pr04_v13 = seed + 113u64;
+        let pr04_v14 = seed + 114u64;
+        let pr04_v15 = seed + 115u64;
+        let pr04_v16 = seed + 116u64;
+        let pr04_v17 = seed + 117u64;
+        let pr04_v18 = seed + 118u64;
+        let pr04_v19 = seed + 119u64;
+        let pr04_v20 = seed + 120u64;
+        let pr04_v21 = seed + 121u64;
+        let pr04_v22 = seed + 122u64;
+        let pr04_v23 = seed + 123u64;
+        let pr04_v24 = seed + 124u64;
+        let arr_a = [pr04_v0, pr04_v1, pr04_v2, pr04_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr04_v4 {
+            if acc > pr04_v5 + pr04_v6 {
+                acc = acc + pr04_v7 + pr04_v8 + pr04_v9;
+            } else {
+                acc = acc + pr04_v10 + pr04_v11;
+            }
+        } else {
+            if pr04_v12 > pr04_v13 {
+                acc = acc + pr04_v14 + pr04_v15;
+            } else {
+                acc = acc + pr04_v16 + pr04_v17;
+            }
+        }
+        acc += pr04_v18 / (19u64);
+        acc += pr04_v19 / (20u64);
+        acc += pr04_v20 / (21u64);
+        acc += pr04_v21 / (22u64);
+        acc += pr04_v22 / (23u64);
+        acc += pr04_v23 / (24u64);
+        acc += pr04_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_005(seed: u64) -> u64 {
+        let pr05_v0 = seed + 125u64;
+        let pr05_v1 = seed + 126u64;
+        let pr05_v2 = seed + 127u64;
+        let pr05_v3 = seed + 128u64;
+        let pr05_v4 = seed + 129u64;
+        let pr05_v5 = seed + 130u64;
+        let pr05_v6 = seed + 131u64;
+        let pr05_v7 = seed + 132u64;
+        let pr05_v8 = seed + 133u64;
+        let pr05_v9 = seed + 134u64;
+        let pr05_v10 = seed + 135u64;
+        let pr05_v11 = seed + 136u64;
+        let pr05_v12 = seed + 137u64;
+        let pr05_v13 = seed + 138u64;
+        let pr05_v14 = seed + 139u64;
+        let pr05_v15 = seed + 140u64;
+        let pr05_v16 = seed + 141u64;
+        let pr05_v17 = seed + 142u64;
+        let pr05_v18 = seed + 143u64;
+        let pr05_v19 = seed + 144u64;
+        let pr05_v20 = seed + 145u64;
+        let pr05_v21 = seed + 146u64;
+        let pr05_v22 = seed + 147u64;
+        let pr05_v23 = seed + 148u64;
+        let pr05_v24 = seed + 149u64;
+        let arr_a = [pr05_v0, pr05_v1, pr05_v2, pr05_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr05_v4 {
+            if acc > pr05_v5 + pr05_v6 {
+                acc = acc + pr05_v7 + pr05_v8 + pr05_v9;
+            } else {
+                acc = acc + pr05_v10 + pr05_v11;
+            }
+        } else {
+            if pr05_v12 > pr05_v13 {
+                acc = acc + pr05_v14 + pr05_v15;
+            } else {
+                acc = acc + pr05_v16 + pr05_v17;
+            }
+        }
+        acc += pr05_v18 / (19u64);
+        acc += pr05_v19 / (20u64);
+        acc += pr05_v20 / (21u64);
+        acc += pr05_v21 / (22u64);
+        acc += pr05_v22 / (23u64);
+        acc += pr05_v23 / (24u64);
+        acc += pr05_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_006(seed: u64) -> u64 {
+        let pr06_v0 = seed + 150u64;
+        let pr06_v1 = seed + 151u64;
+        let pr06_v2 = seed + 152u64;
+        let pr06_v3 = seed + 153u64;
+        let pr06_v4 = seed + 154u64;
+        let pr06_v5 = seed + 155u64;
+        let pr06_v6 = seed + 156u64;
+        let pr06_v7 = seed + 157u64;
+        let pr06_v8 = seed + 158u64;
+        let pr06_v9 = seed + 159u64;
+        let pr06_v10 = seed + 160u64;
+        let pr06_v11 = seed + 161u64;
+        let pr06_v12 = seed + 162u64;
+        let pr06_v13 = seed + 163u64;
+        let pr06_v14 = seed + 164u64;
+        let pr06_v15 = seed + 165u64;
+        let pr06_v16 = seed + 166u64;
+        let pr06_v17 = seed + 167u64;
+        let pr06_v18 = seed + 168u64;
+        let pr06_v19 = seed + 169u64;
+        let pr06_v20 = seed + 170u64;
+        let pr06_v21 = seed + 171u64;
+        let pr06_v22 = seed + 172u64;
+        let pr06_v23 = seed + 173u64;
+        let pr06_v24 = seed + 174u64;
+        let arr_a = [pr06_v0, pr06_v1, pr06_v2, pr06_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr06_v4 {
+            if acc > pr06_v5 + pr06_v6 {
+                acc = acc + pr06_v7 + pr06_v8 + pr06_v9;
+            } else {
+                acc = acc + pr06_v10 + pr06_v11;
+            }
+        } else {
+            if pr06_v12 > pr06_v13 {
+                acc = acc + pr06_v14 + pr06_v15;
+            } else {
+                acc = acc + pr06_v16 + pr06_v17;
+            }
+        }
+        acc += pr06_v18 / (19u64);
+        acc += pr06_v19 / (20u64);
+        acc += pr06_v20 / (21u64);
+        acc += pr06_v21 / (22u64);
+        acc += pr06_v22 / (23u64);
+        acc += pr06_v23 / (24u64);
+        acc += pr06_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_007(seed: u64) -> u64 {
+        let pr07_v0 = seed + 175u64;
+        let pr07_v1 = seed + 176u64;
+        let pr07_v2 = seed + 177u64;
+        let pr07_v3 = seed + 178u64;
+        let pr07_v4 = seed + 179u64;
+        let pr07_v5 = seed + 180u64;
+        let pr07_v6 = seed + 181u64;
+        let pr07_v7 = seed + 182u64;
+        let pr07_v8 = seed + 183u64;
+        let pr07_v9 = seed + 184u64;
+        let pr07_v10 = seed + 185u64;
+        let pr07_v11 = seed + 186u64;
+        let pr07_v12 = seed + 187u64;
+        let pr07_v13 = seed + 188u64;
+        let pr07_v14 = seed + 189u64;
+        let pr07_v15 = seed + 190u64;
+        let pr07_v16 = seed + 191u64;
+        let pr07_v17 = seed + 192u64;
+        let pr07_v18 = seed + 193u64;
+        let pr07_v19 = seed + 194u64;
+        let pr07_v20 = seed + 195u64;
+        let pr07_v21 = seed + 196u64;
+        let pr07_v22 = seed + 197u64;
+        let pr07_v23 = seed + 198u64;
+        let pr07_v24 = seed + 199u64;
+        let arr_a = [pr07_v0, pr07_v1, pr07_v2, pr07_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr07_v4 {
+            if acc > pr07_v5 + pr07_v6 {
+                acc = acc + pr07_v7 + pr07_v8 + pr07_v9;
+            } else {
+                acc = acc + pr07_v10 + pr07_v11;
+            }
+        } else {
+            if pr07_v12 > pr07_v13 {
+                acc = acc + pr07_v14 + pr07_v15;
+            } else {
+                acc = acc + pr07_v16 + pr07_v17;
+            }
+        }
+        acc += pr07_v18 / (19u64);
+        acc += pr07_v19 / (20u64);
+        acc += pr07_v20 / (21u64);
+        acc += pr07_v21 / (22u64);
+        acc += pr07_v22 / (23u64);
+        acc += pr07_v23 / (24u64);
+        acc += pr07_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_008(seed: u64) -> u64 {
+        let pr08_v0 = seed + 200u64;
+        let pr08_v1 = seed + 201u64;
+        let pr08_v2 = seed + 202u64;
+        let pr08_v3 = seed + 203u64;
+        let pr08_v4 = seed + 204u64;
+        let pr08_v5 = seed + 205u64;
+        let pr08_v6 = seed + 206u64;
+        let pr08_v7 = seed + 207u64;
+        let pr08_v8 = seed + 208u64;
+        let pr08_v9 = seed + 209u64;
+        let pr08_v10 = seed + 210u64;
+        let pr08_v11 = seed + 211u64;
+        let pr08_v12 = seed + 212u64;
+        let pr08_v13 = seed + 213u64;
+        let pr08_v14 = seed + 214u64;
+        let pr08_v15 = seed + 215u64;
+        let pr08_v16 = seed + 216u64;
+        let pr08_v17 = seed + 217u64;
+        let pr08_v18 = seed + 218u64;
+        let pr08_v19 = seed + 219u64;
+        let pr08_v20 = seed + 220u64;
+        let pr08_v21 = seed + 221u64;
+        let pr08_v22 = seed + 222u64;
+        let pr08_v23 = seed + 223u64;
+        let pr08_v24 = seed + 224u64;
+        let arr_a = [pr08_v0, pr08_v1, pr08_v2, pr08_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr08_v4 {
+            if acc > pr08_v5 + pr08_v6 {
+                acc = acc + pr08_v7 + pr08_v8 + pr08_v9;
+            } else {
+                acc = acc + pr08_v10 + pr08_v11;
+            }
+        } else {
+            if pr08_v12 > pr08_v13 {
+                acc = acc + pr08_v14 + pr08_v15;
+            } else {
+                acc = acc + pr08_v16 + pr08_v17;
+            }
+        }
+        acc += pr08_v18 / (19u64);
+        acc += pr08_v19 / (20u64);
+        acc += pr08_v20 / (21u64);
+        acc += pr08_v21 / (22u64);
+        acc += pr08_v22 / (23u64);
+        acc += pr08_v23 / (24u64);
+        acc += pr08_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_009(seed: u64) -> u64 {
+        let pr09_v0 = seed + 225u64;
+        let pr09_v1 = seed + 226u64;
+        let pr09_v2 = seed + 227u64;
+        let pr09_v3 = seed + 228u64;
+        let pr09_v4 = seed + 229u64;
+        let pr09_v5 = seed + 230u64;
+        let pr09_v6 = seed + 231u64;
+        let pr09_v7 = seed + 232u64;
+        let pr09_v8 = seed + 233u64;
+        let pr09_v9 = seed + 234u64;
+        let pr09_v10 = seed + 235u64;
+        let pr09_v11 = seed + 236u64;
+        let pr09_v12 = seed + 237u64;
+        let pr09_v13 = seed + 238u64;
+        let pr09_v14 = seed + 239u64;
+        let pr09_v15 = seed + 240u64;
+        let pr09_v16 = seed + 241u64;
+        let pr09_v17 = seed + 242u64;
+        let pr09_v18 = seed + 243u64;
+        let pr09_v19 = seed + 244u64;
+        let pr09_v20 = seed + 245u64;
+        let pr09_v21 = seed + 246u64;
+        let pr09_v22 = seed + 247u64;
+        let pr09_v23 = seed + 248u64;
+        let pr09_v24 = seed + 249u64;
+        let arr_a = [pr09_v0, pr09_v1, pr09_v2, pr09_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr09_v4 {
+            if acc > pr09_v5 + pr09_v6 {
+                acc = acc + pr09_v7 + pr09_v8 + pr09_v9;
+            } else {
+                acc = acc + pr09_v10 + pr09_v11;
+            }
+        } else {
+            if pr09_v12 > pr09_v13 {
+                acc = acc + pr09_v14 + pr09_v15;
+            } else {
+                acc = acc + pr09_v16 + pr09_v17;
+            }
+        }
+        acc += pr09_v18 / (19u64);
+        acc += pr09_v19 / (20u64);
+        acc += pr09_v20 / (21u64);
+        acc += pr09_v21 / (22u64);
+        acc += pr09_v22 / (23u64);
+        acc += pr09_v23 / (24u64);
+        acc += pr09_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_010(seed: u64) -> u64 {
+        let pr10_v0 = seed + 250u64;
+        let pr10_v1 = seed + 251u64;
+        let pr10_v2 = seed + 252u64;
+        let pr10_v3 = seed + 253u64;
+        let pr10_v4 = seed + 254u64;
+        let pr10_v5 = seed + 255u64;
+        let pr10_v6 = seed + 256u64;
+        let pr10_v7 = seed + 257u64;
+        let pr10_v8 = seed + 258u64;
+        let pr10_v9 = seed + 259u64;
+        let pr10_v10 = seed + 260u64;
+        let pr10_v11 = seed + 261u64;
+        let pr10_v12 = seed + 262u64;
+        let pr10_v13 = seed + 263u64;
+        let pr10_v14 = seed + 264u64;
+        let pr10_v15 = seed + 265u64;
+        let pr10_v16 = seed + 266u64;
+        let pr10_v17 = seed + 267u64;
+        let pr10_v18 = seed + 268u64;
+        let pr10_v19 = seed + 269u64;
+        let pr10_v20 = seed + 270u64;
+        let pr10_v21 = seed + 271u64;
+        let pr10_v22 = seed + 272u64;
+        let pr10_v23 = seed + 273u64;
+        let pr10_v24 = seed + 274u64;
+        let arr_a = [pr10_v0, pr10_v1, pr10_v2, pr10_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr10_v4 {
+            if acc > pr10_v5 + pr10_v6 {
+                acc = acc + pr10_v7 + pr10_v8 + pr10_v9;
+            } else {
+                acc = acc + pr10_v10 + pr10_v11;
+            }
+        } else {
+            if pr10_v12 > pr10_v13 {
+                acc = acc + pr10_v14 + pr10_v15;
+            } else {
+                acc = acc + pr10_v16 + pr10_v17;
+            }
+        }
+        acc += pr10_v18 / (19u64);
+        acc += pr10_v19 / (20u64);
+        acc += pr10_v20 / (21u64);
+        acc += pr10_v21 / (22u64);
+        acc += pr10_v22 / (23u64);
+        acc += pr10_v23 / (24u64);
+        acc += pr10_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_011(seed: u64) -> u64 {
+        let pr11_v0 = seed + 275u64;
+        let pr11_v1 = seed + 276u64;
+        let pr11_v2 = seed + 277u64;
+        let pr11_v3 = seed + 278u64;
+        let pr11_v4 = seed + 279u64;
+        let pr11_v5 = seed + 280u64;
+        let pr11_v6 = seed + 281u64;
+        let pr11_v7 = seed + 282u64;
+        let pr11_v8 = seed + 283u64;
+        let pr11_v9 = seed + 284u64;
+        let pr11_v10 = seed + 285u64;
+        let pr11_v11 = seed + 286u64;
+        let pr11_v12 = seed + 287u64;
+        let pr11_v13 = seed + 288u64;
+        let pr11_v14 = seed + 289u64;
+        let pr11_v15 = seed + 290u64;
+        let pr11_v16 = seed + 291u64;
+        let pr11_v17 = seed + 292u64;
+        let pr11_v18 = seed + 293u64;
+        let pr11_v19 = seed + 294u64;
+        let pr11_v20 = seed + 295u64;
+        let pr11_v21 = seed + 296u64;
+        let pr11_v22 = seed + 297u64;
+        let pr11_v23 = seed + 298u64;
+        let pr11_v24 = seed + 299u64;
+        let arr_a = [pr11_v0, pr11_v1, pr11_v2, pr11_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr11_v4 {
+            if acc > pr11_v5 + pr11_v6 {
+                acc = acc + pr11_v7 + pr11_v8 + pr11_v9;
+            } else {
+                acc = acc + pr11_v10 + pr11_v11;
+            }
+        } else {
+            if pr11_v12 > pr11_v13 {
+                acc = acc + pr11_v14 + pr11_v15;
+            } else {
+                acc = acc + pr11_v16 + pr11_v17;
+            }
+        }
+        acc += pr11_v18 / (19u64);
+        acc += pr11_v19 / (20u64);
+        acc += pr11_v20 / (21u64);
+        acc += pr11_v21 / (22u64);
+        acc += pr11_v22 / (23u64);
+        acc += pr11_v23 / (24u64);
+        acc += pr11_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_012(seed: u64) -> u64 {
+        let pr12_v0 = seed + 300u64;
+        let pr12_v1 = seed + 301u64;
+        let pr12_v2 = seed + 302u64;
+        let pr12_v3 = seed + 303u64;
+        let pr12_v4 = seed + 304u64;
+        let pr12_v5 = seed + 305u64;
+        let pr12_v6 = seed + 306u64;
+        let pr12_v7 = seed + 307u64;
+        let pr12_v8 = seed + 308u64;
+        let pr12_v9 = seed + 309u64;
+        let pr12_v10 = seed + 310u64;
+        let pr12_v11 = seed + 311u64;
+        let pr12_v12 = seed + 312u64;
+        let pr12_v13 = seed + 313u64;
+        let pr12_v14 = seed + 314u64;
+        let pr12_v15 = seed + 315u64;
+        let pr12_v16 = seed + 316u64;
+        let pr12_v17 = seed + 317u64;
+        let pr12_v18 = seed + 318u64;
+        let pr12_v19 = seed + 319u64;
+        let pr12_v20 = seed + 320u64;
+        let pr12_v21 = seed + 321u64;
+        let pr12_v22 = seed + 322u64;
+        let pr12_v23 = seed + 323u64;
+        let pr12_v24 = seed + 324u64;
+        let arr_a = [pr12_v0, pr12_v1, pr12_v2, pr12_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr12_v4 {
+            if acc > pr12_v5 + pr12_v6 {
+                acc = acc + pr12_v7 + pr12_v8 + pr12_v9;
+            } else {
+                acc = acc + pr12_v10 + pr12_v11;
+            }
+        } else {
+            if pr12_v12 > pr12_v13 {
+                acc = acc + pr12_v14 + pr12_v15;
+            } else {
+                acc = acc + pr12_v16 + pr12_v17;
+            }
+        }
+        acc += pr12_v18 / (19u64);
+        acc += pr12_v19 / (20u64);
+        acc += pr12_v20 / (21u64);
+        acc += pr12_v21 / (22u64);
+        acc += pr12_v22 / (23u64);
+        acc += pr12_v23 / (24u64);
+        acc += pr12_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_013(seed: u64) -> u64 {
+        let pr13_v0 = seed + 325u64;
+        let pr13_v1 = seed + 326u64;
+        let pr13_v2 = seed + 327u64;
+        let pr13_v3 = seed + 328u64;
+        let pr13_v4 = seed + 329u64;
+        let pr13_v5 = seed + 330u64;
+        let pr13_v6 = seed + 331u64;
+        let pr13_v7 = seed + 332u64;
+        let pr13_v8 = seed + 333u64;
+        let pr13_v9 = seed + 334u64;
+        let pr13_v10 = seed + 335u64;
+        let pr13_v11 = seed + 336u64;
+        let pr13_v12 = seed + 337u64;
+        let pr13_v13 = seed + 338u64;
+        let pr13_v14 = seed + 339u64;
+        let pr13_v15 = seed + 340u64;
+        let pr13_v16 = seed + 341u64;
+        let pr13_v17 = seed + 342u64;
+        let pr13_v18 = seed + 343u64;
+        let pr13_v19 = seed + 344u64;
+        let pr13_v20 = seed + 345u64;
+        let pr13_v21 = seed + 346u64;
+        let pr13_v22 = seed + 347u64;
+        let pr13_v23 = seed + 348u64;
+        let pr13_v24 = seed + 349u64;
+        let arr_a = [pr13_v0, pr13_v1, pr13_v2, pr13_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr13_v4 {
+            if acc > pr13_v5 + pr13_v6 {
+                acc = acc + pr13_v7 + pr13_v8 + pr13_v9;
+            } else {
+                acc = acc + pr13_v10 + pr13_v11;
+            }
+        } else {
+            if pr13_v12 > pr13_v13 {
+                acc = acc + pr13_v14 + pr13_v15;
+            } else {
+                acc = acc + pr13_v16 + pr13_v17;
+            }
+        }
+        acc += pr13_v18 / (19u64);
+        acc += pr13_v19 / (20u64);
+        acc += pr13_v20 / (21u64);
+        acc += pr13_v21 / (22u64);
+        acc += pr13_v22 / (23u64);
+        acc += pr13_v23 / (24u64);
+        acc += pr13_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_014(seed: u64) -> u64 {
+        let pr14_v0 = seed + 350u64;
+        let pr14_v1 = seed + 351u64;
+        let pr14_v2 = seed + 352u64;
+        let pr14_v3 = seed + 353u64;
+        let pr14_v4 = seed + 354u64;
+        let pr14_v5 = seed + 355u64;
+        let pr14_v6 = seed + 356u64;
+        let pr14_v7 = seed + 357u64;
+        let pr14_v8 = seed + 358u64;
+        let pr14_v9 = seed + 359u64;
+        let pr14_v10 = seed + 360u64;
+        let pr14_v11 = seed + 361u64;
+        let pr14_v12 = seed + 362u64;
+        let pr14_v13 = seed + 363u64;
+        let pr14_v14 = seed + 364u64;
+        let pr14_v15 = seed + 365u64;
+        let pr14_v16 = seed + 366u64;
+        let pr14_v17 = seed + 367u64;
+        let pr14_v18 = seed + 368u64;
+        let pr14_v19 = seed + 369u64;
+        let pr14_v20 = seed + 370u64;
+        let pr14_v21 = seed + 371u64;
+        let pr14_v22 = seed + 372u64;
+        let pr14_v23 = seed + 373u64;
+        let pr14_v24 = seed + 374u64;
+        let arr_a = [pr14_v0, pr14_v1, pr14_v2, pr14_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr14_v4 {
+            if acc > pr14_v5 + pr14_v6 {
+                acc = acc + pr14_v7 + pr14_v8 + pr14_v9;
+            } else {
+                acc = acc + pr14_v10 + pr14_v11;
+            }
+        } else {
+            if pr14_v12 > pr14_v13 {
+                acc = acc + pr14_v14 + pr14_v15;
+            } else {
+                acc = acc + pr14_v16 + pr14_v17;
+            }
+        }
+        acc += pr14_v18 / (19u64);
+        acc += pr14_v19 / (20u64);
+        acc += pr14_v20 / (21u64);
+        acc += pr14_v21 / (22u64);
+        acc += pr14_v22 / (23u64);
+        acc += pr14_v23 / (24u64);
+        acc += pr14_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_015(seed: u64) -> u64 {
+        let pr15_v0 = seed + 375u64;
+        let pr15_v1 = seed + 376u64;
+        let pr15_v2 = seed + 377u64;
+        let pr15_v3 = seed + 378u64;
+        let pr15_v4 = seed + 379u64;
+        let pr15_v5 = seed + 380u64;
+        let pr15_v6 = seed + 381u64;
+        let pr15_v7 = seed + 382u64;
+        let pr15_v8 = seed + 383u64;
+        let pr15_v9 = seed + 384u64;
+        let pr15_v10 = seed + 385u64;
+        let pr15_v11 = seed + 386u64;
+        let pr15_v12 = seed + 387u64;
+        let pr15_v13 = seed + 388u64;
+        let pr15_v14 = seed + 389u64;
+        let pr15_v15 = seed + 390u64;
+        let pr15_v16 = seed + 391u64;
+        let pr15_v17 = seed + 392u64;
+        let pr15_v18 = seed + 393u64;
+        let pr15_v19 = seed + 394u64;
+        let pr15_v20 = seed + 395u64;
+        let pr15_v21 = seed + 396u64;
+        let pr15_v22 = seed + 397u64;
+        let pr15_v23 = seed + 398u64;
+        let pr15_v24 = seed + 399u64;
+        let arr_a = [pr15_v0, pr15_v1, pr15_v2, pr15_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr15_v4 {
+            if acc > pr15_v5 + pr15_v6 {
+                acc = acc + pr15_v7 + pr15_v8 + pr15_v9;
+            } else {
+                acc = acc + pr15_v10 + pr15_v11;
+            }
+        } else {
+            if pr15_v12 > pr15_v13 {
+                acc = acc + pr15_v14 + pr15_v15;
+            } else {
+                acc = acc + pr15_v16 + pr15_v17;
+            }
+        }
+        acc += pr15_v18 / (19u64);
+        acc += pr15_v19 / (20u64);
+        acc += pr15_v20 / (21u64);
+        acc += pr15_v21 / (22u64);
+        acc += pr15_v22 / (23u64);
+        acc += pr15_v23 / (24u64);
+        acc += pr15_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_016(seed: u64) -> u64 {
+        let pr16_v0 = seed + 400u64;
+        let pr16_v1 = seed + 401u64;
+        let pr16_v2 = seed + 402u64;
+        let pr16_v3 = seed + 403u64;
+        let pr16_v4 = seed + 404u64;
+        let pr16_v5 = seed + 405u64;
+        let pr16_v6 = seed + 406u64;
+        let pr16_v7 = seed + 407u64;
+        let pr16_v8 = seed + 408u64;
+        let pr16_v9 = seed + 409u64;
+        let pr16_v10 = seed + 410u64;
+        let pr16_v11 = seed + 411u64;
+        let pr16_v12 = seed + 412u64;
+        let pr16_v13 = seed + 413u64;
+        let pr16_v14 = seed + 414u64;
+        let pr16_v15 = seed + 415u64;
+        let pr16_v16 = seed + 416u64;
+        let pr16_v17 = seed + 417u64;
+        let pr16_v18 = seed + 418u64;
+        let pr16_v19 = seed + 419u64;
+        let pr16_v20 = seed + 420u64;
+        let pr16_v21 = seed + 421u64;
+        let pr16_v22 = seed + 422u64;
+        let pr16_v23 = seed + 423u64;
+        let pr16_v24 = seed + 424u64;
+        let arr_a = [pr16_v0, pr16_v1, pr16_v2, pr16_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr16_v4 {
+            if acc > pr16_v5 + pr16_v6 {
+                acc = acc + pr16_v7 + pr16_v8 + pr16_v9;
+            } else {
+                acc = acc + pr16_v10 + pr16_v11;
+            }
+        } else {
+            if pr16_v12 > pr16_v13 {
+                acc = acc + pr16_v14 + pr16_v15;
+            } else {
+                acc = acc + pr16_v16 + pr16_v17;
+            }
+        }
+        acc += pr16_v18 / (19u64);
+        acc += pr16_v19 / (20u64);
+        acc += pr16_v20 / (21u64);
+        acc += pr16_v21 / (22u64);
+        acc += pr16_v22 / (23u64);
+        acc += pr16_v23 / (24u64);
+        acc += pr16_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_017(seed: u64) -> u64 {
+        let pr17_v0 = seed + 425u64;
+        let pr17_v1 = seed + 426u64;
+        let pr17_v2 = seed + 427u64;
+        let pr17_v3 = seed + 428u64;
+        let pr17_v4 = seed + 429u64;
+        let pr17_v5 = seed + 430u64;
+        let pr17_v6 = seed + 431u64;
+        let pr17_v7 = seed + 432u64;
+        let pr17_v8 = seed + 433u64;
+        let pr17_v9 = seed + 434u64;
+        let pr17_v10 = seed + 435u64;
+        let pr17_v11 = seed + 436u64;
+        let pr17_v12 = seed + 437u64;
+        let pr17_v13 = seed + 438u64;
+        let pr17_v14 = seed + 439u64;
+        let pr17_v15 = seed + 440u64;
+        let pr17_v16 = seed + 441u64;
+        let pr17_v17 = seed + 442u64;
+        let pr17_v18 = seed + 443u64;
+        let pr17_v19 = seed + 444u64;
+        let pr17_v20 = seed + 445u64;
+        let pr17_v21 = seed + 446u64;
+        let pr17_v22 = seed + 447u64;
+        let pr17_v23 = seed + 448u64;
+        let pr17_v24 = seed + 449u64;
+        let arr_a = [pr17_v0, pr17_v1, pr17_v2, pr17_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr17_v4 {
+            if acc > pr17_v5 + pr17_v6 {
+                acc = acc + pr17_v7 + pr17_v8 + pr17_v9;
+            } else {
+                acc = acc + pr17_v10 + pr17_v11;
+            }
+        } else {
+            if pr17_v12 > pr17_v13 {
+                acc = acc + pr17_v14 + pr17_v15;
+            } else {
+                acc = acc + pr17_v16 + pr17_v17;
+            }
+        }
+        acc += pr17_v18 / (19u64);
+        acc += pr17_v19 / (20u64);
+        acc += pr17_v20 / (21u64);
+        acc += pr17_v21 / (22u64);
+        acc += pr17_v22 / (23u64);
+        acc += pr17_v23 / (24u64);
+        acc += pr17_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_018(seed: u64) -> u64 {
+        let pr18_v0 = seed + 450u64;
+        let pr18_v1 = seed + 451u64;
+        let pr18_v2 = seed + 452u64;
+        let pr18_v3 = seed + 453u64;
+        let pr18_v4 = seed + 454u64;
+        let pr18_v5 = seed + 455u64;
+        let pr18_v6 = seed + 456u64;
+        let pr18_v7 = seed + 457u64;
+        let pr18_v8 = seed + 458u64;
+        let pr18_v9 = seed + 459u64;
+        let pr18_v10 = seed + 460u64;
+        let pr18_v11 = seed + 461u64;
+        let pr18_v12 = seed + 462u64;
+        let pr18_v13 = seed + 463u64;
+        let pr18_v14 = seed + 464u64;
+        let pr18_v15 = seed + 465u64;
+        let pr18_v16 = seed + 466u64;
+        let pr18_v17 = seed + 467u64;
+        let pr18_v18 = seed + 468u64;
+        let pr18_v19 = seed + 469u64;
+        let pr18_v20 = seed + 470u64;
+        let pr18_v21 = seed + 471u64;
+        let pr18_v22 = seed + 472u64;
+        let pr18_v23 = seed + 473u64;
+        let pr18_v24 = seed + 474u64;
+        let arr_a = [pr18_v0, pr18_v1, pr18_v2, pr18_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr18_v4 {
+            if acc > pr18_v5 + pr18_v6 {
+                acc = acc + pr18_v7 + pr18_v8 + pr18_v9;
+            } else {
+                acc = acc + pr18_v10 + pr18_v11;
+            }
+        } else {
+            if pr18_v12 > pr18_v13 {
+                acc = acc + pr18_v14 + pr18_v15;
+            } else {
+                acc = acc + pr18_v16 + pr18_v17;
+            }
+        }
+        acc += pr18_v18 / (19u64);
+        acc += pr18_v19 / (20u64);
+        acc += pr18_v20 / (21u64);
+        acc += pr18_v21 / (22u64);
+        acc += pr18_v22 / (23u64);
+        acc += pr18_v23 / (24u64);
+        acc += pr18_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_pr_019(seed: u64) -> u64 {
+        let pr19_v0 = seed + 475u64;
+        let pr19_v1 = seed + 476u64;
+        let pr19_v2 = seed + 477u64;
+        let pr19_v3 = seed + 478u64;
+        let pr19_v4 = seed + 479u64;
+        let pr19_v5 = seed + 480u64;
+        let pr19_v6 = seed + 481u64;
+        let pr19_v7 = seed + 482u64;
+        let pr19_v8 = seed + 483u64;
+        let pr19_v9 = seed + 484u64;
+        let pr19_v10 = seed + 485u64;
+        let pr19_v11 = seed + 486u64;
+        let pr19_v12 = seed + 487u64;
+        let pr19_v13 = seed + 488u64;
+        let pr19_v14 = seed + 489u64;
+        let pr19_v15 = seed + 490u64;
+        let pr19_v16 = seed + 491u64;
+        let pr19_v17 = seed + 492u64;
+        let pr19_v18 = seed + 493u64;
+        let pr19_v19 = seed + 494u64;
+        let pr19_v20 = seed + 495u64;
+        let pr19_v21 = seed + 496u64;
+        let pr19_v22 = seed + 497u64;
+        let pr19_v23 = seed + 498u64;
+        let pr19_v24 = seed + 499u64;
+        let arr_a = [pr19_v0, pr19_v1, pr19_v2, pr19_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > pr19_v4 {
+            if acc > pr19_v5 + pr19_v6 {
+                acc = acc + pr19_v7 + pr19_v8 + pr19_v9;
+            } else {
+                acc = acc + pr19_v10 + pr19_v11;
+            }
+        } else {
+            if pr19_v12 > pr19_v13 {
+                acc = acc + pr19_v14 + pr19_v15;
+            } else {
+                acc = acc + pr19_v16 + pr19_v17;
+            }
+        }
+        acc += pr19_v18 / (19u64);
+        acc += pr19_v19 / (20u64);
+        acc += pr19_v20 / (21u64);
+        acc += pr19_v21 / (22u64);
+        acc += pr19_v22 / (23u64);
+        acc += pr19_v23 / (24u64);
+        acc += pr19_v24 / (25u64);
+        return acc;
+    }
+
+    fn aggregate_primitives(seed: u64) -> u64 {
+        return seed + 1u64;
+    }
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/registry/program.json
+++ b/crates/compiler/benchmarks/fixtures/contrived/registry/program.json
@@ -1,0 +1,13 @@
+{
+    "program": "bench_registry.aleo",
+    "version": "0.1.0",
+    "description": "",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name": "bench_primitives.aleo",
+            "location": "local",
+            "path": "../primitives"
+        }
+    ]
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/registry/src/main.leo
+++ b/crates/compiler/benchmarks/fixtures/contrived/registry/src/main.leo
@@ -1,0 +1,2067 @@
+import bench_primitives.aleo;
+
+program bench_registry.aleo {
+    struct RgItem000 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem001 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem002 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem003 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem004 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem005 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem006 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem007 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem008 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem009 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem010 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem011 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem012 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem013 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem014 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem015 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem016 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem017 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem018 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem019 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem020 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem021 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem022 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem023 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem024 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem025 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem026 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem027 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem028 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem029 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem030 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem031 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem032 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem033 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem034 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem035 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem036 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem037 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem038 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem039 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem040 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem041 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem042 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem043 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem044 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem045 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem046 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem047 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem048 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem049 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem050 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem051 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem052 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem053 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem054 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem055 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem056 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem057 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem058 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem059 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem060 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem061 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem062 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem063 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem064 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem065 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem066 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem067 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem068 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem069 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem070 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem071 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem072 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem073 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem074 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem075 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem076 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem077 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem078 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem079 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem080 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem081 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem082 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem083 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem084 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem085 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem086 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem087 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem088 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem089 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem090 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem091 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem092 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem093 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem094 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem095 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem096 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem097 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem098 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem099 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem100 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem101 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem102 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem103 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem104 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem105 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem106 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem107 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem108 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem109 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem110 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem111 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem112 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem113 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem114 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem115 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem116 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem117 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem118 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RgItem119 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    mapping ledger: address => u64;
+    mapping scores: u32 => u64;
+
+    @noupgrade
+    constructor() {}
+
+    fn compute_rg_000(seed: u64) -> u64 {
+        let rg00_v0 = seed + 0u64;
+        let rg00_v1 = seed + 1u64;
+        let rg00_v2 = seed + 2u64;
+        let rg00_v3 = seed + 3u64;
+        let rg00_v4 = seed + 4u64;
+        let rg00_v5 = seed + 5u64;
+        let rg00_v6 = seed + 6u64;
+        let rg00_v7 = seed + 7u64;
+        let rg00_v8 = seed + 8u64;
+        let rg00_v9 = seed + 9u64;
+        let rg00_v10 = seed + 10u64;
+        let rg00_v11 = seed + 11u64;
+        let rg00_v12 = seed + 12u64;
+        let rg00_v13 = seed + 13u64;
+        let rg00_v14 = seed + 14u64;
+        let rg00_v15 = seed + 15u64;
+        let rg00_v16 = seed + 16u64;
+        let rg00_v17 = seed + 17u64;
+        let rg00_v18 = seed + 18u64;
+        let rg00_v19 = seed + 19u64;
+        let rg00_v20 = seed + 20u64;
+        let rg00_v21 = seed + 21u64;
+        let rg00_v22 = seed + 22u64;
+        let rg00_v23 = seed + 23u64;
+        let rg00_v24 = seed + 24u64;
+        let arr_a = [rg00_v0, rg00_v1, rg00_v2, rg00_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg00_v4 {
+            if acc > rg00_v5 + rg00_v6 {
+                acc = acc + rg00_v7 + rg00_v8 + rg00_v9;
+            } else {
+                acc = acc + rg00_v10 + rg00_v11;
+            }
+        } else {
+            if rg00_v12 > rg00_v13 {
+                acc = acc + rg00_v14 + rg00_v15;
+            } else {
+                acc = acc + rg00_v16 + rg00_v17;
+            }
+        }
+        acc += rg00_v18 / (19u64);
+        acc += rg00_v19 / (20u64);
+        acc += rg00_v20 / (21u64);
+        acc += rg00_v21 / (22u64);
+        acc += rg00_v22 / (23u64);
+        acc += rg00_v23 / (24u64);
+        acc += rg00_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_001(seed: u64) -> u64 {
+        let rg01_v0 = seed + 25u64;
+        let rg01_v1 = seed + 26u64;
+        let rg01_v2 = seed + 27u64;
+        let rg01_v3 = seed + 28u64;
+        let rg01_v4 = seed + 29u64;
+        let rg01_v5 = seed + 30u64;
+        let rg01_v6 = seed + 31u64;
+        let rg01_v7 = seed + 32u64;
+        let rg01_v8 = seed + 33u64;
+        let rg01_v9 = seed + 34u64;
+        let rg01_v10 = seed + 35u64;
+        let rg01_v11 = seed + 36u64;
+        let rg01_v12 = seed + 37u64;
+        let rg01_v13 = seed + 38u64;
+        let rg01_v14 = seed + 39u64;
+        let rg01_v15 = seed + 40u64;
+        let rg01_v16 = seed + 41u64;
+        let rg01_v17 = seed + 42u64;
+        let rg01_v18 = seed + 43u64;
+        let rg01_v19 = seed + 44u64;
+        let rg01_v20 = seed + 45u64;
+        let rg01_v21 = seed + 46u64;
+        let rg01_v22 = seed + 47u64;
+        let rg01_v23 = seed + 48u64;
+        let rg01_v24 = seed + 49u64;
+        let arr_a = [rg01_v0, rg01_v1, rg01_v2, rg01_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg01_v4 {
+            if acc > rg01_v5 + rg01_v6 {
+                acc = acc + rg01_v7 + rg01_v8 + rg01_v9;
+            } else {
+                acc = acc + rg01_v10 + rg01_v11;
+            }
+        } else {
+            if rg01_v12 > rg01_v13 {
+                acc = acc + rg01_v14 + rg01_v15;
+            } else {
+                acc = acc + rg01_v16 + rg01_v17;
+            }
+        }
+        acc += rg01_v18 / (19u64);
+        acc += rg01_v19 / (20u64);
+        acc += rg01_v20 / (21u64);
+        acc += rg01_v21 / (22u64);
+        acc += rg01_v22 / (23u64);
+        acc += rg01_v23 / (24u64);
+        acc += rg01_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_002(seed: u64) -> u64 {
+        let rg02_v0 = seed + 50u64;
+        let rg02_v1 = seed + 51u64;
+        let rg02_v2 = seed + 52u64;
+        let rg02_v3 = seed + 53u64;
+        let rg02_v4 = seed + 54u64;
+        let rg02_v5 = seed + 55u64;
+        let rg02_v6 = seed + 56u64;
+        let rg02_v7 = seed + 57u64;
+        let rg02_v8 = seed + 58u64;
+        let rg02_v9 = seed + 59u64;
+        let rg02_v10 = seed + 60u64;
+        let rg02_v11 = seed + 61u64;
+        let rg02_v12 = seed + 62u64;
+        let rg02_v13 = seed + 63u64;
+        let rg02_v14 = seed + 64u64;
+        let rg02_v15 = seed + 65u64;
+        let rg02_v16 = seed + 66u64;
+        let rg02_v17 = seed + 67u64;
+        let rg02_v18 = seed + 68u64;
+        let rg02_v19 = seed + 69u64;
+        let rg02_v20 = seed + 70u64;
+        let rg02_v21 = seed + 71u64;
+        let rg02_v22 = seed + 72u64;
+        let rg02_v23 = seed + 73u64;
+        let rg02_v24 = seed + 74u64;
+        let arr_a = [rg02_v0, rg02_v1, rg02_v2, rg02_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg02_v4 {
+            if acc > rg02_v5 + rg02_v6 {
+                acc = acc + rg02_v7 + rg02_v8 + rg02_v9;
+            } else {
+                acc = acc + rg02_v10 + rg02_v11;
+            }
+        } else {
+            if rg02_v12 > rg02_v13 {
+                acc = acc + rg02_v14 + rg02_v15;
+            } else {
+                acc = acc + rg02_v16 + rg02_v17;
+            }
+        }
+        acc += rg02_v18 / (19u64);
+        acc += rg02_v19 / (20u64);
+        acc += rg02_v20 / (21u64);
+        acc += rg02_v21 / (22u64);
+        acc += rg02_v22 / (23u64);
+        acc += rg02_v23 / (24u64);
+        acc += rg02_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_003(seed: u64) -> u64 {
+        let rg03_v0 = seed + 75u64;
+        let rg03_v1 = seed + 76u64;
+        let rg03_v2 = seed + 77u64;
+        let rg03_v3 = seed + 78u64;
+        let rg03_v4 = seed + 79u64;
+        let rg03_v5 = seed + 80u64;
+        let rg03_v6 = seed + 81u64;
+        let rg03_v7 = seed + 82u64;
+        let rg03_v8 = seed + 83u64;
+        let rg03_v9 = seed + 84u64;
+        let rg03_v10 = seed + 85u64;
+        let rg03_v11 = seed + 86u64;
+        let rg03_v12 = seed + 87u64;
+        let rg03_v13 = seed + 88u64;
+        let rg03_v14 = seed + 89u64;
+        let rg03_v15 = seed + 90u64;
+        let rg03_v16 = seed + 91u64;
+        let rg03_v17 = seed + 92u64;
+        let rg03_v18 = seed + 93u64;
+        let rg03_v19 = seed + 94u64;
+        let rg03_v20 = seed + 95u64;
+        let rg03_v21 = seed + 96u64;
+        let rg03_v22 = seed + 97u64;
+        let rg03_v23 = seed + 98u64;
+        let rg03_v24 = seed + 99u64;
+        let arr_a = [rg03_v0, rg03_v1, rg03_v2, rg03_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg03_v4 {
+            if acc > rg03_v5 + rg03_v6 {
+                acc = acc + rg03_v7 + rg03_v8 + rg03_v9;
+            } else {
+                acc = acc + rg03_v10 + rg03_v11;
+            }
+        } else {
+            if rg03_v12 > rg03_v13 {
+                acc = acc + rg03_v14 + rg03_v15;
+            } else {
+                acc = acc + rg03_v16 + rg03_v17;
+            }
+        }
+        acc += rg03_v18 / (19u64);
+        acc += rg03_v19 / (20u64);
+        acc += rg03_v20 / (21u64);
+        acc += rg03_v21 / (22u64);
+        acc += rg03_v22 / (23u64);
+        acc += rg03_v23 / (24u64);
+        acc += rg03_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_004(seed: u64) -> u64 {
+        let rg04_v0 = seed + 100u64;
+        let rg04_v1 = seed + 101u64;
+        let rg04_v2 = seed + 102u64;
+        let rg04_v3 = seed + 103u64;
+        let rg04_v4 = seed + 104u64;
+        let rg04_v5 = seed + 105u64;
+        let rg04_v6 = seed + 106u64;
+        let rg04_v7 = seed + 107u64;
+        let rg04_v8 = seed + 108u64;
+        let rg04_v9 = seed + 109u64;
+        let rg04_v10 = seed + 110u64;
+        let rg04_v11 = seed + 111u64;
+        let rg04_v12 = seed + 112u64;
+        let rg04_v13 = seed + 113u64;
+        let rg04_v14 = seed + 114u64;
+        let rg04_v15 = seed + 115u64;
+        let rg04_v16 = seed + 116u64;
+        let rg04_v17 = seed + 117u64;
+        let rg04_v18 = seed + 118u64;
+        let rg04_v19 = seed + 119u64;
+        let rg04_v20 = seed + 120u64;
+        let rg04_v21 = seed + 121u64;
+        let rg04_v22 = seed + 122u64;
+        let rg04_v23 = seed + 123u64;
+        let rg04_v24 = seed + 124u64;
+        let arr_a = [rg04_v0, rg04_v1, rg04_v2, rg04_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg04_v4 {
+            if acc > rg04_v5 + rg04_v6 {
+                acc = acc + rg04_v7 + rg04_v8 + rg04_v9;
+            } else {
+                acc = acc + rg04_v10 + rg04_v11;
+            }
+        } else {
+            if rg04_v12 > rg04_v13 {
+                acc = acc + rg04_v14 + rg04_v15;
+            } else {
+                acc = acc + rg04_v16 + rg04_v17;
+            }
+        }
+        acc += rg04_v18 / (19u64);
+        acc += rg04_v19 / (20u64);
+        acc += rg04_v20 / (21u64);
+        acc += rg04_v21 / (22u64);
+        acc += rg04_v22 / (23u64);
+        acc += rg04_v23 / (24u64);
+        acc += rg04_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_005(seed: u64) -> u64 {
+        let rg05_v0 = seed + 125u64;
+        let rg05_v1 = seed + 126u64;
+        let rg05_v2 = seed + 127u64;
+        let rg05_v3 = seed + 128u64;
+        let rg05_v4 = seed + 129u64;
+        let rg05_v5 = seed + 130u64;
+        let rg05_v6 = seed + 131u64;
+        let rg05_v7 = seed + 132u64;
+        let rg05_v8 = seed + 133u64;
+        let rg05_v9 = seed + 134u64;
+        let rg05_v10 = seed + 135u64;
+        let rg05_v11 = seed + 136u64;
+        let rg05_v12 = seed + 137u64;
+        let rg05_v13 = seed + 138u64;
+        let rg05_v14 = seed + 139u64;
+        let rg05_v15 = seed + 140u64;
+        let rg05_v16 = seed + 141u64;
+        let rg05_v17 = seed + 142u64;
+        let rg05_v18 = seed + 143u64;
+        let rg05_v19 = seed + 144u64;
+        let rg05_v20 = seed + 145u64;
+        let rg05_v21 = seed + 146u64;
+        let rg05_v22 = seed + 147u64;
+        let rg05_v23 = seed + 148u64;
+        let rg05_v24 = seed + 149u64;
+        let arr_a = [rg05_v0, rg05_v1, rg05_v2, rg05_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg05_v4 {
+            if acc > rg05_v5 + rg05_v6 {
+                acc = acc + rg05_v7 + rg05_v8 + rg05_v9;
+            } else {
+                acc = acc + rg05_v10 + rg05_v11;
+            }
+        } else {
+            if rg05_v12 > rg05_v13 {
+                acc = acc + rg05_v14 + rg05_v15;
+            } else {
+                acc = acc + rg05_v16 + rg05_v17;
+            }
+        }
+        acc += rg05_v18 / (19u64);
+        acc += rg05_v19 / (20u64);
+        acc += rg05_v20 / (21u64);
+        acc += rg05_v21 / (22u64);
+        acc += rg05_v22 / (23u64);
+        acc += rg05_v23 / (24u64);
+        acc += rg05_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_006(seed: u64) -> u64 {
+        let rg06_v0 = seed + 150u64;
+        let rg06_v1 = seed + 151u64;
+        let rg06_v2 = seed + 152u64;
+        let rg06_v3 = seed + 153u64;
+        let rg06_v4 = seed + 154u64;
+        let rg06_v5 = seed + 155u64;
+        let rg06_v6 = seed + 156u64;
+        let rg06_v7 = seed + 157u64;
+        let rg06_v8 = seed + 158u64;
+        let rg06_v9 = seed + 159u64;
+        let rg06_v10 = seed + 160u64;
+        let rg06_v11 = seed + 161u64;
+        let rg06_v12 = seed + 162u64;
+        let rg06_v13 = seed + 163u64;
+        let rg06_v14 = seed + 164u64;
+        let rg06_v15 = seed + 165u64;
+        let rg06_v16 = seed + 166u64;
+        let rg06_v17 = seed + 167u64;
+        let rg06_v18 = seed + 168u64;
+        let rg06_v19 = seed + 169u64;
+        let rg06_v20 = seed + 170u64;
+        let rg06_v21 = seed + 171u64;
+        let rg06_v22 = seed + 172u64;
+        let rg06_v23 = seed + 173u64;
+        let rg06_v24 = seed + 174u64;
+        let arr_a = [rg06_v0, rg06_v1, rg06_v2, rg06_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg06_v4 {
+            if acc > rg06_v5 + rg06_v6 {
+                acc = acc + rg06_v7 + rg06_v8 + rg06_v9;
+            } else {
+                acc = acc + rg06_v10 + rg06_v11;
+            }
+        } else {
+            if rg06_v12 > rg06_v13 {
+                acc = acc + rg06_v14 + rg06_v15;
+            } else {
+                acc = acc + rg06_v16 + rg06_v17;
+            }
+        }
+        acc += rg06_v18 / (19u64);
+        acc += rg06_v19 / (20u64);
+        acc += rg06_v20 / (21u64);
+        acc += rg06_v21 / (22u64);
+        acc += rg06_v22 / (23u64);
+        acc += rg06_v23 / (24u64);
+        acc += rg06_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_007(seed: u64) -> u64 {
+        let rg07_v0 = seed + 175u64;
+        let rg07_v1 = seed + 176u64;
+        let rg07_v2 = seed + 177u64;
+        let rg07_v3 = seed + 178u64;
+        let rg07_v4 = seed + 179u64;
+        let rg07_v5 = seed + 180u64;
+        let rg07_v6 = seed + 181u64;
+        let rg07_v7 = seed + 182u64;
+        let rg07_v8 = seed + 183u64;
+        let rg07_v9 = seed + 184u64;
+        let rg07_v10 = seed + 185u64;
+        let rg07_v11 = seed + 186u64;
+        let rg07_v12 = seed + 187u64;
+        let rg07_v13 = seed + 188u64;
+        let rg07_v14 = seed + 189u64;
+        let rg07_v15 = seed + 190u64;
+        let rg07_v16 = seed + 191u64;
+        let rg07_v17 = seed + 192u64;
+        let rg07_v18 = seed + 193u64;
+        let rg07_v19 = seed + 194u64;
+        let rg07_v20 = seed + 195u64;
+        let rg07_v21 = seed + 196u64;
+        let rg07_v22 = seed + 197u64;
+        let rg07_v23 = seed + 198u64;
+        let rg07_v24 = seed + 199u64;
+        let arr_a = [rg07_v0, rg07_v1, rg07_v2, rg07_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg07_v4 {
+            if acc > rg07_v5 + rg07_v6 {
+                acc = acc + rg07_v7 + rg07_v8 + rg07_v9;
+            } else {
+                acc = acc + rg07_v10 + rg07_v11;
+            }
+        } else {
+            if rg07_v12 > rg07_v13 {
+                acc = acc + rg07_v14 + rg07_v15;
+            } else {
+                acc = acc + rg07_v16 + rg07_v17;
+            }
+        }
+        acc += rg07_v18 / (19u64);
+        acc += rg07_v19 / (20u64);
+        acc += rg07_v20 / (21u64);
+        acc += rg07_v21 / (22u64);
+        acc += rg07_v22 / (23u64);
+        acc += rg07_v23 / (24u64);
+        acc += rg07_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_008(seed: u64) -> u64 {
+        let rg08_v0 = seed + 200u64;
+        let rg08_v1 = seed + 201u64;
+        let rg08_v2 = seed + 202u64;
+        let rg08_v3 = seed + 203u64;
+        let rg08_v4 = seed + 204u64;
+        let rg08_v5 = seed + 205u64;
+        let rg08_v6 = seed + 206u64;
+        let rg08_v7 = seed + 207u64;
+        let rg08_v8 = seed + 208u64;
+        let rg08_v9 = seed + 209u64;
+        let rg08_v10 = seed + 210u64;
+        let rg08_v11 = seed + 211u64;
+        let rg08_v12 = seed + 212u64;
+        let rg08_v13 = seed + 213u64;
+        let rg08_v14 = seed + 214u64;
+        let rg08_v15 = seed + 215u64;
+        let rg08_v16 = seed + 216u64;
+        let rg08_v17 = seed + 217u64;
+        let rg08_v18 = seed + 218u64;
+        let rg08_v19 = seed + 219u64;
+        let rg08_v20 = seed + 220u64;
+        let rg08_v21 = seed + 221u64;
+        let rg08_v22 = seed + 222u64;
+        let rg08_v23 = seed + 223u64;
+        let rg08_v24 = seed + 224u64;
+        let arr_a = [rg08_v0, rg08_v1, rg08_v2, rg08_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg08_v4 {
+            if acc > rg08_v5 + rg08_v6 {
+                acc = acc + rg08_v7 + rg08_v8 + rg08_v9;
+            } else {
+                acc = acc + rg08_v10 + rg08_v11;
+            }
+        } else {
+            if rg08_v12 > rg08_v13 {
+                acc = acc + rg08_v14 + rg08_v15;
+            } else {
+                acc = acc + rg08_v16 + rg08_v17;
+            }
+        }
+        acc += rg08_v18 / (19u64);
+        acc += rg08_v19 / (20u64);
+        acc += rg08_v20 / (21u64);
+        acc += rg08_v21 / (22u64);
+        acc += rg08_v22 / (23u64);
+        acc += rg08_v23 / (24u64);
+        acc += rg08_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_009(seed: u64) -> u64 {
+        let rg09_v0 = seed + 225u64;
+        let rg09_v1 = seed + 226u64;
+        let rg09_v2 = seed + 227u64;
+        let rg09_v3 = seed + 228u64;
+        let rg09_v4 = seed + 229u64;
+        let rg09_v5 = seed + 230u64;
+        let rg09_v6 = seed + 231u64;
+        let rg09_v7 = seed + 232u64;
+        let rg09_v8 = seed + 233u64;
+        let rg09_v9 = seed + 234u64;
+        let rg09_v10 = seed + 235u64;
+        let rg09_v11 = seed + 236u64;
+        let rg09_v12 = seed + 237u64;
+        let rg09_v13 = seed + 238u64;
+        let rg09_v14 = seed + 239u64;
+        let rg09_v15 = seed + 240u64;
+        let rg09_v16 = seed + 241u64;
+        let rg09_v17 = seed + 242u64;
+        let rg09_v18 = seed + 243u64;
+        let rg09_v19 = seed + 244u64;
+        let rg09_v20 = seed + 245u64;
+        let rg09_v21 = seed + 246u64;
+        let rg09_v22 = seed + 247u64;
+        let rg09_v23 = seed + 248u64;
+        let rg09_v24 = seed + 249u64;
+        let arr_a = [rg09_v0, rg09_v1, rg09_v2, rg09_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg09_v4 {
+            if acc > rg09_v5 + rg09_v6 {
+                acc = acc + rg09_v7 + rg09_v8 + rg09_v9;
+            } else {
+                acc = acc + rg09_v10 + rg09_v11;
+            }
+        } else {
+            if rg09_v12 > rg09_v13 {
+                acc = acc + rg09_v14 + rg09_v15;
+            } else {
+                acc = acc + rg09_v16 + rg09_v17;
+            }
+        }
+        acc += rg09_v18 / (19u64);
+        acc += rg09_v19 / (20u64);
+        acc += rg09_v20 / (21u64);
+        acc += rg09_v21 / (22u64);
+        acc += rg09_v22 / (23u64);
+        acc += rg09_v23 / (24u64);
+        acc += rg09_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_010(seed: u64) -> u64 {
+        let rg10_v0 = seed + 250u64;
+        let rg10_v1 = seed + 251u64;
+        let rg10_v2 = seed + 252u64;
+        let rg10_v3 = seed + 253u64;
+        let rg10_v4 = seed + 254u64;
+        let rg10_v5 = seed + 255u64;
+        let rg10_v6 = seed + 256u64;
+        let rg10_v7 = seed + 257u64;
+        let rg10_v8 = seed + 258u64;
+        let rg10_v9 = seed + 259u64;
+        let rg10_v10 = seed + 260u64;
+        let rg10_v11 = seed + 261u64;
+        let rg10_v12 = seed + 262u64;
+        let rg10_v13 = seed + 263u64;
+        let rg10_v14 = seed + 264u64;
+        let rg10_v15 = seed + 265u64;
+        let rg10_v16 = seed + 266u64;
+        let rg10_v17 = seed + 267u64;
+        let rg10_v18 = seed + 268u64;
+        let rg10_v19 = seed + 269u64;
+        let rg10_v20 = seed + 270u64;
+        let rg10_v21 = seed + 271u64;
+        let rg10_v22 = seed + 272u64;
+        let rg10_v23 = seed + 273u64;
+        let rg10_v24 = seed + 274u64;
+        let arr_a = [rg10_v0, rg10_v1, rg10_v2, rg10_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg10_v4 {
+            if acc > rg10_v5 + rg10_v6 {
+                acc = acc + rg10_v7 + rg10_v8 + rg10_v9;
+            } else {
+                acc = acc + rg10_v10 + rg10_v11;
+            }
+        } else {
+            if rg10_v12 > rg10_v13 {
+                acc = acc + rg10_v14 + rg10_v15;
+            } else {
+                acc = acc + rg10_v16 + rg10_v17;
+            }
+        }
+        acc += rg10_v18 / (19u64);
+        acc += rg10_v19 / (20u64);
+        acc += rg10_v20 / (21u64);
+        acc += rg10_v21 / (22u64);
+        acc += rg10_v22 / (23u64);
+        acc += rg10_v23 / (24u64);
+        acc += rg10_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_011(seed: u64) -> u64 {
+        let rg11_v0 = seed + 275u64;
+        let rg11_v1 = seed + 276u64;
+        let rg11_v2 = seed + 277u64;
+        let rg11_v3 = seed + 278u64;
+        let rg11_v4 = seed + 279u64;
+        let rg11_v5 = seed + 280u64;
+        let rg11_v6 = seed + 281u64;
+        let rg11_v7 = seed + 282u64;
+        let rg11_v8 = seed + 283u64;
+        let rg11_v9 = seed + 284u64;
+        let rg11_v10 = seed + 285u64;
+        let rg11_v11 = seed + 286u64;
+        let rg11_v12 = seed + 287u64;
+        let rg11_v13 = seed + 288u64;
+        let rg11_v14 = seed + 289u64;
+        let rg11_v15 = seed + 290u64;
+        let rg11_v16 = seed + 291u64;
+        let rg11_v17 = seed + 292u64;
+        let rg11_v18 = seed + 293u64;
+        let rg11_v19 = seed + 294u64;
+        let rg11_v20 = seed + 295u64;
+        let rg11_v21 = seed + 296u64;
+        let rg11_v22 = seed + 297u64;
+        let rg11_v23 = seed + 298u64;
+        let rg11_v24 = seed + 299u64;
+        let arr_a = [rg11_v0, rg11_v1, rg11_v2, rg11_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg11_v4 {
+            if acc > rg11_v5 + rg11_v6 {
+                acc = acc + rg11_v7 + rg11_v8 + rg11_v9;
+            } else {
+                acc = acc + rg11_v10 + rg11_v11;
+            }
+        } else {
+            if rg11_v12 > rg11_v13 {
+                acc = acc + rg11_v14 + rg11_v15;
+            } else {
+                acc = acc + rg11_v16 + rg11_v17;
+            }
+        }
+        acc += rg11_v18 / (19u64);
+        acc += rg11_v19 / (20u64);
+        acc += rg11_v20 / (21u64);
+        acc += rg11_v21 / (22u64);
+        acc += rg11_v22 / (23u64);
+        acc += rg11_v23 / (24u64);
+        acc += rg11_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_012(seed: u64) -> u64 {
+        let rg12_v0 = seed + 300u64;
+        let rg12_v1 = seed + 301u64;
+        let rg12_v2 = seed + 302u64;
+        let rg12_v3 = seed + 303u64;
+        let rg12_v4 = seed + 304u64;
+        let rg12_v5 = seed + 305u64;
+        let rg12_v6 = seed + 306u64;
+        let rg12_v7 = seed + 307u64;
+        let rg12_v8 = seed + 308u64;
+        let rg12_v9 = seed + 309u64;
+        let rg12_v10 = seed + 310u64;
+        let rg12_v11 = seed + 311u64;
+        let rg12_v12 = seed + 312u64;
+        let rg12_v13 = seed + 313u64;
+        let rg12_v14 = seed + 314u64;
+        let rg12_v15 = seed + 315u64;
+        let rg12_v16 = seed + 316u64;
+        let rg12_v17 = seed + 317u64;
+        let rg12_v18 = seed + 318u64;
+        let rg12_v19 = seed + 319u64;
+        let rg12_v20 = seed + 320u64;
+        let rg12_v21 = seed + 321u64;
+        let rg12_v22 = seed + 322u64;
+        let rg12_v23 = seed + 323u64;
+        let rg12_v24 = seed + 324u64;
+        let arr_a = [rg12_v0, rg12_v1, rg12_v2, rg12_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg12_v4 {
+            if acc > rg12_v5 + rg12_v6 {
+                acc = acc + rg12_v7 + rg12_v8 + rg12_v9;
+            } else {
+                acc = acc + rg12_v10 + rg12_v11;
+            }
+        } else {
+            if rg12_v12 > rg12_v13 {
+                acc = acc + rg12_v14 + rg12_v15;
+            } else {
+                acc = acc + rg12_v16 + rg12_v17;
+            }
+        }
+        acc += rg12_v18 / (19u64);
+        acc += rg12_v19 / (20u64);
+        acc += rg12_v20 / (21u64);
+        acc += rg12_v21 / (22u64);
+        acc += rg12_v22 / (23u64);
+        acc += rg12_v23 / (24u64);
+        acc += rg12_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_013(seed: u64) -> u64 {
+        let rg13_v0 = seed + 325u64;
+        let rg13_v1 = seed + 326u64;
+        let rg13_v2 = seed + 327u64;
+        let rg13_v3 = seed + 328u64;
+        let rg13_v4 = seed + 329u64;
+        let rg13_v5 = seed + 330u64;
+        let rg13_v6 = seed + 331u64;
+        let rg13_v7 = seed + 332u64;
+        let rg13_v8 = seed + 333u64;
+        let rg13_v9 = seed + 334u64;
+        let rg13_v10 = seed + 335u64;
+        let rg13_v11 = seed + 336u64;
+        let rg13_v12 = seed + 337u64;
+        let rg13_v13 = seed + 338u64;
+        let rg13_v14 = seed + 339u64;
+        let rg13_v15 = seed + 340u64;
+        let rg13_v16 = seed + 341u64;
+        let rg13_v17 = seed + 342u64;
+        let rg13_v18 = seed + 343u64;
+        let rg13_v19 = seed + 344u64;
+        let rg13_v20 = seed + 345u64;
+        let rg13_v21 = seed + 346u64;
+        let rg13_v22 = seed + 347u64;
+        let rg13_v23 = seed + 348u64;
+        let rg13_v24 = seed + 349u64;
+        let arr_a = [rg13_v0, rg13_v1, rg13_v2, rg13_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg13_v4 {
+            if acc > rg13_v5 + rg13_v6 {
+                acc = acc + rg13_v7 + rg13_v8 + rg13_v9;
+            } else {
+                acc = acc + rg13_v10 + rg13_v11;
+            }
+        } else {
+            if rg13_v12 > rg13_v13 {
+                acc = acc + rg13_v14 + rg13_v15;
+            } else {
+                acc = acc + rg13_v16 + rg13_v17;
+            }
+        }
+        acc += rg13_v18 / (19u64);
+        acc += rg13_v19 / (20u64);
+        acc += rg13_v20 / (21u64);
+        acc += rg13_v21 / (22u64);
+        acc += rg13_v22 / (23u64);
+        acc += rg13_v23 / (24u64);
+        acc += rg13_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_014(seed: u64) -> u64 {
+        let rg14_v0 = seed + 350u64;
+        let rg14_v1 = seed + 351u64;
+        let rg14_v2 = seed + 352u64;
+        let rg14_v3 = seed + 353u64;
+        let rg14_v4 = seed + 354u64;
+        let rg14_v5 = seed + 355u64;
+        let rg14_v6 = seed + 356u64;
+        let rg14_v7 = seed + 357u64;
+        let rg14_v8 = seed + 358u64;
+        let rg14_v9 = seed + 359u64;
+        let rg14_v10 = seed + 360u64;
+        let rg14_v11 = seed + 361u64;
+        let rg14_v12 = seed + 362u64;
+        let rg14_v13 = seed + 363u64;
+        let rg14_v14 = seed + 364u64;
+        let rg14_v15 = seed + 365u64;
+        let rg14_v16 = seed + 366u64;
+        let rg14_v17 = seed + 367u64;
+        let rg14_v18 = seed + 368u64;
+        let rg14_v19 = seed + 369u64;
+        let rg14_v20 = seed + 370u64;
+        let rg14_v21 = seed + 371u64;
+        let rg14_v22 = seed + 372u64;
+        let rg14_v23 = seed + 373u64;
+        let rg14_v24 = seed + 374u64;
+        let arr_a = [rg14_v0, rg14_v1, rg14_v2, rg14_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg14_v4 {
+            if acc > rg14_v5 + rg14_v6 {
+                acc = acc + rg14_v7 + rg14_v8 + rg14_v9;
+            } else {
+                acc = acc + rg14_v10 + rg14_v11;
+            }
+        } else {
+            if rg14_v12 > rg14_v13 {
+                acc = acc + rg14_v14 + rg14_v15;
+            } else {
+                acc = acc + rg14_v16 + rg14_v17;
+            }
+        }
+        acc += rg14_v18 / (19u64);
+        acc += rg14_v19 / (20u64);
+        acc += rg14_v20 / (21u64);
+        acc += rg14_v21 / (22u64);
+        acc += rg14_v22 / (23u64);
+        acc += rg14_v23 / (24u64);
+        acc += rg14_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_015(seed: u64) -> u64 {
+        let rg15_v0 = seed + 375u64;
+        let rg15_v1 = seed + 376u64;
+        let rg15_v2 = seed + 377u64;
+        let rg15_v3 = seed + 378u64;
+        let rg15_v4 = seed + 379u64;
+        let rg15_v5 = seed + 380u64;
+        let rg15_v6 = seed + 381u64;
+        let rg15_v7 = seed + 382u64;
+        let rg15_v8 = seed + 383u64;
+        let rg15_v9 = seed + 384u64;
+        let rg15_v10 = seed + 385u64;
+        let rg15_v11 = seed + 386u64;
+        let rg15_v12 = seed + 387u64;
+        let rg15_v13 = seed + 388u64;
+        let rg15_v14 = seed + 389u64;
+        let rg15_v15 = seed + 390u64;
+        let rg15_v16 = seed + 391u64;
+        let rg15_v17 = seed + 392u64;
+        let rg15_v18 = seed + 393u64;
+        let rg15_v19 = seed + 394u64;
+        let rg15_v20 = seed + 395u64;
+        let rg15_v21 = seed + 396u64;
+        let rg15_v22 = seed + 397u64;
+        let rg15_v23 = seed + 398u64;
+        let rg15_v24 = seed + 399u64;
+        let arr_a = [rg15_v0, rg15_v1, rg15_v2, rg15_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg15_v4 {
+            if acc > rg15_v5 + rg15_v6 {
+                acc = acc + rg15_v7 + rg15_v8 + rg15_v9;
+            } else {
+                acc = acc + rg15_v10 + rg15_v11;
+            }
+        } else {
+            if rg15_v12 > rg15_v13 {
+                acc = acc + rg15_v14 + rg15_v15;
+            } else {
+                acc = acc + rg15_v16 + rg15_v17;
+            }
+        }
+        acc += rg15_v18 / (19u64);
+        acc += rg15_v19 / (20u64);
+        acc += rg15_v20 / (21u64);
+        acc += rg15_v21 / (22u64);
+        acc += rg15_v22 / (23u64);
+        acc += rg15_v23 / (24u64);
+        acc += rg15_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_016(seed: u64) -> u64 {
+        let rg16_v0 = seed + 400u64;
+        let rg16_v1 = seed + 401u64;
+        let rg16_v2 = seed + 402u64;
+        let rg16_v3 = seed + 403u64;
+        let rg16_v4 = seed + 404u64;
+        let rg16_v5 = seed + 405u64;
+        let rg16_v6 = seed + 406u64;
+        let rg16_v7 = seed + 407u64;
+        let rg16_v8 = seed + 408u64;
+        let rg16_v9 = seed + 409u64;
+        let rg16_v10 = seed + 410u64;
+        let rg16_v11 = seed + 411u64;
+        let rg16_v12 = seed + 412u64;
+        let rg16_v13 = seed + 413u64;
+        let rg16_v14 = seed + 414u64;
+        let rg16_v15 = seed + 415u64;
+        let rg16_v16 = seed + 416u64;
+        let rg16_v17 = seed + 417u64;
+        let rg16_v18 = seed + 418u64;
+        let rg16_v19 = seed + 419u64;
+        let rg16_v20 = seed + 420u64;
+        let rg16_v21 = seed + 421u64;
+        let rg16_v22 = seed + 422u64;
+        let rg16_v23 = seed + 423u64;
+        let rg16_v24 = seed + 424u64;
+        let arr_a = [rg16_v0, rg16_v1, rg16_v2, rg16_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg16_v4 {
+            if acc > rg16_v5 + rg16_v6 {
+                acc = acc + rg16_v7 + rg16_v8 + rg16_v9;
+            } else {
+                acc = acc + rg16_v10 + rg16_v11;
+            }
+        } else {
+            if rg16_v12 > rg16_v13 {
+                acc = acc + rg16_v14 + rg16_v15;
+            } else {
+                acc = acc + rg16_v16 + rg16_v17;
+            }
+        }
+        acc += rg16_v18 / (19u64);
+        acc += rg16_v19 / (20u64);
+        acc += rg16_v20 / (21u64);
+        acc += rg16_v21 / (22u64);
+        acc += rg16_v22 / (23u64);
+        acc += rg16_v23 / (24u64);
+        acc += rg16_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rg_017(seed: u64) -> u64 {
+        let rg17_v0 = seed + 425u64;
+        let rg17_v1 = seed + 426u64;
+        let rg17_v2 = seed + 427u64;
+        let rg17_v3 = seed + 428u64;
+        let rg17_v4 = seed + 429u64;
+        let rg17_v5 = seed + 430u64;
+        let rg17_v6 = seed + 431u64;
+        let rg17_v7 = seed + 432u64;
+        let rg17_v8 = seed + 433u64;
+        let rg17_v9 = seed + 434u64;
+        let rg17_v10 = seed + 435u64;
+        let rg17_v11 = seed + 436u64;
+        let rg17_v12 = seed + 437u64;
+        let rg17_v13 = seed + 438u64;
+        let rg17_v14 = seed + 439u64;
+        let rg17_v15 = seed + 440u64;
+        let rg17_v16 = seed + 441u64;
+        let rg17_v17 = seed + 442u64;
+        let rg17_v18 = seed + 443u64;
+        let rg17_v19 = seed + 444u64;
+        let rg17_v20 = seed + 445u64;
+        let rg17_v21 = seed + 446u64;
+        let rg17_v22 = seed + 447u64;
+        let rg17_v23 = seed + 448u64;
+        let rg17_v24 = seed + 449u64;
+        let arr_a = [rg17_v0, rg17_v1, rg17_v2, rg17_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rg17_v4 {
+            if acc > rg17_v5 + rg17_v6 {
+                acc = acc + rg17_v7 + rg17_v8 + rg17_v9;
+            } else {
+                acc = acc + rg17_v10 + rg17_v11;
+            }
+        } else {
+            if rg17_v12 > rg17_v13 {
+                acc = acc + rg17_v14 + rg17_v15;
+            } else {
+                acc = acc + rg17_v16 + rg17_v17;
+            }
+        }
+        acc += rg17_v18 / (19u64);
+        acc += rg17_v19 / (20u64);
+        acc += rg17_v20 / (21u64);
+        acc += rg17_v21 / (22u64);
+        acc += rg17_v22 / (23u64);
+        acc += rg17_v23 / (24u64);
+        acc += rg17_v24 / (25u64);
+        return acc;
+    }
+
+    fn aggregate_registry(seed: u64) -> u64 {
+        let acc = seed;
+        acc = bench_primitives.aleo/aggregate_primitives(acc);
+        return acc + 1u64;
+    }
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/router/program.json
+++ b/crates/compiler/benchmarks/fixtures/contrived/router/program.json
@@ -1,0 +1,23 @@
+{
+    "program": "bench_router.aleo",
+    "version": "0.1.0",
+    "description": "",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name": "bench_primitives.aleo",
+            "location": "local",
+            "path": "../primitives"
+        },
+        {
+            "name": "bench_registry.aleo",
+            "location": "local",
+            "path": "../registry"
+        },
+        {
+            "name": "bench_policy.aleo",
+            "location": "local",
+            "path": "../policy"
+        }
+    ]
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/router/src/main.leo
+++ b/crates/compiler/benchmarks/fixtures/contrived/router/src/main.leo
@@ -1,0 +1,2251 @@
+import bench_primitives.aleo;
+import bench_registry.aleo;
+import bench_policy.aleo;
+
+program bench_router.aleo {
+    struct RtItem000 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem001 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem002 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem003 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem004 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem005 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem006 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem007 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem008 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem009 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem010 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem011 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem012 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem013 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem014 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem015 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem016 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem017 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem018 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem019 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem020 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem021 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem022 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem023 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem024 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem025 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem026 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem027 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem028 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem029 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem030 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem031 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem032 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem033 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem034 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem035 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem036 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem037 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem038 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem039 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem040 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem041 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem042 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem043 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem044 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem045 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem046 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem047 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem048 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem049 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem050 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem051 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem052 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem053 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem054 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem055 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem056 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem057 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem058 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem059 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem060 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem061 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem062 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem063 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem064 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem065 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem066 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem067 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem068 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem069 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem070 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem071 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem072 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem073 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem074 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem075 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem076 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem077 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem078 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem079 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem080 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem081 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem082 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem083 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem084 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem085 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem086 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem087 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem088 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem089 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem090 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem091 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem092 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem093 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem094 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem095 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem096 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem097 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem098 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem099 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem100 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem101 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem102 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem103 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem104 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem105 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem106 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem107 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem108 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem109 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem110 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem111 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem112 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem113 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem114 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem115 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem116 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem117 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem118 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem119 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem120 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem121 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem122 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem123 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem124 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem125 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem126 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem127 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem128 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem129 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem130 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem131 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem132 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem133 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem134 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem135 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem136 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem137 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem138 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct RtItem139 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    mapping ledger: address => u64;
+    mapping scores: u32 => u64;
+
+    @noupgrade
+    constructor() {}
+
+    fn compute_rt_000(seed: u64) -> u64 {
+        let rt00_v0 = seed + 0u64;
+        let rt00_v1 = seed + 1u64;
+        let rt00_v2 = seed + 2u64;
+        let rt00_v3 = seed + 3u64;
+        let rt00_v4 = seed + 4u64;
+        let rt00_v5 = seed + 5u64;
+        let rt00_v6 = seed + 6u64;
+        let rt00_v7 = seed + 7u64;
+        let rt00_v8 = seed + 8u64;
+        let rt00_v9 = seed + 9u64;
+        let rt00_v10 = seed + 10u64;
+        let rt00_v11 = seed + 11u64;
+        let rt00_v12 = seed + 12u64;
+        let rt00_v13 = seed + 13u64;
+        let rt00_v14 = seed + 14u64;
+        let rt00_v15 = seed + 15u64;
+        let rt00_v16 = seed + 16u64;
+        let rt00_v17 = seed + 17u64;
+        let rt00_v18 = seed + 18u64;
+        let rt00_v19 = seed + 19u64;
+        let rt00_v20 = seed + 20u64;
+        let rt00_v21 = seed + 21u64;
+        let rt00_v22 = seed + 22u64;
+        let rt00_v23 = seed + 23u64;
+        let rt00_v24 = seed + 24u64;
+        let arr_a = [rt00_v0, rt00_v1, rt00_v2, rt00_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt00_v4 {
+            if acc > rt00_v5 + rt00_v6 {
+                acc = acc + rt00_v7 + rt00_v8 + rt00_v9;
+            } else {
+                acc = acc + rt00_v10 + rt00_v11;
+            }
+        } else {
+            if rt00_v12 > rt00_v13 {
+                acc = acc + rt00_v14 + rt00_v15;
+            } else {
+                acc = acc + rt00_v16 + rt00_v17;
+            }
+        }
+        acc += rt00_v18 / (19u64);
+        acc += rt00_v19 / (20u64);
+        acc += rt00_v20 / (21u64);
+        acc += rt00_v21 / (22u64);
+        acc += rt00_v22 / (23u64);
+        acc += rt00_v23 / (24u64);
+        acc += rt00_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_001(seed: u64) -> u64 {
+        let rt01_v0 = seed + 25u64;
+        let rt01_v1 = seed + 26u64;
+        let rt01_v2 = seed + 27u64;
+        let rt01_v3 = seed + 28u64;
+        let rt01_v4 = seed + 29u64;
+        let rt01_v5 = seed + 30u64;
+        let rt01_v6 = seed + 31u64;
+        let rt01_v7 = seed + 32u64;
+        let rt01_v8 = seed + 33u64;
+        let rt01_v9 = seed + 34u64;
+        let rt01_v10 = seed + 35u64;
+        let rt01_v11 = seed + 36u64;
+        let rt01_v12 = seed + 37u64;
+        let rt01_v13 = seed + 38u64;
+        let rt01_v14 = seed + 39u64;
+        let rt01_v15 = seed + 40u64;
+        let rt01_v16 = seed + 41u64;
+        let rt01_v17 = seed + 42u64;
+        let rt01_v18 = seed + 43u64;
+        let rt01_v19 = seed + 44u64;
+        let rt01_v20 = seed + 45u64;
+        let rt01_v21 = seed + 46u64;
+        let rt01_v22 = seed + 47u64;
+        let rt01_v23 = seed + 48u64;
+        let rt01_v24 = seed + 49u64;
+        let arr_a = [rt01_v0, rt01_v1, rt01_v2, rt01_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt01_v4 {
+            if acc > rt01_v5 + rt01_v6 {
+                acc = acc + rt01_v7 + rt01_v8 + rt01_v9;
+            } else {
+                acc = acc + rt01_v10 + rt01_v11;
+            }
+        } else {
+            if rt01_v12 > rt01_v13 {
+                acc = acc + rt01_v14 + rt01_v15;
+            } else {
+                acc = acc + rt01_v16 + rt01_v17;
+            }
+        }
+        acc += rt01_v18 / (19u64);
+        acc += rt01_v19 / (20u64);
+        acc += rt01_v20 / (21u64);
+        acc += rt01_v21 / (22u64);
+        acc += rt01_v22 / (23u64);
+        acc += rt01_v23 / (24u64);
+        acc += rt01_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_002(seed: u64) -> u64 {
+        let rt02_v0 = seed + 50u64;
+        let rt02_v1 = seed + 51u64;
+        let rt02_v2 = seed + 52u64;
+        let rt02_v3 = seed + 53u64;
+        let rt02_v4 = seed + 54u64;
+        let rt02_v5 = seed + 55u64;
+        let rt02_v6 = seed + 56u64;
+        let rt02_v7 = seed + 57u64;
+        let rt02_v8 = seed + 58u64;
+        let rt02_v9 = seed + 59u64;
+        let rt02_v10 = seed + 60u64;
+        let rt02_v11 = seed + 61u64;
+        let rt02_v12 = seed + 62u64;
+        let rt02_v13 = seed + 63u64;
+        let rt02_v14 = seed + 64u64;
+        let rt02_v15 = seed + 65u64;
+        let rt02_v16 = seed + 66u64;
+        let rt02_v17 = seed + 67u64;
+        let rt02_v18 = seed + 68u64;
+        let rt02_v19 = seed + 69u64;
+        let rt02_v20 = seed + 70u64;
+        let rt02_v21 = seed + 71u64;
+        let rt02_v22 = seed + 72u64;
+        let rt02_v23 = seed + 73u64;
+        let rt02_v24 = seed + 74u64;
+        let arr_a = [rt02_v0, rt02_v1, rt02_v2, rt02_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt02_v4 {
+            if acc > rt02_v5 + rt02_v6 {
+                acc = acc + rt02_v7 + rt02_v8 + rt02_v9;
+            } else {
+                acc = acc + rt02_v10 + rt02_v11;
+            }
+        } else {
+            if rt02_v12 > rt02_v13 {
+                acc = acc + rt02_v14 + rt02_v15;
+            } else {
+                acc = acc + rt02_v16 + rt02_v17;
+            }
+        }
+        acc += rt02_v18 / (19u64);
+        acc += rt02_v19 / (20u64);
+        acc += rt02_v20 / (21u64);
+        acc += rt02_v21 / (22u64);
+        acc += rt02_v22 / (23u64);
+        acc += rt02_v23 / (24u64);
+        acc += rt02_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_003(seed: u64) -> u64 {
+        let rt03_v0 = seed + 75u64;
+        let rt03_v1 = seed + 76u64;
+        let rt03_v2 = seed + 77u64;
+        let rt03_v3 = seed + 78u64;
+        let rt03_v4 = seed + 79u64;
+        let rt03_v5 = seed + 80u64;
+        let rt03_v6 = seed + 81u64;
+        let rt03_v7 = seed + 82u64;
+        let rt03_v8 = seed + 83u64;
+        let rt03_v9 = seed + 84u64;
+        let rt03_v10 = seed + 85u64;
+        let rt03_v11 = seed + 86u64;
+        let rt03_v12 = seed + 87u64;
+        let rt03_v13 = seed + 88u64;
+        let rt03_v14 = seed + 89u64;
+        let rt03_v15 = seed + 90u64;
+        let rt03_v16 = seed + 91u64;
+        let rt03_v17 = seed + 92u64;
+        let rt03_v18 = seed + 93u64;
+        let rt03_v19 = seed + 94u64;
+        let rt03_v20 = seed + 95u64;
+        let rt03_v21 = seed + 96u64;
+        let rt03_v22 = seed + 97u64;
+        let rt03_v23 = seed + 98u64;
+        let rt03_v24 = seed + 99u64;
+        let arr_a = [rt03_v0, rt03_v1, rt03_v2, rt03_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt03_v4 {
+            if acc > rt03_v5 + rt03_v6 {
+                acc = acc + rt03_v7 + rt03_v8 + rt03_v9;
+            } else {
+                acc = acc + rt03_v10 + rt03_v11;
+            }
+        } else {
+            if rt03_v12 > rt03_v13 {
+                acc = acc + rt03_v14 + rt03_v15;
+            } else {
+                acc = acc + rt03_v16 + rt03_v17;
+            }
+        }
+        acc += rt03_v18 / (19u64);
+        acc += rt03_v19 / (20u64);
+        acc += rt03_v20 / (21u64);
+        acc += rt03_v21 / (22u64);
+        acc += rt03_v22 / (23u64);
+        acc += rt03_v23 / (24u64);
+        acc += rt03_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_004(seed: u64) -> u64 {
+        let rt04_v0 = seed + 100u64;
+        let rt04_v1 = seed + 101u64;
+        let rt04_v2 = seed + 102u64;
+        let rt04_v3 = seed + 103u64;
+        let rt04_v4 = seed + 104u64;
+        let rt04_v5 = seed + 105u64;
+        let rt04_v6 = seed + 106u64;
+        let rt04_v7 = seed + 107u64;
+        let rt04_v8 = seed + 108u64;
+        let rt04_v9 = seed + 109u64;
+        let rt04_v10 = seed + 110u64;
+        let rt04_v11 = seed + 111u64;
+        let rt04_v12 = seed + 112u64;
+        let rt04_v13 = seed + 113u64;
+        let rt04_v14 = seed + 114u64;
+        let rt04_v15 = seed + 115u64;
+        let rt04_v16 = seed + 116u64;
+        let rt04_v17 = seed + 117u64;
+        let rt04_v18 = seed + 118u64;
+        let rt04_v19 = seed + 119u64;
+        let rt04_v20 = seed + 120u64;
+        let rt04_v21 = seed + 121u64;
+        let rt04_v22 = seed + 122u64;
+        let rt04_v23 = seed + 123u64;
+        let rt04_v24 = seed + 124u64;
+        let arr_a = [rt04_v0, rt04_v1, rt04_v2, rt04_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt04_v4 {
+            if acc > rt04_v5 + rt04_v6 {
+                acc = acc + rt04_v7 + rt04_v8 + rt04_v9;
+            } else {
+                acc = acc + rt04_v10 + rt04_v11;
+            }
+        } else {
+            if rt04_v12 > rt04_v13 {
+                acc = acc + rt04_v14 + rt04_v15;
+            } else {
+                acc = acc + rt04_v16 + rt04_v17;
+            }
+        }
+        acc += rt04_v18 / (19u64);
+        acc += rt04_v19 / (20u64);
+        acc += rt04_v20 / (21u64);
+        acc += rt04_v21 / (22u64);
+        acc += rt04_v22 / (23u64);
+        acc += rt04_v23 / (24u64);
+        acc += rt04_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_005(seed: u64) -> u64 {
+        let rt05_v0 = seed + 125u64;
+        let rt05_v1 = seed + 126u64;
+        let rt05_v2 = seed + 127u64;
+        let rt05_v3 = seed + 128u64;
+        let rt05_v4 = seed + 129u64;
+        let rt05_v5 = seed + 130u64;
+        let rt05_v6 = seed + 131u64;
+        let rt05_v7 = seed + 132u64;
+        let rt05_v8 = seed + 133u64;
+        let rt05_v9 = seed + 134u64;
+        let rt05_v10 = seed + 135u64;
+        let rt05_v11 = seed + 136u64;
+        let rt05_v12 = seed + 137u64;
+        let rt05_v13 = seed + 138u64;
+        let rt05_v14 = seed + 139u64;
+        let rt05_v15 = seed + 140u64;
+        let rt05_v16 = seed + 141u64;
+        let rt05_v17 = seed + 142u64;
+        let rt05_v18 = seed + 143u64;
+        let rt05_v19 = seed + 144u64;
+        let rt05_v20 = seed + 145u64;
+        let rt05_v21 = seed + 146u64;
+        let rt05_v22 = seed + 147u64;
+        let rt05_v23 = seed + 148u64;
+        let rt05_v24 = seed + 149u64;
+        let arr_a = [rt05_v0, rt05_v1, rt05_v2, rt05_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt05_v4 {
+            if acc > rt05_v5 + rt05_v6 {
+                acc = acc + rt05_v7 + rt05_v8 + rt05_v9;
+            } else {
+                acc = acc + rt05_v10 + rt05_v11;
+            }
+        } else {
+            if rt05_v12 > rt05_v13 {
+                acc = acc + rt05_v14 + rt05_v15;
+            } else {
+                acc = acc + rt05_v16 + rt05_v17;
+            }
+        }
+        acc += rt05_v18 / (19u64);
+        acc += rt05_v19 / (20u64);
+        acc += rt05_v20 / (21u64);
+        acc += rt05_v21 / (22u64);
+        acc += rt05_v22 / (23u64);
+        acc += rt05_v23 / (24u64);
+        acc += rt05_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_006(seed: u64) -> u64 {
+        let rt06_v0 = seed + 150u64;
+        let rt06_v1 = seed + 151u64;
+        let rt06_v2 = seed + 152u64;
+        let rt06_v3 = seed + 153u64;
+        let rt06_v4 = seed + 154u64;
+        let rt06_v5 = seed + 155u64;
+        let rt06_v6 = seed + 156u64;
+        let rt06_v7 = seed + 157u64;
+        let rt06_v8 = seed + 158u64;
+        let rt06_v9 = seed + 159u64;
+        let rt06_v10 = seed + 160u64;
+        let rt06_v11 = seed + 161u64;
+        let rt06_v12 = seed + 162u64;
+        let rt06_v13 = seed + 163u64;
+        let rt06_v14 = seed + 164u64;
+        let rt06_v15 = seed + 165u64;
+        let rt06_v16 = seed + 166u64;
+        let rt06_v17 = seed + 167u64;
+        let rt06_v18 = seed + 168u64;
+        let rt06_v19 = seed + 169u64;
+        let rt06_v20 = seed + 170u64;
+        let rt06_v21 = seed + 171u64;
+        let rt06_v22 = seed + 172u64;
+        let rt06_v23 = seed + 173u64;
+        let rt06_v24 = seed + 174u64;
+        let arr_a = [rt06_v0, rt06_v1, rt06_v2, rt06_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt06_v4 {
+            if acc > rt06_v5 + rt06_v6 {
+                acc = acc + rt06_v7 + rt06_v8 + rt06_v9;
+            } else {
+                acc = acc + rt06_v10 + rt06_v11;
+            }
+        } else {
+            if rt06_v12 > rt06_v13 {
+                acc = acc + rt06_v14 + rt06_v15;
+            } else {
+                acc = acc + rt06_v16 + rt06_v17;
+            }
+        }
+        acc += rt06_v18 / (19u64);
+        acc += rt06_v19 / (20u64);
+        acc += rt06_v20 / (21u64);
+        acc += rt06_v21 / (22u64);
+        acc += rt06_v22 / (23u64);
+        acc += rt06_v23 / (24u64);
+        acc += rt06_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_007(seed: u64) -> u64 {
+        let rt07_v0 = seed + 175u64;
+        let rt07_v1 = seed + 176u64;
+        let rt07_v2 = seed + 177u64;
+        let rt07_v3 = seed + 178u64;
+        let rt07_v4 = seed + 179u64;
+        let rt07_v5 = seed + 180u64;
+        let rt07_v6 = seed + 181u64;
+        let rt07_v7 = seed + 182u64;
+        let rt07_v8 = seed + 183u64;
+        let rt07_v9 = seed + 184u64;
+        let rt07_v10 = seed + 185u64;
+        let rt07_v11 = seed + 186u64;
+        let rt07_v12 = seed + 187u64;
+        let rt07_v13 = seed + 188u64;
+        let rt07_v14 = seed + 189u64;
+        let rt07_v15 = seed + 190u64;
+        let rt07_v16 = seed + 191u64;
+        let rt07_v17 = seed + 192u64;
+        let rt07_v18 = seed + 193u64;
+        let rt07_v19 = seed + 194u64;
+        let rt07_v20 = seed + 195u64;
+        let rt07_v21 = seed + 196u64;
+        let rt07_v22 = seed + 197u64;
+        let rt07_v23 = seed + 198u64;
+        let rt07_v24 = seed + 199u64;
+        let arr_a = [rt07_v0, rt07_v1, rt07_v2, rt07_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt07_v4 {
+            if acc > rt07_v5 + rt07_v6 {
+                acc = acc + rt07_v7 + rt07_v8 + rt07_v9;
+            } else {
+                acc = acc + rt07_v10 + rt07_v11;
+            }
+        } else {
+            if rt07_v12 > rt07_v13 {
+                acc = acc + rt07_v14 + rt07_v15;
+            } else {
+                acc = acc + rt07_v16 + rt07_v17;
+            }
+        }
+        acc += rt07_v18 / (19u64);
+        acc += rt07_v19 / (20u64);
+        acc += rt07_v20 / (21u64);
+        acc += rt07_v21 / (22u64);
+        acc += rt07_v22 / (23u64);
+        acc += rt07_v23 / (24u64);
+        acc += rt07_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_008(seed: u64) -> u64 {
+        let rt08_v0 = seed + 200u64;
+        let rt08_v1 = seed + 201u64;
+        let rt08_v2 = seed + 202u64;
+        let rt08_v3 = seed + 203u64;
+        let rt08_v4 = seed + 204u64;
+        let rt08_v5 = seed + 205u64;
+        let rt08_v6 = seed + 206u64;
+        let rt08_v7 = seed + 207u64;
+        let rt08_v8 = seed + 208u64;
+        let rt08_v9 = seed + 209u64;
+        let rt08_v10 = seed + 210u64;
+        let rt08_v11 = seed + 211u64;
+        let rt08_v12 = seed + 212u64;
+        let rt08_v13 = seed + 213u64;
+        let rt08_v14 = seed + 214u64;
+        let rt08_v15 = seed + 215u64;
+        let rt08_v16 = seed + 216u64;
+        let rt08_v17 = seed + 217u64;
+        let rt08_v18 = seed + 218u64;
+        let rt08_v19 = seed + 219u64;
+        let rt08_v20 = seed + 220u64;
+        let rt08_v21 = seed + 221u64;
+        let rt08_v22 = seed + 222u64;
+        let rt08_v23 = seed + 223u64;
+        let rt08_v24 = seed + 224u64;
+        let arr_a = [rt08_v0, rt08_v1, rt08_v2, rt08_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt08_v4 {
+            if acc > rt08_v5 + rt08_v6 {
+                acc = acc + rt08_v7 + rt08_v8 + rt08_v9;
+            } else {
+                acc = acc + rt08_v10 + rt08_v11;
+            }
+        } else {
+            if rt08_v12 > rt08_v13 {
+                acc = acc + rt08_v14 + rt08_v15;
+            } else {
+                acc = acc + rt08_v16 + rt08_v17;
+            }
+        }
+        acc += rt08_v18 / (19u64);
+        acc += rt08_v19 / (20u64);
+        acc += rt08_v20 / (21u64);
+        acc += rt08_v21 / (22u64);
+        acc += rt08_v22 / (23u64);
+        acc += rt08_v23 / (24u64);
+        acc += rt08_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_009(seed: u64) -> u64 {
+        let rt09_v0 = seed + 225u64;
+        let rt09_v1 = seed + 226u64;
+        let rt09_v2 = seed + 227u64;
+        let rt09_v3 = seed + 228u64;
+        let rt09_v4 = seed + 229u64;
+        let rt09_v5 = seed + 230u64;
+        let rt09_v6 = seed + 231u64;
+        let rt09_v7 = seed + 232u64;
+        let rt09_v8 = seed + 233u64;
+        let rt09_v9 = seed + 234u64;
+        let rt09_v10 = seed + 235u64;
+        let rt09_v11 = seed + 236u64;
+        let rt09_v12 = seed + 237u64;
+        let rt09_v13 = seed + 238u64;
+        let rt09_v14 = seed + 239u64;
+        let rt09_v15 = seed + 240u64;
+        let rt09_v16 = seed + 241u64;
+        let rt09_v17 = seed + 242u64;
+        let rt09_v18 = seed + 243u64;
+        let rt09_v19 = seed + 244u64;
+        let rt09_v20 = seed + 245u64;
+        let rt09_v21 = seed + 246u64;
+        let rt09_v22 = seed + 247u64;
+        let rt09_v23 = seed + 248u64;
+        let rt09_v24 = seed + 249u64;
+        let arr_a = [rt09_v0, rt09_v1, rt09_v2, rt09_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt09_v4 {
+            if acc > rt09_v5 + rt09_v6 {
+                acc = acc + rt09_v7 + rt09_v8 + rt09_v9;
+            } else {
+                acc = acc + rt09_v10 + rt09_v11;
+            }
+        } else {
+            if rt09_v12 > rt09_v13 {
+                acc = acc + rt09_v14 + rt09_v15;
+            } else {
+                acc = acc + rt09_v16 + rt09_v17;
+            }
+        }
+        acc += rt09_v18 / (19u64);
+        acc += rt09_v19 / (20u64);
+        acc += rt09_v20 / (21u64);
+        acc += rt09_v21 / (22u64);
+        acc += rt09_v22 / (23u64);
+        acc += rt09_v23 / (24u64);
+        acc += rt09_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_010(seed: u64) -> u64 {
+        let rt10_v0 = seed + 250u64;
+        let rt10_v1 = seed + 251u64;
+        let rt10_v2 = seed + 252u64;
+        let rt10_v3 = seed + 253u64;
+        let rt10_v4 = seed + 254u64;
+        let rt10_v5 = seed + 255u64;
+        let rt10_v6 = seed + 256u64;
+        let rt10_v7 = seed + 257u64;
+        let rt10_v8 = seed + 258u64;
+        let rt10_v9 = seed + 259u64;
+        let rt10_v10 = seed + 260u64;
+        let rt10_v11 = seed + 261u64;
+        let rt10_v12 = seed + 262u64;
+        let rt10_v13 = seed + 263u64;
+        let rt10_v14 = seed + 264u64;
+        let rt10_v15 = seed + 265u64;
+        let rt10_v16 = seed + 266u64;
+        let rt10_v17 = seed + 267u64;
+        let rt10_v18 = seed + 268u64;
+        let rt10_v19 = seed + 269u64;
+        let rt10_v20 = seed + 270u64;
+        let rt10_v21 = seed + 271u64;
+        let rt10_v22 = seed + 272u64;
+        let rt10_v23 = seed + 273u64;
+        let rt10_v24 = seed + 274u64;
+        let arr_a = [rt10_v0, rt10_v1, rt10_v2, rt10_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt10_v4 {
+            if acc > rt10_v5 + rt10_v6 {
+                acc = acc + rt10_v7 + rt10_v8 + rt10_v9;
+            } else {
+                acc = acc + rt10_v10 + rt10_v11;
+            }
+        } else {
+            if rt10_v12 > rt10_v13 {
+                acc = acc + rt10_v14 + rt10_v15;
+            } else {
+                acc = acc + rt10_v16 + rt10_v17;
+            }
+        }
+        acc += rt10_v18 / (19u64);
+        acc += rt10_v19 / (20u64);
+        acc += rt10_v20 / (21u64);
+        acc += rt10_v21 / (22u64);
+        acc += rt10_v22 / (23u64);
+        acc += rt10_v23 / (24u64);
+        acc += rt10_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_011(seed: u64) -> u64 {
+        let rt11_v0 = seed + 275u64;
+        let rt11_v1 = seed + 276u64;
+        let rt11_v2 = seed + 277u64;
+        let rt11_v3 = seed + 278u64;
+        let rt11_v4 = seed + 279u64;
+        let rt11_v5 = seed + 280u64;
+        let rt11_v6 = seed + 281u64;
+        let rt11_v7 = seed + 282u64;
+        let rt11_v8 = seed + 283u64;
+        let rt11_v9 = seed + 284u64;
+        let rt11_v10 = seed + 285u64;
+        let rt11_v11 = seed + 286u64;
+        let rt11_v12 = seed + 287u64;
+        let rt11_v13 = seed + 288u64;
+        let rt11_v14 = seed + 289u64;
+        let rt11_v15 = seed + 290u64;
+        let rt11_v16 = seed + 291u64;
+        let rt11_v17 = seed + 292u64;
+        let rt11_v18 = seed + 293u64;
+        let rt11_v19 = seed + 294u64;
+        let rt11_v20 = seed + 295u64;
+        let rt11_v21 = seed + 296u64;
+        let rt11_v22 = seed + 297u64;
+        let rt11_v23 = seed + 298u64;
+        let rt11_v24 = seed + 299u64;
+        let arr_a = [rt11_v0, rt11_v1, rt11_v2, rt11_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt11_v4 {
+            if acc > rt11_v5 + rt11_v6 {
+                acc = acc + rt11_v7 + rt11_v8 + rt11_v9;
+            } else {
+                acc = acc + rt11_v10 + rt11_v11;
+            }
+        } else {
+            if rt11_v12 > rt11_v13 {
+                acc = acc + rt11_v14 + rt11_v15;
+            } else {
+                acc = acc + rt11_v16 + rt11_v17;
+            }
+        }
+        acc += rt11_v18 / (19u64);
+        acc += rt11_v19 / (20u64);
+        acc += rt11_v20 / (21u64);
+        acc += rt11_v21 / (22u64);
+        acc += rt11_v22 / (23u64);
+        acc += rt11_v23 / (24u64);
+        acc += rt11_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_012(seed: u64) -> u64 {
+        let rt12_v0 = seed + 300u64;
+        let rt12_v1 = seed + 301u64;
+        let rt12_v2 = seed + 302u64;
+        let rt12_v3 = seed + 303u64;
+        let rt12_v4 = seed + 304u64;
+        let rt12_v5 = seed + 305u64;
+        let rt12_v6 = seed + 306u64;
+        let rt12_v7 = seed + 307u64;
+        let rt12_v8 = seed + 308u64;
+        let rt12_v9 = seed + 309u64;
+        let rt12_v10 = seed + 310u64;
+        let rt12_v11 = seed + 311u64;
+        let rt12_v12 = seed + 312u64;
+        let rt12_v13 = seed + 313u64;
+        let rt12_v14 = seed + 314u64;
+        let rt12_v15 = seed + 315u64;
+        let rt12_v16 = seed + 316u64;
+        let rt12_v17 = seed + 317u64;
+        let rt12_v18 = seed + 318u64;
+        let rt12_v19 = seed + 319u64;
+        let rt12_v20 = seed + 320u64;
+        let rt12_v21 = seed + 321u64;
+        let rt12_v22 = seed + 322u64;
+        let rt12_v23 = seed + 323u64;
+        let rt12_v24 = seed + 324u64;
+        let arr_a = [rt12_v0, rt12_v1, rt12_v2, rt12_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt12_v4 {
+            if acc > rt12_v5 + rt12_v6 {
+                acc = acc + rt12_v7 + rt12_v8 + rt12_v9;
+            } else {
+                acc = acc + rt12_v10 + rt12_v11;
+            }
+        } else {
+            if rt12_v12 > rt12_v13 {
+                acc = acc + rt12_v14 + rt12_v15;
+            } else {
+                acc = acc + rt12_v16 + rt12_v17;
+            }
+        }
+        acc += rt12_v18 / (19u64);
+        acc += rt12_v19 / (20u64);
+        acc += rt12_v20 / (21u64);
+        acc += rt12_v21 / (22u64);
+        acc += rt12_v22 / (23u64);
+        acc += rt12_v23 / (24u64);
+        acc += rt12_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_013(seed: u64) -> u64 {
+        let rt13_v0 = seed + 325u64;
+        let rt13_v1 = seed + 326u64;
+        let rt13_v2 = seed + 327u64;
+        let rt13_v3 = seed + 328u64;
+        let rt13_v4 = seed + 329u64;
+        let rt13_v5 = seed + 330u64;
+        let rt13_v6 = seed + 331u64;
+        let rt13_v7 = seed + 332u64;
+        let rt13_v8 = seed + 333u64;
+        let rt13_v9 = seed + 334u64;
+        let rt13_v10 = seed + 335u64;
+        let rt13_v11 = seed + 336u64;
+        let rt13_v12 = seed + 337u64;
+        let rt13_v13 = seed + 338u64;
+        let rt13_v14 = seed + 339u64;
+        let rt13_v15 = seed + 340u64;
+        let rt13_v16 = seed + 341u64;
+        let rt13_v17 = seed + 342u64;
+        let rt13_v18 = seed + 343u64;
+        let rt13_v19 = seed + 344u64;
+        let rt13_v20 = seed + 345u64;
+        let rt13_v21 = seed + 346u64;
+        let rt13_v22 = seed + 347u64;
+        let rt13_v23 = seed + 348u64;
+        let rt13_v24 = seed + 349u64;
+        let arr_a = [rt13_v0, rt13_v1, rt13_v2, rt13_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt13_v4 {
+            if acc > rt13_v5 + rt13_v6 {
+                acc = acc + rt13_v7 + rt13_v8 + rt13_v9;
+            } else {
+                acc = acc + rt13_v10 + rt13_v11;
+            }
+        } else {
+            if rt13_v12 > rt13_v13 {
+                acc = acc + rt13_v14 + rt13_v15;
+            } else {
+                acc = acc + rt13_v16 + rt13_v17;
+            }
+        }
+        acc += rt13_v18 / (19u64);
+        acc += rt13_v19 / (20u64);
+        acc += rt13_v20 / (21u64);
+        acc += rt13_v21 / (22u64);
+        acc += rt13_v22 / (23u64);
+        acc += rt13_v23 / (24u64);
+        acc += rt13_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_014(seed: u64) -> u64 {
+        let rt14_v0 = seed + 350u64;
+        let rt14_v1 = seed + 351u64;
+        let rt14_v2 = seed + 352u64;
+        let rt14_v3 = seed + 353u64;
+        let rt14_v4 = seed + 354u64;
+        let rt14_v5 = seed + 355u64;
+        let rt14_v6 = seed + 356u64;
+        let rt14_v7 = seed + 357u64;
+        let rt14_v8 = seed + 358u64;
+        let rt14_v9 = seed + 359u64;
+        let rt14_v10 = seed + 360u64;
+        let rt14_v11 = seed + 361u64;
+        let rt14_v12 = seed + 362u64;
+        let rt14_v13 = seed + 363u64;
+        let rt14_v14 = seed + 364u64;
+        let rt14_v15 = seed + 365u64;
+        let rt14_v16 = seed + 366u64;
+        let rt14_v17 = seed + 367u64;
+        let rt14_v18 = seed + 368u64;
+        let rt14_v19 = seed + 369u64;
+        let rt14_v20 = seed + 370u64;
+        let rt14_v21 = seed + 371u64;
+        let rt14_v22 = seed + 372u64;
+        let rt14_v23 = seed + 373u64;
+        let rt14_v24 = seed + 374u64;
+        let arr_a = [rt14_v0, rt14_v1, rt14_v2, rt14_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt14_v4 {
+            if acc > rt14_v5 + rt14_v6 {
+                acc = acc + rt14_v7 + rt14_v8 + rt14_v9;
+            } else {
+                acc = acc + rt14_v10 + rt14_v11;
+            }
+        } else {
+            if rt14_v12 > rt14_v13 {
+                acc = acc + rt14_v14 + rt14_v15;
+            } else {
+                acc = acc + rt14_v16 + rt14_v17;
+            }
+        }
+        acc += rt14_v18 / (19u64);
+        acc += rt14_v19 / (20u64);
+        acc += rt14_v20 / (21u64);
+        acc += rt14_v21 / (22u64);
+        acc += rt14_v22 / (23u64);
+        acc += rt14_v23 / (24u64);
+        acc += rt14_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_015(seed: u64) -> u64 {
+        let rt15_v0 = seed + 375u64;
+        let rt15_v1 = seed + 376u64;
+        let rt15_v2 = seed + 377u64;
+        let rt15_v3 = seed + 378u64;
+        let rt15_v4 = seed + 379u64;
+        let rt15_v5 = seed + 380u64;
+        let rt15_v6 = seed + 381u64;
+        let rt15_v7 = seed + 382u64;
+        let rt15_v8 = seed + 383u64;
+        let rt15_v9 = seed + 384u64;
+        let rt15_v10 = seed + 385u64;
+        let rt15_v11 = seed + 386u64;
+        let rt15_v12 = seed + 387u64;
+        let rt15_v13 = seed + 388u64;
+        let rt15_v14 = seed + 389u64;
+        let rt15_v15 = seed + 390u64;
+        let rt15_v16 = seed + 391u64;
+        let rt15_v17 = seed + 392u64;
+        let rt15_v18 = seed + 393u64;
+        let rt15_v19 = seed + 394u64;
+        let rt15_v20 = seed + 395u64;
+        let rt15_v21 = seed + 396u64;
+        let rt15_v22 = seed + 397u64;
+        let rt15_v23 = seed + 398u64;
+        let rt15_v24 = seed + 399u64;
+        let arr_a = [rt15_v0, rt15_v1, rt15_v2, rt15_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt15_v4 {
+            if acc > rt15_v5 + rt15_v6 {
+                acc = acc + rt15_v7 + rt15_v8 + rt15_v9;
+            } else {
+                acc = acc + rt15_v10 + rt15_v11;
+            }
+        } else {
+            if rt15_v12 > rt15_v13 {
+                acc = acc + rt15_v14 + rt15_v15;
+            } else {
+                acc = acc + rt15_v16 + rt15_v17;
+            }
+        }
+        acc += rt15_v18 / (19u64);
+        acc += rt15_v19 / (20u64);
+        acc += rt15_v20 / (21u64);
+        acc += rt15_v21 / (22u64);
+        acc += rt15_v22 / (23u64);
+        acc += rt15_v23 / (24u64);
+        acc += rt15_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_016(seed: u64) -> u64 {
+        let rt16_v0 = seed + 400u64;
+        let rt16_v1 = seed + 401u64;
+        let rt16_v2 = seed + 402u64;
+        let rt16_v3 = seed + 403u64;
+        let rt16_v4 = seed + 404u64;
+        let rt16_v5 = seed + 405u64;
+        let rt16_v6 = seed + 406u64;
+        let rt16_v7 = seed + 407u64;
+        let rt16_v8 = seed + 408u64;
+        let rt16_v9 = seed + 409u64;
+        let rt16_v10 = seed + 410u64;
+        let rt16_v11 = seed + 411u64;
+        let rt16_v12 = seed + 412u64;
+        let rt16_v13 = seed + 413u64;
+        let rt16_v14 = seed + 414u64;
+        let rt16_v15 = seed + 415u64;
+        let rt16_v16 = seed + 416u64;
+        let rt16_v17 = seed + 417u64;
+        let rt16_v18 = seed + 418u64;
+        let rt16_v19 = seed + 419u64;
+        let rt16_v20 = seed + 420u64;
+        let rt16_v21 = seed + 421u64;
+        let rt16_v22 = seed + 422u64;
+        let rt16_v23 = seed + 423u64;
+        let rt16_v24 = seed + 424u64;
+        let arr_a = [rt16_v0, rt16_v1, rt16_v2, rt16_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt16_v4 {
+            if acc > rt16_v5 + rt16_v6 {
+                acc = acc + rt16_v7 + rt16_v8 + rt16_v9;
+            } else {
+                acc = acc + rt16_v10 + rt16_v11;
+            }
+        } else {
+            if rt16_v12 > rt16_v13 {
+                acc = acc + rt16_v14 + rt16_v15;
+            } else {
+                acc = acc + rt16_v16 + rt16_v17;
+            }
+        }
+        acc += rt16_v18 / (19u64);
+        acc += rt16_v19 / (20u64);
+        acc += rt16_v20 / (21u64);
+        acc += rt16_v21 / (22u64);
+        acc += rt16_v22 / (23u64);
+        acc += rt16_v23 / (24u64);
+        acc += rt16_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_rt_017(seed: u64) -> u64 {
+        let rt17_v0 = seed + 425u64;
+        let rt17_v1 = seed + 426u64;
+        let rt17_v2 = seed + 427u64;
+        let rt17_v3 = seed + 428u64;
+        let rt17_v4 = seed + 429u64;
+        let rt17_v5 = seed + 430u64;
+        let rt17_v6 = seed + 431u64;
+        let rt17_v7 = seed + 432u64;
+        let rt17_v8 = seed + 433u64;
+        let rt17_v9 = seed + 434u64;
+        let rt17_v10 = seed + 435u64;
+        let rt17_v11 = seed + 436u64;
+        let rt17_v12 = seed + 437u64;
+        let rt17_v13 = seed + 438u64;
+        let rt17_v14 = seed + 439u64;
+        let rt17_v15 = seed + 440u64;
+        let rt17_v16 = seed + 441u64;
+        let rt17_v17 = seed + 442u64;
+        let rt17_v18 = seed + 443u64;
+        let rt17_v19 = seed + 444u64;
+        let rt17_v20 = seed + 445u64;
+        let rt17_v21 = seed + 446u64;
+        let rt17_v22 = seed + 447u64;
+        let rt17_v23 = seed + 448u64;
+        let rt17_v24 = seed + 449u64;
+        let arr_a = [rt17_v0, rt17_v1, rt17_v2, rt17_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > rt17_v4 {
+            if acc > rt17_v5 + rt17_v6 {
+                acc = acc + rt17_v7 + rt17_v8 + rt17_v9;
+            } else {
+                acc = acc + rt17_v10 + rt17_v11;
+            }
+        } else {
+            if rt17_v12 > rt17_v13 {
+                acc = acc + rt17_v14 + rt17_v15;
+            } else {
+                acc = acc + rt17_v16 + rt17_v17;
+            }
+        }
+        acc += rt17_v18 / (19u64);
+        acc += rt17_v19 / (20u64);
+        acc += rt17_v20 / (21u64);
+        acc += rt17_v21 / (22u64);
+        acc += rt17_v22 / (23u64);
+        acc += rt17_v23 / (24u64);
+        acc += rt17_v24 / (25u64);
+        return acc;
+    }
+
+    fn aggregate_router(seed: u64) -> u64 {
+        let acc = seed;
+        acc = bench_primitives.aleo/aggregate_primitives(acc);
+        acc = bench_registry.aleo/aggregate_registry(acc);
+        acc = bench_policy.aleo/aggregate_policy(acc);
+        return acc + 1u64;
+    }
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/settlement/program.json
+++ b/crates/compiler/benchmarks/fixtures/contrived/settlement/program.json
@@ -1,0 +1,28 @@
+{
+    "program": "bench_settlement.aleo",
+    "version": "0.1.0",
+    "description": "",
+    "license": "MIT",
+    "dependencies": [
+        {
+            "name": "bench_primitives.aleo",
+            "location": "local",
+            "path": "../primitives"
+        },
+        {
+            "name": "bench_registry.aleo",
+            "location": "local",
+            "path": "../registry"
+        },
+        {
+            "name": "bench_policy.aleo",
+            "location": "local",
+            "path": "../policy"
+        },
+        {
+            "name": "bench_router.aleo",
+            "location": "local",
+            "path": "../router"
+        }
+    ]
+}

--- a/crates/compiler/benchmarks/fixtures/contrived/settlement/src/main.leo
+++ b/crates/compiler/benchmarks/fixtures/contrived/settlement/src/main.leo
@@ -1,0 +1,2721 @@
+import bench_primitives.aleo;
+import bench_registry.aleo;
+import bench_policy.aleo;
+import bench_router.aleo;
+
+program bench_settlement.aleo {
+    struct StItem000 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem001 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem002 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem003 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem004 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem005 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem006 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem007 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem008 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem009 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem010 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem011 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem012 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem013 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem014 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem015 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem016 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem017 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem018 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem019 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem020 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem021 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem022 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem023 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem024 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem025 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem026 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem027 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem028 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem029 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem030 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem031 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem032 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem033 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem034 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem035 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem036 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem037 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem038 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem039 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem040 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem041 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem042 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem043 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem044 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem045 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem046 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem047 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem048 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem049 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem050 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem051 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem052 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem053 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem054 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem055 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem056 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem057 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem058 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem059 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem060 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem061 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem062 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem063 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem064 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem065 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem066 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem067 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem068 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem069 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem070 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem071 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem072 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem073 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem074 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem075 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem076 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem077 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem078 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem079 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem080 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem081 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem082 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem083 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem084 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem085 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem086 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem087 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem088 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem089 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem090 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem091 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem092 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem093 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem094 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem095 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem096 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem097 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem098 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem099 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem100 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem101 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem102 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem103 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem104 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem105 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem106 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem107 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem108 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem109 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem110 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem111 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem112 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem113 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem114 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem115 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem116 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem117 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem118 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem119 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem120 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem121 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem122 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem123 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem124 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem125 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem126 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem127 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem128 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem129 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem130 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem131 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem132 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem133 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem134 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem135 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem136 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem137 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem138 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem139 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem140 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem141 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem142 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem143 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem144 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem145 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem146 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem147 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem148 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem149 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem150 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem151 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem152 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem153 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem154 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem155 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem156 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem157 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem158 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem159 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem160 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem161 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem162 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem163 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem164 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem165 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem166 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem167 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem168 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem169 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem170 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem171 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem172 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem173 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem174 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem175 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem176 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem177 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem178 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    struct StItem179 {
+        amount: u64,
+        weight: u32,
+        active: bool,
+        score: u64,
+        epoch: u32,
+        nonce: u64,
+    }
+
+    mapping ledger: address => u64;
+    mapping scores: u32 => u64;
+
+    @noupgrade
+    constructor() {}
+
+    fn compute_st_000(seed: u64) -> u64 {
+        let st00_v0 = seed + 0u64;
+        let st00_v1 = seed + 1u64;
+        let st00_v2 = seed + 2u64;
+        let st00_v3 = seed + 3u64;
+        let st00_v4 = seed + 4u64;
+        let st00_v5 = seed + 5u64;
+        let st00_v6 = seed + 6u64;
+        let st00_v7 = seed + 7u64;
+        let st00_v8 = seed + 8u64;
+        let st00_v9 = seed + 9u64;
+        let st00_v10 = seed + 10u64;
+        let st00_v11 = seed + 11u64;
+        let st00_v12 = seed + 12u64;
+        let st00_v13 = seed + 13u64;
+        let st00_v14 = seed + 14u64;
+        let st00_v15 = seed + 15u64;
+        let st00_v16 = seed + 16u64;
+        let st00_v17 = seed + 17u64;
+        let st00_v18 = seed + 18u64;
+        let st00_v19 = seed + 19u64;
+        let st00_v20 = seed + 20u64;
+        let st00_v21 = seed + 21u64;
+        let st00_v22 = seed + 22u64;
+        let st00_v23 = seed + 23u64;
+        let st00_v24 = seed + 24u64;
+        let arr_a = [st00_v0, st00_v1, st00_v2, st00_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st00_v4 {
+            if acc > st00_v5 + st00_v6 {
+                acc = acc + st00_v7 + st00_v8 + st00_v9;
+            } else {
+                acc = acc + st00_v10 + st00_v11;
+            }
+        } else {
+            if st00_v12 > st00_v13 {
+                acc = acc + st00_v14 + st00_v15;
+            } else {
+                acc = acc + st00_v16 + st00_v17;
+            }
+        }
+        acc += st00_v18 / (19u64);
+        acc += st00_v19 / (20u64);
+        acc += st00_v20 / (21u64);
+        acc += st00_v21 / (22u64);
+        acc += st00_v22 / (23u64);
+        acc += st00_v23 / (24u64);
+        acc += st00_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_001(seed: u64) -> u64 {
+        let st01_v0 = seed + 25u64;
+        let st01_v1 = seed + 26u64;
+        let st01_v2 = seed + 27u64;
+        let st01_v3 = seed + 28u64;
+        let st01_v4 = seed + 29u64;
+        let st01_v5 = seed + 30u64;
+        let st01_v6 = seed + 31u64;
+        let st01_v7 = seed + 32u64;
+        let st01_v8 = seed + 33u64;
+        let st01_v9 = seed + 34u64;
+        let st01_v10 = seed + 35u64;
+        let st01_v11 = seed + 36u64;
+        let st01_v12 = seed + 37u64;
+        let st01_v13 = seed + 38u64;
+        let st01_v14 = seed + 39u64;
+        let st01_v15 = seed + 40u64;
+        let st01_v16 = seed + 41u64;
+        let st01_v17 = seed + 42u64;
+        let st01_v18 = seed + 43u64;
+        let st01_v19 = seed + 44u64;
+        let st01_v20 = seed + 45u64;
+        let st01_v21 = seed + 46u64;
+        let st01_v22 = seed + 47u64;
+        let st01_v23 = seed + 48u64;
+        let st01_v24 = seed + 49u64;
+        let arr_a = [st01_v0, st01_v1, st01_v2, st01_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st01_v4 {
+            if acc > st01_v5 + st01_v6 {
+                acc = acc + st01_v7 + st01_v8 + st01_v9;
+            } else {
+                acc = acc + st01_v10 + st01_v11;
+            }
+        } else {
+            if st01_v12 > st01_v13 {
+                acc = acc + st01_v14 + st01_v15;
+            } else {
+                acc = acc + st01_v16 + st01_v17;
+            }
+        }
+        acc += st01_v18 / (19u64);
+        acc += st01_v19 / (20u64);
+        acc += st01_v20 / (21u64);
+        acc += st01_v21 / (22u64);
+        acc += st01_v22 / (23u64);
+        acc += st01_v23 / (24u64);
+        acc += st01_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_002(seed: u64) -> u64 {
+        let st02_v0 = seed + 50u64;
+        let st02_v1 = seed + 51u64;
+        let st02_v2 = seed + 52u64;
+        let st02_v3 = seed + 53u64;
+        let st02_v4 = seed + 54u64;
+        let st02_v5 = seed + 55u64;
+        let st02_v6 = seed + 56u64;
+        let st02_v7 = seed + 57u64;
+        let st02_v8 = seed + 58u64;
+        let st02_v9 = seed + 59u64;
+        let st02_v10 = seed + 60u64;
+        let st02_v11 = seed + 61u64;
+        let st02_v12 = seed + 62u64;
+        let st02_v13 = seed + 63u64;
+        let st02_v14 = seed + 64u64;
+        let st02_v15 = seed + 65u64;
+        let st02_v16 = seed + 66u64;
+        let st02_v17 = seed + 67u64;
+        let st02_v18 = seed + 68u64;
+        let st02_v19 = seed + 69u64;
+        let st02_v20 = seed + 70u64;
+        let st02_v21 = seed + 71u64;
+        let st02_v22 = seed + 72u64;
+        let st02_v23 = seed + 73u64;
+        let st02_v24 = seed + 74u64;
+        let arr_a = [st02_v0, st02_v1, st02_v2, st02_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st02_v4 {
+            if acc > st02_v5 + st02_v6 {
+                acc = acc + st02_v7 + st02_v8 + st02_v9;
+            } else {
+                acc = acc + st02_v10 + st02_v11;
+            }
+        } else {
+            if st02_v12 > st02_v13 {
+                acc = acc + st02_v14 + st02_v15;
+            } else {
+                acc = acc + st02_v16 + st02_v17;
+            }
+        }
+        acc += st02_v18 / (19u64);
+        acc += st02_v19 / (20u64);
+        acc += st02_v20 / (21u64);
+        acc += st02_v21 / (22u64);
+        acc += st02_v22 / (23u64);
+        acc += st02_v23 / (24u64);
+        acc += st02_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_003(seed: u64) -> u64 {
+        let st03_v0 = seed + 75u64;
+        let st03_v1 = seed + 76u64;
+        let st03_v2 = seed + 77u64;
+        let st03_v3 = seed + 78u64;
+        let st03_v4 = seed + 79u64;
+        let st03_v5 = seed + 80u64;
+        let st03_v6 = seed + 81u64;
+        let st03_v7 = seed + 82u64;
+        let st03_v8 = seed + 83u64;
+        let st03_v9 = seed + 84u64;
+        let st03_v10 = seed + 85u64;
+        let st03_v11 = seed + 86u64;
+        let st03_v12 = seed + 87u64;
+        let st03_v13 = seed + 88u64;
+        let st03_v14 = seed + 89u64;
+        let st03_v15 = seed + 90u64;
+        let st03_v16 = seed + 91u64;
+        let st03_v17 = seed + 92u64;
+        let st03_v18 = seed + 93u64;
+        let st03_v19 = seed + 94u64;
+        let st03_v20 = seed + 95u64;
+        let st03_v21 = seed + 96u64;
+        let st03_v22 = seed + 97u64;
+        let st03_v23 = seed + 98u64;
+        let st03_v24 = seed + 99u64;
+        let arr_a = [st03_v0, st03_v1, st03_v2, st03_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st03_v4 {
+            if acc > st03_v5 + st03_v6 {
+                acc = acc + st03_v7 + st03_v8 + st03_v9;
+            } else {
+                acc = acc + st03_v10 + st03_v11;
+            }
+        } else {
+            if st03_v12 > st03_v13 {
+                acc = acc + st03_v14 + st03_v15;
+            } else {
+                acc = acc + st03_v16 + st03_v17;
+            }
+        }
+        acc += st03_v18 / (19u64);
+        acc += st03_v19 / (20u64);
+        acc += st03_v20 / (21u64);
+        acc += st03_v21 / (22u64);
+        acc += st03_v22 / (23u64);
+        acc += st03_v23 / (24u64);
+        acc += st03_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_004(seed: u64) -> u64 {
+        let st04_v0 = seed + 100u64;
+        let st04_v1 = seed + 101u64;
+        let st04_v2 = seed + 102u64;
+        let st04_v3 = seed + 103u64;
+        let st04_v4 = seed + 104u64;
+        let st04_v5 = seed + 105u64;
+        let st04_v6 = seed + 106u64;
+        let st04_v7 = seed + 107u64;
+        let st04_v8 = seed + 108u64;
+        let st04_v9 = seed + 109u64;
+        let st04_v10 = seed + 110u64;
+        let st04_v11 = seed + 111u64;
+        let st04_v12 = seed + 112u64;
+        let st04_v13 = seed + 113u64;
+        let st04_v14 = seed + 114u64;
+        let st04_v15 = seed + 115u64;
+        let st04_v16 = seed + 116u64;
+        let st04_v17 = seed + 117u64;
+        let st04_v18 = seed + 118u64;
+        let st04_v19 = seed + 119u64;
+        let st04_v20 = seed + 120u64;
+        let st04_v21 = seed + 121u64;
+        let st04_v22 = seed + 122u64;
+        let st04_v23 = seed + 123u64;
+        let st04_v24 = seed + 124u64;
+        let arr_a = [st04_v0, st04_v1, st04_v2, st04_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st04_v4 {
+            if acc > st04_v5 + st04_v6 {
+                acc = acc + st04_v7 + st04_v8 + st04_v9;
+            } else {
+                acc = acc + st04_v10 + st04_v11;
+            }
+        } else {
+            if st04_v12 > st04_v13 {
+                acc = acc + st04_v14 + st04_v15;
+            } else {
+                acc = acc + st04_v16 + st04_v17;
+            }
+        }
+        acc += st04_v18 / (19u64);
+        acc += st04_v19 / (20u64);
+        acc += st04_v20 / (21u64);
+        acc += st04_v21 / (22u64);
+        acc += st04_v22 / (23u64);
+        acc += st04_v23 / (24u64);
+        acc += st04_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_005(seed: u64) -> u64 {
+        let st05_v0 = seed + 125u64;
+        let st05_v1 = seed + 126u64;
+        let st05_v2 = seed + 127u64;
+        let st05_v3 = seed + 128u64;
+        let st05_v4 = seed + 129u64;
+        let st05_v5 = seed + 130u64;
+        let st05_v6 = seed + 131u64;
+        let st05_v7 = seed + 132u64;
+        let st05_v8 = seed + 133u64;
+        let st05_v9 = seed + 134u64;
+        let st05_v10 = seed + 135u64;
+        let st05_v11 = seed + 136u64;
+        let st05_v12 = seed + 137u64;
+        let st05_v13 = seed + 138u64;
+        let st05_v14 = seed + 139u64;
+        let st05_v15 = seed + 140u64;
+        let st05_v16 = seed + 141u64;
+        let st05_v17 = seed + 142u64;
+        let st05_v18 = seed + 143u64;
+        let st05_v19 = seed + 144u64;
+        let st05_v20 = seed + 145u64;
+        let st05_v21 = seed + 146u64;
+        let st05_v22 = seed + 147u64;
+        let st05_v23 = seed + 148u64;
+        let st05_v24 = seed + 149u64;
+        let arr_a = [st05_v0, st05_v1, st05_v2, st05_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st05_v4 {
+            if acc > st05_v5 + st05_v6 {
+                acc = acc + st05_v7 + st05_v8 + st05_v9;
+            } else {
+                acc = acc + st05_v10 + st05_v11;
+            }
+        } else {
+            if st05_v12 > st05_v13 {
+                acc = acc + st05_v14 + st05_v15;
+            } else {
+                acc = acc + st05_v16 + st05_v17;
+            }
+        }
+        acc += st05_v18 / (19u64);
+        acc += st05_v19 / (20u64);
+        acc += st05_v20 / (21u64);
+        acc += st05_v21 / (22u64);
+        acc += st05_v22 / (23u64);
+        acc += st05_v23 / (24u64);
+        acc += st05_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_006(seed: u64) -> u64 {
+        let st06_v0 = seed + 150u64;
+        let st06_v1 = seed + 151u64;
+        let st06_v2 = seed + 152u64;
+        let st06_v3 = seed + 153u64;
+        let st06_v4 = seed + 154u64;
+        let st06_v5 = seed + 155u64;
+        let st06_v6 = seed + 156u64;
+        let st06_v7 = seed + 157u64;
+        let st06_v8 = seed + 158u64;
+        let st06_v9 = seed + 159u64;
+        let st06_v10 = seed + 160u64;
+        let st06_v11 = seed + 161u64;
+        let st06_v12 = seed + 162u64;
+        let st06_v13 = seed + 163u64;
+        let st06_v14 = seed + 164u64;
+        let st06_v15 = seed + 165u64;
+        let st06_v16 = seed + 166u64;
+        let st06_v17 = seed + 167u64;
+        let st06_v18 = seed + 168u64;
+        let st06_v19 = seed + 169u64;
+        let st06_v20 = seed + 170u64;
+        let st06_v21 = seed + 171u64;
+        let st06_v22 = seed + 172u64;
+        let st06_v23 = seed + 173u64;
+        let st06_v24 = seed + 174u64;
+        let arr_a = [st06_v0, st06_v1, st06_v2, st06_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st06_v4 {
+            if acc > st06_v5 + st06_v6 {
+                acc = acc + st06_v7 + st06_v8 + st06_v9;
+            } else {
+                acc = acc + st06_v10 + st06_v11;
+            }
+        } else {
+            if st06_v12 > st06_v13 {
+                acc = acc + st06_v14 + st06_v15;
+            } else {
+                acc = acc + st06_v16 + st06_v17;
+            }
+        }
+        acc += st06_v18 / (19u64);
+        acc += st06_v19 / (20u64);
+        acc += st06_v20 / (21u64);
+        acc += st06_v21 / (22u64);
+        acc += st06_v22 / (23u64);
+        acc += st06_v23 / (24u64);
+        acc += st06_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_007(seed: u64) -> u64 {
+        let st07_v0 = seed + 175u64;
+        let st07_v1 = seed + 176u64;
+        let st07_v2 = seed + 177u64;
+        let st07_v3 = seed + 178u64;
+        let st07_v4 = seed + 179u64;
+        let st07_v5 = seed + 180u64;
+        let st07_v6 = seed + 181u64;
+        let st07_v7 = seed + 182u64;
+        let st07_v8 = seed + 183u64;
+        let st07_v9 = seed + 184u64;
+        let st07_v10 = seed + 185u64;
+        let st07_v11 = seed + 186u64;
+        let st07_v12 = seed + 187u64;
+        let st07_v13 = seed + 188u64;
+        let st07_v14 = seed + 189u64;
+        let st07_v15 = seed + 190u64;
+        let st07_v16 = seed + 191u64;
+        let st07_v17 = seed + 192u64;
+        let st07_v18 = seed + 193u64;
+        let st07_v19 = seed + 194u64;
+        let st07_v20 = seed + 195u64;
+        let st07_v21 = seed + 196u64;
+        let st07_v22 = seed + 197u64;
+        let st07_v23 = seed + 198u64;
+        let st07_v24 = seed + 199u64;
+        let arr_a = [st07_v0, st07_v1, st07_v2, st07_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st07_v4 {
+            if acc > st07_v5 + st07_v6 {
+                acc = acc + st07_v7 + st07_v8 + st07_v9;
+            } else {
+                acc = acc + st07_v10 + st07_v11;
+            }
+        } else {
+            if st07_v12 > st07_v13 {
+                acc = acc + st07_v14 + st07_v15;
+            } else {
+                acc = acc + st07_v16 + st07_v17;
+            }
+        }
+        acc += st07_v18 / (19u64);
+        acc += st07_v19 / (20u64);
+        acc += st07_v20 / (21u64);
+        acc += st07_v21 / (22u64);
+        acc += st07_v22 / (23u64);
+        acc += st07_v23 / (24u64);
+        acc += st07_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_008(seed: u64) -> u64 {
+        let st08_v0 = seed + 200u64;
+        let st08_v1 = seed + 201u64;
+        let st08_v2 = seed + 202u64;
+        let st08_v3 = seed + 203u64;
+        let st08_v4 = seed + 204u64;
+        let st08_v5 = seed + 205u64;
+        let st08_v6 = seed + 206u64;
+        let st08_v7 = seed + 207u64;
+        let st08_v8 = seed + 208u64;
+        let st08_v9 = seed + 209u64;
+        let st08_v10 = seed + 210u64;
+        let st08_v11 = seed + 211u64;
+        let st08_v12 = seed + 212u64;
+        let st08_v13 = seed + 213u64;
+        let st08_v14 = seed + 214u64;
+        let st08_v15 = seed + 215u64;
+        let st08_v16 = seed + 216u64;
+        let st08_v17 = seed + 217u64;
+        let st08_v18 = seed + 218u64;
+        let st08_v19 = seed + 219u64;
+        let st08_v20 = seed + 220u64;
+        let st08_v21 = seed + 221u64;
+        let st08_v22 = seed + 222u64;
+        let st08_v23 = seed + 223u64;
+        let st08_v24 = seed + 224u64;
+        let arr_a = [st08_v0, st08_v1, st08_v2, st08_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st08_v4 {
+            if acc > st08_v5 + st08_v6 {
+                acc = acc + st08_v7 + st08_v8 + st08_v9;
+            } else {
+                acc = acc + st08_v10 + st08_v11;
+            }
+        } else {
+            if st08_v12 > st08_v13 {
+                acc = acc + st08_v14 + st08_v15;
+            } else {
+                acc = acc + st08_v16 + st08_v17;
+            }
+        }
+        acc += st08_v18 / (19u64);
+        acc += st08_v19 / (20u64);
+        acc += st08_v20 / (21u64);
+        acc += st08_v21 / (22u64);
+        acc += st08_v22 / (23u64);
+        acc += st08_v23 / (24u64);
+        acc += st08_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_009(seed: u64) -> u64 {
+        let st09_v0 = seed + 225u64;
+        let st09_v1 = seed + 226u64;
+        let st09_v2 = seed + 227u64;
+        let st09_v3 = seed + 228u64;
+        let st09_v4 = seed + 229u64;
+        let st09_v5 = seed + 230u64;
+        let st09_v6 = seed + 231u64;
+        let st09_v7 = seed + 232u64;
+        let st09_v8 = seed + 233u64;
+        let st09_v9 = seed + 234u64;
+        let st09_v10 = seed + 235u64;
+        let st09_v11 = seed + 236u64;
+        let st09_v12 = seed + 237u64;
+        let st09_v13 = seed + 238u64;
+        let st09_v14 = seed + 239u64;
+        let st09_v15 = seed + 240u64;
+        let st09_v16 = seed + 241u64;
+        let st09_v17 = seed + 242u64;
+        let st09_v18 = seed + 243u64;
+        let st09_v19 = seed + 244u64;
+        let st09_v20 = seed + 245u64;
+        let st09_v21 = seed + 246u64;
+        let st09_v22 = seed + 247u64;
+        let st09_v23 = seed + 248u64;
+        let st09_v24 = seed + 249u64;
+        let arr_a = [st09_v0, st09_v1, st09_v2, st09_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st09_v4 {
+            if acc > st09_v5 + st09_v6 {
+                acc = acc + st09_v7 + st09_v8 + st09_v9;
+            } else {
+                acc = acc + st09_v10 + st09_v11;
+            }
+        } else {
+            if st09_v12 > st09_v13 {
+                acc = acc + st09_v14 + st09_v15;
+            } else {
+                acc = acc + st09_v16 + st09_v17;
+            }
+        }
+        acc += st09_v18 / (19u64);
+        acc += st09_v19 / (20u64);
+        acc += st09_v20 / (21u64);
+        acc += st09_v21 / (22u64);
+        acc += st09_v22 / (23u64);
+        acc += st09_v23 / (24u64);
+        acc += st09_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_010(seed: u64) -> u64 {
+        let st10_v0 = seed + 250u64;
+        let st10_v1 = seed + 251u64;
+        let st10_v2 = seed + 252u64;
+        let st10_v3 = seed + 253u64;
+        let st10_v4 = seed + 254u64;
+        let st10_v5 = seed + 255u64;
+        let st10_v6 = seed + 256u64;
+        let st10_v7 = seed + 257u64;
+        let st10_v8 = seed + 258u64;
+        let st10_v9 = seed + 259u64;
+        let st10_v10 = seed + 260u64;
+        let st10_v11 = seed + 261u64;
+        let st10_v12 = seed + 262u64;
+        let st10_v13 = seed + 263u64;
+        let st10_v14 = seed + 264u64;
+        let st10_v15 = seed + 265u64;
+        let st10_v16 = seed + 266u64;
+        let st10_v17 = seed + 267u64;
+        let st10_v18 = seed + 268u64;
+        let st10_v19 = seed + 269u64;
+        let st10_v20 = seed + 270u64;
+        let st10_v21 = seed + 271u64;
+        let st10_v22 = seed + 272u64;
+        let st10_v23 = seed + 273u64;
+        let st10_v24 = seed + 274u64;
+        let arr_a = [st10_v0, st10_v1, st10_v2, st10_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st10_v4 {
+            if acc > st10_v5 + st10_v6 {
+                acc = acc + st10_v7 + st10_v8 + st10_v9;
+            } else {
+                acc = acc + st10_v10 + st10_v11;
+            }
+        } else {
+            if st10_v12 > st10_v13 {
+                acc = acc + st10_v14 + st10_v15;
+            } else {
+                acc = acc + st10_v16 + st10_v17;
+            }
+        }
+        acc += st10_v18 / (19u64);
+        acc += st10_v19 / (20u64);
+        acc += st10_v20 / (21u64);
+        acc += st10_v21 / (22u64);
+        acc += st10_v22 / (23u64);
+        acc += st10_v23 / (24u64);
+        acc += st10_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_011(seed: u64) -> u64 {
+        let st11_v0 = seed + 275u64;
+        let st11_v1 = seed + 276u64;
+        let st11_v2 = seed + 277u64;
+        let st11_v3 = seed + 278u64;
+        let st11_v4 = seed + 279u64;
+        let st11_v5 = seed + 280u64;
+        let st11_v6 = seed + 281u64;
+        let st11_v7 = seed + 282u64;
+        let st11_v8 = seed + 283u64;
+        let st11_v9 = seed + 284u64;
+        let st11_v10 = seed + 285u64;
+        let st11_v11 = seed + 286u64;
+        let st11_v12 = seed + 287u64;
+        let st11_v13 = seed + 288u64;
+        let st11_v14 = seed + 289u64;
+        let st11_v15 = seed + 290u64;
+        let st11_v16 = seed + 291u64;
+        let st11_v17 = seed + 292u64;
+        let st11_v18 = seed + 293u64;
+        let st11_v19 = seed + 294u64;
+        let st11_v20 = seed + 295u64;
+        let st11_v21 = seed + 296u64;
+        let st11_v22 = seed + 297u64;
+        let st11_v23 = seed + 298u64;
+        let st11_v24 = seed + 299u64;
+        let arr_a = [st11_v0, st11_v1, st11_v2, st11_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st11_v4 {
+            if acc > st11_v5 + st11_v6 {
+                acc = acc + st11_v7 + st11_v8 + st11_v9;
+            } else {
+                acc = acc + st11_v10 + st11_v11;
+            }
+        } else {
+            if st11_v12 > st11_v13 {
+                acc = acc + st11_v14 + st11_v15;
+            } else {
+                acc = acc + st11_v16 + st11_v17;
+            }
+        }
+        acc += st11_v18 / (19u64);
+        acc += st11_v19 / (20u64);
+        acc += st11_v20 / (21u64);
+        acc += st11_v21 / (22u64);
+        acc += st11_v22 / (23u64);
+        acc += st11_v23 / (24u64);
+        acc += st11_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_012(seed: u64) -> u64 {
+        let st12_v0 = seed + 300u64;
+        let st12_v1 = seed + 301u64;
+        let st12_v2 = seed + 302u64;
+        let st12_v3 = seed + 303u64;
+        let st12_v4 = seed + 304u64;
+        let st12_v5 = seed + 305u64;
+        let st12_v6 = seed + 306u64;
+        let st12_v7 = seed + 307u64;
+        let st12_v8 = seed + 308u64;
+        let st12_v9 = seed + 309u64;
+        let st12_v10 = seed + 310u64;
+        let st12_v11 = seed + 311u64;
+        let st12_v12 = seed + 312u64;
+        let st12_v13 = seed + 313u64;
+        let st12_v14 = seed + 314u64;
+        let st12_v15 = seed + 315u64;
+        let st12_v16 = seed + 316u64;
+        let st12_v17 = seed + 317u64;
+        let st12_v18 = seed + 318u64;
+        let st12_v19 = seed + 319u64;
+        let st12_v20 = seed + 320u64;
+        let st12_v21 = seed + 321u64;
+        let st12_v22 = seed + 322u64;
+        let st12_v23 = seed + 323u64;
+        let st12_v24 = seed + 324u64;
+        let arr_a = [st12_v0, st12_v1, st12_v2, st12_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st12_v4 {
+            if acc > st12_v5 + st12_v6 {
+                acc = acc + st12_v7 + st12_v8 + st12_v9;
+            } else {
+                acc = acc + st12_v10 + st12_v11;
+            }
+        } else {
+            if st12_v12 > st12_v13 {
+                acc = acc + st12_v14 + st12_v15;
+            } else {
+                acc = acc + st12_v16 + st12_v17;
+            }
+        }
+        acc += st12_v18 / (19u64);
+        acc += st12_v19 / (20u64);
+        acc += st12_v20 / (21u64);
+        acc += st12_v21 / (22u64);
+        acc += st12_v22 / (23u64);
+        acc += st12_v23 / (24u64);
+        acc += st12_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_013(seed: u64) -> u64 {
+        let st13_v0 = seed + 325u64;
+        let st13_v1 = seed + 326u64;
+        let st13_v2 = seed + 327u64;
+        let st13_v3 = seed + 328u64;
+        let st13_v4 = seed + 329u64;
+        let st13_v5 = seed + 330u64;
+        let st13_v6 = seed + 331u64;
+        let st13_v7 = seed + 332u64;
+        let st13_v8 = seed + 333u64;
+        let st13_v9 = seed + 334u64;
+        let st13_v10 = seed + 335u64;
+        let st13_v11 = seed + 336u64;
+        let st13_v12 = seed + 337u64;
+        let st13_v13 = seed + 338u64;
+        let st13_v14 = seed + 339u64;
+        let st13_v15 = seed + 340u64;
+        let st13_v16 = seed + 341u64;
+        let st13_v17 = seed + 342u64;
+        let st13_v18 = seed + 343u64;
+        let st13_v19 = seed + 344u64;
+        let st13_v20 = seed + 345u64;
+        let st13_v21 = seed + 346u64;
+        let st13_v22 = seed + 347u64;
+        let st13_v23 = seed + 348u64;
+        let st13_v24 = seed + 349u64;
+        let arr_a = [st13_v0, st13_v1, st13_v2, st13_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st13_v4 {
+            if acc > st13_v5 + st13_v6 {
+                acc = acc + st13_v7 + st13_v8 + st13_v9;
+            } else {
+                acc = acc + st13_v10 + st13_v11;
+            }
+        } else {
+            if st13_v12 > st13_v13 {
+                acc = acc + st13_v14 + st13_v15;
+            } else {
+                acc = acc + st13_v16 + st13_v17;
+            }
+        }
+        acc += st13_v18 / (19u64);
+        acc += st13_v19 / (20u64);
+        acc += st13_v20 / (21u64);
+        acc += st13_v21 / (22u64);
+        acc += st13_v22 / (23u64);
+        acc += st13_v23 / (24u64);
+        acc += st13_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_014(seed: u64) -> u64 {
+        let st14_v0 = seed + 350u64;
+        let st14_v1 = seed + 351u64;
+        let st14_v2 = seed + 352u64;
+        let st14_v3 = seed + 353u64;
+        let st14_v4 = seed + 354u64;
+        let st14_v5 = seed + 355u64;
+        let st14_v6 = seed + 356u64;
+        let st14_v7 = seed + 357u64;
+        let st14_v8 = seed + 358u64;
+        let st14_v9 = seed + 359u64;
+        let st14_v10 = seed + 360u64;
+        let st14_v11 = seed + 361u64;
+        let st14_v12 = seed + 362u64;
+        let st14_v13 = seed + 363u64;
+        let st14_v14 = seed + 364u64;
+        let st14_v15 = seed + 365u64;
+        let st14_v16 = seed + 366u64;
+        let st14_v17 = seed + 367u64;
+        let st14_v18 = seed + 368u64;
+        let st14_v19 = seed + 369u64;
+        let st14_v20 = seed + 370u64;
+        let st14_v21 = seed + 371u64;
+        let st14_v22 = seed + 372u64;
+        let st14_v23 = seed + 373u64;
+        let st14_v24 = seed + 374u64;
+        let arr_a = [st14_v0, st14_v1, st14_v2, st14_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st14_v4 {
+            if acc > st14_v5 + st14_v6 {
+                acc = acc + st14_v7 + st14_v8 + st14_v9;
+            } else {
+                acc = acc + st14_v10 + st14_v11;
+            }
+        } else {
+            if st14_v12 > st14_v13 {
+                acc = acc + st14_v14 + st14_v15;
+            } else {
+                acc = acc + st14_v16 + st14_v17;
+            }
+        }
+        acc += st14_v18 / (19u64);
+        acc += st14_v19 / (20u64);
+        acc += st14_v20 / (21u64);
+        acc += st14_v21 / (22u64);
+        acc += st14_v22 / (23u64);
+        acc += st14_v23 / (24u64);
+        acc += st14_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_015(seed: u64) -> u64 {
+        let st15_v0 = seed + 375u64;
+        let st15_v1 = seed + 376u64;
+        let st15_v2 = seed + 377u64;
+        let st15_v3 = seed + 378u64;
+        let st15_v4 = seed + 379u64;
+        let st15_v5 = seed + 380u64;
+        let st15_v6 = seed + 381u64;
+        let st15_v7 = seed + 382u64;
+        let st15_v8 = seed + 383u64;
+        let st15_v9 = seed + 384u64;
+        let st15_v10 = seed + 385u64;
+        let st15_v11 = seed + 386u64;
+        let st15_v12 = seed + 387u64;
+        let st15_v13 = seed + 388u64;
+        let st15_v14 = seed + 389u64;
+        let st15_v15 = seed + 390u64;
+        let st15_v16 = seed + 391u64;
+        let st15_v17 = seed + 392u64;
+        let st15_v18 = seed + 393u64;
+        let st15_v19 = seed + 394u64;
+        let st15_v20 = seed + 395u64;
+        let st15_v21 = seed + 396u64;
+        let st15_v22 = seed + 397u64;
+        let st15_v23 = seed + 398u64;
+        let st15_v24 = seed + 399u64;
+        let arr_a = [st15_v0, st15_v1, st15_v2, st15_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st15_v4 {
+            if acc > st15_v5 + st15_v6 {
+                acc = acc + st15_v7 + st15_v8 + st15_v9;
+            } else {
+                acc = acc + st15_v10 + st15_v11;
+            }
+        } else {
+            if st15_v12 > st15_v13 {
+                acc = acc + st15_v14 + st15_v15;
+            } else {
+                acc = acc + st15_v16 + st15_v17;
+            }
+        }
+        acc += st15_v18 / (19u64);
+        acc += st15_v19 / (20u64);
+        acc += st15_v20 / (21u64);
+        acc += st15_v21 / (22u64);
+        acc += st15_v22 / (23u64);
+        acc += st15_v23 / (24u64);
+        acc += st15_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_016(seed: u64) -> u64 {
+        let st16_v0 = seed + 400u64;
+        let st16_v1 = seed + 401u64;
+        let st16_v2 = seed + 402u64;
+        let st16_v3 = seed + 403u64;
+        let st16_v4 = seed + 404u64;
+        let st16_v5 = seed + 405u64;
+        let st16_v6 = seed + 406u64;
+        let st16_v7 = seed + 407u64;
+        let st16_v8 = seed + 408u64;
+        let st16_v9 = seed + 409u64;
+        let st16_v10 = seed + 410u64;
+        let st16_v11 = seed + 411u64;
+        let st16_v12 = seed + 412u64;
+        let st16_v13 = seed + 413u64;
+        let st16_v14 = seed + 414u64;
+        let st16_v15 = seed + 415u64;
+        let st16_v16 = seed + 416u64;
+        let st16_v17 = seed + 417u64;
+        let st16_v18 = seed + 418u64;
+        let st16_v19 = seed + 419u64;
+        let st16_v20 = seed + 420u64;
+        let st16_v21 = seed + 421u64;
+        let st16_v22 = seed + 422u64;
+        let st16_v23 = seed + 423u64;
+        let st16_v24 = seed + 424u64;
+        let arr_a = [st16_v0, st16_v1, st16_v2, st16_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st16_v4 {
+            if acc > st16_v5 + st16_v6 {
+                acc = acc + st16_v7 + st16_v8 + st16_v9;
+            } else {
+                acc = acc + st16_v10 + st16_v11;
+            }
+        } else {
+            if st16_v12 > st16_v13 {
+                acc = acc + st16_v14 + st16_v15;
+            } else {
+                acc = acc + st16_v16 + st16_v17;
+            }
+        }
+        acc += st16_v18 / (19u64);
+        acc += st16_v19 / (20u64);
+        acc += st16_v20 / (21u64);
+        acc += st16_v21 / (22u64);
+        acc += st16_v22 / (23u64);
+        acc += st16_v23 / (24u64);
+        acc += st16_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_017(seed: u64) -> u64 {
+        let st17_v0 = seed + 425u64;
+        let st17_v1 = seed + 426u64;
+        let st17_v2 = seed + 427u64;
+        let st17_v3 = seed + 428u64;
+        let st17_v4 = seed + 429u64;
+        let st17_v5 = seed + 430u64;
+        let st17_v6 = seed + 431u64;
+        let st17_v7 = seed + 432u64;
+        let st17_v8 = seed + 433u64;
+        let st17_v9 = seed + 434u64;
+        let st17_v10 = seed + 435u64;
+        let st17_v11 = seed + 436u64;
+        let st17_v12 = seed + 437u64;
+        let st17_v13 = seed + 438u64;
+        let st17_v14 = seed + 439u64;
+        let st17_v15 = seed + 440u64;
+        let st17_v16 = seed + 441u64;
+        let st17_v17 = seed + 442u64;
+        let st17_v18 = seed + 443u64;
+        let st17_v19 = seed + 444u64;
+        let st17_v20 = seed + 445u64;
+        let st17_v21 = seed + 446u64;
+        let st17_v22 = seed + 447u64;
+        let st17_v23 = seed + 448u64;
+        let st17_v24 = seed + 449u64;
+        let arr_a = [st17_v0, st17_v1, st17_v2, st17_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st17_v4 {
+            if acc > st17_v5 + st17_v6 {
+                acc = acc + st17_v7 + st17_v8 + st17_v9;
+            } else {
+                acc = acc + st17_v10 + st17_v11;
+            }
+        } else {
+            if st17_v12 > st17_v13 {
+                acc = acc + st17_v14 + st17_v15;
+            } else {
+                acc = acc + st17_v16 + st17_v17;
+            }
+        }
+        acc += st17_v18 / (19u64);
+        acc += st17_v19 / (20u64);
+        acc += st17_v20 / (21u64);
+        acc += st17_v21 / (22u64);
+        acc += st17_v22 / (23u64);
+        acc += st17_v23 / (24u64);
+        acc += st17_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_018(seed: u64) -> u64 {
+        let st18_v0 = seed + 450u64;
+        let st18_v1 = seed + 451u64;
+        let st18_v2 = seed + 452u64;
+        let st18_v3 = seed + 453u64;
+        let st18_v4 = seed + 454u64;
+        let st18_v5 = seed + 455u64;
+        let st18_v6 = seed + 456u64;
+        let st18_v7 = seed + 457u64;
+        let st18_v8 = seed + 458u64;
+        let st18_v9 = seed + 459u64;
+        let st18_v10 = seed + 460u64;
+        let st18_v11 = seed + 461u64;
+        let st18_v12 = seed + 462u64;
+        let st18_v13 = seed + 463u64;
+        let st18_v14 = seed + 464u64;
+        let st18_v15 = seed + 465u64;
+        let st18_v16 = seed + 466u64;
+        let st18_v17 = seed + 467u64;
+        let st18_v18 = seed + 468u64;
+        let st18_v19 = seed + 469u64;
+        let st18_v20 = seed + 470u64;
+        let st18_v21 = seed + 471u64;
+        let st18_v22 = seed + 472u64;
+        let st18_v23 = seed + 473u64;
+        let st18_v24 = seed + 474u64;
+        let arr_a = [st18_v0, st18_v1, st18_v2, st18_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st18_v4 {
+            if acc > st18_v5 + st18_v6 {
+                acc = acc + st18_v7 + st18_v8 + st18_v9;
+            } else {
+                acc = acc + st18_v10 + st18_v11;
+            }
+        } else {
+            if st18_v12 > st18_v13 {
+                acc = acc + st18_v14 + st18_v15;
+            } else {
+                acc = acc + st18_v16 + st18_v17;
+            }
+        }
+        acc += st18_v18 / (19u64);
+        acc += st18_v19 / (20u64);
+        acc += st18_v20 / (21u64);
+        acc += st18_v21 / (22u64);
+        acc += st18_v22 / (23u64);
+        acc += st18_v23 / (24u64);
+        acc += st18_v24 / (25u64);
+        return acc;
+    }
+
+    fn compute_st_019(seed: u64) -> u64 {
+        let st19_v0 = seed + 475u64;
+        let st19_v1 = seed + 476u64;
+        let st19_v2 = seed + 477u64;
+        let st19_v3 = seed + 478u64;
+        let st19_v4 = seed + 479u64;
+        let st19_v5 = seed + 480u64;
+        let st19_v6 = seed + 481u64;
+        let st19_v7 = seed + 482u64;
+        let st19_v8 = seed + 483u64;
+        let st19_v9 = seed + 484u64;
+        let st19_v10 = seed + 485u64;
+        let st19_v11 = seed + 486u64;
+        let st19_v12 = seed + 487u64;
+        let st19_v13 = seed + 488u64;
+        let st19_v14 = seed + 489u64;
+        let st19_v15 = seed + 490u64;
+        let st19_v16 = seed + 491u64;
+        let st19_v17 = seed + 492u64;
+        let st19_v18 = seed + 493u64;
+        let st19_v19 = seed + 494u64;
+        let st19_v20 = seed + 495u64;
+        let st19_v21 = seed + 496u64;
+        let st19_v22 = seed + 497u64;
+        let st19_v23 = seed + 498u64;
+        let st19_v24 = seed + 499u64;
+        let arr_a = [st19_v0, st19_v1, st19_v2, st19_v3];
+        let acc = 0u64;
+        for i: u8 in 0u8..8u8 {
+            acc += arr_a[i % 4u8] + (i as u64);
+        }
+        if acc > st19_v4 {
+            if acc > st19_v5 + st19_v6 {
+                acc = acc + st19_v7 + st19_v8 + st19_v9;
+            } else {
+                acc = acc + st19_v10 + st19_v11;
+            }
+        } else {
+            if st19_v12 > st19_v13 {
+                acc = acc + st19_v14 + st19_v15;
+            } else {
+                acc = acc + st19_v16 + st19_v17;
+            }
+        }
+        acc += st19_v18 / (19u64);
+        acc += st19_v19 / (20u64);
+        acc += st19_v20 / (21u64);
+        acc += st19_v21 / (22u64);
+        acc += st19_v22 / (23u64);
+        acc += st19_v23 / (24u64);
+        acc += st19_v24 / (25u64);
+        return acc;
+    }
+
+    fn aggregate_settlement(seed: u64) -> u64 {
+        let acc = seed;
+        acc = bench_primitives.aleo/aggregate_primitives(acc);
+        acc = bench_registry.aleo/aggregate_registry(acc);
+        acc = bench_policy.aleo/aggregate_policy(acc);
+        acc = bench_router.aleo/aggregate_router(acc);
+        return acc + 1u64;
+    }
+}

--- a/crates/compiler/benchmarks/fixtures/single/control_flow_matrix.leo
+++ b/crates/compiler/benchmarks/fixtures/single/control_flow_matrix.leo
@@ -1,0 +1,518 @@
+// Realistic single-file benchmark: routing and risk scoring for DEX-style pools.
+// Written in current Leo syntax with top-level helper functions and program entry fns.
+
+struct Pool {
+    reserve_x: u64,
+    reserve_y: u64,
+    fee_bps: u16,
+    depth: u64,
+}
+
+struct RouteParams {
+    amount_in: u64,
+    slippage_limit_bps: u64,
+    risk_limit: u64,
+    horizon: u32,
+}
+
+struct TradeWindow {
+    w0: u64,
+    w1: u64,
+    w2: u64,
+    w3: u64,
+    w4: u64,
+    w5: u64,
+    w6: u64,
+    w7: u64,
+}
+
+fn min_u64(a: u64, b: u64) -> u64 {
+    if a < b {
+        return a;
+    } else {
+        return b;
+    }
+}
+
+fn max_u64(a: u64, b: u64) -> u64 {
+    if a > b {
+        return a;
+    } else {
+        return b;
+    }
+}
+
+fn abs_diff(a: u64, b: u64) -> u64 {
+    if a > b {
+        return a - b;
+    } else {
+        return b - a;
+    }
+}
+
+fn clamp_fee_bps(fee_bps: u16) -> u16 {
+    if fee_bps > 1500u16 {
+        return 1500u16;
+    } else {
+        return fee_bps;
+    }
+}
+
+fn apply_fee(amount: u64, fee_bps: u16) -> (u64, u64) {
+    let fee = (amount * fee_bps as u64) / 10_000u64;
+    return (amount - fee, fee);
+}
+
+fn quote_constant_product(amount_in: u64, reserve_in: u64, reserve_out: u64, fee_bps: u16) -> u64 {
+    let (effective_in, _) = apply_fee(amount_in, fee_bps);
+    let numerator = effective_in * reserve_out;
+    let denominator = reserve_in + effective_in;
+    return numerator / denominator;
+}
+
+fn impact_bps(amount_in: u64, reserve_in: u64) -> u64 {
+    if reserve_in == 0u64 {
+        return 10_000u64;
+    }
+    return (amount_in * 10_000u64) / reserve_in;
+}
+
+fn liquidity_ratio(reserve_x: u64, reserve_y: u64) -> u64 {
+    let hi = max_u64(reserve_x, reserve_y);
+    let lo = min_u64(reserve_x, reserve_y);
+    if lo == 0u64 {
+        return 0u64;
+    }
+    return (hi * 10_000u64) / lo;
+}
+
+fn skew_penalty(reserve_x: u64, reserve_y: u64) -> u64 {
+    return abs_diff(reserve_x, reserve_y) / 10u64;
+}
+
+fn window_pressure(window: TradeWindow) -> u64 {
+    let lanes = [
+        window.w0,
+        window.w1,
+        window.w2,
+        window.w3,
+        window.w4,
+        window.w5,
+        window.w6,
+        window.w7,
+    ];
+    let acc = 0u64;
+    for i: u8 in 0u8..8u8 {
+        acc += lanes[i] / (i as u64 + 1u64);
+    }
+    return acc;
+}
+
+fn window_variance(window: TradeWindow) -> u64 {
+    let lanes = [
+        window.w0,
+        window.w1,
+        window.w2,
+        window.w3,
+        window.w4,
+        window.w5,
+        window.w6,
+        window.w7,
+    ];
+    let low = lanes[0u8];
+    let high = lanes[0u8];
+    for i: u8 in 1u8..8u8 {
+        if lanes[i] < low {
+            low = lanes[i];
+        }
+        if lanes[i] > high {
+            high = lanes[i];
+        }
+    }
+    return high - low;
+}
+
+fn lane_score_00(pool: Pool, params: RouteParams) -> u64 {
+    let out = quote_constant_product(
+        params.amount_in,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(params.amount_in, pool.reserve_x);
+    let ratio = liquidity_ratio(pool.reserve_x, pool.reserve_y);
+    return out + ratio - impact;
+}
+
+fn lane_score_01(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 20u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(scaled, pool.reserve_x);
+    let penalty = skew_penalty(pool.reserve_x, pool.reserve_y);
+    return out + pool.depth - impact - penalty;
+}
+
+fn lane_score_02(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + (params.horizon as u64 * 3u64);
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(scaled, pool.reserve_x);
+    return out + pool.reserve_y / 4u64 - impact;
+}
+
+fn lane_score_03(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + params.risk_limit / 100u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let ratio = liquidity_ratio(pool.reserve_x, pool.reserve_y);
+    return out + ratio + pool.depth / 10u64;
+}
+
+fn lane_score_04(pool: Pool, params: RouteParams) -> u64 {
+    let out = quote_constant_product(
+        params.amount_in + 7u64,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(params.amount_in + 7u64, pool.reserve_x);
+    let penalty = skew_penalty(pool.reserve_x, pool.reserve_y);
+    return out + params.risk_limit / 10u64 - impact - penalty;
+}
+
+fn lane_score_05(pool: Pool, params: RouteParams) -> u64 {
+    let out = quote_constant_product(
+        params.amount_in + 11u64,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let ratio = liquidity_ratio(pool.reserve_x, pool.reserve_y);
+    return out + ratio + pool.reserve_x / 20u64;
+}
+
+fn lane_score_06(pool: Pool, params: RouteParams) -> u64 {
+    let out = quote_constant_product(
+        params.amount_in + 13u64,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(params.amount_in + 13u64, pool.reserve_x);
+    return out + pool.depth / 5u64 - impact;
+}
+
+fn lane_score_07(pool: Pool, params: RouteParams) -> u64 {
+    let out = quote_constant_product(
+        params.amount_in + 17u64,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let penalty = skew_penalty(pool.reserve_x, pool.reserve_y);
+    return out + params.slippage_limit_bps - penalty;
+}
+
+fn lane_score_08(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 33u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(scaled, pool.reserve_x);
+    let ratio = liquidity_ratio(pool.reserve_x, pool.reserve_y);
+    return out + ratio + params.horizon as u64 - impact;
+}
+
+fn lane_score_09(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 25u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let penalty = skew_penalty(pool.reserve_x, pool.reserve_y);
+    return out + pool.reserve_x / 16u64 - penalty;
+}
+
+fn lane_score_10(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 40u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(scaled, pool.reserve_x);
+    return out + params.risk_limit / 20u64 - impact;
+}
+
+fn lane_score_11(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 45u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let ratio = liquidity_ratio(pool.reserve_x, pool.reserve_y);
+    return out + ratio + params.slippage_limit_bps / 2u64;
+}
+
+fn lane_score_12(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 50u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(scaled, pool.reserve_x);
+    let penalty = skew_penalty(pool.reserve_x, pool.reserve_y);
+    return out + pool.depth / 7u64 - impact - penalty;
+}
+
+fn lane_score_13(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 55u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let ratio = liquidity_ratio(pool.reserve_x, pool.reserve_y);
+    return out + ratio + params.horizon as u64;
+}
+
+fn lane_score_14(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 60u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let impact = impact_bps(scaled, pool.reserve_x);
+    return out + params.slippage_limit_bps / 3u64 - impact;
+}
+
+fn lane_score_15(pool: Pool, params: RouteParams) -> u64 {
+    let scaled = params.amount_in + pool.depth / 65u64;
+    let out = quote_constant_product(
+        scaled,
+        pool.reserve_x,
+        pool.reserve_y,
+        clamp_fee_bps(pool.fee_bps),
+    );
+    let penalty = skew_penalty(pool.reserve_x, pool.reserve_y);
+    return out + params.risk_limit / 30u64 - penalty;
+}
+
+fn route_total(pool: Pool, params: RouteParams) -> u64 {
+    let lanes = [
+        lane_score_00(pool, params),
+        lane_score_01(pool, params),
+        lane_score_02(pool, params),
+        lane_score_03(pool, params),
+        lane_score_04(pool, params),
+        lane_score_05(pool, params),
+        lane_score_06(pool, params),
+        lane_score_07(pool, params),
+        lane_score_08(pool, params),
+        lane_score_09(pool, params),
+        lane_score_10(pool, params),
+        lane_score_11(pool, params),
+        lane_score_12(pool, params),
+        lane_score_13(pool, params),
+        lane_score_14(pool, params),
+        lane_score_15(pool, params),
+    ];
+    let acc = 0u64;
+    for i: u8 in 0u8..16u8 {
+        acc += lanes[i] / (i as u64 + 1u64);
+    }
+    return acc;
+}
+
+fn best_of_three(a: u64, b: u64, c: u64) -> u64 {
+    if a >= b {
+        if a >= c {
+            return a;
+        } else {
+            return c;
+        }
+    } else {
+        if b >= c {
+            return b;
+        } else {
+            return c;
+        }
+    }
+}
+
+fn worst_of_three(a: u64, b: u64, c: u64) -> u64 {
+    if a <= b {
+        if a <= c {
+            return a;
+        } else {
+            return c;
+        }
+    } else {
+        if b <= c {
+            return b;
+        } else {
+            return c;
+        }
+    }
+}
+
+fn stress_mix_00(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a + b + c;
+    if lane % 2u64 == 0u64 {
+        return lane / 2u64;
+    } else {
+        return lane + 19u64;
+    }
+}
+
+fn stress_mix_01(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a * 2u64 + b + c;
+    if lane % 3u64 == 0u64 {
+        return lane / 3u64;
+    } else {
+        return lane + 23u64;
+    }
+}
+
+fn stress_mix_02(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a + b * 2u64 + c;
+    if lane % 5u64 == 0u64 {
+        return lane / 5u64;
+    } else {
+        return lane + 29u64;
+    }
+}
+
+fn stress_mix_03(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a + b + c * 2u64;
+    if lane % 7u64 == 0u64 {
+        return lane / 7u64;
+    } else {
+        return lane + 31u64;
+    }
+}
+
+fn stress_mix_04(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a * 3u64 + b + c;
+    if lane % 11u64 == 0u64 {
+        return lane / 11u64;
+    } else {
+        return lane + 37u64;
+    }
+}
+
+fn stress_mix_05(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a + b * 3u64 + c;
+    if lane % 13u64 == 0u64 {
+        return lane / 13u64;
+    } else {
+        return lane + 41u64;
+    }
+}
+
+fn stress_mix_06(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a + b + c * 3u64;
+    if lane % 17u64 == 0u64 {
+        return lane / 17u64;
+    } else {
+        return lane + 43u64;
+    }
+}
+
+fn stress_mix_07(a: u64, b: u64, c: u64) -> u64 {
+    let lane = a * 4u64 + b + c;
+    if lane % 19u64 == 0u64 {
+        return lane / 19u64;
+    } else {
+        return lane + 47u64;
+    }
+}
+
+program bench_control_flow_matrix.aleo {
+    fn evaluate_route(
+        pool_a: Pool,
+        pool_b: Pool,
+        pool_c: Pool,
+        params: RouteParams,
+        window: TradeWindow,
+    ) -> u64 {
+        let score_a = route_total(pool_a, params);
+        let score_b = route_total(pool_b, params);
+        let score_c = route_total(pool_c, params);
+        let best = best_of_three(score_a, score_b, score_c);
+        let worst = worst_of_three(score_a, score_b, score_c);
+        let pressure = window_pressure(window);
+        let variance = window_variance(window);
+        let adjusted = best + pressure;
+        let penalty = worst / 4u64 + variance;
+        if adjusted > penalty {
+            return adjusted - penalty;
+        } else {
+            return best / 2u64;
+        }
+    }
+
+    fn matrix_probe(pool: Pool, params: RouteParams) -> u64 {
+        let lanes = [
+            lane_score_00(pool, params),
+            lane_score_01(pool, params),
+            lane_score_02(pool, params),
+            lane_score_03(pool, params),
+            lane_score_04(pool, params),
+            lane_score_05(pool, params),
+            lane_score_06(pool, params),
+            lane_score_07(pool, params),
+            lane_score_08(pool, params),
+            lane_score_09(pool, params),
+            lane_score_10(pool, params),
+            lane_score_11(pool, params),
+            lane_score_12(pool, params),
+            lane_score_13(pool, params),
+            lane_score_14(pool, params),
+            lane_score_15(pool, params),
+        ];
+        let acc = 0u64;
+        for i: u8 in 0u8..16u8 {
+            if i % 2u8 == 0u8 {
+                acc += lanes[i] / (i as u64 + 1u64);
+            } else {
+                acc += lanes[i] / (i as u64 + 2u64);
+            }
+        }
+        let floor = params.slippage_limit_bps * 10u64;
+        let ceiling = params.risk_limit * 5u64;
+        if acc < floor {
+            return floor;
+        }
+        if acc > ceiling {
+            return ceiling;
+        }
+        return acc;
+    }
+}

--- a/crates/compiler/benchmarks/src/lib.rs
+++ b/crates/compiler/benchmarks/src/lib.rs
@@ -1,0 +1,294 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Benchmark fixtures and compiler helpers for Criterion-based frontend benchmarks.
+//!
+//! Run benchmarks with `cargo bench -p leo-benchmarks --bench compiler_benchmarks`.
+
+#![forbid(unsafe_code)]
+
+use leo_ast::{AleoProgram, FunctionStub, Identifier, NetworkName, NodeBuilder, ProgramId, Stub};
+use leo_compiler::{Compiler, CompilerOptions};
+use leo_errors::Handler;
+use leo_package::{Package, ProgramData};
+use leo_parser::parse_ast;
+use leo_span::{Symbol, source_map::FileName, with_session_globals};
+use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    rc::Rc,
+};
+
+use indexmap::IndexMap;
+use walkdir::WalkDir;
+
+pub const BENCH_NETWORK: NetworkName = NetworkName::TestnetV0;
+
+/// Loaded benchmark fixture ready for compiler construction.
+pub struct FixtureData {
+    pub program_name: String,
+    pub source: String,
+    pub filename: FileName,
+    pub modules: Vec<(String, FileName)>,
+    pub import_stubs: IndexMap<Symbol, Stub>,
+    pub network: NetworkName,
+}
+
+impl FixtureData {
+    pub fn module_refs(&self) -> Vec<(&str, FileName)> {
+        self.modules.iter().map(|(source, name)| (source.as_str(), name.clone())).collect()
+    }
+}
+
+fn read_modules(source_dir: &Path, entry: &Path) -> Result<Vec<(String, FileName)>, String> {
+    let mut modules = Vec::new();
+
+    for file in WalkDir::new(source_dir).into_iter().filter_map(Result::ok) {
+        if !file.file_type().is_file()
+            || file.path() == entry
+            || file.path().extension().and_then(|ext| ext.to_str()) != Some("leo")
+        {
+            continue;
+        }
+
+        let source = match fs::read_to_string(file.path()) {
+            Ok(source) => source,
+            Err(err) => {
+                return Err(format!("failed to read fixture module {}: {err}", file.path().display()));
+            }
+        };
+        modules.push((source, FileName::Real(file.path().to_path_buf())));
+    }
+
+    Ok(modules)
+}
+
+/// Parses a local Leo dependency and extracts its public interface as a
+/// `Stub::FromAleo`.
+///
+/// Only the program scope's entry-point function signatures, struct definitions,
+/// and mappings are kept.  This avoids the scope-ordering issues that occur when
+/// `Stub::FromLeo` (which wraps a full `Program` AST) is processed by
+/// reconstructor-based passes.
+fn parse_interface_stub(program_name: Symbol, source: &Path, source_dir: &Path) -> Result<Stub, String> {
+    let source_text = match fs::read_to_string(source) {
+        Ok(source_text) => source_text,
+        Err(err) => {
+            return Err(format!(
+                "failed to read dependency {}.aleo source file {}: {err}",
+                program_name,
+                source.display()
+            ));
+        }
+    };
+    let modules = read_modules(source_dir, source)?;
+    let source_file =
+        with_session_globals(|s| s.source_map.new_source(&source_text, FileName::Real(source.to_path_buf())));
+    let module_source_files = modules
+        .iter()
+        .map(|(source, filename)| with_session_globals(|s| s.source_map.new_source(source, filename.clone())))
+        .collect::<Vec<_>>();
+    let node_builder = NodeBuilder::default();
+
+    let program = match parse_ast(Handler::default(), &node_builder, &source_file, &module_source_files, BENCH_NETWORK)
+    {
+        Ok(ast) => ast.ast,
+        Err(err) => {
+            return Err(format!(
+                "failed to parse dependency {}.aleo interface source {}: {err}",
+                program_name,
+                source.display()
+            ));
+        }
+    };
+
+    // Extract the single program scope.
+    let scope = match program.program_scopes.values().next() {
+        Some(scope) => scope,
+        None => {
+            return Err(format!("no program scope found for dependency {}.aleo in {}", program_name, source.display()));
+        }
+    };
+
+    // Build function stubs from entry-point signatures (no bodies).
+    let functions = scope
+        .functions
+        .iter()
+        .map(|(sym, func)| {
+            (*sym, FunctionStub {
+                annotations: func.annotations.clone(),
+                variant: func.variant,
+                identifier: func.identifier,
+                input: func.input.clone(),
+                output: func.output.clone(),
+                output_type: func.output_type.clone(),
+                span: func.span,
+                id: func.id,
+            })
+        })
+        .collect();
+
+    let imports = program
+        .imports
+        .keys()
+        .map(|sym| ProgramId {
+            name: Identifier { name: *sym, span: Default::default(), id: Default::default() },
+            network: Identifier { name: Symbol::intern("aleo"), span: Default::default(), id: Default::default() },
+        })
+        .collect();
+
+    let aleo_program = AleoProgram {
+        imports,
+        stub_id: scope.program_id,
+        consts: scope.consts.clone(),
+        composites: scope.composites.clone(),
+        mappings: scope.mappings.clone(),
+        functions,
+        span: scope.span,
+    };
+
+    Ok(aleo_program.into())
+}
+
+fn disassemble_bytecode(program_name: Symbol, bytecode: &str) -> Result<Stub, String> {
+    let disassembled = match BENCH_NETWORK {
+        NetworkName::MainnetV0 => leo_disassembler::disassemble_from_str::<MainnetV0>(program_name, bytecode),
+        NetworkName::TestnetV0 => leo_disassembler::disassemble_from_str::<TestnetV0>(program_name, bytecode),
+        NetworkName::CanaryV0 => leo_disassembler::disassemble_from_str::<CanaryV0>(program_name, bytecode),
+    };
+
+    match disassembled {
+        Ok(stub) => Ok(stub.into()),
+        Err(err) => Err(format!("failed to disassemble dependency {}.aleo bytecode: {err}", program_name)),
+    }
+}
+
+/// Loads source/modules and resolves transitive dependencies with `Package::from_directory`
+/// (same flow as CLI `leo build`).
+///
+/// Local Leo dependencies are parsed and their public interfaces extracted into
+/// `Stub::FromAleo` stubs to avoid scope-hierarchy conflicts with the main
+/// program's compiler passes.
+///
+pub fn load_fixture(package_dir: &Path) -> Result<FixtureData, String> {
+    let home = aleo_std::aleo_dir();
+
+    let package = match Package::from_directory(
+        package_dir,
+        &home,
+        false, // no_cache
+        false, // no_local
+        Some(BENCH_NETWORK),
+        None, // no endpoint needed for local-only fixtures
+    ) {
+        Ok(package) => package,
+        Err(err) => {
+            return Err(format!(
+                "failed to resolve fixture dependencies for {} (network unavailable?): {err}",
+                package_dir.display()
+            ));
+        }
+    };
+
+    let mut import_stubs = IndexMap::new();
+
+    for program in &package.programs {
+        match &program.data {
+            ProgramData::Bytecode(bytecode) => {
+                let stub = disassemble_bytecode(program.name, bytecode)?;
+                import_stubs.insert(program.name, stub);
+            }
+            ProgramData::SourcePath { directory, source } => {
+                let source_dir =
+                    if source.starts_with(directory.join("src")) { directory.join("src") } else { directory.clone() };
+
+                let stub = parse_interface_stub(program.name, source, &source_dir)?;
+                import_stubs.insert(program.name, stub);
+            }
+        }
+    }
+
+    let entry = package_dir.join("src/main.leo");
+    let source = match fs::read_to_string(&entry) {
+        Ok(source) => source,
+        Err(err) => {
+            return Err(format!("failed to read fixture source {}: {err}", entry.display()));
+        }
+    };
+    let modules = read_modules(&package_dir.join("src"), &entry)?;
+    let program_name = package.manifest.program.trim_end_matches(".aleo").to_string();
+
+    Ok(FixtureData {
+        program_name,
+        source,
+        filename: FileName::Real(entry),
+        modules,
+        import_stubs,
+        network: BENCH_NETWORK,
+    })
+}
+
+/// Loads a standalone `.leo` source file as a fixture with no dependencies.
+pub fn load_source_fixture(source_path: &Path) -> Result<FixtureData, String> {
+    let source = match fs::read_to_string(source_path) {
+        Ok(source) => source,
+        Err(err) => {
+            return Err(format!("failed to read source fixture {}: {err}", source_path.display()));
+        }
+    };
+    Ok(FixtureData {
+        program_name: String::new(),
+        source,
+        filename: FileName::Real(source_path.to_path_buf()),
+        modules: Vec::new(),
+        import_stubs: IndexMap::new(),
+        network: BENCH_NETWORK,
+    })
+}
+
+/// Creates a fresh [`Compiler`] with all fixture dependencies pre-loaded.
+pub fn create_compiler(fixture: &FixtureData) -> Compiler {
+    let expected_program_name = if fixture.program_name.is_empty() { None } else { Some(fixture.program_name.clone()) };
+
+    Compiler::new(
+        expected_program_name,
+        false,
+        Handler::default(),
+        Rc::new(NodeBuilder::default()),
+        PathBuf::default(),
+        Some(CompilerOptions::default()),
+        fixture.import_stubs.clone(),
+        fixture.network,
+    )
+}
+
+/// Creates a lightweight [`Compiler`] with no import stubs for parse-only benchmarks.
+pub fn create_parse_only_compiler(fixture: &FixtureData) -> Compiler {
+    let expected_program_name = if fixture.program_name.is_empty() { None } else { Some(fixture.program_name.clone()) };
+
+    Compiler::new(
+        expected_program_name,
+        false,
+        Handler::default(),
+        Rc::new(NodeBuilder::default()),
+        PathBuf::default(),
+        Some(CompilerOptions::default()),
+        IndexMap::new(),
+        fixture.network,
+    )
+}

--- a/crates/compiler/src/compiler.rs
+++ b/crates/compiler/src/compiler.rs
@@ -73,6 +73,10 @@ pub struct Compiler {
 }
 
 impl Compiler {
+    pub fn network(&self) -> NetworkName {
+        self.state.network
+    }
+
     pub fn parse(&mut self, source: &str, filename: FileName, modules: &[(&str, FileName)]) -> Result<()> {
         // Register the source in the source map.
         let source_file = with_session_globals(|s| s.source_map.new_source(source, filename.clone()));
@@ -166,7 +170,7 @@ impl Compiler {
         }
     }
 
-    fn do_pass<P: Pass>(&mut self, input: P::Input) -> Result<P::Output> {
+    pub fn do_pass<P: Pass>(&mut self, input: P::Input) -> Result<P::Output> {
         let output = P::do_pass(input, &mut self.state)?;
 
         let write = match &self.compiler_options.ast_snapshots {
@@ -182,6 +186,19 @@ impl Compiler {
         Ok(output)
     }
 
+    /// Runs all frontend passes: NameValidation through StaticAnalyzing.
+    pub fn frontend_passes(&mut self) -> Result<()> {
+        self.do_pass::<NameValidation>(())?;
+        self.do_pass::<GlobalVarsCollection>(())?;
+        self.do_pass::<PathResolution>(())?;
+        self.do_pass::<GlobalItemsCollection>(())?;
+        self.do_pass::<CheckInterfaces>(())?;
+        self.do_pass::<TypeChecking>(TypeCheckingInput::new(self.state.network))?;
+        self.do_pass::<Disambiguate>(())?;
+        self.do_pass::<ProcessingAsync>(TypeCheckingInput::new(self.state.network))?;
+        self.do_pass::<StaticAnalyzing>(())
+    }
+
     /// Runs the compiler stages.
     ///
     /// Returns the generated ABIs (primary and imports), which are captured
@@ -190,23 +207,7 @@ impl Compiler {
     pub fn intermediate_passes(&mut self) -> Result<(leo_abi::Program, IndexMap<String, leo_abi::Program>)> {
         let type_checking_config = TypeCheckingInput::new(self.state.network);
 
-        self.do_pass::<NameValidation>(())?;
-
-        self.do_pass::<GlobalVarsCollection>(())?;
-
-        self.do_pass::<PathResolution>(())?;
-
-        self.do_pass::<GlobalItemsCollection>(())?;
-
-        self.do_pass::<CheckInterfaces>(())?;
-
-        self.do_pass::<TypeChecking>(type_checking_config.clone())?;
-
-        self.do_pass::<Disambiguate>(())?;
-
-        self.do_pass::<ProcessingAsync>(type_checking_config.clone())?;
-
-        self.do_pass::<StaticAnalyzing>(())?;
+        self.frontend_passes()?;
 
         self.do_pass::<ConstPropUnrollAndMorphing>(type_checking_config.clone())?;
 


### PR DESCRIPTION
Add a dedicated `leo-benchmarks` crate (`crates/compiler/benchmarks/`) with Criterion benchmarks for the frontend compiler pipeline, plus a CodSpeed CI workflow for automatic regression detection on PRs.

**Motivation:**
This work was initially taken on to get a realistic sense of compiler speed before starting on the new Leo LSP server. The LSP will recompile the entire file and its dependency tree from scratch on every keystroke, so we needed to know if the frontend pipeline is fast enough without incremental compilation.

Early testing against real-world partner projects (Sealance and Hyperlane) on the pre-4.0 syntax showed promising numbers:
- `hyp_synthetic` full dependency chain: **~9.5ms**
- `hook_manager` with deps: **~7.1ms**

These projects still need to be updated to Leo 4.0 syntax before they can be used as benchmarks again. In the meantime, this PR includes contrived fixture programs (~2k lines each, 5 transitive deps) that exercise the same compiler paths at comparable scale.

**Benchmarks:**
- `frontend_with_deps` — full frontend pipeline (parse → static analysis) with transitive dependencies
- `dependency_chain` — incremental chain buildup (1→5 programs), shows per-dep cost scaling
- `frontend_single_file` — single file without dependencies
- `individual_passes` — each of the 10 frontend passes in isolation

Here are the benchmarking results running locally on my machine against these these fixtures. This is on an macbook pro M4. Interestingly the codspeed report in the comment below seems to be 8x slower which might be more indicative of the machine non power users are running leo projects on. 

| Benchmark | Mid-range time |
  |---|---:|
  | frontend_with_deps/contrived_settlement | 10.320 ms |
  | dependency_chain/01_primitives | 4.1122 ms |
  | dependency_chain/02_registry | 5.1947 ms |
  | dependency_chain/03_policy | 6.5149 ms |
  | dependency_chain/04_router | 8.1451 ms |
  | dependency_chain/05_settlement | 10.369 ms |
  | frontend_single_file/control_flow_matrix | 1.3682 ms |
  | individual_passes/01_parsing/contrived_settlement | 2.0968 ms |
  | individual_passes/02_name_validation/contrived_settlement | 6.4703 ms |
  | individual_passes/03_global_vars_collection/contrived_settlement | 113.87 µs |
  | individual_passes/04_path_resolution/contrived_settlement | 466.98 µs |
  | individual_passes/05_global_items_collection/contrived_settlement | 388.68 µs |
  | individual_passes/06_check_interfaces/contrived_settlement | 205.41 µs |
  | individual_passes/07_type_checking/contrived_settlement | 952.80 µs |
  | individual_passes/08_disambiguate/contrived_settlement | 395.61 µs |
  | individual_passes/09_processing_async/contrived_settlement | 478.96 µs |
  | individual_passes/10_static_analyzing/contrived_settlement | 220.52 µs |


**Compiler changes:**
- Add `frontend_passes()` method (passes 1–10, LSP-relevant subset)
- Add partial-pipeline helpers for per-pass benchmarking

**CI:**
- CodSpeed workflow triggers on PRs touching `crates/compiler/` and pushes to `master`
- Posts benchmark regression reports as PR comments
- Uses `codspeed-criterion-compat` so `cargo bench -p leo-benchmarks` works locally with standard Criterion

Closes #28552