### PR TITLE
Fix array indexing bug

### DIFF
--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -403,7 +403,7 @@ impl CodeGeneratingVisitor<'_> {
             Expression::Literal(Literal {
                 variant: LiteralVariant::Integer(_, s) | LiteralVariant::Unsuffixed(s),
                 ..
-            }) => AleoExpr::U32(s.parse().unwrap()),
+            }) => AleoExpr::U32(u32::from_str_by_radix(&s.replace('_', "")).unwrap()),
             _ => panic!("Array indices must be integer literals"),
         };
 

--- a/tests/expectations/compiler/array/array_index_hex_literal.out
+++ b/tests/expectations/compiler/array/array_index_hex_literal.out
@@ -1,0 +1,5 @@
+program test.aleo;
+
+function foo:
+    input r0 as [boolean; 8u32].private;
+    output r0[1u32] as boolean.private;

--- a/tests/expectations/compiler/array/array_index_underscore_literal.out
+++ b/tests/expectations/compiler/array/array_index_underscore_literal.out
@@ -1,0 +1,5 @@
+program test.aleo;
+
+function foo:
+    input r0 as [boolean; 256u32].private;
+    output r0[10u32] as boolean.private;

--- a/tests/expectations/compiler/type_inference/unsuffixed_hex_literal_array_index.out
+++ b/tests/expectations/compiler/type_inference/unsuffixed_hex_literal_array_index.out
@@ -1,0 +1,4 @@
+program test.aleo;
+
+function main:
+    output 6u32 as u32.private;

--- a/tests/tests/compiler/array/array_index_hex_literal.leo
+++ b/tests/tests/compiler/array/array_index_hex_literal.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    fn foo(a: [bool; 8]) -> bool {
+        return a[0x1u32];
+    }
+}

--- a/tests/tests/compiler/array/array_index_underscore_literal.leo
+++ b/tests/tests/compiler/array/array_index_underscore_literal.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    fn foo(a: [bool; 256]) -> bool {
+        return a[1_0u32];
+    }
+}

--- a/tests/tests/compiler/type_inference/unsuffixed_hex_literal_array_index.leo
+++ b/tests/tests/compiler/type_inference/unsuffixed_hex_literal_array_index.leo
@@ -1,0 +1,6 @@
+program test.aleo {
+    fn main() -> u32 {
+        let arr = [1u32, 2u32, 3u32];
+        return arr[0x0] + arr[0x1] + arr[0x2];
+    }
+}


### PR DESCRIPTION
Allow indexing of arrays with non strictly decimal literals which previously failed at codegen because it wasn't handled properly.

Fixes #29229
