### PR TITLE
[Fix] Harden leo-fmt for 4.0 syntax validation and integrate CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,12 @@ jobs:
           no_output_timeout: 35m
           command: cargo +nightly fmt --all -- --check
       - run:
+          name: Validate Leo formatter semantics
+          no_output_timeout: 35m
+          command: |
+            cargo nextest run -p leo-fmt --locked --cargo-profile ci --features validate \
+              -E 'test(/validate_/) - test(validate_ast_equivalence_repos) - test(validate_workspace_ast_equivalence)'
+      - run:
           name: Clippy
           no_output_timeout: 35m
           command: |

--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -116,6 +116,13 @@ pub fn format_node(node: &SyntaxNode, out: &mut Output) {
 // =============================================================================
 
 fn format_root(node: &SyntaxNode, out: &mut Output) {
+    if node.children().any(|child| {
+        !matches!(child.kind(), IMPORT | PROGRAM_DECL | ANNOTATION | ERROR) && !is_program_item(child.kind())
+    }) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     let mut prev_was_import = false;
     let mut prev_was_block_item = false;
     let mut had_output = false;
@@ -189,6 +196,9 @@ fn format_root(node: &SyntaxNode, out: &mut Output) {
                     had_output = true;
                     linebreak_count = 0;
                 } else if kind == ERROR {
+                    if should_inline_adjacent_error(&n) {
+                        continue;
+                    }
                     let text = n.text().to_string();
                     let text = text.trim();
                     if !text.is_empty() {
@@ -299,6 +309,9 @@ fn format_program(node: &SyntaxNode, out: &mut Output) {
                             || linebreak_count >= 2
                             || has_blank_line_in_leading_trivia(n));
                     if kind == ERROR {
+                        if should_inline_adjacent_error(n) {
+                            continue;
+                        }
                         let text = n.text().to_string();
                         let text = text.trim();
                         if !text.is_empty() {
@@ -358,6 +371,12 @@ fn is_block_item(kind: SyntaxKind) -> bool {
 // =============================================================================
 
 fn format_function(node: &SyntaxNode, out: &mut Output) {
+    if write_node_with_inline_error_verbatim(node, out) {
+        out.set_mark();
+        out.ensure_newline();
+        return;
+    }
+
     // Emit leading comments (trivia that appears before the first keyword)
     emit_leading_comments(node, out);
 
@@ -422,6 +441,7 @@ fn format_function(node: &SyntaxNode, out: &mut Output) {
     if let Some(next) = node.next_sibling() {
         emit_stolen_trailing_comments(&next, out);
     }
+    emit_inline_error_suffix(node, out);
     out.set_mark();
     out.ensure_newline();
 }
@@ -591,6 +611,7 @@ fn format_composite(node: &SyntaxNode, out: &mut Output) {
     if let Some(next) = node.next_sibling() {
         emit_stolen_trailing_comments(&next, out);
     }
+    emit_inline_error_suffix(node, out);
     out.set_mark();
     out.ensure_newline();
 }
@@ -644,7 +665,7 @@ fn format_interface(node: &SyntaxNode, out: &mut Output) {
             }
             SyntaxElement::Node(n) => match n.kind() {
                 PARENT_LIST => format_parent_list(n, out),
-                FN_PROTOTYPE_DEF | RECORD_PROTOTYPE_DEF => {
+                FN_PROTOTYPE_DEF | RECORD_PROTOTYPE_DEF | MAPPING_DEF | STORAGE_DEF => {
                     out.indented(|out| format_node(n, out));
                     out.newline();
                 }
@@ -752,6 +773,17 @@ fn format_parent_list(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_struct_member(node: &SyntaxNode, out: &mut Output) {
+    let ident_count = node
+        .children_with_tokens()
+        .filter(|elem| matches!(elem, SyntaxElement::Token(tok) if tok.kind() == IDENT))
+        .count();
+    let type_count = node.children().filter(|child| child.kind().is_type()).count();
+
+    if has_error_descendant(node) || ident_count != 1 || type_count != 1 {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     // Emit leading comments (the parser attaches comments as leading trivia
     // of the next token, so STRUCT_MEMBER may start with comments).
     emit_leading_comments(node, out);
@@ -815,6 +847,49 @@ fn format_import(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_mapping(node: &SyntaxNode, out: &mut Output) {
+    if write_node_with_inline_error_verbatim(node, out) {
+        out.ensure_newline();
+        return;
+    }
+
+    let ident_count = node
+        .children_with_tokens()
+        .filter(|elem| matches!(elem, SyntaxElement::Token(tok) if tok.kind() == IDENT))
+        .count();
+    let type_count = node.children().filter(|child| child.kind().is_type()).count();
+    let colon_count = node
+        .children_with_tokens()
+        .filter(|elem| matches!(elem, SyntaxElement::Token(tok) if tok.kind() == COLON))
+        .count();
+    let fat_arrow_count = node
+        .children_with_tokens()
+        .filter(|elem| matches!(elem, SyntaxElement::Token(tok) if tok.kind() == FAT_ARROW))
+        .count();
+    let has_nested_mapping_syntax = node.children().filter(|child| child.kind().is_type()).any(|child| {
+        let text = child.text().to_string();
+        text.contains("=>") || text.contains("->")
+    });
+    let has_unsupported_tokens = node.children_with_tokens().any(|elem| match elem {
+        SyntaxElement::Token(tok) => !matches!(
+            tok.kind(),
+            KW_MAPPING | IDENT | COLON | FAT_ARROW | SEMICOLON | WHITESPACE | LINEBREAK | COMMENT_LINE | COMMENT_BLOCK
+        ),
+        SyntaxElement::Node(n) => !n.kind().is_type() && n.kind() != ERROR,
+    });
+
+    if has_error_descendant(node)
+        || ident_count != 1
+        || type_count != 2
+        || colon_count != 1
+        || fat_arrow_count != 1
+        || has_nested_mapping_syntax
+        || has_unsupported_tokens
+    {
+        write_node_verbatim(node, out);
+        out.ensure_newline();
+        return;
+    }
+
     emit_leading_comments(node, out);
     for elem in node.children_with_tokens() {
         match elem {
@@ -880,6 +955,12 @@ fn format_storage(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_global_const(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) {
+        write_node_verbatim(node, out);
+        out.ensure_newline();
+        return;
+    }
+
     emit_leading_comments(node, out);
     for elem in node.children_with_tokens() {
         match elem {
@@ -911,8 +992,10 @@ fn format_global_const(node: &SyntaxNode, out: &mut Output) {
                 let k = n.kind();
                 if k.is_type() {
                     format_type(&n, out);
-                } else if k.is_expression() {
+                } else if k.is_expression() || matches!(k, IDENT_PATTERN | TUPLE_PATTERN | WILDCARD_PATTERN) {
                     format_node(&n, out);
+                } else if k == ERROR {
+                    write_node_verbatim(&n, out);
                 }
             }
         }
@@ -929,8 +1012,22 @@ fn format_parameter_list(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_parameter_list_with_suffix(node: &SyntaxNode, out: &mut Output, suffix_width: usize) {
-    let params: Vec<_> =
-        node.children().filter(|c| matches!(c.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT)).collect();
+    let has_direct_non_list_tokens = node.children_with_tokens().any(|elem| match elem {
+        SyntaxElement::Token(tok) => {
+            !matches!(tok.kind(), L_PAREN | R_PAREN | COMMA | WHITESPACE | LINEBREAK | COMMENT_LINE | COMMENT_BLOCK)
+        }
+        SyntaxElement::Node(n) => !matches!(n.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | ERROR),
+    });
+
+    if has_error_descendant(node) || has_direct_non_list_tokens {
+        write_node_verbatim(node, out);
+        return;
+    }
+
+    let params: Vec<_> = node
+        .children()
+        .filter(|c| matches!(c.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | ERROR))
+        .collect();
 
     if params.is_empty() {
         out.write("()");
@@ -952,7 +1049,11 @@ fn format_parameter_list_with_suffix(node: &SyntaxNode, out: &mut Output, suffix
         // Single-line: (param1, param2)
         out.write("(");
         for (i, param) in params.iter().enumerate() {
-            format_parameter(param, out);
+            if matches!(param.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT) {
+                format_parameter(param, out);
+            } else {
+                format_node(param, out);
+            }
             if i < params.len() - 1 {
                 out.write(",");
                 out.space();
@@ -966,7 +1067,11 @@ fn format_parameter_list_with_suffix(node: &SyntaxNode, out: &mut Output, suffix
         out.indented(|out| {
             for (i, param) in params.iter().enumerate() {
                 emit_leading_comments_inner(param, out, i == 0);
-                format_parameter(param, out);
+                if matches!(param.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT) {
+                    format_parameter(param, out);
+                } else {
+                    format_node(param, out);
+                }
                 out.write(",");
                 emit_node_trailing_comments(param, out);
                 if i < params.len() - 1 {
@@ -982,6 +1087,19 @@ fn format_parameter_list_with_suffix(node: &SyntaxNode, out: &mut Output, suffix
 }
 
 fn format_parameter(node: &SyntaxNode, out: &mut Output) {
+    let ident_count = node
+        .children_with_tokens()
+        .filter(|elem| matches!(elem, SyntaxElement::Token(tok) if tok.kind() == IDENT))
+        .count();
+    let has_mut_ident = node
+        .children_with_tokens()
+        .any(|elem| matches!(elem, SyntaxElement::Token(tok) if tok.kind() == IDENT && tok.text() == "mut"));
+
+    if has_error_descendant(node) || ident_count != 1 || has_mut_ident {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     for elem in node.children_with_tokens() {
         match elem {
             SyntaxElement::Token(tok) => {
@@ -1001,12 +1119,18 @@ fn format_parameter(node: &SyntaxNode, out: &mut Output) {
                 }
             }
             SyntaxElement::Node(n) if n.kind().is_type() => format_type(&n, out),
+            SyntaxElement::Node(n) if n.kind() == ERROR => write_node_verbatim(&n, out),
             _ => {}
         }
     }
 }
 
 fn format_return_type(node: &SyntaxNode, out: &mut Output) {
+    if has_deep_comment(node) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     // First try single-line
     let single_line = format_return_type_to_string(node);
     let col = out.current_column();
@@ -1238,6 +1362,11 @@ fn format_type_path(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_type_array(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) || has_token(node, COMMA) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     out.write("[");
     for elem in node.children_with_tokens() {
         match elem {
@@ -1403,6 +1532,9 @@ fn format_block(node: &SyntaxNode, out: &mut Output) {
                         saw_linebreak = false;
                     }
                     SyntaxElement::Node(n) if after_lbrace && n.kind() == ERROR => {
+                        if should_inline_adjacent_error(n) {
+                            continue;
+                        }
                         let text = n.text().to_string();
                         let text = text.trim();
                         if !text.is_empty() {
@@ -1439,6 +1571,21 @@ fn format_return(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_definition(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node)
+        || node.children_with_tokens().any(|elem| match elem {
+            SyntaxElement::Token(tok) => {
+                !matches!(tok.kind(), KW_LET | WHITESPACE | LINEBREAK | COLON | EQ | SEMICOLON)
+            }
+            SyntaxElement::Node(n) => {
+                let k = n.kind();
+                !(k.is_type() || k.is_expression() || matches!(k, IDENT_PATTERN | TUPLE_PATTERN | WILDCARD_PATTERN))
+            }
+        })
+    {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     out.write("let");
     out.space();
 
@@ -1476,6 +1623,11 @@ fn format_definition(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_const_stmt(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     for elem in node.children_with_tokens() {
         match elem {
             SyntaxElement::Token(tok) => {
@@ -1506,8 +1658,10 @@ fn format_const_stmt(node: &SyntaxNode, out: &mut Output) {
                 let k = n.kind();
                 if k.is_type() {
                     format_type(&n, out);
-                } else if k.is_expression() {
+                } else if k.is_expression() || matches!(k, IDENT_PATTERN | TUPLE_PATTERN | WILDCARD_PATTERN) {
                     format_node(&n, out);
+                } else if k == ERROR {
+                    write_node_verbatim(&n, out);
                 }
             }
         }
@@ -1515,6 +1669,11 @@ fn format_const_stmt(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_assign(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     for elem in node.children_with_tokens() {
         match elem {
             SyntaxElement::Token(tok) => {
@@ -1538,6 +1697,11 @@ fn format_assign(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_conditional(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     let mut first_block = true;
     for elem in node.children_with_tokens() {
         match elem {
@@ -1576,6 +1740,11 @@ fn format_conditional(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_iteration(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     for elem in node.children_with_tokens() {
         match elem {
             SyntaxElement::Token(tok) => {
@@ -1621,6 +1790,11 @@ fn format_iteration(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_assert(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) || node.children().filter(|child| child.kind().is_expression()).count() != 1 {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     out.write("assert(");
 
     for child in node.children() {
@@ -1635,6 +1809,11 @@ fn format_assert(node: &SyntaxNode, out: &mut Output) {
 
 fn format_assert_pair(node: &SyntaxNode, out: &mut Output, keyword: &str) {
     let exprs: Vec<_> = node.children().filter(|c| c.kind().is_expression()).collect();
+
+    if has_error_descendant(node) || exprs.len() != 2 {
+        write_node_verbatim(node, out);
+        return;
+    }
     let expr_strings: Vec<String> = exprs.iter().map(format_node_to_string).collect();
 
     out.write(keyword);
@@ -1667,6 +1846,11 @@ fn format_assert_pair(node: &SyntaxNode, out: &mut Output, keyword: &str) {
 }
 
 fn format_expr_stmt(node: &SyntaxNode, out: &mut Output) {
+    if has_error_descendant(node) || node.children().filter(|child| child.kind().is_expression()).count() != 1 {
+        write_node_verbatim(node, out);
+        return;
+    }
+
     for child in node.children() {
         if child.kind().is_expression() {
             format_node(&child, out);
@@ -2135,6 +2319,60 @@ fn format_ident_pattern(node: &SyntaxNode, out: &mut Output) {
             }
         }
     }
+}
+
+fn write_node_verbatim(node: &SyntaxNode, out: &mut Output) {
+    let text = node.text().to_string();
+    let text = text.trim();
+    let base_indent = out.current_indent_width();
+
+    for (idx, line) in text.split('\n').enumerate() {
+        if idx > 0 {
+            out.newline();
+        }
+        let line = line.trim_end();
+        if idx == 0 {
+            out.write(line);
+            continue;
+        }
+
+        let mut stripped = line;
+        let mut to_trim = base_indent;
+        while to_trim > 0 && stripped.starts_with(' ') {
+            stripped = &stripped[1..];
+            to_trim -= 1;
+        }
+        out.write(stripped);
+    }
+}
+
+fn write_node_with_inline_error_verbatim(node: &SyntaxNode, out: &mut Output) -> bool {
+    if let Some(next) = node.next_sibling()
+        && should_inline_adjacent_error(&next)
+    {
+        out.write(format!("{}{}", node.text(), next.text()).trim());
+        return true;
+    }
+    false
+}
+
+fn emit_inline_error_suffix(node: &SyntaxNode, out: &mut Output) {
+    if let Some(next) = node.next_sibling()
+        && should_inline_adjacent_error(&next)
+    {
+        out.write(next.text().to_string().trim_end());
+    }
+}
+
+fn should_inline_adjacent_error(node: &SyntaxNode) -> bool {
+    let text = node.text().to_string();
+    let Some(prev) = node.prev_sibling() else {
+        return false;
+    };
+
+    node.kind() == ERROR
+        && text.chars().next().is_some_and(|ch| !ch.is_whitespace())
+        && matches!(prev.kind(), FUNCTION_DEF | FINAL_FN_DEF | CONSTRUCTOR_DEF | STRUCT_DEF | RECORD_DEF | MAPPING_DEF)
 }
 
 fn format_tuple_pattern(node: &SyntaxNode, out: &mut Output) {
@@ -2658,4 +2896,8 @@ fn has_deep_comment(node: &SyntaxNode) -> bool {
         }
     }
     false
+}
+
+fn has_error_descendant(node: &SyntaxNode) -> bool {
+    node.kind() == ERROR || node.children().any(|child| has_error_descendant(&child))
 }

--- a/crates/fmt/src/output.rs
+++ b/crates/fmt/src/output.rs
@@ -139,6 +139,11 @@ impl Output {
         }
     }
 
+    /// Return the current automatic indentation width in spaces.
+    pub fn current_indent_width(&self) -> usize {
+        self.depth * INDENT.len()
+    }
+
     /// Consume the buffer and return the raw string without trailing-newline
     /// normalization. Used by measurement helpers.
     pub fn into_raw(self) -> String {

--- a/crates/fmt/tests/harness.rs
+++ b/crates/fmt/tests/harness.rs
@@ -142,8 +142,9 @@ mod validate {
     use leo_ast::{NetworkName, NodeBuilder};
     use leo_compiler::Compiler;
     use leo_errors::Handler;
+    use leo_parser_rowan::{SyntaxElement, SyntaxNode, parse_file};
     use leo_span::{create_session_if_not_set_then, source_map::FileName};
-    use std::rc::Rc;
+    use std::{process::Command, rc::Rc};
 
     /// Files that are expected to fail type checking (error recovery tests,
     /// import tests, empty programs, annotated functions).
@@ -156,14 +157,31 @@ mod validate {
         "empty_program",
         "function_annotated",
         "comment_before_program",
+        "wrap_binary_chain",
     ];
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ValidationMode {
+        CompilerAst,
+        RowanFallback,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum ValidationSnapshot {
+        CompilerAst(serde_json::Value),
+        Rowan(RowanSnapshot),
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct RowanSnapshot {
+        tree: Vec<String>,
+        parse_errors: Vec<String>,
+        lex_errors: Vec<String>,
+    }
 
     /// Parse a Leo source string and return a normalized AST JSON value
     /// with spans and node IDs stripped, suitable for semantic comparison.
-    ///
-    /// Returns `None` if parsing fails (some source files have intentionally
-    /// malformed whitespace that the compiler's parser rejects).
-    fn source_to_ast_json(name: &str, source: &str) -> Option<serde_json::Value> {
+    fn try_source_to_ast_json(name: &str, source: &str) -> Result<serde_json::Value, String> {
         let (handler, _) = Handler::new_with_buf();
         let mut compiler = Compiler::new(
             None,
@@ -175,12 +193,97 @@ mod validate {
             Default::default(),
             NetworkName::TestnetV0,
         );
-        let program = compiler.parse_and_return_ast(source, FileName::Custom(name.into()), &[]).ok()?;
-        let mut json = serde_json::to_value(&program).unwrap();
+        let program =
+            compiler.parse_and_return_ast(source, FileName::Custom(name.into()), &[]).map_err(|e| e.to_string())?;
+        let mut json =
+            serde_json::to_value(&program).expect("serializing the compiler AST to JSON should always succeed");
         for key in ["span", "_span", "id", "lo", "hi"] {
             json = leo_ast::remove_key_from_json(json, key);
         }
-        Some(leo_ast::normalize_json_value(json))
+        Ok(leo_ast::normalize_json_value(json))
+    }
+
+    fn comparison_label(mode: ValidationMode) -> &'static str {
+        match mode {
+            ValidationMode::CompilerAst => "AST",
+            ValidationMode::RowanFallback => "rowan parse tree",
+        }
+    }
+
+    fn snapshot_for_source(name: &str, source: &str) -> (ValidationMode, ValidationSnapshot, Option<String>) {
+        match try_source_to_ast_json(name, source) {
+            Ok(ast) => (ValidationMode::CompilerAst, ValidationSnapshot::CompilerAst(ast), None),
+            Err(error) => {
+                (ValidationMode::RowanFallback, ValidationSnapshot::Rowan(rowan_snapshot(source)), Some(error))
+            }
+        }
+    }
+
+    fn snapshot_in_mode(mode: ValidationMode, name: &str, source: &str) -> Result<ValidationSnapshot, String> {
+        match mode {
+            ValidationMode::CompilerAst => try_source_to_ast_json(name, source).map(ValidationSnapshot::CompilerAst),
+            ValidationMode::RowanFallback => Ok(ValidationSnapshot::Rowan(rowan_snapshot(source))),
+        }
+    }
+
+    fn rowan_snapshot(source: &str) -> RowanSnapshot {
+        let parse = parse_file(source);
+        RowanSnapshot {
+            tree: normalize_rowan_tree(&parse.syntax()),
+            parse_errors: parse
+                .errors()
+                .iter()
+                .map(|error| format!("{}|found={:?}|expected={:?}", error.message, error.found, error.expected))
+                .collect(),
+            lex_errors: parse.lex_errors().iter().map(|error| format!("{:?}", error.kind)).collect(),
+        }
+    }
+
+    fn normalize_rowan_tree(node: &SyntaxNode) -> Vec<String> {
+        fn visit(node: &SyntaxNode, out: &mut Vec<String>) {
+            out.push(format!("ENTER:{:?}", node.kind()));
+            for child in node.children_with_tokens() {
+                match child {
+                    SyntaxElement::Node(child) => visit(&child, out),
+                    SyntaxElement::Token(token) if !token.kind().is_trivia() => {
+                        out.push(format!("TOKEN:{:?}:{:?}", token.kind(), token.text()));
+                    }
+                    SyntaxElement::Token(_) => {}
+                }
+            }
+            out.push(format!("EXIT:{:?}", node.kind()));
+        }
+
+        let mut out = Vec::new();
+        visit(node, &mut out);
+        out
+    }
+
+    /// Get the repository workspace root.
+    fn workspace_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("..").join("..")
+    }
+
+    /// Collect tracked workspace `.leo` files, excluding formatter fixtures.
+    fn collect_workspace_leo_files() -> Vec<PathBuf> {
+        let root = workspace_root();
+        let output = Command::new("git")
+            .arg("-C")
+            .arg(&root)
+            .args(["ls-files", "-z", "--", "*.leo", ":(exclude)crates/fmt/tests/*"])
+            .output()
+            .expect("failed to run git ls-files");
+        assert!(output.status.success(), "git ls-files failed for {}", root.display());
+
+        output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|entry| !entry.is_empty())
+            .map(|entry| {
+                let path = std::str::from_utf8(entry).expect("git ls-files should return UTF-8 paths");
+                root.join(path)
+            })
+            .collect()
     }
 
     /// Validate that target files pass Leo type checking.
@@ -261,22 +364,92 @@ mod validate {
                 let source = std::fs::read_to_string(source_path)
                     .unwrap_or_else(|_| panic!("Failed to read: {}", source_path.display()));
 
-                // Skip files whose source can't be parsed by the compiler
-                // (e.g. files with intentionally exaggerated whitespace in paths).
-                let Some(before) = source_to_ast_json(name, &source) else {
-                    continue;
-                };
-                let after = source_to_ast_json(name, &format_source(&source))
-                    .unwrap_or_else(|| panic!("Formatted output of {name} failed to parse"));
+                let (mode, before, _) = snapshot_for_source(name, &source);
+                let label = comparison_label(mode);
+                let after = snapshot_in_mode(mode, name, &format_source(&source))
+                    .unwrap_or_else(|error| panic!("Formatted output of {name} failed {label} validation: {error}"));
 
                 if before != after {
                     println!("\n=== AST MISMATCH: {} ===", source_path.display());
-                    println!("ASTs differ after formatting (ignoring spans/IDs)");
+                    println!("{label} differs after formatting");
                     println!("=== END ===\n");
                     failures.push(source_path.clone());
                 }
             }
 
+            assert!(failures.is_empty(), "{} file(s) have AST mismatches: {failures:?}", failures.len());
+        });
+    }
+
+    /// Validate AST equivalence across tracked workspace `.leo` files.
+    ///
+    /// Uses the same tracked-file scope as the CI `leo-fmt --check` step:
+    /// all tracked `.leo` files excluding `crates/fmt/tests/*`.
+    ///
+    /// Files that cannot be lowered into the compiler AST fall back to a
+    /// normalized rowan parse-tree comparison, which still validates the exact
+    /// parser structure the formatter sees.
+    ///
+    /// Run with: `cargo test -p leo-fmt --features validate -- validate_workspace_ast_equivalence`
+    #[test]
+    fn validate_workspace_ast_equivalence() {
+        let leo_files = collect_workspace_leo_files();
+
+        create_session_if_not_set_then(|_| {
+            let mut failures = Vec::new();
+            let mut compiler_ast_tested = 0;
+            let mut rowan_tested = 0;
+
+            for file_path in &leo_files {
+                let name = file_path.file_stem().unwrap().to_str().unwrap();
+                let source = std::fs::read_to_string(file_path)
+                    .unwrap_or_else(|_| panic!("Failed to read: {}", file_path.display()));
+                let (mode, before, ast_error) = snapshot_for_source(name, &source);
+                let label = comparison_label(mode);
+
+                match mode {
+                    ValidationMode::CompilerAst => compiler_ast_tested += 1,
+                    ValidationMode::RowanFallback => {
+                        rowan_tested += 1;
+                        if std::env::var_os("LEO_FMT_PRINT_FALLBACKS").is_some() {
+                            println!("\n=== ROWAN FALLBACK: {} ===", file_path.display());
+                            println!(
+                                "{}",
+                                ast_error.expect("rowan fallback should always carry the compiler AST error"),
+                            );
+                            println!("=== END ===\n");
+                        }
+                    }
+                }
+
+                let formatted = format_source(&source);
+                let Ok(after) = snapshot_in_mode(mode, name, &formatted) else {
+                    println!("\n=== FORMAT BROKE PARSING: {} ===", file_path.display());
+                    println!("Original source passed {label} validation but formatted output did not");
+                    println!("=== END ===\n");
+                    failures.push(file_path.clone());
+                    continue;
+                };
+
+                if before != after {
+                    println!("\n=== AST MISMATCH: {} ===", file_path.display());
+                    println!("{label} differs after formatting");
+                    println!("=== END ===\n");
+                    failures.push(file_path.clone());
+                }
+            }
+
+            println!(
+                "\nWorkspace files: {} tested ({} compiler AST, {} rowan fallback)",
+                leo_files.len(),
+                compiler_ast_tested,
+                rowan_tested
+            );
+            assert_eq!(
+                compiler_ast_tested + rowan_tested,
+                leo_files.len(),
+                "every tracked workspace .leo file should use either compiler AST or rowan fallback validation"
+            );
             assert!(failures.is_empty(), "{} file(s) have AST mismatches: {failures:?}", failures.len());
         });
     }
@@ -344,16 +517,17 @@ mod validate {
     /// Validate AST equivalence against real-world Leo repositories.
     ///
     /// Clones external repos (cached in `target/test-repos/`), formats every
-    /// `.leo` file, and asserts the AST is unchanged. Files that can't be parsed
-    /// by the compiler (e.g. due to unresolved imports) are skipped.
+    /// `.leo` file, and asserts the compiler AST is unchanged when available.
+    /// Files the compiler AST cannot represent fall back to normalized rowan
+    /// parse-tree comparison instead of being skipped.
     ///
     /// Run with: `cargo test -p leo-fmt --features validate -- validate_ast_equivalence_repos`
     #[test]
     fn validate_ast_equivalence_repos() {
         create_session_if_not_set_then(|_| {
             let mut failures = Vec::new();
-            let mut tested = 0;
-            let mut skipped = 0;
+            let mut compiler_ast_tested = 0;
+            let mut rowan_tested = 0;
 
             for (name, url, rev) in EXTERNAL_REPOS {
                 let repo_dir = ensure_repo(name, url, rev);
@@ -364,18 +538,18 @@ mod validate {
                     let file_name = file_path.file_stem().unwrap().to_str().unwrap();
                     let source = std::fs::read_to_string(file_path)
                         .unwrap_or_else(|_| panic!("Failed to read: {}", file_path.display()));
+                    let (mode, before, _) = snapshot_for_source(file_name, &source);
+                    let label = comparison_label(mode);
 
-                    // Skip files the compiler can't parse (e.g. unresolved imports).
-                    let Some(before) = source_to_ast_json(file_name, &source) else {
-                        skipped += 1;
-                        continue;
-                    };
+                    match mode {
+                        ValidationMode::CompilerAst => compiler_ast_tested += 1,
+                        ValidationMode::RowanFallback => rowan_tested += 1,
+                    }
 
                     let formatted = format_source(&source);
-                    let Some(after) = source_to_ast_json(file_name, &formatted) else {
-                        // Original parsed OK but formatted output didn't — formatter broke something.
+                    let Ok(after) = snapshot_in_mode(mode, file_name, &formatted) else {
                         println!("\n=== FORMAT BROKE PARSING: {} ===", file_path.display());
-                        println!("Original parsed OK but formatted output failed to parse");
+                        println!("Original source passed {label} validation but formatted output did not");
                         println!("=== END ===\n");
                         failures.push(file_path.clone());
                         continue;
@@ -383,16 +557,19 @@ mod validate {
 
                     if before != after {
                         println!("\n=== AST MISMATCH: {} ===", file_path.display());
-                        println!("ASTs differ after formatting (ignoring spans/IDs)");
+                        println!("{label} differs after formatting");
                         println!("=== END ===\n");
                         failures.push(file_path.clone());
                     }
-
-                    tested += 1;
                 }
             }
 
-            println!("\nExternal repos: {tested} files tested, {skipped} skipped (unparseable)");
+            println!(
+                "\nExternal repos: {} files tested ({} compiler AST, {} rowan fallback)",
+                compiler_ast_tested + rowan_tested,
+                compiler_ast_tested,
+                rowan_tested
+            );
             assert!(failures.is_empty(), "{} file(s) have AST mismatches: {failures:?}", failures.len());
         });
     }

--- a/crates/parser-rowan/src/parser/mod.rs
+++ b/crates/parser-rowan/src/parser/mod.rs
@@ -1139,6 +1139,34 @@ mod tests {
     }
 
     #[test]
+    fn recover_valid_statement_after_malformed_assert_eq_in_block() {
+        let parse = parse_file(
+            r#"program test.aleo {
+                fn main(a: bool) -> bool {
+                    assert_eq(a == 1u8);
+                    assert(1u8);
+                    return a;
+                }
+            }"#,
+        );
+        assert!(!parse.errors().is_empty(), "should have errors");
+        let tree = format!("{:#?}", parse.syntax());
+        assert!(tree.contains("ASSERT_EQ_STMT"), "tree should have ASSERT_EQ_STMT");
+        assert_eq!(tree.matches("ASSERT_STMT@").count(), 1, "should preserve the valid assert statement");
+        assert!(tree.contains("RETURN_STMT"), "tree should preserve the following return statement");
+    }
+
+    #[test]
+    fn recover_trailing_tokens_inside_expression_statement() {
+        let parse = parse_stmt_result("final finalize_foo(a);");
+        assert!(!parse.errors().is_empty(), "should have errors");
+        let tree = format!("{:#?}", parse.syntax());
+        assert!(tree.contains("EXPR_STMT"), "tree should have EXPR_STMT");
+        assert!(tree.contains("ERROR"), "tree should capture trailing junk in an ERROR node");
+        assert!(tree.contains("\"finalize_foo\""), "tree should preserve the trailing call tokens");
+    }
+
+    #[test]
     fn recover_missing_assignment_rhs() {
         let parse = parse_stmt_result("x = ;");
         assert!(!parse.errors().is_empty(), "should have errors");

--- a/crates/parser-rowan/src/parser/statements.rs
+++ b/crates/parser-rowan/src/parser/statements.rs
@@ -32,6 +32,24 @@ impl Parser<'_, '_> {
     /// Recovery tokens for pattern parsing.
     const PATTERN_RECOVERY: &'static [SyntaxKind] = &[COMMA, R_PAREN, COLON, EQ];
 
+    /// Recover trailing junk in a semicolon-terminated statement.
+    fn recover_statement_terminator(&mut self) {
+        if self.eat(SEMICOLON) {
+            return;
+        }
+
+        // Preserve the original missing-semicolon diagnostic at the first
+        // unexpected token, then optionally recover trailing junk afterwards.
+        self.expect(SEMICOLON);
+
+        if self.at(R_BRACE) || self.at_eof() {
+            return;
+        }
+
+        self.recover(&[SEMICOLON, R_BRACE]);
+        self.eat(SEMICOLON);
+    }
+
     /// Parse a statement.
     pub fn parse_stmt(&mut self) -> Option<CompletedMarker> {
         self.skip_trivia();
@@ -69,7 +87,7 @@ impl Parser<'_, '_> {
             self.error_recover("expected expression", EXPR_RECOVERY);
         }
 
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, LET_STMT))
     }
 
@@ -102,7 +120,7 @@ impl Parser<'_, '_> {
             self.error_recover("expected expression", EXPR_RECOVERY);
         }
 
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, CONST_STMT))
     }
 
@@ -117,7 +135,7 @@ impl Parser<'_, '_> {
             self.error_recover("expected expression or ';'", EXPR_RECOVERY);
         }
 
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, RETURN_STMT))
     }
 
@@ -210,7 +228,7 @@ impl Parser<'_, '_> {
         }
         self.expect(R_PAREN);
 
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, ASSERT_STMT))
     }
 
@@ -229,7 +247,7 @@ impl Parser<'_, '_> {
         }
         self.expect(R_PAREN);
 
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, ASSERT_EQ_STMT))
     }
 
@@ -248,7 +266,7 @@ impl Parser<'_, '_> {
         }
         self.expect(R_PAREN);
 
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, ASSERT_NEQ_STMT))
     }
 
@@ -273,10 +291,13 @@ impl Parser<'_, '_> {
                 self.error_recover("expected statement", STMT_RECOVERY);
             } else if self.erroring && !had_error {
                 // The statement parsed but encountered errors and left
-                // unconsumed tokens. Skip to the next semicolon or
-                // statement boundary to prevent cascading errors.
-                self.recover(&[SEMICOLON, R_BRACE]);
-                self.eat(SEMICOLON);
+                // unconsumed tokens. Preserve a trailing `}` marker for the
+                // existing tree shape, but leave other statement boundaries
+                // alone so the next valid statement can still parse.
+                if self.at(R_BRACE) || !self.at_any(STMT_RECOVERY) {
+                    self.recover(STMT_RECOVERY);
+                    self.eat(SEMICOLON);
+                }
             }
         }
 
@@ -300,12 +321,12 @@ impl Parser<'_, '_> {
             if self.parse_expr().is_none() {
                 self.error_recover("expected expression after assignment operator", EXPR_RECOVERY);
             }
-            self.expect(SEMICOLON);
+            self.recover_statement_terminator();
             return Some(m.complete(self, assign_kind));
         }
 
         // Expression statement
-        self.expect(SEMICOLON);
+        self.recover_statement_terminator();
         Some(m.complete(self, EXPR_STMT))
     }
 

--- a/tests/expectations/cli/leo_devnode_missing_private_key/COMMANDS
+++ b/tests/expectations/cli/leo_devnode_missing_private_key/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} devnode start
+${LEO_BIN} --disable-update-check devnode start

--- a/tests/expectations/cli/local_aleo_dependency/COMMANDS
+++ b/tests/expectations/cli/local_aleo_dependency/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} build
+${LEO_BIN} --disable-update-check build

--- a/tests/expectations/cli/multiple_leo_deps/COMMANDS
+++ b/tests/expectations/cli/multiple_leo_deps/COMMANDS
@@ -3,4 +3,4 @@
 LEO_BIN=${1}
 
 cd parent || exit 1
-$LEO_BIN build
+$LEO_BIN --disable-update-check build

--- a/tests/expectations/cli/test_command_shortcuts/COMMANDS
+++ b/tests/expectations/cli/test_command_shortcuts/COMMANDS
@@ -2,5 +2,5 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} b
-${LEO_BIN} r main 1u32 2u32
+${LEO_BIN} --disable-update-check b
+${LEO_BIN} --disable-update-check r main 1u32 2u32

--- a/tests/expectations/cli/test_fmt/COMMANDS
+++ b/tests/expectations/cli/test_fmt/COMMANDS
@@ -2,6 +2,6 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} fmt --check || true
-${LEO_BIN} fmt
-${LEO_BIN} fmt --check
+${LEO_BIN} --disable-update-check fmt --check || true
+${LEO_BIN} --disable-update-check fmt
+${LEO_BIN} --disable-update-check fmt --check

--- a/tests/expectations/cli/test_simple_test/COMMANDS
+++ b/tests/expectations/cli/test_simple_test/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} test
+${LEO_BIN} --disable-update-check test

--- a/tests/expectations/cli/test_version/COMMANDS
+++ b/tests/expectations/cli/test_version/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} --version
+${LEO_BIN} --disable-update-check --version

--- a/tests/tests/cli/leo_devnode_missing_private_key/COMMANDS
+++ b/tests/tests/cli/leo_devnode_missing_private_key/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} devnode start
+${LEO_BIN} --disable-update-check devnode start

--- a/tests/tests/cli/local_aleo_dependency/COMMANDS
+++ b/tests/tests/cli/local_aleo_dependency/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} build
+${LEO_BIN} --disable-update-check build

--- a/tests/tests/cli/multiple_leo_deps/COMMANDS
+++ b/tests/tests/cli/multiple_leo_deps/COMMANDS
@@ -3,4 +3,4 @@
 LEO_BIN=${1}
 
 cd parent || exit 1
-$LEO_BIN build
+$LEO_BIN --disable-update-check build

--- a/tests/tests/cli/test_command_shortcuts/COMMANDS
+++ b/tests/tests/cli/test_command_shortcuts/COMMANDS
@@ -2,5 +2,5 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} b
-${LEO_BIN} r main 1u32 2u32
+${LEO_BIN} --disable-update-check b
+${LEO_BIN} --disable-update-check r main 1u32 2u32

--- a/tests/tests/cli/test_fmt/COMMANDS
+++ b/tests/tests/cli/test_fmt/COMMANDS
@@ -2,6 +2,6 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} fmt --check || true
-${LEO_BIN} fmt
-${LEO_BIN} fmt --check
+${LEO_BIN} --disable-update-check fmt --check || true
+${LEO_BIN} --disable-update-check fmt
+${LEO_BIN} --disable-update-check fmt --check

--- a/tests/tests/cli/test_simple_test/COMMANDS
+++ b/tests/tests/cli/test_simple_test/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} test
+${LEO_BIN} --disable-update-check test

--- a/tests/tests/cli/test_version/COMMANDS
+++ b/tests/tests/cli/test_version/COMMANDS
@@ -2,4 +2,4 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} --version
+${LEO_BIN} --disable-update-check --version


### PR DESCRIPTION
## Summary

Hardens `leo-fmt` and integrates it into CI ahead of the workspace-wide reformat.

- Fixes formatter/parser edge cases found while validating against the workspace corpus
- Adds CI step for formatter fixture validation (source/target AST equivalence and type checking)
- Adds test infrastructure for workspace-wide and external-repo AST equivalence validation (intentionally disabled in CI for now)

The bulk reformat of every tracked `.leo` file and re-enabling the workspace-wide validation are deferred to a stacked follow-up PR.

Closes #29182
Part of #28579