### PR TITLE
Add size to program id validation

### DIFF
--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -514,7 +514,7 @@ impl TypeCheckingVisitor<'_> {
         };
 
         // Define a regex to match valid program IDs.
-        let program_id_regex = regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9_]*\.aleo$").unwrap();
+        let program_id_regex = regex::Regex::new(r"^[a-zA-Z][a-zA-Z0-9_]{0,30}\.aleo$").unwrap();
 
         fn struct_not_supported<T, U>(_: &T) -> anyhow::Result<U> {
             bail!("structs are not supported")

--- a/tests/expectations/compiler/function/program_core_functions_long_name_fail.out
+++ b/tests/expectations/compiler/function/program_core_functions_long_name_fail.out
@@ -1,0 +1,15 @@
+Error [ETYC0372156]: `Program::checksum` must be called on a program ID, e.g. `foo.aleo`
+    --> compiler-test:3:41
+     |
+   3 |     let c: [u8; 32] = Program::checksum(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aleo);
+     |                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372156]: `Program::edition` must be called on a program ID, e.g. `foo.aleo`
+    --> compiler-test:4:35
+     |
+   4 |     let d: u16 = Program::edition(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aleo);
+     |                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372156]: `Program::program_owner` must be called on a program ID, e.g. `foo.aleo`
+    --> compiler-test:5:45
+     |
+   5 |     let e: address = Program::program_owner(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aleo);
+     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/tests/compiler/function/program_core_functions_long_name_fail.leo
+++ b/tests/tests/compiler/function/program_core_functions_long_name_fail.leo
@@ -1,0 +1,12 @@
+
+final fn foo() {
+    let c: [u8; 32] = Program::checksum(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aleo);
+    let d: u16 = Program::edition(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aleo);
+    let e: address = Program::program_owner(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.aleo);
+}
+
+program test.aleo {
+    fn bar() -> Final {
+        return final { foo(); };
+    }
+}


### PR DESCRIPTION
Program IDs can't be more than 30 characters, this change changes the regex we use for validation to take that into account instead of failing later when the VM parses the name.

Fixes #29225
