### PR TITLE
Functions in libraries

### DIFF
--- a/crates/ast/src/library.rs
+++ b/crates/ast/src/library.rs
@@ -16,13 +16,13 @@
 
 use leo_span::Symbol;
 
-use crate::{Composite, ConstDeclaration, Indent};
+use crate::{Composite, ConstDeclaration, Function, Indent};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 /// Stores the Leo library abstract syntax tree.
 ///
-/// Libraries may contain `const` declarations and `struct` definitions.
+/// Libraries may contain `const` declarations, `struct` definitions, and `fn` functions.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Library {
     pub name: Symbol,
@@ -30,6 +30,8 @@ pub struct Library {
     pub consts: Vec<(Symbol, ConstDeclaration)>,
     /// The struct definitions in this library.
     pub structs: Vec<(Symbol, Composite)>,
+    /// The function definitions in this library.
+    pub functions: Vec<(Symbol, Function)>,
 }
 
 impl fmt::Display for Library {
@@ -38,6 +40,10 @@ impl fmt::Display for Library {
 
         for (_, struct_def) in self.structs.iter() {
             writeln!(f, "{}", Indent(struct_def))?;
+        }
+
+        for (_, func) in self.functions.iter() {
+            writeln!(f, "{}", Indent(func))?;
         }
 
         for (_, const_decl) in self.consts.iter() {

--- a/crates/ast/src/passes/reconstructor.rs
+++ b/crates/ast/src/passes/reconstructor.rs
@@ -607,6 +607,7 @@ pub trait ProgramReconstructor: AstReconstructor {
                 })
                 .collect(),
             structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
         }
     }
 

--- a/crates/ast/src/passes/visitor.rs
+++ b/crates/ast/src/passes/visitor.rs
@@ -345,6 +345,7 @@ pub trait ProgramVisitor: AstVisitor {
     fn visit_library(&mut self, input: &Library) {
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
+        input.functions.iter().for_each(|(_, f)| self.visit_function(f));
     }
 
     fn visit_stub(&mut self, input: &Stub) {

--- a/crates/parser/src/rowan.rs
+++ b/crates/parser/src/rowan.rs
@@ -1802,6 +1802,7 @@ impl<'a> ConversionContext<'a> {
         item: &SyntaxNode,
         consts: &mut Vec<(Symbol, leo_ast::ConstDeclaration)>,
         structs: &mut Vec<(Symbol, leo_ast::Composite)>,
+        functions: &mut Vec<(Symbol, leo_ast::Function)>,
     ) -> Result<()> {
         if is_library_item(item.kind()) {
             match item.kind() {
@@ -1813,14 +1814,18 @@ impl<'a> ConversionContext<'a> {
                     let composite = self.to_composite(item)?;
                     structs.push((composite.identifier.name, composite));
                 }
-                // Future library items (functions, etc.) will be handled here.
+                FUNCTION_DEF => {
+                    // `is_in_program_block = false` so the variant is always `Fn` (not EntryPoint).
+                    let func = self.to_function(item, false)?;
+                    functions.push((func.identifier.name, func));
+                }
                 _ => {}
             }
         } else if is_program_item(item.kind()) {
             // A recognized program-only item appeared in a library file.
             let span = self.to_span(item);
             self.handler.emit_err(ParserError::custom(
-                "Only `const` declarations and `struct` definitions are allowed in a library.",
+                "Only `const` declarations, `struct` definitions, and `fn` functions are allowed in a library.",
                 span,
             ));
         }
@@ -1978,12 +1983,13 @@ impl<'a> ConversionContext<'a> {
     fn to_library(&self, name: Symbol, node: &SyntaxNode) -> Result<leo_ast::Library> {
         let mut consts = Vec::new();
         let mut structs = Vec::new();
+        let mut functions = Vec::new();
 
         for child in children(node) {
-            self.collect_library_item(&child, &mut consts, &mut structs)?;
+            self.collect_library_item(&child, &mut consts, &mut structs, &mut functions)?;
         }
 
-        Ok(leo_ast::Library { name, consts, structs })
+        Ok(leo_ast::Library { name, consts, structs, functions })
     }
 
     /// Extract a ProgramId from an IMPORT node. Guarantees `network` is always present.
@@ -3055,7 +3061,7 @@ fn compute_module_key(name: &FileName, root_dir: Option<&std::path::Path>) -> Op
 /// Currently `const` declarations and `struct` definitions are allowed; this list will grow
 /// as library support expands to include functions and other items.
 fn is_library_item(kind: SyntaxKind) -> bool {
-    matches!(kind, GLOBAL_CONST | STRUCT_DEF)
+    matches!(kind, GLOBAL_CONST | STRUCT_DEF | FUNCTION_DEF)
 }
 
 /// Returns `true` for syntax node kinds that are valid inside a program (`main.leo`).

--- a/crates/passes/src/common_subexpression_elimination/program.rs
+++ b/crates/passes/src/common_subexpression_elimination/program.rs
@@ -16,9 +16,16 @@
 
 use super::CommonSubexpressionEliminatingVisitor;
 
-use leo_ast::{AstReconstructor, Constructor, Function, Module, ProgramReconstructor};
+use leo_ast::{AstReconstructor, Constructor, Function, Library, Module, ProgramReconstructor};
 
 impl ProgramReconstructor for CommonSubexpressionEliminatingVisitor<'_> {
+    fn reconstruct_library(&mut self, input: Library) -> Library {
+        // Library function bodies are no longer relevant after function inlining and may not
+        // satisfy CSE's invariants (e.g. expression type-table entries for raw function bodies).
+        // Pass functions through unchanged.
+        input
+    }
+
     fn reconstruct_program_scope(&mut self, mut input: leo_ast::ProgramScope) -> leo_ast::ProgramScope {
         input.functions = input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect();
         input.constructor = input.constructor.map(|c| self.reconstruct_constructor(c));

--- a/crates/passes/src/const_propagation/program.rs
+++ b/crates/passes/src/const_propagation/program.rs
@@ -99,6 +99,14 @@ impl ProgramReconstructor for ConstPropagationVisitor<'_> {
             *c = declaration;
         }
 
+        // Skip generic functions (those with const parameters): they cannot be fully evaluated
+        // until they are monomorphized into the consuming program's scope.
+        input.functions = input
+            .functions
+            .into_iter()
+            .map(|(i, f)| if f.const_parameters.is_empty() { (i, self.reconstruct_function(f)) } else { (i, f) })
+            .collect();
+
         input
     }
 

--- a/crates/passes/src/flattening/program.rs
+++ b/crates/passes/src/flattening/program.rs
@@ -21,6 +21,7 @@ use leo_ast::{
     Constructor,
     Expression,
     Function,
+    Library,
     ProgramReconstructor,
     ProgramScope,
     ReturnStatement,
@@ -28,6 +29,19 @@ use leo_ast::{
 };
 
 impl ProgramReconstructor for FlatteningVisitor<'_> {
+    fn reconstruct_library(&mut self, input: Library) -> Library {
+        let prev_program = self.program;
+        self.program = input.name;
+        let library = Library {
+            name: input.name,
+            consts: input.consts,
+            structs: input.structs,
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+        };
+        self.program = prev_program;
+        library
+    }
+
     /// Flattens a program scope.
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         self.program = input.program_id.as_symbol();

--- a/crates/passes/src/function_inlining/transform.rs
+++ b/crates/passes/src/function_inlining/transform.rs
@@ -78,7 +78,11 @@ impl ProgramReconstructor for TransformVisitor<'_> {
             }
         }
 
-        // This is a sanity check to ensure that functions in the program scope have been processed.
+        // Drop any library functions that were not reachable from this program (dead library code).
+        // They are not needed and would fail the sanity check below.
+        self.function_map.retain(|loc, _| !self.state.symbol_table.is_library(loc.program));
+
+        // This is a sanity check to ensure that all non-library functions in the program scope have been processed.
         assert!(self.function_map.is_empty(), "All functions in the program should have been processed.");
 
         // Reconstruct the constructor.
@@ -87,11 +91,15 @@ impl ProgramReconstructor for TransformVisitor<'_> {
 
         // Note that this intentionally clears `self.reconstructed_functions` for the next program scope.
         let functions = core::mem::take(&mut self.reconstructed_functions)
-            .iter()
+            .into_iter()
             .filter_map(|(loc, f)| {
-                // Only consider functions defined at program scope. The rest are not relevant since they should all
-                // have been inlined by now.
-                loc.path.split_last().filter(|(_, rest)| rest.is_empty()).map(|(last, _)| (*last, f.clone()))
+                // Only emit functions that belong to the current program scope and have a single-segment
+                // path (no module prefix). Library functions and module-nested functions have all been
+                // inlined at their call sites and must not appear as standalone functions in output.
+                if loc.program != self.program {
+                    return None;
+                }
+                loc.path.split_last().filter(|(_, rest)| rest.is_empty()).map(|(last, _)| (*last, f))
             })
             .collect();
 
@@ -150,8 +158,8 @@ impl ProgramReconstructor for TransformVisitor<'_> {
     }
 
     fn reconstruct_program(&mut self, input: Program) -> Program {
-        // Populate `self.function_map` using the functions in the program scopes and the modules
-        // Use full Location (program + path) as keys to avoid collisions between programs
+        // Populate `self.function_map` using the functions in the program scopes and the modules.
+        // Use full Location (program + path) as keys to avoid collisions between programs.
         input
             .modules
             .iter()
@@ -168,6 +176,16 @@ impl ProgramReconstructor for TransformVisitor<'_> {
             .for_each(|(location, f)| {
                 self.function_map.insert(location, f);
             });
+
+        // Populate `function_map` with library functions from FromLibrary stubs.
+        // Library functions are inlined at call sites just like module functions.
+        input.stubs.iter().for_each(|(_, stub)| {
+            if let Stub::FromLibrary { library, .. } = stub {
+                library.functions.iter().for_each(|(name, f)| {
+                    self.function_map.entry(Location::new(library.name, vec![*name])).or_insert_with(|| f.clone());
+                });
+            }
+        });
 
         // Reconstruct program scopes. Inline functions defined in modules will be traversed
         // using the call graph and reconstructed in the right order.
@@ -204,15 +222,17 @@ impl AstReconstructor for TransformVisitor<'_> {
 
     /* Expressions */
     fn reconstruct_call(&mut self, input: CallExpression, _additional: &()) -> (Expression, Self::AdditionalOutput) {
-        // Type checking guarantees that only functions local to the program scope can be inlined.
-        if input.function.expect_global_location().program != self.program {
+        let function_location = input.function.expect_global_location();
+
+        // Pass through calls to external programs (non-library). Library functions and module
+        // functions are always inlined; only true cross-program calls are left as-is.
+        if function_location.program != self.program && !self.state.symbol_table.is_library(function_location.program) {
             return (input.into(), Default::default());
         }
 
         // Lookup the reconstructed callee function.
         // Since this pass processes functions in post-order, the callee function is guaranteed to exist in `self.reconstructed_functions`
         // Use full Location (program + path) to ensure correct lookup across multiple programs.
-        let function_location = input.function.expect_global_location();
         let (_, callee) = self
             .reconstructed_functions
             .iter()
@@ -241,6 +261,10 @@ impl AstReconstructor for TransformVisitor<'_> {
             function_location.program == self.program && function_location.path.len() > 1,
             "this is a module function",
         ) || match callee.variant {
+            // Always inline library functions (they cannot exist as standalone Aleo functions).
+            _ if self.state.symbol_table.is_library(function_location.program) => {
+                mandatory_cond(true, "this is a library function")
+            }
             Variant::FinalFn => mandatory_cond(true, "this is a final fn"),
             Variant::Fn => {
                 mandatory_cond(

--- a/crates/passes/src/global_items_collection.rs
+++ b/crates/passes/src/global_items_collection.rs
@@ -207,6 +207,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
 
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.functions.iter().for_each(|(_, f)| self.visit_function(f));
     }
 
     fn visit_aleo_program(&mut self, input: &AleoProgram) {

--- a/crates/passes/src/monomorphization/ast.rs
+++ b/crates/passes/src/monomorphization/ast.rs
@@ -26,7 +26,7 @@ use leo_ast::{
     Expression,
     Identifier,
     Node as _,
-    ProgramReconstructor,
+    ProgramReconstructor as _,
     Type,
 };
 
@@ -121,8 +121,12 @@ impl AstReconstructor for MonomorphizationVisitor<'_> {
         input_call: CallExpression,
         _additional: &(),
     ) -> (Expression, Self::AdditionalOutput) {
-        // Skip calls to functions from other programs.
-        if input_call.function.expect_global_location().program != self.program {
+        let callee_loc = input_call.function.expect_global_location();
+        let callee_program = callee_loc.program;
+
+        // Skip calls to external programs that are not libraries (cross-program calls).
+        // Library functions and current-program functions (including modules) proceed below.
+        if callee_program != self.program && !self.state.symbol_table.is_library(callee_program) {
             return (input_call.into(), Default::default());
         }
 

--- a/crates/passes/src/monomorphization/program.rs
+++ b/crates/passes/src/monomorphization/program.rs
@@ -57,6 +57,22 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                     _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
                 })
                 .collect(),
+            // Collect library function instances. Non-generic functions are kept from the
+            // original input; generic functions are superseded by their reconstructed versions
+            // in `reconstructed_functions` (which also contains any monomorphized variants like
+            // `"pad::[3u32]"`). Excluding generic originals prevents duplicates that would cause
+            // TypeChecking to report "defined multiple times" errors on the next iteration.
+            functions: input
+                .functions
+                .into_iter()
+                .filter(|(_, f)| f.const_parameters.is_empty())
+                .chain(self.reconstructed_functions.iter().filter_map(|(loc, f)| {
+                    loc.path
+                        .split_last()
+                        .filter(|(_, rest)| rest.is_empty() && loc.program == input.name)
+                        .map(|(last, _)| (*last, f.clone()))
+                }))
+                .collect(),
         }
     }
 
@@ -116,7 +132,17 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
             })
             .unwrap() // This unwrap is safe because the type checker guarantees an acyclic graph.
             .into_iter()
-            .filter(|location| location.program == self.program)
+            .filter(|location| {
+                // Always include current-program functions.
+                if location.program == self.program {
+                    return true;
+                }
+                // Also include generic library functions reachable from the current program.
+                // Non-generic library functions need no monomorphization and are handled by
+                // the early-return in `reconstruct_call` (no const arguments).
+                self.state.symbol_table.is_library(location.program)
+                    && self.function_map.get(location).map(|f| !f.const_parameters.is_empty()).unwrap_or(false)
+            })
             .collect::<Vec<_>>();
 
         for function_name in &order {
@@ -243,6 +269,11 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
                 library.structs.iter().for_each(|(name, c)| {
                     self.composite_map.entry(Location::new(library.name, vec![*name])).or_insert_with(|| c.clone());
                 });
+                // Seed function_map with library function definitions so that reconstruct_call can
+                // inline them into the consuming program under mangled names.
+                library.functions.iter().for_each(|(name, f)| {
+                    self.function_map.entry(Location::new(library.name, vec![*name])).or_insert_with(|| f.clone());
+                });
             }
         });
 
@@ -262,7 +293,10 @@ impl ProgramReconstructor for MonomorphizationVisitor<'_> {
         // Program objects may not carry library stubs — can still access them.
         let prev_program = self.program;
         self.composite_map.retain(|loc, _| loc.program != prev_program);
-        self.function_map.clear();
+        // Retain library functions (analogous to composite_map.retain above) so that deeply-nested
+        // FromLeo programs — whose inner Program objects may not carry library stubs — can still
+        // inline library functions when their scopes are processed.
+        self.function_map.retain(|loc, _| self.state.symbol_table.is_library(loc.program));
 
         self.program =
             *input.program_scopes.first().expect("a program must have a single program scope at this stage").0;

--- a/crates/passes/src/option_lowering/program.rs
+++ b/crates/passes/src/option_lowering/program.rs
@@ -20,6 +20,7 @@ use leo_ast::{
     ConstParameter,
     Function,
     Input,
+    Library,
     Location,
     Module,
     Output,
@@ -31,6 +32,26 @@ use leo_ast::{
 use leo_span::Symbol;
 
 impl ProgramReconstructor for OptionLoweringVisitor<'_> {
+    fn reconstruct_library(&mut self, input: Library) -> Library {
+        let prev_program = self.program;
+        self.program = input.name;
+        let library = Library {
+            name: input.name,
+            consts: input
+                .consts
+                .into_iter()
+                .map(|(i, c)| match self.reconstruct_const(c) {
+                    (Statement::Const(declaration), _) => (i, declaration),
+                    _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
+                })
+                .collect(),
+            structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+        };
+        self.program = prev_program;
+        library
+    }
+
     fn reconstruct_program(&mut self, input: Program) -> Program {
         self.program =
             *input.program_scopes.first().expect("a program must have a single program scope at this time.").0;

--- a/crates/passes/src/path_resolution/program.rs
+++ b/crates/passes/src/path_resolution/program.rs
@@ -62,6 +62,7 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
                     _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
                 })
                 .collect(),
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
         }
     }
 

--- a/crates/passes/src/ssa_const_propagation/program.rs
+++ b/crates/passes/src/ssa_const_propagation/program.rs
@@ -16,9 +16,15 @@
 
 use super::SsaConstPropagationVisitor;
 
-use leo_ast::{AstReconstructor, Constructor, Function, ProgramReconstructor, ProgramScope, Statement};
+use leo_ast::{AstReconstructor, Constructor, Function, Library, ProgramReconstructor, ProgramScope, Statement};
 
 impl ProgramReconstructor for SsaConstPropagationVisitor<'_> {
+    fn reconstruct_library(&mut self, input: Library) -> Library {
+        // Library functions have already been inlined into the consuming program by the
+        // function-inlining pass. Pass the library stub through unchanged.
+        input
+    }
+
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         self.program = input.program_id.as_symbol();
 

--- a/crates/passes/src/static_single_assignment/program.rs
+++ b/crates/passes/src/static_single_assignment/program.rs
@@ -25,6 +25,8 @@ use leo_ast::{
     Function,
     FunctionConsumer,
     Identifier,
+    Library,
+    LibraryConsumer,
     Member,
     Module,
     ModuleConsumer,
@@ -160,13 +162,33 @@ impl ProgramConsumer for SsaFormingVisitor<'_> {
     }
 }
 
+impl LibraryConsumer for SsaFormingVisitor<'_> {
+    type Output = Library;
+
+    fn consume_library(&mut self, input: Library) -> Library {
+        let prev_program = self.program;
+        self.program = input.name;
+        let library = Library {
+            name: input.name,
+            consts: input.consts,
+            structs: input.structs,
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
+        };
+        self.program = prev_program;
+        library
+    }
+}
+
 impl StubConsumer for SsaFormingVisitor<'_> {
     type Output = Stub;
 
     fn consume_stub(&mut self, input: Stub) -> Self::Output {
         match input {
             Stub::FromLeo { program, .. } => self.consume_program(program).into(),
-            Stub::FromAleo { .. } | Stub::FromLibrary { .. } => input,
+            Stub::FromLibrary { library, parents } => {
+                Stub::FromLibrary { library: self.consume_library(library), parents }
+            }
+            Stub::FromAleo { .. } => input,
         }
     }
 }

--- a/crates/passes/src/storage_lowering/program.rs
+++ b/crates/passes/src/storage_lowering/program.rs
@@ -19,6 +19,7 @@ use leo_ast::{
     AstReconstructor,
     Identifier,
     IntegerType,
+    Library,
     Location,
     Mapping,
     ProgramReconstructor,
@@ -31,6 +32,26 @@ use leo_ast::{
 use leo_span::Symbol;
 
 impl ProgramReconstructor for StorageLoweringVisitor<'_> {
+    fn reconstruct_library(&mut self, input: Library) -> Library {
+        let prev_program = self.program;
+        self.program = input.name;
+        let library = Library {
+            name: input.name,
+            consts: input
+                .consts
+                .into_iter()
+                .map(|(i, c)| match self.reconstruct_const(c) {
+                    (Statement::Const(declaration), _) => (i, declaration),
+                    _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
+                })
+                .collect(),
+            structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+        };
+        self.program = prev_program;
+        library
+    }
+
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         self.program = input.program_id.as_symbol();
 

--- a/crates/passes/src/test_passes.rs
+++ b/crates/passes/src/test_passes.rs
@@ -104,10 +104,11 @@ This structure ensures that **adding a new compiler pass test is minimal**:
 */
 
 use crate::*;
-use leo_ast::NetworkName;
-use leo_errors::{BufferEmitter, Handler};
-use leo_parser::parse_program;
-use leo_span::{create_session_if_not_set_then, source_map::FileName, with_session_globals};
+use indexmap::{IndexMap, IndexSet};
+use leo_ast::{NetworkName, Stub};
+use leo_errors::{BufferEmitter, Handler, Result};
+use leo_parser::{parse_library, parse_program};
+use leo_span::{Symbol, create_session_if_not_set_then, source_map::FileName, with_session_globals};
 use serial_test::serial;
 use std::rc::Rc;
 
@@ -158,6 +159,7 @@ macro_rules! compiler_passes {
                 (GlobalItemsCollection, ()),
                 (TypeChecking, (TypeCheckingInput::new(NetworkName::TestnetV0))),
                 (Disambiguate, ()),
+                (SsaForming, (SsaFormingInput { rename_defs: true })),
                 (Flattening, ())
             ]),
             (function_inlining_runner, [
@@ -254,14 +256,13 @@ macro_rules! make_runner {
             create_session_if_not_set_then(|_| {
                 let mut state = CompilerState { handler: handler.clone(), node_builder: Rc::clone(&node_builder), ..Default::default() };
 
-                state.ast = match handler.extend_if_error(parse_program(
-                    handler.clone(),
-                    &state.node_builder,
-                    &with_session_globals(|s| s.source_map.new_source(source, FileName::Custom("test".into()))),
-                    &[],
+                state.ast = match handler.extend_if_error(parse_passes_test_source(
+                    source,
+                    &handler,
+                    &node_builder,
                     NetworkName::TestnetV0,
                 )) {
-                    Ok(ast) => leo_ast::Ast::Program(ast),
+                    Ok(ast) => ast,
                     Err(()) => return format!("{}{}", buf.extract_errs(), buf.extract_warnings()),
                 };
 
@@ -327,3 +328,96 @@ macro_rules! make_all_tests_inner {
 }
 
 compiler_passes!(make_all_tests);
+
+/// Delimiter used to separate library / program sections in multi-part passes tests.
+const PASSES_PROGRAM_DELIMITER: &str = "// --- Next Program --- //";
+
+/// Parses a passes test source string into an `Ast`.
+///
+/// If the source contains no `PASSES_PROGRAM_DELIMITER`, it is treated as a
+/// single standalone program (the existing behaviour). Otherwise the source is
+/// split into sections:
+///
+/// - Each section before the last may be a library header
+///   (`// --- library: NAME --- //` followed by library source) or a plain
+///   program section (currently ignored in passes tests).
+/// - The last section is the main program.
+///
+/// Library stubs are parsed and injected into the main program's `stubs` map
+/// so that the prelude passes (GlobalVarsCollection, PathResolution, TypeChecking,
+/// …) see the library declarations exactly as they would during a full compile.
+fn parse_passes_test_source(
+    source: &str,
+    handler: &Handler,
+    node_builder: &Rc<leo_ast::NodeBuilder>,
+    network: NetworkName,
+) -> Result<leo_ast::Ast> {
+    if !source.contains(PASSES_PROGRAM_DELIMITER) {
+        // Fast path: single-program source, existing behaviour.
+        let sf = with_session_globals(|s| s.source_map.new_source(source, FileName::Custom("test".into())));
+        return parse_program(handler.clone(), node_builder, &sf, &[], network).map(leo_ast::Ast::Program);
+    }
+
+    // Multi-part source: split into sections.
+    let sections: Vec<&str> = source.split(PASSES_PROGRAM_DELIMITER).collect();
+    let (main_section, dep_sections) = sections.split_last().expect("split always yields at least one element");
+    let main_source = main_section.trim();
+
+    // Parse library stubs from dependency sections.
+    let mut stubs: IndexMap<Symbol, Stub> = IndexMap::new();
+    for section in dep_sections {
+        let trimmed = section.trim();
+        if let Some((lib_name, lib_source)) = extract_passes_library_header(trimmed) {
+            let sf =
+                with_session_globals(|s| s.source_map.new_source(lib_source, FileName::Custom("compiler-test".into())));
+            let library = parse_library(handler.clone(), node_builder, lib_name, &sf, network)?;
+            stubs.insert(lib_name, Stub::FromLibrary { library, parents: IndexSet::new() });
+        }
+        // Non-library program stubs are not needed for individual-pass tests.
+    }
+
+    // Parse the main program to obtain its declared name.
+    let main_sf = with_session_globals(|s| s.source_map.new_source(main_source, FileName::Custom("test".into())));
+    let mut program = parse_program(handler.clone(), node_builder, &main_sf, &[], network)?;
+
+    let main_symbol = program
+        .program_scopes
+        .values()
+        .next()
+        .map(|scope| scope.program_id.as_symbol())
+        .expect("a program must have at least one scope");
+
+    // Establish parent relationships so GlobalVarsCollection sets up visibility
+    // correctly: later stubs are parents of earlier ones (transitive deps), and
+    // the main program is a parent of every library it uses.
+    let lib_symbols: Vec<Symbol> = stubs.keys().copied().collect();
+    for (i, sym) in lib_symbols.iter().enumerate() {
+        if let Some(Stub::FromLibrary { parents, .. }) = stubs.get_mut(sym) {
+            parents.extend(lib_symbols[i + 1..].iter().copied());
+            parents.insert(main_symbol);
+        }
+    }
+
+    // Inject the collected stubs into the parsed program.
+    program.stubs = stubs;
+
+    Ok(leo_ast::Ast::Program(program))
+}
+
+/// Extracts a `// --- library: NAME --- //` header from the start of `source`.
+///
+/// Returns `(library_name_symbol, source_after_header)` on success, or `None`
+/// if the source does not begin with a library header.
+fn extract_passes_library_header(source: &str) -> Option<(Symbol, &str)> {
+    let mut offset = 0;
+    for line in source.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("// --- library:") && trimmed.ends_with("--- //") {
+            let name = trimmed.trim_start_matches("// --- library:").trim_end_matches("--- //").trim();
+            let rest = source[offset + line.len()..].trim_start_matches('\n');
+            return Some((Symbol::intern(name), rest));
+        }
+        offset += line.len() + 1;
+    }
+    None
+}

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -171,6 +171,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
+        input.functions.iter().for_each(|(_, f)| self.visit_function(f));
     }
 
     fn visit_aleo_program(&mut self, input: &AleoProgram) {

--- a/tests/expectations/compiler/libraries/lib_fn_basic.out
+++ b/tests/expectations/compiler/libraries/lib_fn_basic.out
@@ -1,0 +1,10 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_called_multiple_times.out
+++ b/tests/expectations/compiler/libraries/lib_fn_called_multiple_times.out
@@ -1,0 +1,12 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    mul r0 r0 into r2;
+    mul r1 r1 into r3;
+    add r2 r3 into r4;
+    output r4 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_calls_lib_fn.out
+++ b/tests/expectations/compiler/libraries/lib_fn_calls_lib_fn.out
@@ -1,0 +1,10 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    add r1 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_conditional.out
+++ b/tests/expectations/compiler/libraries/lib_fn_conditional.out
@@ -1,0 +1,14 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    lt r0 r1 into r2;
+    ternary r2 r0 r1 into r3;
+    gt r0 r1 into r4;
+    ternary r4 r0 r1 into r5;
+    output r3 as u32.private;
+    output r5 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_cross_lib.out
+++ b/tests/expectations/compiler/libraries/lib_fn_cross_lib.out
@@ -1,0 +1,10 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    add r1 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_cross_lib_with_struct.out
+++ b/tests/expectations/compiler/libraries/lib_fn_cross_lib_with_struct.out
@@ -1,0 +1,22 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    add r4.x r2 into r5;
+    add r4.y r3 into r6;
+    cast r5 r6 into r7 as Point__7VbTm7beYPk;
+    mul r7.x r7.x into r8;
+    mul r7.y r7.y into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_dead_code.out
+++ b/tests/expectations/compiler/libraries/lib_fn_dead_code.out
@@ -1,0 +1,9 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 1u32 into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_generic.out
+++ b/tests/expectations/compiler/libraries/lib_fn_generic.out
@@ -1,0 +1,9 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    mul r0 5u32 into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_generic_calls_generic.out
+++ b/tests/expectations/compiler/libraries/lib_fn_generic_calls_generic.out
@@ -1,0 +1,9 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_generic_multi.out
+++ b/tests/expectations/compiler/libraries/lib_fn_generic_multi.out
@@ -1,0 +1,11 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    mul r0 3u32 into r1;
+    mul r0 7u32 into r2;
+    output r1 as u32.private;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_generic_multi_params.out
+++ b/tests/expectations/compiler/libraries/lib_fn_generic_multi_params.out
@@ -1,0 +1,10 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    mul r0 3u32 into r1;
+    add r1 7u32 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_in_final.out
+++ b/tests/expectations/compiler/libraries/lib_fn_in_final.out
@@ -1,0 +1,21 @@
+program main.aleo;
+
+mapping totals:
+    key as address.public;
+    value as u64.public;
+
+function accumulate:
+    input r0 as address.private;
+    input r1 as u64.private;
+    async accumulate r0 r1 into r2;
+    output r2 as main.aleo/accumulate.future;
+
+finalize accumulate:
+    input r0 as address.public;
+    input r1 as u64.public;
+    get.or_use totals[r0] 0u64 into r2;
+    add r2 r1 into r3;
+    set r3 into totals[r0];
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_multiple.out
+++ b/tests/expectations/compiler/libraries/lib_fn_multiple.out
@@ -1,0 +1,12 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    mul r0 r1 into r3;
+    sub r3 r2 into r4;
+    output r4 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_non_const_arg_fail.out
+++ b/tests/expectations/compiler/libraries/lib_fn_non_const_arg_fail.out
@@ -1,0 +1,5 @@
+Error [ECMP0376012]: Unable to resolve call to generic function `math_lib::scale`. A non-const expression was provided where a const generic parameter is required.
+    --> compiler-test:5:34
+     |
+   5 |         return math_lib::scale::[n](x);  // n is a runtime variable, not a const
+     |                                  ^

--- a/tests/expectations/compiler/libraries/lib_fn_struct_call_chain.out
+++ b/tests/expectations/compiler/libraries/lib_fn_struct_call_chain.out
@@ -1,0 +1,22 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    add r4.x r2 into r5;
+    add r4.y r3 into r6;
+    cast r5 r6 into r7 as Point__7VbTm7beYPk;
+    mul r7.x r7.x into r8;
+    mul r7.y r7.y into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_tuple_return.out
+++ b/tests/expectations/compiler/libraries/lib_fn_tuple_return.out
@@ -1,0 +1,12 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    div r0 r1 into r2;
+    rem r0 r1 into r3;
+    add r2 r3 into r4;
+    output r4 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_uses_lib_const.out
+++ b/tests/expectations/compiler/libraries/lib_fn_uses_lib_const.out
@@ -1,0 +1,9 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 10u32 into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_uses_lib_struct_locally.out
+++ b/tests/expectations/compiler/libraries/lib_fn_uses_lib_struct_locally.out
@@ -1,0 +1,15 @@
+program main.aleo;
+
+struct Vec2__2uTzJohxeLR:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    cast r0 r1 into r2 as Vec2__2uTzJohxeLR;
+    add r2.x r2.y into r3;
+    output r3 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_with_struct.out
+++ b/tests/expectations/compiler/libraries/lib_fn_with_struct.out
@@ -1,0 +1,22 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    add r4.x r2 into r5;
+    add r4.y r3 into r6;
+    cast r5 r6 into r7 as Point__7VbTm7beYPk;
+    mul r7.x r7.x into r8;
+    mul r7.y r7.y into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/libraries/lib_fn_wrong_arg_count_fail.out
+++ b/tests/expectations/compiler/libraries/lib_fn_wrong_arg_count_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372006]: Call expected `2` args, but got `1`
+    --> compiler-test:5:16
+     |
+   5 |         return math_lib::add(x);  // missing second argument
+     |                ^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/libraries/lib_fn_wrong_arg_type_fail.out
+++ b/tests/expectations/compiler/libraries/lib_fn_wrong_arg_type_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372117]: Expected type `u32` but type `bool` was found.
+    --> compiler-test:5:33
+     |
+   5 |         return math_lib::add(x, true);  // bool where u32 expected
+     |                                 ^^^^

--- a/tests/expectations/execution/libraries/lib_fn_basic.out
+++ b/tests/expectations/execution/libraries/lib_fn_basic.out
@@ -1,0 +1,12 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 7u32

--- a/tests/expectations/execution/libraries/lib_fn_called_multiple_times.out
+++ b/tests/expectations/execution/libraries/lib_fn_called_multiple_times.out
@@ -1,0 +1,14 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    mul r0 r0 into r2;
+    mul r1 r1 into r3;
+    add r2 r3 into r4;
+    output r4 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 13u32

--- a/tests/expectations/execution/libraries/lib_fn_calls_lib_fn.out
+++ b/tests/expectations/execution/libraries/lib_fn_calls_lib_fn.out
@@ -1,0 +1,12 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    add r1 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 20u32

--- a/tests/expectations/execution/libraries/lib_fn_conditional.out
+++ b/tests/expectations/execution/libraries/lib_fn_conditional.out
@@ -1,0 +1,13 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    lt r0 r1 into r2;
+    ternary r2 r0 r1 into r3;
+    output r3 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 3u32

--- a/tests/expectations/execution/libraries/lib_fn_cross_lib.out
+++ b/tests/expectations/execution/libraries/lib_fn_cross_lib.out
@@ -1,0 +1,12 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 r0 into r1;
+    add r1 r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 12u32

--- a/tests/expectations/execution/libraries/lib_fn_cross_lib_with_struct.out
+++ b/tests/expectations/execution/libraries/lib_fn_cross_lib_with_struct.out
@@ -1,0 +1,24 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    add r4.x r2 into r5;
+    add r4.y r3 into r6;
+    cast r5 r6 into r7 as Point__7VbTm7beYPk;
+    mul r7.x r7.x into r8;
+    mul r7.y r7.y into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 52u32

--- a/tests/expectations/execution/libraries/lib_fn_generic.out
+++ b/tests/expectations/execution/libraries/lib_fn_generic.out
@@ -1,0 +1,11 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    mul r0 5u32 into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 15u32

--- a/tests/expectations/execution/libraries/lib_fn_struct_call_chain.out
+++ b/tests/expectations/execution/libraries/lib_fn_struct_call_chain.out
@@ -1,0 +1,24 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    add r4.x r2 into r5;
+    add r4.y r3 into r6;
+    cast r5 r6 into r7 as Point__7VbTm7beYPk;
+    mul r7.x r7.x into r8;
+    mul r7.y r7.y into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 52u32

--- a/tests/expectations/execution/libraries/lib_fn_uses_lib_const.out
+++ b/tests/expectations/execution/libraries/lib_fn_uses_lib_const.out
@@ -1,0 +1,11 @@
+program main.aleo;
+
+function compute:
+    input r0 as u32.private;
+    add r0 10u32 into r1;
+    output r1 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 15u32

--- a/tests/expectations/execution/libraries/lib_fn_with_struct.out
+++ b/tests/expectations/execution/libraries/lib_fn_with_struct.out
@@ -1,0 +1,24 @@
+program main.aleo;
+
+struct Point__7VbTm7beYPk:
+    x as u32;
+    y as u32;
+
+function compute:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    input r2 as u32.private;
+    input r3 as u32.private;
+    cast r0 r1 into r4 as Point__7VbTm7beYPk;
+    add r4.x r2 into r5;
+    add r4.y r3 into r6;
+    cast r5 r6 into r7 as Point__7VbTm7beYPk;
+    mul r7.x r7.x into r8;
+    mul r7.y r7.y into r9;
+    add r8 r9 into r10;
+    output r10 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 52u32

--- a/tests/expectations/parser-library/bad_items_fail.out
+++ b/tests/expectations/parser-library/bad_items_fail.out
@@ -1,52 +1,47 @@
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
+Error [EPAR0370047]: Only `const` declarations, `struct` definitions, and `fn` functions are allowed in a library.
     --> test_0:1:1
-     |
-   1 | fn foo() {}
-     | ^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
-    --> test_1:1:1
      |
    1 | final fn bar() {}
      | ^^^^^^^^^^^^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_2:1:1
+    --> test_1:1:1
      |
    1 | record Bar { owner: address }
      | ^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_3:1:1
+    --> test_2:1:1
      |
    1 | mapping my_map: u32 => u32;
      | ^^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_4:1:1
+    --> test_3:1:1
      |
    1 | storage foo: u32;
      | ^^^^^^^
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
-    --> test_5:1:1
+Error [EPAR0370047]: Only `const` declarations, `struct` definitions, and `fn` functions are allowed in a library.
+    --> test_4:1:1
      |
    1 | interface MyInterface { fn baz(); }
      | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
-    --> test_6:1:1
+Error [EPAR0370047]: Only `const` declarations, `struct` definitions, and `fn` functions are allowed in a library.
+    --> test_5:1:1
      |
    1 | import foo.aleo;
      | ^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
-    --> test_7:1:1
+Error [EPAR0370047]: Only `const` declarations, `struct` definitions, and `fn` functions are allowed in a library.
+    --> test_6:1:1
      |
    1 | program foo.aleo {}
      | ^^^^^^^^^^^^^^^^^^^
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
-    --> test_8:1:1
+Error [EPAR0370047]: Only `const` declarations, `struct` definitions, and `fn` functions are allowed in a library.
+    --> test_7:1:1
      |
    1 | @noupgrade
      | ^^^^^^^^^^
    2 | constructor() {}
      | ^^^^^^^^^^^^^^^^
 Error [EPAR0370047]: expected `import`, `program`, or module item at top level
-    --> test_9:1:1
+    --> test_8:1:1
      |
    1 | {
      | ^

--- a/tests/expectations/parser-library/fn_bad_items_fail.out
+++ b/tests/expectations/parser-library/fn_bad_items_fail.out
@@ -1,0 +1,5 @@
+Error [EPAR0370047]: expected `import`, `program`, or module item at top level
+    --> test_0:1:1
+     |
+   1 | transition bad() {}
+     | ^^^^^^^^^^

--- a/tests/expectations/parser-library/functions.out
+++ b/tests/expectations/parser-library/functions.out
@@ -1,0 +1,35 @@
+library test_lib {
+    fn simple(a: u32, b: u32) -> u32 {
+        return a + b;
+    }
+}
+
+
+library test_lib {
+    fn no_args() -> u32 {
+        return 42u32;
+    }
+}
+
+
+library test_lib {
+    fn generic::[N: u32](x: u32) -> u32 {
+        return x * N;
+    }
+}
+
+
+library test_lib {
+    fn multi_generic::[A: u32, B: u32](x: u32) -> u32 {
+        return x * A + B;
+    }
+}
+
+
+library test_lib {
+    fn calls_other(x: u32) -> u32 {
+        return simple(x, x);
+    }
+}
+
+

--- a/tests/expectations/parser-library/struct_bad_items_fail.out
+++ b/tests/expectations/parser-library/struct_bad_items_fail.out
@@ -3,8 +3,3 @@ Error [EPAR0370047]: expected `import`, `program`, or module item at top level
      |
    1 | record Foo { owner: address, data: u32 }
      | ^^^^^^
-Error [EPAR0370047]: Only `const` declarations and `struct` definitions are allowed in a library.
-    --> test_1:1:1
-     |
-   1 | fn helper() -> u32 { return 0u32; }
-     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/passes/flattening/lib_fn_conditional_flattening.out
+++ b/tests/expectations/passes/flattening/lib_fn_conditional_flattening.out
@@ -1,0 +1,23 @@
+library math_lib {
+    fn min(a$$0: u32, b$$1: u32) -> u32 {
+        let $var$2 = a$$0 < b$$1;
+        let $var$3 = $var$2 ? a$$0 : b$$1;
+        {
+        }
+        return $var$3;
+    }
+}
+
+program test.aleo {
+    @noupgrade
+    async constructor() {
+        return;
+    }
+    fn main(a$$4: u32, b$$5: u32) -> u32 {
+        let $var$6 = math_lib::min(a$$4, b$$5);
+        {
+        }
+        return $var$6;
+    }
+}
+

--- a/tests/expectations/passes/flattening/lib_fn_flattening.out
+++ b/tests/expectations/passes/flattening/lib_fn_flattening.out
@@ -1,0 +1,22 @@
+library math_lib {
+    fn add(a$$0: u32, b$$1: u32) -> u32 {
+        let $var$2 = a$$0 + b$$1;
+        {
+        }
+        return $var$2;
+    }
+}
+
+program test.aleo {
+    @noupgrade
+    async constructor() {
+        return;
+    }
+    fn main(x$$3: u32, y$$4: u32) -> u32 {
+        let $var$5 = math_lib::add(x$$3, y$$4);
+        {
+        }
+        return $var$5;
+    }
+}
+

--- a/tests/expectations/passes/flattening/simple_flattening.out
+++ b/tests/expectations/passes/flattening/simple_flattening.out
@@ -1,15 +1,15 @@
 program test.aleo {
-    fn main(cond: bool, a: u32, b: u32) -> u32 {
-        let condition$0 = cond;
+    fn main(cond$$0: bool, a$$1: u32, b$$2: u32) -> u32 {
+        let condition$3 = cond$$0;
         {
         }
-        let condition$1 = cond.not();
+        let condition$4 = cond$$0.not();
         {
         }
         {
         }
-        let $ret$2 = condition$0 ? a : b;
-        return $ret$2;
+        let $ret$5 = condition$3 ? a$$1 : b$$2;
+        return $ret$5;
     }
 }
 

--- a/tests/expectations/passes/function_inlining/lib_fn_generic_inline.out
+++ b/tests/expectations/passes/function_inlining/lib_fn_generic_inline.out
@@ -1,0 +1,15 @@
+library math_lib {
+    fn scale::[N: u32](x: u32) -> u32 {
+        return x * N;
+    }
+}
+
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    fn main(x: u32) -> u32 {
+        return $var$0;
+    }
+}
+

--- a/tests/expectations/passes/function_inlining/lib_fn_inline.out
+++ b/tests/expectations/passes/function_inlining/lib_fn_inline.out
@@ -1,0 +1,15 @@
+library math_lib {
+    fn add(a: u32, b: u32) -> u32 {
+        return a + b;
+    }
+}
+
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    fn main(x: u32, y: u32) -> u32 {
+        return $var$0;
+    }
+}
+

--- a/tests/expectations/passes/function_inlining/lib_fn_inline_multiple.out
+++ b/tests/expectations/passes/function_inlining/lib_fn_inline_multiple.out
@@ -1,0 +1,19 @@
+library math_lib {
+    fn square(x: u32) -> u32 {
+        return x * x;
+    }
+}
+
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    fn main(a: u32, b: u32) -> u32 {
+        let $var$0 = a * a;
+        let sa: u32 = $var$0;
+        let $var$1 = b * b;
+        let sb: u32 = $var$1;
+        return sa + sb;
+    }
+}
+

--- a/tests/expectations/passes/ssa_forming/lib_fn_ssa.out
+++ b/tests/expectations/passes/ssa_forming/lib_fn_ssa.out
@@ -1,0 +1,17 @@
+library math_lib {
+    fn add(a$$0: u32, b$$1: u32) -> u32 {
+        let $var$2 = a$$0 + b$$1;
+        return $var$2;
+    }
+}
+
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    fn main(x$$3: u32, y$$4: u32) -> u32 {
+        let $var$5 = math_lib::add(x$$3, y$$4);
+        return $var$5;
+    }
+}
+

--- a/tests/tests/compiler/libraries/lib_fn_basic.leo
+++ b/tests/tests/compiler/libraries/lib_fn_basic.leo
@@ -1,0 +1,18 @@
+// Test: basic non-generic library function call.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32, y: u32) -> u32 {
+        return math_lib::add(x, y);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_called_multiple_times.leo
+++ b/tests/tests/compiler/libraries/lib_fn_called_multiple_times.leo
@@ -1,0 +1,21 @@
+// Test: the same library function is called more than once within a single program function.
+// Each call site must be independently inlined.
+
+// --- library: math_lib --- //
+
+fn square(x: u32) -> u32 {
+    return x * x;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(a: u32, b: u32) -> u32 {
+        let sa: u32 = math_lib::square(a);
+        let sb: u32 = math_lib::square(b);
+        return sa + sb;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_calls_lib_fn.leo
+++ b/tests/tests/compiler/libraries/lib_fn_calls_lib_fn.leo
@@ -1,0 +1,22 @@
+// Test: a library function calls another function in the same library.
+
+// --- library: math_lib --- //
+
+fn double(a: u32) -> u32 {
+    return a + a;
+}
+
+fn quadruple(a: u32) -> u32 {
+    return double(a) + double(a);
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::quadruple(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_conditional.leo
+++ b/tests/tests/compiler/libraries/lib_fn_conditional.leo
@@ -1,0 +1,22 @@
+// Test: library function with a ternary conditional expression.
+
+// --- library: math_lib --- //
+
+fn min(a: u32, b: u32) -> u32 {
+    return a < b ? a : b;
+}
+
+fn max(a: u32, b: u32) -> u32 {
+    return a > b ? a : b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(a: u32, b: u32) -> (u32, u32) {
+        return (math_lib::min(a, b), math_lib::max(a, b));
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_cross_lib.leo
+++ b/tests/tests/compiler/libraries/lib_fn_cross_lib.leo
@@ -1,0 +1,26 @@
+// Test: a function in lib B calls a function from lib A.
+
+// --- library: base_lib --- //
+
+fn double(x: u32) -> u32 {
+    return x + x;
+}
+
+// --- Next Program --- //
+
+// --- library: derived_lib --- //
+
+fn quadruple(x: u32) -> u32 {
+    return base_lib::double(base_lib::double(x));
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return derived_lib::quadruple(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_cross_lib_with_struct.leo
+++ b/tests/tests/compiler/libraries/lib_fn_cross_lib_with_struct.leo
@@ -1,0 +1,42 @@
+// Test: cross-library function call where both libraries operate on the same struct type.
+//
+// geo_lib defines Point and translate(). shape_lib defines pipeline() which calls
+// geo_lib::translate() and returns a geo_lib::Point. The program calls shape_lib::pipeline().
+// This exercises the cross-library call graph where the function argument and return types
+// cross the library boundary.
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn translate(p: Point, dx: u32, dy: u32) -> Point {
+    return Point { x: p.x + dx, y: p.y + dy };
+}
+
+fn distance_sq(p: Point) -> u32 {
+    return p.x * p.x + p.y * p.y;
+}
+
+// --- Next Program --- //
+
+// --- library: shape_lib --- //
+
+fn move_and_measure(p: geo_lib::Point, dx: u32, dy: u32) -> u32 {
+    let q: geo_lib::Point = geo_lib::translate(p, dx, dy);
+    return geo_lib::distance_sq(q);
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(px: u32, py: u32, dx: u32, dy: u32) -> u32 {
+        let p: geo_lib::Point = geo_lib::Point { x: px, y: py };
+        return shape_lib::move_and_measure(p, dx, dy);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_dead_code.leo
+++ b/tests/tests/compiler/libraries/lib_fn_dead_code.leo
@@ -1,0 +1,22 @@
+// Test: a library function is defined but never called. Should compile without errors.
+
+// --- library: math_lib --- //
+
+fn used(x: u32) -> u32 {
+    return x + 1u32;
+}
+
+fn unused(x: u32) -> u32 {
+    return x * 99u32;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::used(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_generic.leo
+++ b/tests/tests/compiler/libraries/lib_fn_generic.leo
@@ -1,0 +1,18 @@
+// Test: generic library function with a const parameter used in the body.
+
+// --- library: math_lib --- //
+
+fn scale::[N: u32](a: u32) -> u32 {
+    return a * N;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::scale::[5u32](x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_generic_calls_generic.leo
+++ b/tests/tests/compiler/libraries/lib_fn_generic_calls_generic.leo
@@ -1,0 +1,24 @@
+// Test: one generic library function whose body calls a non-generic function in the same library.
+// scale::[N] calls `add`, which is a concrete helper.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+fn scale::[N: u32](x: u32) -> u32 {
+    // Use add to perform x * N via repeated addition (N=2 for simplicity).
+    return add(x, x);
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::scale::[2u32](x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_generic_multi.leo
+++ b/tests/tests/compiler/libraries/lib_fn_generic_multi.leo
@@ -1,0 +1,21 @@
+// Test: a generic library function called at two distinct const arguments,
+// producing two independent monomorphized copies.
+
+// --- library: math_lib --- //
+
+fn scale::[N: u32](a: u32) -> u32 {
+    return a * N;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> (u32, u32) {
+        let a: u32 = math_lib::scale::[3u32](x);
+        let b: u32 = math_lib::scale::[7u32](x);
+        return (a, b);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_generic_multi_params.leo
+++ b/tests/tests/compiler/libraries/lib_fn_generic_multi_params.leo
@@ -1,0 +1,18 @@
+// Test: generic library function with two const parameters.
+
+// --- library: math_lib --- //
+
+fn affine::[A: u32, B: u32](x: u32) -> u32 {
+    return x * A + B;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::affine::[3u32, 7u32](x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_in_final.leo
+++ b/tests/tests/compiler/libraries/lib_fn_in_final.leo
@@ -1,0 +1,23 @@
+// Test: a library function called inside a final {} block (on-chain execution context).
+
+// --- library: math_lib --- //
+
+fn add(a: u64, b: u64) -> u64 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    mapping totals: address => u64;
+
+    fn accumulate(owner: address, amount: u64) -> Final {
+        return final {
+            let prev: u64 = Mapping::get_or_use(totals, owner, 0u64);
+            Mapping::set(totals, owner, math_lib::add(prev, amount));
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_multiple.leo
+++ b/tests/tests/compiler/libraries/lib_fn_multiple.leo
@@ -1,0 +1,28 @@
+// Test: multiple distinct non-generic library functions called from the same program.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+fn mul(a: u32, b: u32) -> u32 {
+    return a * b;
+}
+
+fn sub(a: u32, b: u32) -> u32 {
+    return a - b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32, y: u32) -> u32 {
+        let s: u32 = math_lib::add(x, y);
+        let p: u32 = math_lib::mul(x, y);
+        return math_lib::sub(p, s);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_non_const_arg_fail.leo
+++ b/tests/tests/compiler/libraries/lib_fn_non_const_arg_fail.leo
@@ -1,0 +1,19 @@
+// Test: non-const expression used as a const argument to a generic library function.
+// Expects the same non-const-argument error as for local generic functions.
+
+// --- library: math_lib --- //
+
+fn scale::[N: u32](a: u32) -> u32 {
+    return a * N;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32, n: u32) -> u32 {
+        return math_lib::scale::[n](x);  // n is a runtime variable, not a const
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_struct_call_chain.leo
+++ b/tests/tests/compiler/libraries/lib_fn_struct_call_chain.leo
@@ -1,0 +1,36 @@
+// Test: intra-library call chain involving library structs.
+//
+// `pipeline` calls `translate` (same library) and passes the returned `Point` to
+// `distance_sq` (same library). This exercises the combined intra-library call graph
+// and struct graph: functions reference each other AND share the same library-local struct.
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn translate(p: Point, dx: u32, dy: u32) -> Point {
+    return Point { x: p.x + dx, y: p.y + dy };
+}
+
+fn distance_sq(p: Point) -> u32 {
+    return p.x * p.x + p.y * p.y;
+}
+
+fn pipeline(p: Point, dx: u32, dy: u32) -> u32 {
+    return distance_sq(translate(p, dx, dy));
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(px: u32, py: u32, dx: u32, dy: u32) -> u32 {
+        let p: geo_lib::Point = geo_lib::Point { x: px, y: py };
+        return geo_lib::pipeline(p, dx, dy);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_tuple_return.leo
+++ b/tests/tests/compiler/libraries/lib_fn_tuple_return.leo
@@ -1,0 +1,19 @@
+// Test: library function returning a tuple, destructured at the call site.
+
+// --- library: math_lib --- //
+
+fn divmod(a: u32, b: u32) -> (u32, u32) {
+    return (a / b, a % b);
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(a: u32, b: u32) -> u32 {
+        let (q, r): (u32, u32) = math_lib::divmod(a, b);
+        return q + r;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_uses_lib_const.leo
+++ b/tests/tests/compiler/libraries/lib_fn_uses_lib_const.leo
@@ -1,0 +1,20 @@
+// Test: library function body references a const from the same library.
+
+// --- library: math_lib --- //
+
+const OFFSET: u32 = 10u32;
+
+fn shift(x: u32) -> u32 {
+    return x + OFFSET;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::shift(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_uses_lib_struct_locally.leo
+++ b/tests/tests/compiler/libraries/lib_fn_uses_lib_struct_locally.leo
@@ -1,0 +1,29 @@
+// Test: library function creates and uses a library struct as a local variable.
+
+// --- library: geo_lib --- //
+
+struct Vec2 {
+    x: u32,
+    y: u32,
+}
+
+fn make_vec(x: u32, y: u32) -> Vec2 {
+    let v: Vec2 = Vec2 { x, y };
+    return v;
+}
+
+fn sum_components(x: u32, y: u32) -> u32 {
+    let v: Vec2 = make_vec(x, y);
+    return v.x + v.y;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(a: u32, b: u32) -> u32 {
+        return geo_lib::sum_components(a, b);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_with_struct.leo
+++ b/tests/tests/compiler/libraries/lib_fn_with_struct.leo
@@ -1,0 +1,29 @@
+// Test: library function accepting and returning a library struct.
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn translate(p: Point, dx: u32, dy: u32) -> Point {
+    return Point { x: p.x + dx, y: p.y + dy };
+}
+
+fn distance_sq(p: Point) -> u32 {
+    return p.x * p.x + p.y * p.y;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(px: u32, py: u32, dx: u32, dy: u32) -> u32 {
+        let p: geo_lib::Point = geo_lib::Point { x: px, y: py };
+        let q: geo_lib::Point = geo_lib::translate(p, dx, dy);
+        return geo_lib::distance_sq(q);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_wrong_arg_count_fail.leo
+++ b/tests/tests/compiler/libraries/lib_fn_wrong_arg_count_fail.leo
@@ -1,0 +1,18 @@
+// Test: calling a library function with the wrong number of arguments should fail.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::add(x);  // missing second argument
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/libraries/lib_fn_wrong_arg_type_fail.leo
+++ b/tests/tests/compiler/libraries/lib_fn_wrong_arg_type_fail.leo
@@ -1,0 +1,18 @@
+// Test: passing the wrong argument type to a library function should fail.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::add(x, true);  // bool where u32 expected
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_basic.leo
+++ b/tests/tests/execution/libraries/lib_fn_basic.leo
@@ -1,0 +1,23 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["3u32", "4u32"]
+*/
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32, y: u32) -> u32 {
+        return math_lib::add(x, y);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_called_multiple_times.leo
+++ b/tests/tests/execution/libraries/lib_fn_called_multiple_times.leo
@@ -1,0 +1,27 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["2u32", "3u32"]
+*/
+
+// Test: same library function called twice. square(2) + square(3) = 4 + 9 = 13.
+
+// --- library: math_lib --- //
+
+fn square(x: u32) -> u32 {
+    return x * x;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(a: u32, b: u32) -> u32 {
+        let sa: u32 = math_lib::square(a);
+        let sb: u32 = math_lib::square(b);
+        return sa + sb;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_calls_lib_fn.leo
+++ b/tests/tests/execution/libraries/lib_fn_calls_lib_fn.leo
@@ -1,0 +1,27 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["5u32"]
+*/
+
+// --- library: math_lib --- //
+
+fn double(a: u32) -> u32 {
+    return a + a;
+}
+
+fn quadruple(a: u32) -> u32 {
+    return double(a) + double(a);
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::quadruple(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_conditional.leo
+++ b/tests/tests/execution/libraries/lib_fn_conditional.leo
@@ -1,0 +1,25 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["10u32", "3u32"]
+*/
+
+// Test: library function with a ternary conditional. min(10, 3) = 3.
+
+// --- library: math_lib --- //
+
+fn min(a: u32, b: u32) -> u32 {
+    return a < b ? a : b;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(a: u32, b: u32) -> u32 {
+        return math_lib::min(a, b);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_cross_lib.leo
+++ b/tests/tests/execution/libraries/lib_fn_cross_lib.leo
@@ -1,0 +1,33 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["3u32"]
+*/
+
+// Test: fn in lib B calls fn from lib A. quadruple(3) = double(double(3)) = 12.
+
+// --- library: base_lib --- //
+
+fn double(x: u32) -> u32 {
+    return x + x;
+}
+
+// --- Next Program --- //
+
+// --- library: derived_lib --- //
+
+fn quadruple(x: u32) -> u32 {
+    return base_lib::double(base_lib::double(x));
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return derived_lib::quadruple(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_cross_lib_with_struct.leo
+++ b/tests/tests/execution/libraries/lib_fn_cross_lib_with_struct.leo
@@ -1,0 +1,45 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["1u32", "2u32", "3u32", "4u32"]
+*/
+
+// Test: cross-library function call where the callee operates on a struct from another library.
+// move_and_measure(Point{1,2}, 3, 4) -> translate -> Point{4,6} -> distance_sq -> 16+36 = 52.
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn translate(p: Point, dx: u32, dy: u32) -> Point {
+    return Point { x: p.x + dx, y: p.y + dy };
+}
+
+fn distance_sq(p: Point) -> u32 {
+    return p.x * p.x + p.y * p.y;
+}
+
+// --- Next Program --- //
+
+// --- library: shape_lib --- //
+
+fn move_and_measure(p: geo_lib::Point, dx: u32, dy: u32) -> u32 {
+    let q: geo_lib::Point = geo_lib::translate(p, dx, dy);
+    return geo_lib::distance_sq(q);
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(px: u32, py: u32, dx: u32, dy: u32) -> u32 {
+        let p: geo_lib::Point = geo_lib::Point { x: px, y: py };
+        return shape_lib::move_and_measure(p, dx, dy);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_generic.leo
+++ b/tests/tests/execution/libraries/lib_fn_generic.leo
@@ -1,0 +1,23 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["3u32"]
+*/
+
+// --- library: math_lib --- //
+
+fn scale::[N: u32](a: u32) -> u32 {
+    return a * N;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::scale::[5u32](x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_struct_call_chain.leo
+++ b/tests/tests/execution/libraries/lib_fn_struct_call_chain.leo
@@ -1,0 +1,40 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["1u32", "2u32", "3u32", "4u32"]
+*/
+
+// Test: intra-library call chain involving library structs.
+// pipeline(Point{1,2}, 3, 4) -> translate -> Point{4,6} -> distance_sq -> 16+36 = 52.
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn translate(p: Point, dx: u32, dy: u32) -> Point {
+    return Point { x: p.x + dx, y: p.y + dy };
+}
+
+fn distance_sq(p: Point) -> u32 {
+    return p.x * p.x + p.y * p.y;
+}
+
+fn pipeline(p: Point, dx: u32, dy: u32) -> u32 {
+    return distance_sq(translate(p, dx, dy));
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(px: u32, py: u32, dx: u32, dy: u32) -> u32 {
+        let p: geo_lib::Point = geo_lib::Point { x: px, y: py };
+        return geo_lib::pipeline(p, dx, dy);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_uses_lib_const.leo
+++ b/tests/tests/execution/libraries/lib_fn_uses_lib_const.leo
@@ -1,0 +1,27 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["5u32"]
+*/
+
+// Test: function body uses a library-level const. shift(5) = 5 + 10 = 15.
+
+// --- library: math_lib --- //
+
+const OFFSET: u32 = 10u32;
+
+fn shift(x: u32) -> u32 {
+    return x + OFFSET;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(x: u32) -> u32 {
+        return math_lib::shift(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/libraries/lib_fn_with_struct.leo
+++ b/tests/tests/execution/libraries/lib_fn_with_struct.leo
@@ -1,0 +1,37 @@
+/*
+[case]
+program = "main.aleo"
+function = "compute"
+input = ["1u32", "2u32", "3u32", "4u32"]
+*/
+
+// Test: library function accepting and returning a library struct.
+// translate(Point{1,2}, 3, 4) -> Point{4,6}; distance_sq = 16+36 = 52.
+
+// --- library: geo_lib --- //
+
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+fn translate(p: Point, dx: u32, dy: u32) -> Point {
+    return Point { x: p.x + dx, y: p.y + dy };
+}
+
+fn distance_sq(p: Point) -> u32 {
+    return p.x * p.x + p.y * p.y;
+}
+
+// --- Next Program --- //
+
+program main.aleo {
+    fn compute(px: u32, py: u32, dx: u32, dy: u32) -> u32 {
+        let p: geo_lib::Point = geo_lib::Point { x: px, y: py };
+        let q: geo_lib::Point = geo_lib::translate(p, dx, dy);
+        return geo_lib::distance_sq(q);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/parser-library/bad_items_fail.leo
+++ b/tests/tests/parser-library/bad_items_fail.leo
@@ -1,6 +1,4 @@
 
-fn foo() {}
-
 final fn bar() {}
 
 record Bar { owner: address }

--- a/tests/tests/parser-library/fn_bad_items_fail.leo
+++ b/tests/tests/parser-library/fn_bad_items_fail.leo
@@ -1,0 +1,1 @@
+transition bad() {}

--- a/tests/tests/parser-library/functions.leo
+++ b/tests/tests/parser-library/functions.leo
@@ -1,0 +1,19 @@
+fn simple(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+fn no_args() -> u32 {
+    return 42u32;
+}
+
+fn generic::[N: u32](x: u32) -> u32 {
+    return x * N;
+}
+
+fn multi_generic::[A: u32, B: u32](x: u32) -> u32 {
+    return x * A + B;
+}
+
+fn calls_other(x: u32) -> u32 {
+    return simple(x, x);
+}

--- a/tests/tests/parser-library/struct_bad_items_fail.leo
+++ b/tests/tests/parser-library/struct_bad_items_fail.leo
@@ -1,4 +1,2 @@
 
 record Foo { owner: address, data: u32 }
-
-fn helper() -> u32 { return 0u32; }

--- a/tests/tests/passes/flattening/lib_fn_conditional_flattening.leo
+++ b/tests/tests/passes/flattening/lib_fn_conditional_flattening.leo
@@ -1,0 +1,18 @@
+// Test: a library function with a ternary is flattened into guarded returns.
+
+// --- library: math_lib --- //
+
+fn min(a: u32, b: u32) -> u32 {
+    return a < b ? a : b;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn main(a: u32, b: u32) -> u32 {
+        return math_lib::min(a, b);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/flattening/lib_fn_flattening.leo
+++ b/tests/tests/passes/flattening/lib_fn_flattening.leo
@@ -1,0 +1,18 @@
+// Test: a library function body is flattened before the inliner sees it.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn main(x: u32, y: u32) -> u32 {
+        return math_lib::add(x, y);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/function_inlining/lib_fn_generic_inline.leo
+++ b/tests/tests/passes/function_inlining/lib_fn_generic_inline.leo
@@ -1,0 +1,18 @@
+// Test: a monomorphized generic library function is inlined.
+
+// --- library: math_lib --- //
+
+fn scale::[N: u32](x: u32) -> u32 {
+    return x * N;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn main(x: u32) -> u32 {
+        return math_lib::scale::[5u32](x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/function_inlining/lib_fn_inline.leo
+++ b/tests/tests/passes/function_inlining/lib_fn_inline.leo
@@ -1,0 +1,18 @@
+// Test: a library function is inlined at its single call site.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn main(x: u32, y: u32) -> u32 {
+        return math_lib::add(x, y);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/function_inlining/lib_fn_inline_multiple.leo
+++ b/tests/tests/passes/function_inlining/lib_fn_inline_multiple.leo
@@ -1,0 +1,20 @@
+// Test: the same library function called twice; both call sites get inlined independently.
+
+// --- library: math_lib --- //
+
+fn square(x: u32) -> u32 {
+    return x * x;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn main(a: u32, b: u32) -> u32 {
+        let sa: u32 = math_lib::square(a);
+        let sb: u32 = math_lib::square(b);
+        return sa + sb;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/ssa_forming/lib_fn_ssa.leo
+++ b/tests/tests/passes/ssa_forming/lib_fn_ssa.leo
@@ -1,0 +1,18 @@
+// Test: library function parameters are SSA-renamed; body variables get unique names.
+
+// --- library: math_lib --- //
+
+fn add(a: u32, b: u32) -> u32 {
+    return a + b;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn main(x: u32, y: u32) -> u32 {
+        return math_lib::add(x, y);
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
## Summary

This PR extends Leo library support (started in #29196 and #29217) to allow `fn` function definitions inside library files. Library functions are inlined at their call sites by the function-inlining pass, exactly like module helper functions — they have no on-chain footprint and never appear as standalone Aleo functions in the compiled bytecode.

### What changed

**AST (`crates/ast`)**
- `Library` gains a `functions: Vec<(Symbol, Function)>` field alongside the existing `consts` and `structs`.
- The default `visit_library` in `ProgramVisitor` now visits function bodies, so passes that rely on the default (e.g. `NameValidationVisitor`, `StaticAnalyzingVisitor`) automatically cover library functions.

**Parser (`crates/parser`)**
- `FUNCTION_DEF` nodes are now recognized as valid library items in `is_library_item`.
- `collect_library_item` parses them via the existing `to_function` path with `is_in_program_block = false` (so all functions get variant `Fn`; entry-point variants are illegal in libraries).
- The "not allowed in a library" error message is updated to include `fn` in the list of allowed items.

**Passes (`crates/passes`)**

| Pass | Change |
|------|--------|
| SSA Forming | New `LibraryConsumer` impl runs SSA on every library function body. `consume_stub` dispatches `FromLibrary` through this impl. |
| Flattening | Overrides `reconstruct_library` to run flattening on library function bodies (requires SSA to have run first). |
| PathResolution | `reconstruct_library` reconstructs library function bodies. |
| OptionLowering / StorageLowering | Override `reconstruct_library` to reconstruct consts, structs, and function bodies, setting/restoring `self.program` around the library scope. |
| ConstPropagation | Skips generic library functions (those with `const_parameters`) — they cannot be fully evaluated until monomorphized. |
| GlobalItemsCollection / TypeChecking | `visit_library` now visits function bodies so signatures are registered in the symbol table and type-checked. |
| Monomorphization | Generic library functions reachable from the consuming program are included in the post-order call-graph traversal and monomorphized. `reconstruct_library` collects monomorphized variants back into the library stub, filtering out the generic originals to prevent "defined multiple times" errors on subsequent TypeChecking iterations. `function_map` is seeded with library functions before `reconstruct_program_scope` runs, and library entries are retained across nested `FromLeo` stub recursions. |
| FunctionInlining | `function_map` is seeded with all library functions from `FromLibrary` stubs. The post-order inliner treats library functions identically to module functions: looked up in `reconstructed_functions` and inlined at every call site. Dead library functions (never called) are dropped before the sanity assert. |
| CSE / SsaConstPropagation | Override `reconstruct_library` to pass library stubs through unchanged — library functions are already inlined by this stage. |

**Tests**

- *Parser*: `functions.leo` (basic, generic, multi-generic, intra-library call declarations); `fn_bad_items_fail.leo` (entry-point variants rejected). Existing `bad_items_fail.leo` and `struct_bad_items_fail.leo` updated to remove items that are now valid.
- *Passes*: new `lib_fn_*.leo` tests under `function_inlining/`, `flattening/`, and `ssa_forming/` exercising library functions through individual passes. Pass test infrastructure (`test_passes.rs`) extended to support the `// --- library: NAME --- //` / `// --- Next Program --- //` multi-section format. The `flattening_runner` now includes SSA forming, matching the real compiler pipeline.
- *Compiler* (19 new tests): basic call, intra-library call chain, call chain with struct (`pipeline` calling `translate` and `distance_sq` from the same library), generic function, multi-param generic, generic calling concrete helper, cross-library call, cross-library call with struct (lib B calls lib A functions passing lib A struct types), function using library const, function using library struct locally, tuple return, conditional, called multiple times, dead code, call inside `final {}` block; plus three fail tests (wrong arg count, wrong arg type, non-const generic arg).
- *Execution* (10 new tests): all key passing scenarios exercised end-to-end with concrete input/output verification, including cross-library struct passing and intra-library call chains.

## Design notes

**No `import` required.** Library items are referenced via `lib_name::item` path syntax. The dependency entry in `program.json` is sufficient, matching existing struct/const behavior.

**Always inlined.** Library functions are unconditionally inlined. The `is_library` predicate on the symbol table drives this decision throughout the inliner and monomorphizer.

**Ordering invariant.** SSA forming runs before flattening on library function bodies (via the `LibraryConsumer` impl and the `reconstruct_library` override). This matches the program-function pipeline and is required because the flattening pass asserts SSA form on every function body it processes.

**Monomorphization + ConstPropUnrollAndMorphing loop.** Generic library functions are monomorphized inside the consuming program's `reconstruct_program_scope`. The resulting instances are collected back into the library stub by `reconstruct_library`, replacing the generic originals, so the next TypeChecking iteration sees a consistent library with only concrete functions.