### PR TITLE
Mark generated tree-sitter artifacts as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,8 @@
 *.out text eol=lf  
 *.rs text eol=lf
 *.in text eol=lf
+
+# Hide generated tree-sitter artifacts in GitHub diffs.
+tree-sitter/src/parser.c linguist-generated=true
+tree-sitter/src/grammar.json linguist-generated=true
+tree-sitter/src/node-types.json linguist-generated=true


### PR DESCRIPTION
Marks the generated tree-sitter artifacts as generated in GitHub so PRs collapse the noisy parser diffs by default while keeping the generated sources checked in for normal builds.

Testing: not run (config-only change).