### PR TITLE
Better errors for forbidden items in final blocks

### DIFF
--- a/crates/errors/src/errors/type_checker/type_checker_error.rs
+++ b/crates/errors/src/errors/type_checker/type_checker_error.rs
@@ -1180,8 +1180,8 @@ create_messages!(
     @formatted
     invalid_operation_inside_final_block {
         args: (operation: impl Display),
-        msg: format!("Invalid expression in a final block. `{operation}` cannot be used directly here"),
-        help: None,
+        msg: format!("Invalid expression in a final block. `{operation}` cannot be used directly here."),
+        help: Some(format!("Bind `{operation}` to a variable before the `final` block: `let val = {operation};`")),
     }
 
     @formatted
@@ -1423,5 +1423,12 @@ create_messages!(
         args: (),
         msg: format!("`@no_inline` is not allowed on `final fn` functions because they must always be inlined."),
         help: None,
+    }
+
+    @formatted
+    record_captured_by_final_block {
+        args: (var_name: impl Display),
+        msg: format!("A `final` block cannot capture the record variable `{var_name}`. Records cannot be used in on-chain code."),
+        help: Some(format!("Extract the needed fields before the `final` block. For example: `let val = {var_name}.field_name;`")),
     }
 );

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -566,6 +566,17 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
             BlockToFunctionRewriter::new(self.state, self.scope_state.program_name.unwrap());
         let (new_function, _) =
             block_to_function_rewriter.rewrite_block(&input.block, Symbol::intern("unused"), Variant::Finalize);
+
+        // Check that no captured variable is a record type.
+        for func_input in &new_function.input {
+            if let Type::Composite(composite) = &func_input.type_
+                && let Some(comp) = self.lookup_composite(composite.path.expect_global_location())
+                && comp.is_record
+            {
+                self.emit_err(TypeCheckerError::record_captured_by_final_block(func_input.identifier.name, input.span));
+            }
+        }
+
         let input_types = new_function.input.iter().map(|Input { type_, .. }| type_.clone()).collect();
         self.async_function_input_types.insert(
             Location::new(self.scope_state.program_name.unwrap(), vec![Symbol::intern(&format!(

--- a/tests/expectations/compiler/async_blocks/invalid_expr_in_async_block_fail.out
+++ b/tests/expectations/compiler/async_blocks/invalid_expr_in_async_block_fail.out
@@ -1,10 +1,14 @@
-Error [ETYC0372147]: Invalid expression in a final block. `self.signer` cannot be used directly here
+Error [ETYC0372147]: Invalid expression in a final block. `self.signer` cannot be used directly here.
     --> compiler-test:4:21
      |
    4 |             let s = self.signer;
      |                     ^^^^^^^^^^^
-Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here
+     |
+     = Bind `self.signer` to a variable before the `final` block: `let val = self.signer;`
+Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here.
     --> compiler-test:5:21
      |
    5 |             let c = self.caller;
      |                     ^^^^^^^^^^^
+     |
+     = Bind `self.caller` to a variable before the `final` block: `let val = self.caller;`

--- a/tests/expectations/compiler/async_blocks/record_capture_in_async_block_fail.out
+++ b/tests/expectations/compiler/async_blocks/record_capture_in_async_block_fail.out
@@ -1,0 +1,11 @@
+Error [ETYC0372176]: A `final` block cannot capture the record variable `t`. Records cannot be used in on-chain code.
+    --> compiler-test:9:17
+     |
+   9 |         let f = final {
+     |                 ^^^^^^^
+  10 |             assert(t.owner == aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc);
+     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  11 |         };
+     |         ^
+     |
+     = Extract the needed fields before the `final` block. For example: `let val = t.field_name;`

--- a/tests/expectations/compiler/async_blocks/self_in_async_block_fail.out
+++ b/tests/expectations/compiler/async_blocks/self_in_async_block_fail.out
@@ -1,0 +1,14 @@
+Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here.
+    --> compiler-test:4:21
+     |
+   4 |             let c = self.caller;
+     |                     ^^^^^^^^^^^
+     |
+     = Bind `self.caller` to a variable before the `final` block: `let val = self.caller;`
+Error [ETYC0372147]: Invalid expression in a final block. `self.signer` cannot be used directly here.
+    --> compiler-test:5:21
+     |
+   5 |             let s = self.signer;
+     |                     ^^^^^^^^^^^
+     |
+     = Bind `self.signer` to a variable before the `final` block: `let val = self.signer;`

--- a/tests/expectations/compiler/finalize/get_incorrect_num_operands.out
+++ b/tests/expectations/compiler/finalize/get_incorrect_num_operands.out
@@ -3,11 +3,13 @@ Error [ETYC0372031]: A mapping's value cannot be a record
      |
    9 |     mapping tokens: address => Token;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here
+Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here.
     --> compiler-test:12:47
      |
   12 |         return final { finalize_decrease_self(self.caller, amount); };
      |                                               ^^^^^^^^^^^
+     |
+     = Bind `self.caller` to a variable before the `final` block: `let val = self.caller;`
 Error [ETYC0372006]: Call expected `2` args, but got `3`
     --> compiler-test:17:5
      |

--- a/tests/expectations/compiler/finalize/get_or_incorrect_num_operands.out
+++ b/tests/expectations/compiler/finalize/get_or_incorrect_num_operands.out
@@ -3,11 +3,13 @@ Error [ETYC0372031]: A mapping's value cannot be a record
      |
    9 |     mapping tokens: address => Token;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here
+Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here.
     --> compiler-test:12:47
      |
   12 |         return final { finalize_decrease_self(self.caller, amount); };
      |                                               ^^^^^^^^^^^
+     |
+     = Bind `self.caller` to a variable before the `final` block: `let val = self.caller;`
 Error [ETYC0372006]: Call expected `3` args, but got `4`
     --> compiler-test:17:5
      |

--- a/tests/expectations/compiler/finalize/set_incorrect_num_operands.out
+++ b/tests/expectations/compiler/finalize/set_incorrect_num_operands.out
@@ -3,11 +3,13 @@ Error [ETYC0372031]: A mapping's value cannot be a record
      |
    9 |     mapping tokens: address => Token;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here
+Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here.
     --> compiler-test:12:47
      |
   12 |         return final { finalize_decrease_self(self.caller, amount); };
      |                                               ^^^^^^^^^^^
+     |
+     = Bind `self.caller` to a variable before the `final` block: `let val = self.caller;`
 Error [ETYC0372006]: Call expected `3` args, but got `4`
     --> compiler-test:17:5
      |

--- a/tests/expectations/compiler/function/self_finalize_fail.out
+++ b/tests/expectations/compiler/function/self_finalize_fail.out
@@ -1,8 +1,10 @@
-Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here
+Error [ETYC0372147]: Invalid expression in a final block. `self.caller` cannot be used directly here.
     --> compiler-test:4:63
      |
    4 |         return (self.caller == addr, final { finalize_matches(self.caller); });
      |                                                               ^^^^^^^^^^^
+     |
+     = Bind `self.caller` to a variable before the `final` block: `let val = self.caller;`
 Error [ETYC0372066]: `self.caller` is not a valid operand in a finalization context.
     --> compiler-test:9:21
      |

--- a/tests/tests/compiler/async_blocks/record_capture_in_async_block_fail.leo
+++ b/tests/tests/compiler/async_blocks/record_capture_in_async_block_fail.leo
@@ -1,0 +1,13 @@
+program test.aleo {
+    record Token {
+        owner: address,
+        amount: u64,
+    }
+
+    fn mint(owner: address, amount: u64) {
+        let t: Token = Token { owner, amount };
+        let f = final {
+            assert(t.owner == aleo1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3ljyzc);
+        };
+    }
+}

--- a/tests/tests/compiler/async_blocks/self_in_async_block_fail.leo
+++ b/tests/tests/compiler/async_blocks/self_in_async_block_fail.leo
@@ -1,0 +1,8 @@
+program test.aleo {
+    fn t1() {
+        let f1 = final {
+            let c = self.caller;
+            let s = self.signer;
+        };
+    }
+}


### PR DESCRIPTION
Final blocks may not contain invocations of `self.caller` or `self.signer` or captures of record values. However this can almost always be alleviated by capturing a local variable representing the value of these items.

The current errors for those cases, though common in rewriting code for the new syntax, is very unclear. This change provides better errors and guidance to the developper.

Fixes #29185