### PR TITLE
feat(abi): migrate JSON ABI terminology from 3.5 to 4.0

### DIFF
--- a/crates/abi-types/src/lib.rs
+++ b/crates/abi-types/src/lib.rs
@@ -17,7 +17,7 @@
 //! ABI type definitions for Leo programs.
 //!
 //! This crate provides types that describe the public interface of a Leo program,
-//! including transitions, mappings, and all related types. The ABI enables downstream
+//! including functions, mappings, and all related types. The ABI enables downstream
 //! tooling to interact with deployed Leo programs.
 //!
 //! # Lowered Types
@@ -46,8 +46,9 @@ pub struct Program {
     pub mappings: Vec<Mapping>,
     /// Storage variable definitions.
     pub storage_variables: Vec<StorageVariable>,
-    /// Public entry points (transitions only, not internal functions).
-    pub transitions: Vec<Transition>,
+    /// Public entry points (program functions only, not internal helpers).
+    /// Compiled to Aleo `transition`s.
+    pub functions: Vec<Function>,
 }
 
 /// A struct type definition.
@@ -100,11 +101,12 @@ pub enum StorageType {
     Vector(Box<StorageType>),
 }
 
-/// A transition function (public entry point).
+/// A public entry point (`fn` inside `program {}`). Compiled to an Aleo `transition`.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct Transition {
+pub struct Function {
     pub name: String,
-    pub is_async: bool,
+    /// Whether this function has a finalize block. Compiled to an Aleo `finalize` scope.
+    pub is_final: bool,
     pub inputs: Vec<Input>,
     pub outputs: Vec<Output>,
 }
@@ -124,18 +126,18 @@ pub struct RecordField {
     pub mode: Mode,
 }
 
-/// A transition input.
+/// A function input.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Input {
     pub name: String,
-    pub ty: TransitionInput,
+    pub ty: FunctionInput,
     pub mode: Mode,
 }
 
-/// A transition output.
+/// A function output.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Output {
-    pub ty: TransitionOutput,
+    pub ty: FunctionOutput,
     pub mode: Mode,
 }
 
@@ -193,20 +195,20 @@ pub enum Plaintext {
     Optional(Optional),
 }
 
-/// Valid types for transition inputs.
+/// Valid types for function inputs. Aleo: `transition` inputs.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum TransitionInput {
+pub enum FunctionInput {
     Plaintext(Plaintext),
     Record(RecordRef),
 }
 
-/// Valid types for transition outputs.
+/// Valid types for function outputs. Aleo: `transition` outputs.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub enum TransitionOutput {
+pub enum FunctionOutput {
     Plaintext(Plaintext),
     Record(RecordRef),
-    /// A future returned by async transitions.
-    Future,
+    /// Aleo `future` - the handle for an on-chain finalization.
+    Final,
 }
 
 /// Primitive types that map directly to Aleo literal types.

--- a/crates/abi/src/aleo.rs
+++ b/crates/abi/src/aleo.rs
@@ -37,7 +37,7 @@ use std::collections::HashSet;
 /// generated ABI are always single-element (just the type name).
 ///
 /// The returned ABI is pruned to only include types that appear in the public
-/// interface (transitions, mappings).
+/// interface (functions, mappings).
 pub fn generate(aleo: &ast::AleoProgram) -> abi::Program {
     let program = aleo.stub_id.to_string();
 
@@ -57,14 +57,14 @@ pub fn generate(aleo: &ast::AleoProgram) -> abi::Program {
     let record_names: HashSet<Symbol> =
         aleo.composites.iter().filter(|(_, c)| c.is_record).map(|(name, _)| *name).collect();
 
-    let transitions = aleo
+    let functions = aleo
         .functions
         .iter()
         .filter(|(_, f)| f.variant.is_entry())
         .map(|(_, f)| convert_function_stub(f, &record_names))
         .collect();
 
-    let mut program = abi::Program { program, structs, records, mappings, storage_variables, transitions };
+    let mut program = abi::Program { program, structs, records, mappings, storage_variables, functions };
 
     // Prune types not used in the public interface.
     prune_non_interface_types(&mut program);
@@ -72,53 +72,53 @@ pub fn generate(aleo: &ast::AleoProgram) -> abi::Program {
     program
 }
 
-/// Converts a function stub to a transition for ABI.
-fn convert_function_stub(function: &ast::FunctionStub, record_names: &HashSet<Symbol>) -> abi::Transition {
+/// Converts a function stub to an ABI function.
+fn convert_function_stub(function: &ast::FunctionStub, record_names: &HashSet<Symbol>) -> abi::Function {
     let name = function.identifier.name.to_string();
-    let is_async = function.has_final_output();
+    let is_final = function.has_final_output();
     let inputs = function.input.iter().map(|i| convert_input(i, record_names)).collect();
     let outputs = function.output.iter().map(|o| convert_output(o, record_names)).collect();
-    abi::Transition { name, is_async, inputs, outputs }
+    abi::Function { name, is_final, inputs, outputs }
 }
 
 fn convert_input(input: &ast::Input, record_names: &HashSet<Symbol>) -> abi::Input {
     abi::Input {
         name: input.identifier.name.to_string(),
-        ty: convert_transition_input(&input.type_, record_names),
+        ty: convert_function_input(&input.type_, record_names),
         mode: convert_mode(input.mode),
     }
 }
 
 fn convert_output(output: &ast::Output, record_names: &HashSet<Symbol>) -> abi::Output {
-    abi::Output { ty: convert_transition_output(&output.type_, record_names), mode: convert_mode(output.mode) }
+    abi::Output { ty: convert_function_output(&output.type_, record_names), mode: convert_mode(output.mode) }
 }
 
-fn convert_transition_input(ty: &ast::Type, record_names: &HashSet<Symbol>) -> abi::TransitionInput {
+fn convert_function_input(ty: &ast::Type, record_names: &HashSet<Symbol>) -> abi::FunctionInput {
     if let ast::Type::Composite(comp_ty) = ty {
         let name = comp_ty.path.identifier().name;
         if record_names.contains(&name) {
-            return abi::TransitionInput::Record(abi::RecordRef {
+            return abi::FunctionInput::Record(abi::RecordRef {
                 path: comp_ty.path.segments_iter().map(|s| s.to_string()).collect(),
                 program: comp_ty.path.program().map(|s| s.to_string()),
             });
         }
     }
-    abi::TransitionInput::Plaintext(convert_plaintext(ty))
+    abi::FunctionInput::Plaintext(convert_plaintext(ty))
 }
 
-fn convert_transition_output(ty: &ast::Type, record_names: &HashSet<Symbol>) -> abi::TransitionOutput {
+fn convert_function_output(ty: &ast::Type, record_names: &HashSet<Symbol>) -> abi::FunctionOutput {
     match ty {
-        ast::Type::Future(_) => abi::TransitionOutput::Future,
+        ast::Type::Future(_) => abi::FunctionOutput::Final,
         ast::Type::Composite(comp_ty) => {
             let name = comp_ty.path.identifier().name;
             if record_names.contains(&name) {
-                return abi::TransitionOutput::Record(abi::RecordRef {
+                return abi::FunctionOutput::Record(abi::RecordRef {
                     path: comp_ty.path.segments_iter().map(|s| s.to_string()).collect(),
                     program: comp_ty.path.program().map(|s| s.to_string()),
                 });
             }
-            abi::TransitionOutput::Plaintext(convert_plaintext(ty))
+            abi::FunctionOutput::Plaintext(convert_plaintext(ty))
         }
-        _ => abi::TransitionOutput::Plaintext(convert_plaintext(ty)),
+        _ => abi::FunctionOutput::Plaintext(convert_plaintext(ty)),
     }
 }

--- a/crates/abi/src/lib.rs
+++ b/crates/abi/src/lib.rs
@@ -39,7 +39,7 @@ struct Ctx<'a> {
 /// Generates the ABI for a Leo program.
 ///
 /// The returned ABI is pruned to only include types that appear in the public
-/// interface (transitions, mappings, storage variables).
+/// interface (functions, mappings, storage variables).
 pub fn generate(ast: &ast::Program) -> abi::Program {
     let scope = ast.program_scopes.values().next().unwrap();
     let ctx = Ctx { scope, stubs: &ast.stubs, modules: &ast.modules };
@@ -68,14 +68,10 @@ pub fn generate(ast: &ast::Program) -> abi::Program {
 
     let storage_variables = scope.storage_variables.iter().map(|(_, sv)| convert_storage_variable(sv)).collect();
 
-    let transitions = scope
-        .functions
-        .iter()
-        .filter(|(_, f)| f.variant.is_entry())
-        .map(|(_, f)| convert_transition(f, &ctx))
-        .collect();
+    let functions =
+        scope.functions.iter().filter(|(_, f)| f.variant.is_entry()).map(|(_, f)| convert_function(f, &ctx)).collect();
 
-    let mut program = abi::Program { program, structs, records, mappings, storage_variables, transitions };
+    let mut program = abi::Program { program, structs, records, mappings, storage_variables, functions };
 
     // Prune types not used in the public interface.
     prune_non_interface_types(&mut program);
@@ -128,24 +124,24 @@ fn convert_storage_type(ty: &ast::Type) -> abi::StorageType {
     }
 }
 
-fn convert_transition(function: &ast::Function, ctx: &Ctx) -> abi::Transition {
+fn convert_function(function: &ast::Function, ctx: &Ctx) -> abi::Function {
     let name = function.identifier.name.to_string();
-    let is_async = function.has_final_output();
+    let is_final = function.has_final_output();
     let inputs = function.input.iter().map(|i| convert_input(i, ctx)).collect();
     let outputs = function.output.iter().map(|o| convert_output(o, ctx)).collect();
-    abi::Transition { name, is_async, inputs, outputs }
+    abi::Function { name, is_final, inputs, outputs }
 }
 
 fn convert_input(input: &ast::Input, ctx: &Ctx) -> abi::Input {
     abi::Input {
         name: input.identifier.name.to_string(),
-        ty: convert_transition_input(&input.type_, ctx),
+        ty: convert_function_input(&input.type_, ctx),
         mode: convert_mode(input.mode),
     }
 }
 
 fn convert_output(output: &ast::Output, ctx: &Ctx) -> abi::Output {
-    abi::Output { ty: convert_transition_output(&output.type_, ctx), mode: convert_mode(output.mode) }
+    abi::Output { ty: convert_function_output(&output.type_, ctx), mode: convert_mode(output.mode) }
 }
 
 fn convert_mode(mode: ast::Mode) -> abi::Mode {
@@ -197,26 +193,26 @@ fn convert_plaintext(ty: &ast::Type) -> abi::Plaintext {
     }
 }
 
-fn convert_transition_input(ty: &ast::Type, ctx: &Ctx) -> abi::TransitionInput {
+fn convert_function_input(ty: &ast::Type, ctx: &Ctx) -> abi::FunctionInput {
     if let ast::Type::Composite(comp_ty) = ty
         && is_record(comp_ty, ctx)
     {
-        return abi::TransitionInput::Record(abi::RecordRef {
+        return abi::FunctionInput::Record(abi::RecordRef {
             path: comp_ty.path.segments_iter().map(|s| s.to_string()).collect(),
             program: comp_ty.path.program().map(|s| s.to_string()),
         });
     }
-    abi::TransitionInput::Plaintext(convert_plaintext(ty))
+    abi::FunctionInput::Plaintext(convert_plaintext(ty))
 }
 
-fn convert_transition_output(ty: &ast::Type, ctx: &Ctx) -> abi::TransitionOutput {
+fn convert_function_output(ty: &ast::Type, ctx: &Ctx) -> abi::FunctionOutput {
     match ty {
-        ast::Type::Future(_) => abi::TransitionOutput::Future,
-        ast::Type::Composite(comp_ty) if is_record(comp_ty, ctx) => abi::TransitionOutput::Record(abi::RecordRef {
+        ast::Type::Future(_) => abi::FunctionOutput::Final,
+        ast::Type::Composite(comp_ty) if is_record(comp_ty, ctx) => abi::FunctionOutput::Record(abi::RecordRef {
             path: comp_ty.path.segments_iter().map(|s| s.to_string()).collect(),
             program: comp_ty.path.program().map(|s| s.to_string()),
         }),
-        _ => abi::TransitionOutput::Plaintext(convert_plaintext(ty)),
+        _ => abi::FunctionOutput::Plaintext(convert_plaintext(ty)),
     }
 }
 
@@ -287,7 +283,7 @@ fn convert_integer(int_ty: ast::IntegerType) -> abi::Primitive {
     }
 }
 
-/// Prunes types not referenced in the public interface (transitions, mappings, storage).
+/// Prunes types not referenced in the public interface (functions, mappings, storage).
 pub fn prune_non_interface_types(program: &mut abi::Program) {
     let mut used_types: HashSet<abi::Path> = HashSet::new();
 
@@ -295,12 +291,12 @@ pub fn prune_non_interface_types(program: &mut abi::Program) {
     let program_name = &program.program;
 
     // Phase 1: Collect from interface items
-    for transition in &program.transitions {
-        for input in &transition.inputs {
-            collect_from_transition_input(&input.ty, program_name, &mut used_types);
+    for function in &program.functions {
+        for input in &function.inputs {
+            collect_from_function_input(&input.ty, program_name, &mut used_types);
         }
-        for output in &transition.outputs {
-            collect_from_transition_output(&output.ty, program_name, &mut used_types);
+        for output in &function.outputs {
+            collect_from_function_output(&output.ty, program_name, &mut used_types);
         }
     }
 
@@ -354,10 +350,10 @@ fn collect_from_abi_storage_type(ty: &abi::StorageType, program_name: &str, used
     }
 }
 
-fn collect_from_transition_input(ty: &abi::TransitionInput, program_name: &str, used: &mut HashSet<abi::Path>) {
+fn collect_from_function_input(ty: &abi::FunctionInput, program_name: &str, used: &mut HashSet<abi::Path>) {
     match ty {
-        abi::TransitionInput::Plaintext(p) => collect_from_plaintext(p, program_name, used),
-        abi::TransitionInput::Record(rec_ref) => {
+        abi::FunctionInput::Plaintext(p) => collect_from_plaintext(p, program_name, used),
+        abi::FunctionInput::Record(rec_ref) => {
             if is_local_type(rec_ref.program.as_deref(), program_name) {
                 used.insert(rec_ref.path.clone());
             }
@@ -365,15 +361,15 @@ fn collect_from_transition_input(ty: &abi::TransitionInput, program_name: &str, 
     }
 }
 
-fn collect_from_transition_output(ty: &abi::TransitionOutput, program_name: &str, used: &mut HashSet<abi::Path>) {
+fn collect_from_function_output(ty: &abi::FunctionOutput, program_name: &str, used: &mut HashSet<abi::Path>) {
     match ty {
-        abi::TransitionOutput::Plaintext(p) => collect_from_plaintext(p, program_name, used),
-        abi::TransitionOutput::Record(rec_ref) => {
+        abi::FunctionOutput::Plaintext(p) => collect_from_plaintext(p, program_name, used),
+        abi::FunctionOutput::Record(rec_ref) => {
             if is_local_type(rec_ref.program.as_deref(), program_name) {
                 used.insert(rec_ref.path.clone());
             }
         }
-        abi::TransitionOutput::Future => {}
+        abi::FunctionOutput::Final => {}
     }
 }
 

--- a/tests/expectations/cli/broadcast_error/contents/build/abi.json
+++ b/tests/expectations/cli/broadcast_error/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/local_aleo_dependency/contents/build/abi.json
+++ b/tests/expectations/cli/local_aleo_dependency/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/build/abi.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "b",

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/build/imports/child1.aleo.abi.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/build/imports/child1.aleo.abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "b",

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/build/imports/child2.aleo.abi.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/build/imports/child2.aleo.abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "b",

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/build/imports/grandchild.aleo.abi.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/build/imports/grandchild.aleo.abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "b",

--- a/tests/expectations/cli/network_dependency/contents/test_program1/build/abi.json
+++ b/tests/expectations/cli/network_dependency/contents/test_program1/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "b",

--- a/tests/expectations/cli/network_dependency/contents/test_program2/build/abi.json
+++ b/tests/expectations/cli/network_dependency/contents/test_program2/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [],
       "outputs": [
         {

--- a/tests/expectations/cli/test_abi_comprehensive/contents/build/abi.json
+++ b/tests/expectations/cli/test_abi_comprehensive/contents/build/abi.json
@@ -315,10 +315,10 @@
       }
     }
   ],
-  "transitions": [
+  "functions": [
     {
       "name": "single_primitive",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",
@@ -347,7 +347,7 @@
     },
     {
       "name": "multi_input",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",
@@ -398,7 +398,7 @@
     },
     {
       "name": "multi_output",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",
@@ -437,7 +437,7 @@
     },
     {
       "name": "visibility_modes",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",
@@ -488,7 +488,7 @@
     },
     {
       "name": "struct_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "p",
@@ -523,7 +523,7 @@
     },
     {
       "name": "nested_struct_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "r",
@@ -558,7 +558,7 @@
     },
     {
       "name": "array_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arr",
@@ -597,7 +597,7 @@
     },
     {
       "name": "nested_array_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arr",
@@ -646,7 +646,7 @@
     },
     {
       "name": "record_input",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "t",
@@ -676,7 +676,7 @@
     },
     {
       "name": "record_output",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "owner",
@@ -724,7 +724,7 @@
     },
     {
       "name": "all_primitives_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "p",
@@ -759,7 +759,7 @@
     },
     {
       "name": "module_struct_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "v",
@@ -796,7 +796,7 @@
     },
     {
       "name": "async_with_finalize",
-      "is_async": true,
+      "is_final": true,
       "inputs": [
         {
           "name": "amount",
@@ -812,14 +812,14 @@
       ],
       "outputs": [
         {
-          "ty": "Future",
+          "ty": "Final",
           "mode": "None"
         }
       ]
     },
     {
       "name": "update_balance",
-      "is_async": true,
+      "is_final": true,
       "inputs": [
         {
           "name": "user",
@@ -844,7 +844,7 @@
       ],
       "outputs": [
         {
-          "ty": "Future",
+          "ty": "Final",
           "mode": "None"
         }
       ]

--- a/tests/expectations/cli/test_abi_from_aleo/STDOUT
+++ b/tests/expectations/cli/test_abi_from_aleo/STDOUT
@@ -65,10 +65,10 @@
     }
   ],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "add_numbers",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -108,7 +108,7 @@
     },
     {
       "name": "get_point",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -143,7 +143,7 @@
     },
     {
       "name": "get_token",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -243,10 +243,10 @@
     }
   ],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "add_numbers",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -286,7 +286,7 @@
     },
     {
       "name": "get_point",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -321,7 +321,7 @@
     },
     {
       "name": "get_token",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -602,10 +602,10 @@
     }
   ],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "single_primitive",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -634,7 +634,7 @@
     },
     {
       "name": "multi_input",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -685,7 +685,7 @@
     },
     {
       "name": "multi_output",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -724,7 +724,7 @@
     },
     {
       "name": "visibility_modes",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -775,7 +775,7 @@
     },
     {
       "name": "struct_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -810,7 +810,7 @@
     },
     {
       "name": "nested_struct_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -845,7 +845,7 @@
     },
     {
       "name": "array_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -884,7 +884,7 @@
     },
     {
       "name": "nested_array_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -933,7 +933,7 @@
     },
     {
       "name": "record_input",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -963,7 +963,7 @@
     },
     {
       "name": "record_output",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -1011,7 +1011,7 @@
     },
     {
       "name": "all_primitives_io",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -1046,7 +1046,7 @@
     },
     {
       "name": "async_with_finalize",
-      "is_async": true,
+      "is_final": true,
       "inputs": [
         {
           "name": "arg1",
@@ -1062,14 +1062,14 @@
       ],
       "outputs": [
         {
-          "ty": "Future",
+          "ty": "Final",
           "mode": "None"
         }
       ]
     },
     {
       "name": "update_balance",
-      "is_async": true,
+      "is_final": true,
       "inputs": [
         {
           "name": "arg1",
@@ -1094,7 +1094,7 @@
       ],
       "outputs": [
         {
-          "ty": "Future",
+          "ty": "Final",
           "mode": "None"
         }
       ]

--- a/tests/expectations/cli/test_abi_from_aleo/contents/simple.abi.json
+++ b/tests/expectations/cli/test_abi_from_aleo/contents/simple.abi.json
@@ -64,10 +64,10 @@
     }
   ],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "add_numbers",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -107,7 +107,7 @@
     },
     {
       "name": "get_point",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",
@@ -142,7 +142,7 @@
     },
     {
       "name": "get_token",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "arg1",

--- a/tests/expectations/cli/test_add/contents/build/abi.json
+++ b/tests/expectations/cli/test_add/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_command_shortcuts/contents/build/abi.json
+++ b/tests/expectations/cli/test_command_shortcuts/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_deploy/contents/build/abi.json
+++ b/tests/expectations/cli/test_deploy/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_failure_exit_code/contents/build/abi.json
+++ b/tests/expectations/cli/test_failure_exit_code/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_failure_exit_code/contents/build/imports/test_failure_exit_code.aleo.abi.json
+++ b/tests/expectations/cli/test_failure_exit_code/contents/build/imports/test_failure_exit_code.aleo.abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_identifier_input/contents/build/abi.json
+++ b/tests/expectations/cli/test_identifier_input/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "x",

--- a/tests/expectations/cli/test_json/contents/build/abi.json
+++ b/tests/expectations/cli/test_json/contents/build/abi.json
@@ -21,10 +21,10 @@
     }
   ],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_json/contents/build/imports/test_json_program.aleo.abi.json
+++ b/tests/expectations/cli/test_json/contents/build/imports/test_json_program.aleo.abi.json
@@ -21,10 +21,10 @@
     }
   ],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_library_build/contents/my_program/build/abi.json
+++ b/tests/expectations/cli/test_library_build/contents/my_program/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [],
       "outputs": [
         {

--- a/tests/expectations/cli/test_simple_build/contents/build/abi.json
+++ b/tests/expectations/cli/test_simple_build/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_simple_test/contents/build/abi.json
+++ b/tests/expectations/cli/test_simple_test/contents/build/abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",

--- a/tests/expectations/cli/test_simple_test/contents/build/imports/some_sample_leo_program.aleo.abi.json
+++ b/tests/expectations/cli/test_simple_test/contents/build/imports/some_sample_leo_program.aleo.abi.json
@@ -4,10 +4,10 @@
   "records": [],
   "mappings": [],
   "storage_variables": [],
-  "transitions": [
+  "functions": [
     {
       "name": "main",
-      "is_async": false,
+      "is_final": false,
       "inputs": [
         {
           "name": "a",


### PR DESCRIPTION
Rename ABI types and JSON fields to match Leo 4.0 syntax:

- `Transition` -> `Function`, `transitions` -> `functions`
- `is_async` -> `is_final`
- `TransitionInput`/`TransitionOutput` -> `FunctionInput`/`FunctionOutput`
- `FunctionOutput::Future` -> `FunctionOutput::Final`

Add doc comments mapping Leo ABI names to their Aleo bytecode equivalents (e.g. `Function` compiles to an Aleo `transition`).

Partly addresses #29216 