### PR TITLE
Structs in libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ tests/mismatches/
 tree-sitter/node_modules/
 tree-sitter/build/
 tree-sitter/result
+
+AGENTS.md

--- a/crates/ast/src/common/path.rs
+++ b/crates/ast/src/common/path.rs
@@ -16,7 +16,7 @@
 
 use crate::{Expression, Identifier, Location, Node, NodeID, ProgramId, simple_node_impl};
 
-use leo_span::{Span, Symbol};
+use leo_span::{Span, Symbol, with_session_globals};
 
 use indexmap::IndexSet;
 use itertools::Itertools;
@@ -294,19 +294,28 @@ impl Path {
 
 impl fmt::Display for Path {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Determine the effective program symbol
-        let program: Option<Symbol> = self
-            .user_program
-            .as_ref()
-            .map(|id| id.as_symbol()) // Convert Identifier -> Symbol
-            .or_else(|| self.try_global_location().map(|global| global.program));
-
-        // Program prefix
-        if let Some(program) = program {
-            write!(f, "{}/", program)?;
+        // Determine the program prefix and separator:
+        //
+        // 1. If the user explicitly wrote a program (e.g. `credits.aleo/Foo`), always use it
+        //    with a `/` separator.
+        //
+        // 2. Otherwise fall back to the resolved global location's program, but only when it is
+        //    an `.aleo` program.  `.aleo` programs never appear in the qualifier, so we must
+        //    reconstruct the prefix here to produce readable error messages like
+        //    `parent.aleo/Foo` vs `child.aleo/Foo`.
+        //
+        // 3. Library programs (no `.aleo` suffix) already have their name as the first qualifier
+        //    segment (e.g. `math_lib::Foo`), so adding a prefix here would double-print it.
+        if let Some(pid) = &self.user_program {
+            write!(f, "{}/", pid.as_symbol())?;
+        } else if let Some(loc) = self.try_global_location() {
+            // Use the global program as prefix only for .aleo programs.
+            if with_session_globals(|sg| loc.program.as_str(sg, |s| s.ends_with(".aleo"))) {
+                write!(f, "{}/", loc.program)?;
+            }
         }
 
-        // Qualifiers
+        // Qualifiers (always `::` separator, covers library names like `math_lib::Foo`).
         if !self.qualifier.is_empty() {
             write!(f, "{}::", self.qualifier.iter().map(|id| &id.name).format("::"))?;
         }

--- a/crates/ast/src/library.rs
+++ b/crates/ast/src/library.rs
@@ -16,24 +16,29 @@
 
 use leo_span::Symbol;
 
-use crate::{ConstDeclaration, Indent};
+use crate::{Composite, ConstDeclaration, Indent};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Stores the Leo library abstract syntax tree.
 ///
-/// Currently libraries may only contain `const` declarations. Extending this to support
-/// structs and other items is left for future work.
+/// Libraries may contain `const` declarations and `struct` definitions.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Library {
     pub name: Symbol,
     /// The constants defined in this library.
     pub consts: Vec<(Symbol, ConstDeclaration)>,
+    /// The struct definitions in this library.
+    pub structs: Vec<(Symbol, Composite)>,
 }
 
 impl fmt::Display for Library {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         writeln!(f, "library {} {{", self.name)?;
+
+        for (_, struct_def) in self.structs.iter() {
+            writeln!(f, "{}", Indent(struct_def))?;
+        }
 
         for (_, const_decl) in self.consts.iter() {
             writeln!(f, "{};", Indent(const_decl))?;

--- a/crates/ast/src/passes/reconstructor.rs
+++ b/crates/ast/src/passes/reconstructor.rs
@@ -581,6 +581,7 @@ pub trait ProgramReconstructor: AstReconstructor {
                     _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
                 })
                 .collect(),
+            structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
         }
     }
 

--- a/crates/ast/src/passes/visitor.rs
+++ b/crates/ast/src/passes/visitor.rs
@@ -325,6 +325,7 @@ pub trait ProgramVisitor: AstVisitor {
 
     fn visit_library(&mut self, input: &Library) {
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
     }
 
     fn visit_stub(&mut self, input: &Stub) {

--- a/crates/parser/src/rowan.rs
+++ b/crates/parser/src/rowan.rs
@@ -1731,21 +1731,28 @@ impl<'a> ConversionContext<'a> {
         &self,
         item: &SyntaxNode,
         consts: &mut Vec<(Symbol, leo_ast::ConstDeclaration)>,
+        structs: &mut Vec<(Symbol, leo_ast::Composite)>,
     ) -> Result<()> {
         if is_library_item(item.kind()) {
-            #[allow(clippy::single_match)]
             match item.kind() {
                 GLOBAL_CONST => {
                     let global_const = self.to_global_const(item)?;
                     consts.push((global_const.place.name, global_const));
                 }
-                // Future library items (structs, functions, etc.) will be handled here.
+                STRUCT_DEF => {
+                    let composite = self.to_composite(item)?;
+                    structs.push((composite.identifier.name, composite));
+                }
+                // Future library items (functions, etc.) will be handled here.
                 _ => {}
             }
         } else if is_program_item(item.kind()) {
             // A recognized program-only item appeared in a library file.
             let span = self.to_span(item);
-            self.handler.emit_err(ParserError::custom("Only `const` declarations are allowed in a library.", span));
+            self.handler.emit_err(ParserError::custom(
+                "Only `const` declarations and `struct` definitions are allowed in a library.",
+                span,
+            ));
         }
         // Other node kinds (e.g. ERROR nodes from CST-level parse failures) are
         // already reported by the rowan parser; nothing to do here.
@@ -1899,14 +1906,14 @@ impl<'a> ConversionContext<'a> {
 
     /// Convert a syntax node to a library (`lib.leo` file).
     fn to_library(&self, name: Symbol, node: &SyntaxNode) -> Result<leo_ast::Library> {
-        // A library file contains only top-level `const` declarations.
         let mut consts = Vec::new();
+        let mut structs = Vec::new();
 
         for child in children(node) {
-            self.collect_library_item(&child, &mut consts)?;
+            self.collect_library_item(&child, &mut consts, &mut structs)?;
         }
 
-        Ok(leo_ast::Library { name, consts })
+        Ok(leo_ast::Library { name, consts, structs })
     }
 
     /// Extract a ProgramId from an IMPORT node. Guarantees `network` is always present.
@@ -2974,10 +2981,10 @@ fn compute_module_key(name: &FileName, root_dir: Option<&std::path::Path>) -> Op
 
 /// Returns `true` for syntax node kinds that are valid inside a library (`lib.leo`).
 ///
-/// Currently only `const` declarations are allowed; this list will grow as library support
-/// expands to include structs and functions.
+/// Currently `const` declarations and `struct` definitions are allowed; this list will grow
+/// as library support expands to include functions and other items.
 fn is_library_item(kind: SyntaxKind) -> bool {
-    matches!(kind, GLOBAL_CONST)
+    matches!(kind, GLOBAL_CONST | STRUCT_DEF)
 }
 
 /// Returns `true` for syntax node kinds that are valid inside a program (`main.leo`).

--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -339,12 +339,12 @@ impl CodeGeneratingVisitor<'_> {
                 AleoType::Record { name: record_name.to_string(), program: None }
             } else {
                 // foo; // no visibility for structs
-                let struct_name = Self::legalize_path(&composite_location.path)
-                    .expect("path format cannot be legalized at this point");
-                if program == this_program_name {
-                    AleoType::Ident { name: struct_name.to_string() }
+                let struct_name = self.legalize_composite_name(composite_location);
+                if program == this_program_name || self.state.symbol_table.is_library(program) {
+                    // Library composites are inlined, so emit without program qualifier.
+                    AleoType::Ident { name: struct_name }
                 } else {
-                    AleoType::Location { program: program.to_string(), name: struct_name.to_string() }
+                    AleoType::Location { program: program.to_string(), name: struct_name }
                 }
             }
         } else {

--- a/crates/passes/src/code_generation/program.rs
+++ b/crates/passes/src/code_generation/program.rs
@@ -34,7 +34,6 @@ use leo_ast::{
 use leo_span::{Symbol, sym};
 
 use indexmap::IndexMap;
-use itertools::Itertools;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 
 impl<'a> CodeGeneratingVisitor<'a> {
@@ -66,7 +65,12 @@ impl<'a> CodeGeneratingVisitor<'a> {
                     .symbol_table
                     .lookup_struct(this_program, loc)
                     .or_else(|| self.state.symbol_table.lookup_record(this_program, loc))
+            } else if self.state.symbol_table.is_library(loc.program) {
+                // Library composites are inlined into the consuming program.
+                // Libraries cannot contain records, so only look up structs.
+                self.state.symbol_table.lookup_struct(loc.program, loc)
             } else {
+                // Regular program dependencies own their composites; don't emit them here.
                 None
             }
         };
@@ -144,12 +148,14 @@ impl<'a> CodeGeneratingVisitor<'a> {
     }
 
     fn visit_struct(&mut self, struct_: &'a Composite, loc: &Location) -> AleoStruct {
-        // Add private symbol to composite types.
-        self.composite_mapping.insert(loc.clone(), false); // todo: private by default here.
+        // Register this struct in composite_mapping under its location.
+        // Library structs are stored under their original (library) location so that
+        // expression and type-reference sites, which use the original location, resolve correctly.
+        self.composite_mapping.insert(loc.clone(), false);
 
-        // todo: check if this is safe from name conflicts.
-        let name = Self::legalize_path(&loc.path)
-            .unwrap_or_else(|| panic!("path format cannot be legalized at this point: {}", loc.path.iter().join("::")));
+        // Emit the struct name: for library structs, prefix with the library name so the
+        // generated identifier is unique and cannot collide with a local struct of the same base name.
+        let name = self.legalize_composite_name(loc);
 
         // Construct and append the record variables.
         let fields = struct_
@@ -396,7 +402,11 @@ impl<'a> CodeGeneratingVisitor<'a> {
                 Type::Mapping(_) | Type::Tuple(_) => panic!("Mappings cannot contain mappings or tuples."),
                 Type::Identifier(identifier) => {
                     // Lookup the type in the composite mapping.
-                    // Note that this unwrap is safe since all struct and records have been added to the composite mapping.
+                    // Invariant: `Type::Identifier` in a mapping position refers to a locally-defined
+                    // composite (struct or record). Library composites arrive as `Type::Composite` with
+                    // a qualified locator and are handled by the `type_` arm below; they never reach
+                    // here as `Type::Identifier`. The unwrap is therefore safe because all local
+                    // composites are registered in `composite_mapping` during codegen setup.
                     let is_record = self.composite_mapping.get(&Location::new(program, vec![identifier.name])).unwrap();
                     assert!(!is_record, "Type checking guarantees that mappings cannot contain records.");
                     self.visit_type_with_visibility(type_, Some(AleoVisibility::Public))

--- a/crates/passes/src/code_generation/type_.rs
+++ b/crates/passes/src/code_generation/type_.rs
@@ -45,12 +45,15 @@ impl CodeGeneratingVisitor<'_> {
                 let composite_location = composite.path.expect_global_location();
                 let this_program_name = self.program_id.unwrap().as_symbol();
                 let program_name = composite_location.program;
-                let composite_name = Self::legalize_path(&composite_location.path)
-                    .expect("path format cannot be legalized at this point");
-                if program_name == this_program_name {
-                    AleoType::Ident { name: composite_name.to_string() }
+                // Use legalize_composite_name so library types get a unique, collision-free name
+                // (prefixed with the library name), while local types use the path directly.
+                let composite_name = self.legalize_composite_name(composite_location);
+                if program_name == this_program_name || self.state.symbol_table.is_library(program_name) {
+                    // Library composites are inlined into the consuming program, so they
+                    // are emitted without a program qualifier, just like local types.
+                    AleoType::Ident { name: composite_name }
                 } else {
-                    AleoType::Location { program: program_name.to_string(), name: composite_name.to_string() }
+                    AleoType::Location { program: program_name.to_string(), name: composite_name }
                 }
             }
             Type::Boolean => AleoType::Boolean,

--- a/crates/passes/src/code_generation/visitor.rs
+++ b/crates/passes/src/code_generation/visitor.rs
@@ -135,6 +135,23 @@ impl CodeGeneratingVisitor<'_> {
         AleoReg::R(self.next_register - 1)
     }
 
+    /// Returns the legalized Aleo name for a composite at the given location.
+    ///
+    /// For local composites the path alone is used (e.g. `[Foo]` → `"Foo"`).
+    /// For library composites the library name is prepended so that the resulting
+    /// identifier is unique and cannot collide with a local type of the same base
+    /// name (e.g. `[math_lib, Foo]` → `"Foo__<hash>"`).
+    pub(crate) fn legalize_composite_name(&self, loc: &Location) -> String {
+        if self.state.symbol_table.is_library(loc.program) {
+            let full_path: Vec<Symbol> = std::iter::once(loc.program).chain(loc.path.iter().copied()).collect();
+            Self::legalize_path(&full_path)
+                .unwrap_or_else(|| panic!("path format cannot be legalized at this point: {}", loc))
+        } else {
+            Self::legalize_path(&loc.path)
+                .unwrap_or_else(|| panic!("path format cannot be legalized at this point: {}", loc))
+        }
+    }
+
     /// Converts a path into a legal Aleo identifier, if possible.
     ///
     /// # Behavior

--- a/crates/passes/src/const_propagation/program.rs
+++ b/crates/passes/src/const_propagation/program.rs
@@ -84,6 +84,14 @@ impl ProgramReconstructor for ConstPropagationVisitor<'_> {
     fn reconstruct_library(&mut self, mut input: Library) -> Library {
         self.program = input.name;
 
+        // Skip generic structs (those with const parameters): their types cannot be fully
+        // evaluated until they are monomorphized into the consuming program's scope.
+        input.structs = input
+            .structs
+            .into_iter()
+            .map(|(i, s)| if s.const_parameters.is_empty() { (i, self.reconstruct_composite(s)) } else { (i, s) })
+            .collect();
+
         for (_sym, c) in input.consts.iter_mut() {
             let Statement::Const(declaration) = self.reconstruct_const(std::mem::take(c)).0 else {
                 panic!("`reconstruct_const` always returns `Statement::Const`");

--- a/crates/passes/src/global_items_collection.rs
+++ b/crates/passes/src/global_items_collection.rs
@@ -205,6 +205,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
     fn visit_library(&mut self, input: &Library) {
         self.program_name = input.name;
 
+        input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
     }
 

--- a/crates/passes/src/monomorphization/program.rs
+++ b/crates/passes/src/monomorphization/program.rs
@@ -15,10 +15,51 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::MonomorphizationVisitor;
-use leo_ast::{AstReconstructor, Location, Module, Program, ProgramReconstructor, ProgramScope, Statement, Variant};
+use leo_ast::{
+    AstReconstructor,
+    Library,
+    Location,
+    Module,
+    Program,
+    ProgramReconstructor,
+    ProgramScope,
+    Statement,
+    Stub,
+    Variant,
+};
 use leo_span::sym;
 
 impl ProgramReconstructor for MonomorphizationVisitor<'_> {
+    fn reconstruct_library(&mut self, input: Library) -> Library {
+        // Collect the (re-)constructed versions of library composites that were processed
+        // during reconstruct_program_scope. We filter by the library's program name so that
+        // only composites belonging to this library are included.
+        //
+        // This ensures the library stub is updated with correct field types after monomorphization
+        // (e.g., `Bar.f` pointing to the consuming program's monomorphized `Foo::[42u32]`).
+        Library {
+            name: input.name,
+            structs: self
+                .reconstructed_composites
+                .iter()
+                .filter_map(|(loc, c)| {
+                    loc.path
+                        .split_last()
+                        .filter(|(_, rest)| rest.is_empty() && loc.program == input.name)
+                        .map(|(last, _)| (*last, c.clone()))
+                })
+                .collect(),
+            consts: input
+                .consts
+                .into_iter()
+                .map(|(i, c)| match self.reconstruct_const(c) {
+                    (Statement::Const(declaration), _) => (i, declaration),
+                    _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
+                })
+                .collect(),
+        }
+    }
+
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         // Set the current program name from the input.
         self.program = input.program_id.as_symbol();
@@ -32,14 +73,18 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
             if let Some(composite) = self.composite_map.swap_remove(loc) {
                 // Perform monomorphization or other reconstruction logic.
                 let reconstructed_composite = self.reconstruct_composite(composite);
-                // Store the reconstructed composite for inclusion in the output scope.
-                self.reconstructed_composites
-                    .insert(Location::new(self.program, loc.path.clone()), reconstructed_composite);
+                // Store the reconstructed composite under its original location.
+                // For library composites loc.program != self.program; preserving the library
+                // program name here is what allows monomorphize_composite to find them later.
+                // Both the program-scope and module output-collection loops filter by
+                // `loc.program == self.program`, so library entries stay invisible to the output.
+                self.reconstructed_composites.insert(loc.clone(), reconstructed_composite);
             }
         }
 
-        // If there are some composites left in `composite_map`, that means these are dead composites since they do not show up
-        // in `composite_graph`. Therefore, they won't be reconstructed, implying a change in the reconstructed program.
+        // If there are some local composites left in `composite_map`, that means these are dead
+        // composites since they do not show up in `composite_graph`. Therefore, they won't be
+        // reconstructed, implying a change in the reconstructed program.
         if !self.composite_map.is_empty() {
             self.changed = true;
         }
@@ -64,16 +109,15 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                 self.function_map
                     .get(location)
                     .map(|f| {
-                        matches!(
-                            f.variant,
-                             Variant::EntryPoint
-                        ) | (f.variant == Variant::Fn && f.const_parameters.is_empty())
+                        matches!(f.variant, Variant::EntryPoint)
+                            | (f.variant == Variant::Fn && f.const_parameters.is_empty())
                     })
                     .unwrap_or(false)
             })
             .unwrap() // This unwrap is safe because the type checker guarantees an acyclic graph.
             .into_iter()
-            .filter(|location| location.program == self.program).collect::<Vec<_>>();
+            .filter(|location| location.program == self.program)
+            .collect::<Vec<_>>();
 
         for function_name in &order {
             // Reconstruct functions in post-order.
@@ -157,17 +201,73 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
     }
 
     fn reconstruct_program(&mut self, input: Program) -> Program {
-        let stubs = input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect();
+        // STUB ORDERING INVARIANT
+        //
+        // The ordering of operations in this function is critical for correctness:
+        //
+        // 1. FromLeo stubs are processed FIRST (before the current program's scope).
+        //    Each FromLeo stub recursively calls reconstruct_program for the dependency,
+        //    which populates `reconstructed_composites` with the dependency's composites.
+        //    This means that when the current program's scope is processed, any composites
+        //    from FromLeo dependencies (e.g. `child.aleo/Bar`) are already available for
+        //    monomorphization.
+        //
+        // 2. The current program's composite_map and function_map are populated AFTER
+        //    FromLeo stubs are processed (since each FromLeo recursive call clears and
+        //    repopulates these maps for its own scope).
+        //
+        // 3. Library composites (from FromLibrary stubs) are added to composite_map so
+        //    they are processed in reconstruct_program_scope (their field types updated).
+        //
+        // 4. program_scopes are processed AFTER FromLeo stubs and after composite_map is
+        //    populated for the current program.
+        //
+        // 5. FromLibrary/FromAleo stubs are processed AFTER program_scopes, so that
+        //    reconstruct_library can collect monomorphized composites from reconstructed_composites.
 
-        // Set up for the next program.
-        // This is likely to change when we support cross-program monomorphization.
-        self.composite_map.clear();
+        // Partition stubs early (non-consuming borrow not possible, so partition now and
+        // process in two phases).
+        let (from_leo_stubs, other_stubs): (Vec<_>, Vec<_>) =
+            input.stubs.into_iter().partition(|(_, stub)| matches!(stub, Stub::FromLeo { .. }));
+
+        // Pre-Phase 1: Seed composite_map with library composites BEFORE recursing into
+        // FromLeo stubs. This is critical for correctness: when a FromLeo dependency
+        // (e.g. `helper.aleo`) uses library structs, its inner `Program` may not carry the
+        // library stubs (they are only present on the top-level compilation unit). By inserting
+        // the library composites here — before the recursive call — they are already in
+        // composite_map when the inner call's Phase 2 retains non-previous-program entries.
+        // Entries that are already in reconstructed_composites (processed by a prior inner call)
+        // will be silently skipped by the composite_order loop via `swap_remove` returning None.
+        other_stubs.iter().for_each(|(_, stub)| {
+            if let Stub::FromLibrary { library, .. } = stub {
+                library.structs.iter().for_each(|(name, c)| {
+                    self.composite_map.entry(Location::new(library.name, vec![*name])).or_insert_with(|| c.clone());
+                });
+            }
+        });
+
+        // Phase 1: Process FromLeo stubs.
+        // This recursively calls reconstruct_program for each dependency, populating
+        // reconstructed_composites with their composites before the current scope runs.
+        let from_leo_stubs: indexmap::IndexMap<_, _> =
+            from_leo_stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect();
+
+        // Phase 2: Set up for the current program.
+        // After processing FromLeo stubs, reset and populate composite_map / function_map
+        // for the current program's scope.
+        //
+        // IMPORTANT: Instead of clearing composite_map entirely, we only remove composites
+        // belonging to the previous program (self.program). Library composites (loc.program !=
+        // self.program) are retained so that deeply nested FromLeo programs — whose inner
+        // Program objects may not carry library stubs — can still access them.
+        let prev_program = self.program;
+        self.composite_map.retain(|loc, _| loc.program != prev_program);
         self.function_map.clear();
 
         self.program =
             *input.program_scopes.first().expect("a program must have a single program scope at this stage").0;
 
-        // Populate `self.function_map` using the functions in the program scopes and the modules
+        // Populate `self.function_map` using the functions in the program scopes and the modules.
         input
             .modules
             .iter()
@@ -186,7 +286,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                 self.function_map.insert(Location::new(self.program, full_name), f);
             });
 
-        // Populate `self.composite_map` using the composites in the program scopes and the modules
+        // Populate `self.composite_map` using the composites in the program scopes and the modules.
         input
             .modules
             .iter()
@@ -205,15 +305,28 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                 self.composite_map.insert(Location::new(self.program, full_name), f);
             });
 
-        // Reconstruct prrogram scopes first then reconstruct the modules after `self.reconstructed_composites`
-        // and `self.reconstructed_functions` have been populated.
+        // Phase 3: Process the current program's scope.
+        // composite_map now has:
+        //   - the current program's own composites,
+        //   - library composites from FromLibrary stubs.
+        // reconstructed_composites now has composites from all FromLeo dependencies.
+        let program_scopes =
+            input.program_scopes.into_iter().map(|(id, scope)| (id, self.reconstruct_program_scope(scope))).collect();
+
+        // Phase 4: Process FromLibrary/FromAleo stubs AFTER program_scopes.
+        // reconstruct_library collects monomorphized composites from reconstructed_composites,
+        // which is now populated with the current program's library composite instances.
+        let other_stubs: indexmap::IndexMap<_, _> =
+            other_stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect();
+
+        // Combine stubs (FromLeo first, then others) preserving stable ordering.
+        let stubs = from_leo_stubs.into_iter().chain(other_stubs).collect();
+
+        // Reconstruct modules after `self.reconstructed_composites` and `self.reconstructed_functions`
+        // have been populated.
         Program {
             stubs,
-            program_scopes: input
-                .program_scopes
-                .into_iter()
-                .map(|(id, scope)| (id, self.reconstruct_program_scope(scope)))
-                .collect(),
+            program_scopes,
             modules: input.modules.into_iter().map(|(id, module)| (id, self.reconstruct_module(module))).collect(),
             ..input
         }
@@ -221,7 +334,9 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
 
     fn reconstruct_module(&mut self, input: Module) -> Module {
         // Here we're reconstructing composites and functions from `reconstructed_functions` and
-        // `reconstructed_composites` based on their paths and whether they match the module path
+        // `reconstructed_composites` based on their paths and whether they match the module path.
+        // Use `input.program_name` rather than `self.program` since `self.program` may have been
+        // updated by a nested reconstruct_program call (e.g., for a Stub::FromLeo dependency).
         Module {
             composites: self
                 .reconstructed_composites
@@ -229,7 +344,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                 .filter_map(|(loc, c)| {
                     loc.path
                         .split_last()
-                        .filter(|(_, rest)| *rest == input.path && loc.program == self.program)
+                        .filter(|(_, rest)| *rest == input.path && loc.program == input.program_name)
                         .map(|(last, _)| (*last, c.clone()))
                 })
                 .collect(),
@@ -240,7 +355,7 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                 .filter_map(|(loc, f)| {
                     loc.path
                         .split_last()
-                        .filter(|(_, rest)| *rest == input.path && loc.program == self.program)
+                        .filter(|(_, rest)| *rest == input.path && loc.program == input.program_name)
                         .map(|(last, _)| (*last, f.clone()))
                 })
                 .collect(),

--- a/crates/passes/src/monomorphization/visitor.rs
+++ b/crates/passes/src/monomorphization/visitor.rs
@@ -73,27 +73,43 @@ impl MonomorphizationVisitor<'_> {
     ///
     /// Note: this functions already assumes that all provided const arguments are literals.
     pub(crate) fn monomorphize_composite(&mut self, path: &Path, const_arguments: &Vec<Expression>) -> Path {
-        // Generate a unique name for the monomorphized composite based on const arguments.
+        let original_loc = path.expect_global_location();
+
+        // Generate a unique monomorphized name for the composite.
         //
-        // For `struct Foo::[x: u32, y: u32](..)`, the generated name would be `Foo::[1u32, 2u32]` for a composite
-        // expression that sets `x` to `1u32` and `y` to `2u32`. We know this name is safe to use because it's not a
-        // valid identifier in the user code.
+        // For both local and library composites, the name uses the base struct name plus its
+        // const arguments: e.g. `Foo::[1u32]`. Uniqueness within the consuming program is
+        // guaranteed by the storage location (see below).
         //
-        // Later, we have to legalize these names because they are not valid Aleo identifiers. We do this in codegen.
-        let new_composite_path = path.clone().with_updated_last_symbol(leo_span::Symbol::intern(&format!(
-            "{}::[{}]",
-            path.identifier().name,
-            const_arguments.iter().format(", ")
-        )));
+        // These names are not valid Leo identifiers and are legalized in codegen.
+        let monomorphized_name =
+            leo_span::Symbol::intern(&format!("{}::[{}]", path.identifier().name, const_arguments.iter().format(", ")));
+
+        // Compute the storage location for the monomorphized composite:
+        // - Library composites stay under their own library program (e.g. `math_lib/["Foo::[1u32]"]`),
+        //   just as module composites stay in their module. `reconstruct_library` picks them up
+        //   naturally and code generation inlines them into the consuming program's bytecode.
+        // - Local composites stay in the same program scope.
+        let storage_loc = if original_loc.program != self.program {
+            Location::new(original_loc.program, vec![monomorphized_name])
+        } else {
+            let mut path_segs = original_loc.path[..original_loc.path.len() - 1].to_vec();
+            path_segs.push(monomorphized_name);
+            Location::new(original_loc.program, path_segs)
+        };
+
+        // Build the new path pointing directly to the storage location.
+        let new_composite_path =
+            path.clone().with_updated_last_symbol(monomorphized_name).to_global(storage_loc.clone());
 
         // Check if the new composite name is not already present in `reconstructed_composites`. This ensures that we do not
         // add a duplicate definition for the same composite.
-        if self.reconstructed_composites.get(new_composite_path.expect_global_location()).is_none() {
+        if self.reconstructed_composites.get(&storage_loc).is_none() {
             // Look up the already reconstructed composite by name.
             let composite = self
                 .reconstructed_composites
-                .get(path.expect_global_location())
-                .expect("Composite should already be reconstructed (post-order traversal).");
+                .get(original_loc)
+                .unwrap_or_else(|| panic!("Composite should already be reconstructed (post-order traversal)."));
 
             // Build mapping from const parameters to const argument values.
             let const_param_map: IndexMap<_, _> = composite
@@ -122,16 +138,15 @@ impl MonomorphizationVisitor<'_> {
             // Now, reconstruct the composite to actually monomorphize its content such as generic composite type
             // instantiations.
             composite = self.reconstruct_composite(composite);
-            composite.identifier =
-                Identifier::new(new_composite_path.identifier().name, self.state.node_builder.next_id());
+            composite.identifier = Identifier::new(monomorphized_name, self.state.node_builder.next_id());
             composite.const_parameters = vec![];
             composite.id = self.state.node_builder.next_id();
 
             // Keep track of the new composite in case other composites need it.
-            self.reconstructed_composites.insert(new_composite_path.expect_global_location().clone(), composite);
+            self.reconstructed_composites.insert(storage_loc.clone(), composite);
 
             // Now keep track of the composite we just monomorphized
-            self.monomorphized_composites.insert(path.expect_global_location().clone());
+            self.monomorphized_composites.insert(original_loc.clone());
         }
 
         new_composite_path

--- a/crates/passes/src/path_resolution/program.rs
+++ b/crates/passes/src/path_resolution/program.rs
@@ -53,6 +53,7 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
 
         Library {
             name: input.name,
+            structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
             consts: input
                 .consts
                 .into_iter()

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -169,6 +169,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
         // Set the scope state.
         self.scope_state.program_name = Some(input.name);
 
+        input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
     }
 

--- a/tests/expectations/compiler/libraries/const_args_to_concrete_lib_struct_fail.out
+++ b/tests/expectations/compiler/libraries/const_args_to_concrete_lib_struct_fail.out
@@ -1,0 +1,10 @@
+Error [ETYC0372140]: Composite type expected `0` const args, but got `1`
+    --> compiler-test:5:16
+     |
+   5 |         let p: foo_lib::Point::[5u32] = foo_lib::Point::[5u32] { x: 1u32, y: 2u32 };
+     |                ^^^^^^^^^^^^^^
+Error [ETYC0372140]: Composite expression expected `0` const args, but got `1`
+    --> compiler-test:5:41
+     |
+   5 |         let p: foo_lib::Point::[5u32] = foo_lib::Point::[5u32] { x: 1u32, y: 2u32 };
+     |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/libraries/cross_lib_struct_composition.out
+++ b/tests/expectations/compiler/libraries/cross_lib_struct_composition.out
@@ -1,0 +1,27 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+struct Rect__yHB5zqEAd9:
+    top_left as Point__7VbTm7beYPk;
+    bottom_right as Point__7VbTm7beYPk;
+
+function make_rect:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    cast r2 r3 into r5 as Point__7VbTm7beYPk;
+    cast r4 r5 into r6 as Rect__yHB5zqEAd9;
+    output r6 as Rect__yHB5zqEAd9.private;
+
+function width:
+    input r0 as Rect__yHB5zqEAd9.private;
+    sub r0.bottom_right.x r0.top_left.x into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_const_as_struct_generic_arg.out
+++ b/tests/expectations/compiler/libraries/lib_const_as_struct_generic_arg.out
@@ -1,0 +1,24 @@
+program main.aleo;
+
+struct Grid__BuoLASDcHZe:
+    cells as [u32; 4u32];
+
+struct Square__EJsWIiwZaLk:
+    grid as Grid__BuoLASDcHZe;
+
+struct Grid__E7XglmTW4uA:
+    cells as [u32; 8u32];
+
+struct BigSquare__3j8s7bQFQI5:
+    grid as Grid__E7XglmTW4uA;
+
+function get_cell:
+    input r0 as Square__EJsWIiwZaLk.private;
+    output r0.grid.cells[0u32] as u32.private;
+
+function get_big_cell:
+    input r0 as BigSquare__3j8s7bQFQI5.private;
+    output r0.grid.cells[0u32] as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_struct_fn_param.out
+++ b/tests/expectations/compiler/libraries/lib_struct_fn_param.out
@@ -1,0 +1,31 @@
+program main.aleo;
+
+struct Vec2__EfrQi4S1ZpD:
+    x as u32;
+    y as u32;
+
+struct VecN__BSuA4MDO6tz:
+    len as u32;
+
+struct VecN__5bpuWKU620J:
+    len as u32;
+
+function scale:
+    input r0 as Vec2__EfrQi4S1ZpD.private;
+    input r1 as u32.private;
+    mul r0.x r1 into r2;
+    mul r0.y r1 into r3;
+    cast r2 r3 into r4 as Vec2__EfrQi4S1ZpD;
+    output r4 as Vec2__EfrQi4S1ZpD.private;
+
+function make_vec3:
+    input r0 as Vec2__EfrQi4S1ZpD.private;
+    cast 3u32 into r1 as VecN__BSuA4MDO6tz;
+    output r1 as VecN__BSuA4MDO6tz.private;
+
+function get_len:
+    input r0 as VecN__5bpuWKU620J.private;
+    output r0.len as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_struct_in_mapping.out
+++ b/tests/expectations/compiler/libraries/lib_struct_in_mapping.out
@@ -1,0 +1,15 @@
+program store.aleo;
+
+struct Entry__7dD9zrVBcrI:
+    size as u32;
+
+mapping store:
+    key as address.public;
+    value as Entry__7dD9zrVBcrI.public;
+
+function get_size:
+    input r0 as Entry__7dD9zrVBcrI.private;
+    output r0.size as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_struct_multi_const_params.out
+++ b/tests/expectations/compiler/libraries/lib_struct_multi_const_params.out
@@ -1,0 +1,28 @@
+program main.aleo;
+
+struct Matrix__AlcBz9NgBy0:
+    rows as u32;
+    cols as u32;
+
+struct Matrix__Bjoxw8HsNUL:
+    rows as u32;
+    cols as u32;
+
+function make_2x3:
+    cast 2u32 3u32 into r0 as Matrix__AlcBz9NgBy0;
+    output r0 as Matrix__AlcBz9NgBy0.private;
+
+function make_3x4:
+    cast 3u32 4u32 into r0 as Matrix__Bjoxw8HsNUL;
+    output r0 as Matrix__Bjoxw8HsNUL.private;
+
+function get_rows_2x3:
+    input r0 as Matrix__AlcBz9NgBy0.private;
+    output r0.rows as u32.private;
+
+function get_cols_3x4:
+    input r0 as Matrix__Bjoxw8HsNUL.private;
+    output r0.cols as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_struct_non_const_arg_fail.out
+++ b/tests/expectations/compiler/libraries/lib_struct_non_const_arg_fail.out
@@ -1,0 +1,10 @@
+Error [ECMP0376012]: Unable to resolve composite expression `foo_lib::Foo`. A non-const expression was provided where a const generic parameter is required.
+    --> compiler-test:5:51
+     |
+   5 |         let f: foo_lib::Foo::[n] = foo_lib::Foo::[n] { x: 0u32 };
+     |                                                   ^
+Error [ECMP0376012]: Unable to resolve composite type `foo_lib::Foo`. A non-const expression was provided where a const generic parameter is required.
+    --> compiler-test:5:31
+     |
+   5 |         let f: foo_lib::Foo::[n] = foo_lib::Foo::[n] { x: 0u32 };
+     |                               ^

--- a/tests/expectations/compiler/libraries/nested_library_structs.out
+++ b/tests/expectations/compiler/libraries/nested_library_structs.out
@@ -1,0 +1,81 @@
+program helper.aleo;
+
+struct Foo__23hLlpkr7IV:
+    x as [u32; 43u32];
+
+struct Bar__8bgR37XBVQ5:
+    f as Foo__23hLlpkr7IV;
+
+struct Foo__DW5CFNFqCBH:
+    x as [u32; 100u32];
+
+struct Foo__KZDH7kc0tn0:
+    x as [u32; 44u32];
+
+function add_offset:
+    input r0 as u32.private;
+    cast 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 12u32 into r1 as [u32; 100u32];
+    cast r1 into r2 as Foo__DW5CFNFqCBH;
+    cast 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 4u32 into r3 as [u32; 43u32];
+    cast r3 into r4 as Foo__23hLlpkr7IV;
+    cast r4 into r5 as Bar__8bgR37XBVQ5;
+    add r0 15u32 into r6;
+    add r6 10u32 into r7;
+    add r7 r2.x[42u32] into r8;
+    add r8 r5.f.x[3u32] into r9;
+    output r9 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+// --- Next Program --- //
+import helper.aleo;
+program main.aleo;
+
+struct Foo:
+    y as u32;
+
+struct Foo__23hLlpkr7IV:
+    x as [u32; 43u32];
+
+struct Bar__8bgR37XBVQ5:
+    f as Foo__23hLlpkr7IV;
+
+struct Foo__DW5CFNFqCBH:
+    x as [u32; 100u32];
+
+struct Foo__KZDH7kc0tn0:
+    x as [u32; 44u32];
+
+function compute:
+    input r0 as u32.private;
+    call helper.aleo/add_offset r0 into r1;
+    cast 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 1000u32 into r2 as [u32; 43u32];
+    cast r2 into r3 as Foo__23hLlpkr7IV;
+    cast r3 into r4 as Bar__8bgR37XBVQ5;
+    add r4.f.x[0u32] r1 into r5;
+    add r5 35u32 into r6;
+    add r6 20u32 into r7;
+    cast 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 99u32 into r8 as [u32; 44u32];
+    cast r8 into r9 as Foo__KZDH7kc0tn0;
+    cast 199u32 into r10 as Foo;
+    output r7 as u32.private;
+    output r9 as Foo__KZDH7kc0tn0.private;
+    output r10 as Foo.private;
+
+constructor:
+    assert.eq edition 0u16;
+
+
+---
+Note: Treating dependencies as Aleo produces different results:
+
+Error [ETYC0372005]: Unknown variable `math_lib::OFFSET`
+    --> compiler-test:1:19
+     |
+   1 | const BASE: u32 = math_lib::OFFSET + 5u32;
+     |                   ^^^^^^^^^^^^^^^^
+Error [ETYC0372005]: Unknown variable `math_lib::SCALE`
+    --> compiler-test:2:21
+     |
+   2 | const FACTOR: u32 = math_lib::SCALE + BASE;
+     |                     ^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/libraries/wrong_num_const_args_lib_struct_fail.out
+++ b/tests/expectations/compiler/libraries/wrong_num_const_args_lib_struct_fail.out
@@ -1,0 +1,10 @@
+Error [ETYC0372140]: Composite type expected `1` const args, but got `2`
+    --> compiler-test:5:16
+     |
+   5 |         let f: foo_lib::Foo::[1u32, 2u32] = foo_lib::Foo::[1u32, 2u32] { x: 0u32 };
+     |                ^^^^^^^^^^^^
+Error [ETYC0372140]: Composite expression expected `1` const args, but got `2`
+    --> compiler-test:5:45
+     |
+   5 |         let f: foo_lib::Foo::[1u32, 2u32] = foo_lib::Foo::[1u32, 2u32] { x: 0u32 };
+     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/libraries/wrong_type_const_arg_lib_struct_fail.out
+++ b/tests/expectations/compiler/libraries/wrong_type_const_arg_lib_struct_fail.out
@@ -1,0 +1,10 @@
+Error [ETYC0372117]: Expected type `u32` but type `bool` was found.
+    --> compiler-test:5:31
+     |
+   5 |         let f: foo_lib::Foo::[true] = foo_lib::Foo::[true] { x: 0u32 };
+     |                               ^^^^
+Error [ETYC0372117]: Expected type `u32` but type `bool` was found.
+    --> compiler-test:5:54
+     |
+   5 |         let f: foo_lib::Foo::[true] = foo_lib::Foo::[true] { x: 0u32 };
+     |                                                      ^^^^

--- a/tests/expectations/execution/libraries/lib_struct_basic.out
+++ b/tests/expectations/execution/libraries/lib_struct_basic.out
@@ -1,0 +1,13 @@
+program main.aleo;
+
+struct Slot__KHhnb8Opt0N:
+    size as u32;
+
+function get_val:
+    cast 7u32 into r0 as Slot__KHhnb8Opt0N;
+    output r0.size as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 7u32

--- a/tests/expectations/execution/libraries/lib_struct_fn_roundtrip.out
+++ b/tests/expectations/execution/libraries/lib_struct_fn_roundtrip.out
@@ -1,0 +1,16 @@
+program main.aleo;
+
+struct Wrap__7dHW66DosY9:
+    val as u32;
+
+function roundtrip:
+    input r0 as u32.private;
+    cast r0 into r1 as Wrap__7dHW66DosY9;
+    mul r1.val 2u32 into r2;
+    cast r2 into r3 as Wrap__7dHW66DosY9;
+    output r3.val as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 84u32

--- a/tests/expectations/execution/libraries/lib_struct_multi_instantiation.out
+++ b/tests/expectations/execution/libraries/lib_struct_multi_instantiation.out
@@ -1,0 +1,18 @@
+program main.aleo;
+
+struct Tag__EC5wxurBkvd:
+    id as u32;
+
+struct Tag__4mJSZ48wg4H:
+    id as u32;
+
+function sum_tags:
+    cast 10u32 into r0 as Tag__EC5wxurBkvd;
+    cast 20u32 into r1 as Tag__4mJSZ48wg4H;
+    add r0.id r1.id into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 30u32

--- a/tests/expectations/parser-library/bad_items_fail.out
+++ b/tests/expectations/parser-library/bad_items_fail.out
@@ -1,57 +1,52 @@
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
     --> test_0:1:1
      |
    1 | fn foo() {}
      | ^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
     --> test_1:1:1
      |
    1 | final fn bar() {}
      | ^^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
-    --> test_2:1:1
-     |
-   1 | struct Foo { x: u32 }
-     | ^^^^^^^^^^^^^^^^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_3:1:1
+    --> test_2:1:1
      |
    1 | record Bar { owner: address }
      | ^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_4:1:1
+    --> test_3:1:1
      |
    1 | mapping my_map: u32 => u32;
      | ^^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_5:1:1
+    --> test_4:1:1
      |
    1 | storage foo: u32;
      | ^^^^^^^
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
-    --> test_6:1:1
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
+    --> test_5:1:1
      |
    1 | interface MyInterface { fn baz(); }
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
-    --> test_7:1:1
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
+    --> test_6:1:1
      |
    1 | import foo.aleo;
      | ^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
-    --> test_8:1:1
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
+    --> test_7:1:1
      |
    1 | program foo.aleo {}
      | ^^^^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations are allowed in a library.
-    --> test_9:1:1
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
+    --> test_8:1:1
      |
    1 | @noupgrade
      | ^^^^^^^^^^
    2 | constructor() {}
      | ^^^^^^^^^^^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_10:1:1
+    --> test_9:1:1
      |
    1 | {
      | ^

--- a/tests/expectations/parser-library/struct_bad_items_fail.out
+++ b/tests/expectations/parser-library/struct_bad_items_fail.out
@@ -1,0 +1,10 @@
+Error [EPAR0370047]: expected `import`, `program`, or module item at top level
+    --> test_0:1:1
+     |
+   1 | record Foo { owner: address, data: u32 }
+     | ^^^^^^
+Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
+    --> test_1:1:1
+     |
+   1 | fn helper() -> u32 { return 0u32; }
+     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/parser-library/structs.out
+++ b/tests/expectations/parser-library/structs.out
@@ -1,0 +1,30 @@
+library test_lib {
+    struct Point {
+        x: u32,
+        y: u32,
+    }
+}
+
+
+library test_lib {
+    struct Vec::[N: u32] {
+        data: u32,
+    }
+}
+
+
+library test_lib {
+    struct Matrix::[R: u32, C: u32] {
+        rows: u32,
+        cols: u32,
+    }
+    struct Grid::[N: u32] {
+        cells: u32,
+    }
+    struct Board {
+        grid: Grid::[SIZE],
+    }
+    const SIZE: u32 = 8u32;
+}
+
+

--- a/tests/expectations/parser/structs/lib_struct_composite_types.out
+++ b/tests/expectations/parser/structs/lib_struct_composite_types.out
@@ -1,0 +1,13 @@
+program test.aleo {
+    struct Local::[N: u32] {
+        v: u32,
+    }
+    mapping cache: address => some_lib::Entry::[8u32];
+    fn f(a: some_lib::Vec::[4u32], b: some_lib::Vec::[4u32]) -> some_lib::Vec::[4u32] {
+        let x: some_lib::Vec::[4u32] = some_lib::Vec::[4u32] { size: 4u32 };
+        let y: Local::[3u32] = Local::[3u32] { v: 0u32 };
+        return x;
+    }
+}
+
+

--- a/tests/expectations/parser/structs/lib_struct_multi_const_params.out
+++ b/tests/expectations/parser/structs/lib_struct_multi_const_params.out
@@ -1,0 +1,8 @@
+program test.aleo {
+    fn make(a: some_lib::Matrix::[2u32, 3u32]) -> some_lib::Matrix::[3u32, 4u32] {
+        let m: some_lib::Matrix::[2u32, 3u32] = some_lib::Matrix::[2u32, 3u32] { r: 2u32, c: 3u32 };
+        return some_lib::Matrix::[3u32, 4u32] { r: 3u32, c: 4u32 };
+    }
+}
+
+

--- a/tests/tests/compiler/libraries/const_args_to_concrete_lib_struct_fail.leo
+++ b/tests/tests/compiler/libraries/const_args_to_concrete_lib_struct_fail.leo
@@ -1,0 +1,22 @@
+// Test: providing const arguments to a non-generic (concrete) library struct.
+// Point has no const parameters so Point::[5u32] is invalid.
+// Expects a TypeCheckerError for unexpected const args.
+
+// --- library: foo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute() -> u32 {
+        let p: foo_lib::Point::[5u32] = foo_lib::Point::[5u32] { x: 1u32, y: 2u32 };
+        return p.x;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/cross_lib_struct_composition.leo
+++ b/tests/tests/compiler/libraries/cross_lib_struct_composition.leo
@@ -1,0 +1,44 @@
+// Test: a struct in library B uses a non-generic struct from library A as a field type.
+//
+// Verifies that the composite dependency graph contains the cross-library edge
+// shape_lib/Rect -> geo_lib/Point and that post-order traversal processes Point
+// before Rect, so that geo_lib::Point is emitted in the bytecode before shape_lib::Rect.
+//
+// Dependency graph:
+//   geo_lib    (library: concrete struct Point)
+//   shape_lib  (library: struct Rect containing geo_lib::Point fields)
+//   main.aleo  (program: uses shape_lib::Rect)
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+// --- Next Program --- //
+
+// --- library: shape_lib --- //
+
+struct Rect {
+    top_left: geo_lib::Point,
+    bottom_right: geo_lib::Point,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn make_rect(x1: u32, y1: u32, x2: u32, y2: u32) -> shape_lib::Rect {
+        return shape_lib::Rect {
+            top_left: geo_lib::Point { x: x1, y: y1 },
+            bottom_right: geo_lib::Point { x: x2, y: y2 },
+        };
+    }
+
+    fn width(r: shape_lib::Rect) -> u32 {
+        return r.bottom_right.x - r.top_left.x;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_const_as_struct_generic_arg.leo
+++ b/tests/tests/compiler/libraries/lib_const_as_struct_generic_arg.leo
@@ -1,0 +1,44 @@
+// Test: a library const used directly as a generic argument in a struct definition
+// within the same library (not a literal).
+//
+// Grid::[SIDE] and Grid::[DOUBLE_SIDE] in the Square/BigSquare field types are
+// library-const references, not literals. After const propagation they should become
+// Grid::[4u32] and Grid::[8u32] respectively. This test checks that const propagation
+// visits library composite definitions so that monomorphization receives evaluated
+// literals rather than unresolved Path expressions.
+//
+// Dependency graph:
+//   shape_lib  (library: const SIDE=4, DOUBLE_SIDE=8, struct Grid::[N], Square, BigSquare)
+//   main.aleo  (program: uses shape_lib::Square and shape_lib::BigSquare)
+
+// --- library: shape_lib --- //
+
+const SIDE: u32 = 4u32;
+const DOUBLE_SIDE: u32 = SIDE + SIDE;
+
+struct Grid::[N: u32] {
+    cells: [u32; N]
+}
+
+struct Square {
+    grid: Grid::[SIDE]
+}
+
+struct BigSquare {
+    grid: Grid::[DOUBLE_SIDE]
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn get_cell(s: shape_lib::Square) -> u32 {
+        return s.grid.cells[0];
+    }
+
+    fn get_big_cell(b: shape_lib::BigSquare) -> u32 {
+        return b.grid.cells[0];
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_struct_fn_param.leo
+++ b/tests/tests/compiler/libraries/lib_struct_fn_param.leo
@@ -1,0 +1,39 @@
+// Test: a library struct (both concrete and generic) in function parameter and return types.
+//
+// Verifies that library composite types in function signature positions (not just inside
+// function bodies) are correctly reconstructed and that monomorphization is triggered
+// from function signature scanning, not only from body expressions.
+//
+// Dependency graph:
+//   vec_lib   (library: concrete struct Vec2, generic struct VecN::[N: u32])
+//   main.aleo (program: functions with vec_lib types in params and return types)
+
+// --- library: vec_lib --- //
+
+struct Vec2 {
+    x: u32,
+    y: u32,
+}
+
+struct VecN::[N: u32] {
+    len: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn scale(v: vec_lib::Vec2, factor: u32) -> vec_lib::Vec2 {
+        return vec_lib::Vec2 { x: v.x * factor, y: v.y * factor };
+    }
+
+    fn make_vec3(v: vec_lib::Vec2) -> vec_lib::VecN::[3u32] {
+        return vec_lib::VecN::[3u32] { len: 3u32 };
+    }
+
+    fn get_len(v: vec_lib::VecN::[5u32]) -> u32 {
+        return v.len;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_struct_in_mapping.leo
+++ b/tests/tests/compiler/libraries/lib_struct_in_mapping.leo
@@ -1,0 +1,28 @@
+// Test: a monomorphized library generic struct used as a mapping value type.
+//
+// Verifies that CompositeType with const arguments is handled correctly in mapping
+// positions (reconstruct_mapping in the monomorphizer has a separate code path from
+// function-body struct uses).
+//
+// Dependency graph:
+//   cache_lib  (library: struct Entry::[N: u32])
+//   store.aleo (program: mapping store: address => cache_lib::Entry::[8u32])
+
+// --- library: cache_lib --- //
+
+struct Entry::[N: u32] {
+    size: u32,
+}
+
+// --- Next Program --- //
+
+program store.aleo {
+    mapping store: address => cache_lib::Entry::[8u32];
+
+    fn get_size(e: cache_lib::Entry::[8u32]) -> u32 {
+        return e.size;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_struct_multi_const_params.leo
+++ b/tests/tests/compiler/libraries/lib_struct_multi_const_params.leo
@@ -1,0 +1,39 @@
+// Test: a library struct with two const generic parameters.
+//
+// Verifies that zip_eq of const_parameters and const_arguments in monomorphize_composite
+// handles arity > 1 correctly, and that Matrix::[2u32, 3u32] and Matrix::[3u32, 4u32]
+// are independently cached as distinct monomorphized composites.
+//
+// Dependency graph:
+//   linalg  (library: struct Matrix::[R: u32, C: u32])
+//   main.aleo (program: uses Matrix::[2, 3] and Matrix::[3, 4])
+
+// --- library: linalg --- //
+
+struct Matrix::[R: u32, C: u32] {
+    rows: u32,
+    cols: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn make_2x3() -> linalg::Matrix::[2u32, 3u32] {
+        return linalg::Matrix::[2u32, 3u32] { rows: 2u32, cols: 3u32 };
+    }
+
+    fn make_3x4() -> linalg::Matrix::[3u32, 4u32] {
+        return linalg::Matrix::[3u32, 4u32] { rows: 3u32, cols: 4u32 };
+    }
+
+    fn get_rows_2x3(m: linalg::Matrix::[2u32, 3u32]) -> u32 {
+        return m.rows;
+    }
+
+    fn get_cols_3x4(m: linalg::Matrix::[3u32, 4u32]) -> u32 {
+        return m.cols;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_struct_non_const_arg_fail.leo
+++ b/tests/tests/compiler/libraries/lib_struct_non_const_arg_fail.leo
@@ -1,0 +1,21 @@
+// Test: a non-const runtime variable used as a library struct const argument.
+// Expects the same non-const-argument error as for local generic structs/functions
+// (see const_generics/non_const_arg_fail.leo).
+
+// --- library: foo_lib --- //
+
+struct Foo::[N: u32] {
+    x: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn bar(n: u32) -> u32 {
+        let f: foo_lib::Foo::[n] = foo_lib::Foo::[n] { x: 0u32 };
+        return f.x;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/nested_library_structs.leo
+++ b/tests/tests/compiler/libraries/nested_library_structs.leo
@@ -1,0 +1,74 @@
+// Test: nested library dependencies with generic structs.
+//
+// Dependency graph:
+//   math_lib          (library: generic struct Foo, concrete struct Bar, consts OFFSET/SCALE)
+//   config_lib        (library: consts BASE/FACTOR, depends on math_lib)
+//   helper.aleo       (program: uses math_lib structs and both library consts; has module dep.leo)
+//   main.aleo         (program: imports helper.aleo, uses math_lib structs and library consts)
+//
+// Verifies:
+//  - Generic library structs (Foo::[N]) are monomorphized at each distinct call site.
+//  - Concrete library structs (Bar containing Foo::[42]) work transitively.
+//  - Library consts are resolved at compile time and not emitted as bytecode imports.
+//  - A program can use the same generic library struct at multiple different sizes.
+//  - Modules inside a program compile alongside library struct usage.
+
+// --- library: math_lib --- //
+
+struct Foo::[N: u32] {
+    x: [u32; N + 1]
+}
+
+struct Bar {
+    f: Foo::[42],
+}
+
+const OFFSET: u32 = 10u32;
+const SCALE: u32 = OFFSET + OFFSET;
+
+// --- Next Program --- //
+
+// --- library: config_lib --- //
+
+const BASE: u32 = math_lib::OFFSET + 5u32;
+const FACTOR: u32 = math_lib::SCALE + BASE;
+
+// --- Next Program --- //
+
+program helper.aleo {
+    fn add_offset(x: u32) -> u32 {
+        let f = math_lib::Foo::[99] { x: [12; 100] };
+        let b = math_lib::Bar {
+            f: math_lib::Foo::[42] { x: [4; 43] }
+        };
+        return x + config_lib::BASE + math_lib::OFFSET + f.x[42] + b.f.x[3];
+    }
+
+    @noupgrade
+    constructor() {}
+}
+// --- Next Module: dep.leo --- //
+struct B::[N: u32] { z: u32 }
+
+// --- Next Program --- //
+
+import helper.aleo;
+
+struct Foo {
+    y: u32,
+}
+
+program main.aleo {
+    fn compute(x: u32) -> (u32, math_lib::Foo::[43], Foo) {
+        let a: u32 = helper.aleo/add_offset(x);
+        let b: math_lib::Bar = math_lib::Bar {
+            f: math_lib::Foo::[42] {
+                x: [1000; 43]
+            }
+        };
+        return (b.f.x[0] + a + config_lib::FACTOR + math_lib::SCALE, math_lib::Foo::[43] { x: [99; 44] }, Foo { y: 199 });
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/wrong_num_const_args_lib_struct_fail.leo
+++ b/tests/tests/compiler/libraries/wrong_num_const_args_lib_struct_fail.leo
@@ -1,0 +1,20 @@
+// Test: passing the wrong number of const arguments to a library generic struct.
+// Expects a type-checker error for incorrect const argument arity.
+
+// --- library: foo_lib --- //
+
+struct Foo::[N: u32] {
+    x: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute() -> u32 {
+        let f: foo_lib::Foo::[1u32, 2u32] = foo_lib::Foo::[1u32, 2u32] { x: 0u32 };
+        return f.x;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/wrong_type_const_arg_lib_struct_fail.leo
+++ b/tests/tests/compiler/libraries/wrong_type_const_arg_lib_struct_fail.leo
@@ -1,0 +1,21 @@
+// Test: passing a const argument of the wrong type to a library generic struct.
+// Foo::[N: u32] expects a u32 const arg but receives a bool literal.
+// Expects a type mismatch error.
+
+// --- library: foo_lib --- //
+
+struct Foo::[N: u32] {
+    x: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute() -> u32 {
+        let f: foo_lib::Foo::[true] = foo_lib::Foo::[true] { x: 0u32 };
+        return f.x;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_struct_basic.leo
+++ b/tests/tests/execution/libraries/lib_struct_basic.leo
@@ -1,0 +1,28 @@
+/*
+[case]
+program = "main.aleo"
+function = "get_val"
+input = []
+*/
+
+// Test: instantiate a library generic struct, access a field, and return it.
+// vec_lib::Slot::[7u32] has a `size` field. We construct it with size=7 and return it.
+// Expected output: 7u32.
+
+// --- library: vec_lib --- //
+
+struct Slot::[N: u32] {
+    size: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn get_val() -> u32 {
+        let s: vec_lib::Slot::[7u32] = vec_lib::Slot::[7u32] { size: 7u32 };
+        return s.size;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_struct_fn_roundtrip.leo
+++ b/tests/tests/execution/libraries/lib_struct_fn_roundtrip.leo
@@ -1,0 +1,33 @@
+/*
+[case]
+program = "main.aleo"
+function = "roundtrip"
+input = ["42u32"]
+*/
+
+// Test: pass a library struct through a function call and back.
+// scale doubles the `val` field of a Wrap::[3u32] struct.
+// Input: 42u32. Expected output: the `val` of the returned struct = 84u32.
+
+// --- library: wrap_lib --- //
+
+struct Wrap::[N: u32] {
+    val: u32,
+}
+
+// --- Next Program --- //
+
+fn scale(w: wrap_lib::Wrap::[3u32]) -> wrap_lib::Wrap::[3u32] {
+    return wrap_lib::Wrap::[3u32] { val: w.val * 2u32 };
+}
+
+program main.aleo {
+    fn roundtrip(x: u32) -> u32 {
+        let w: wrap_lib::Wrap::[3u32] = wrap_lib::Wrap::[3u32] { val: x };
+        let w2: wrap_lib::Wrap::[3u32] = scale(w);
+        return w2.val;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_struct_multi_instantiation.leo
+++ b/tests/tests/execution/libraries/lib_struct_multi_instantiation.leo
@@ -1,0 +1,29 @@
+/*
+[case]
+program = "main.aleo"
+function = "sum_tags"
+input = []
+*/
+
+// Test: two distinct monomorphizations of the same library generic struct.
+// Tag::[1u32] and Tag::[2u32] are independent types; their `id` fields are summed.
+// Expected output: 10u32 + 20u32 = 30u32.
+
+// --- library: tag_lib --- //
+
+struct Tag::[N: u32] {
+    id: u32,
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn sum_tags() -> u32 {
+        let a: tag_lib::Tag::[1u32] = tag_lib::Tag::[1u32] { id: 10u32 };
+        let b: tag_lib::Tag::[2u32] = tag_lib::Tag::[2u32] { id: 20u32 };
+        return a.id + b.id;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/parser-library/bad_items_fail.leo
+++ b/tests/tests/parser-library/bad_items_fail.leo
@@ -3,8 +3,6 @@ fn foo() {}
 
 final fn bar() {}
 
-struct Foo { x: u32 }
-
 record Bar { owner: address }
 
 mapping my_map: u32 => u32;

--- a/tests/tests/parser-library/struct_bad_items_fail.leo
+++ b/tests/tests/parser-library/struct_bad_items_fail.leo
@@ -1,0 +1,4 @@
+
+record Foo { owner: address, data: u32 }
+
+fn helper() -> u32 { return 0u32; }

--- a/tests/tests/parser-library/structs.leo
+++ b/tests/tests/parser-library/structs.leo
@@ -1,0 +1,9 @@
+
+struct Point { x: u32, y: u32 }
+
+struct Vec::[N: u32] { data: u32 }
+
+struct Matrix::[R: u32, C: u32] { rows: u32, cols: u32 }
+const SIZE: u32 = 8u32;
+struct Grid::[N: u32] { cells: u32 }
+struct Board { grid: Grid::[SIZE] }

--- a/tests/tests/parser/structs/lib_struct_composite_types.leo
+++ b/tests/tests/parser/structs/lib_struct_composite_types.leo
@@ -1,0 +1,15 @@
+// Parser test: library struct composite types with const generic arguments in
+// various syntactic positions — function parameters, return types, local variable
+// declarations, struct field types, and mapping value types.
+
+struct Local::[N: u32] { v: u32 }
+
+program test.aleo {
+    mapping cache: address => some_lib::Entry::[8u32];
+
+    fn f(a: some_lib::Vec::[4u32], b: some_lib::Vec::[4u32]) -> some_lib::Vec::[4u32] {
+        let x: some_lib::Vec::[4u32] = some_lib::Vec::[4u32] { size: 4u32 };
+        let y: Local::[3u32] = Local::[3u32] { v: 0u32 };
+        return x;
+    }
+}

--- a/tests/tests/parser/structs/lib_struct_multi_const_params.leo
+++ b/tests/tests/parser/structs/lib_struct_multi_const_params.leo
@@ -1,0 +1,9 @@
+// Parser test: library struct with multiple const generic parameters in type positions.
+// Verifies the parser correctly handles arity > 1 in composite type expressions.
+
+program test.aleo {
+    fn make(a: some_lib::Matrix::[2u32, 3u32]) -> some_lib::Matrix::[3u32, 4u32] {
+        let m: some_lib::Matrix::[2u32, 3u32] = some_lib::Matrix::[2u32, 3u32] { r: 2u32, c: 3u32 };
+        return some_lib::Matrix::[3u32, 4u32] { r: 3u32, c: 4u32 };
+    }
+}


### PR DESCRIPTION
Closes #29208

## Add Struct Support to Leo Libraries

Libraries can now define `struct` types (including generic structs with `const` parameters) alongside `const` declarations. Consuming programs monomorphize library structs at each distinct set of const arguments, and the resulting types are inlined into the program's Aleo bytecode with collision-safe hashed names (e.g. `geo_lib::Point` → `Point__7VbTm7beYPk`).

### What's new

- **Parser**: `is_library_item` now accepts `STRUCT_DEF`; `collect_library_item` populates `Library.structs`.
- **Type checking & const propagation**: Library struct definitions are visited and validated; generic library structs are correctly skipped during const propagation (they can't be evaluated before monomorphization).
- **Monomorphization**: Library composites are pre-loaded before processing `FromLeo` stubs. Each distinct set of const arguments produces an independently cached monomorphized struct. Monomorphized composites are collected back into the library stub for use by downstream programs.
- **Code generation**: `legalize_composite_name` handles library composites separately from local ones, emitting them as inlined `Ident` types rather than external `Location` references.

### Tests

- **Compiler**: 9 new tests covering concrete and generic library structs, multi-param generics, cross-library composition, struct-in-mapping, library-const-as-generic-arg, and error cases (wrong arity, wrong type, non-const arg, const args on concrete struct).
- **Execution**: 3 new end-to-end tests that compile and run programs using library structs and verify computed outputs.
- **Parser**: 4 new tests for library struct syntax in both `parser` and `parser-library` categories.