### PR TITLE
Fix a panic in `BlockToFunctionRewriter` when a `final` block contains a tuple field assignment on a non-tuple variable

### DIFF
--- a/crates/passes/src/common/block_to_function_rewriter.rs
+++ b/crates/passes/src/common/block_to_function_rewriter.rs
@@ -141,7 +141,9 @@ impl BlockToFunctionRewriter<'_> {
                 match index_opt {
                     Some(index) => {
                         let Type::Tuple(TupleType { elements }) = var_type else {
-                            panic!("Expected tuple type when accessing tuple field: {symbol}.{index}");
+                            // The type checker has already emitted an error for this invalid access;
+                            // return no inputs so compilation can continue to report all diagnostics.
+                            return vec![];
                         };
 
                         let synthetic_name = format!("\"{symbol}.{index}\"");

--- a/tests/expectations/compiler/bugs/b29223_fail.out
+++ b/tests/expectations/compiler/bugs/b29223_fail.out
@@ -1,0 +1,10 @@
+Error [ETYC0372155]: Cannot assign to `p` inside a `final` block because it was declared outside the block.
+    --> compiler-test:7:13
+     |
+   7 |             p.0 = 1u32;
+     |             ^
+Error [ETYC0372117]: Expected a tuple but type `u32` was found.
+    --> compiler-test:7:13
+     |
+   7 |             p.0 = 1u32;
+     |             ^^^

--- a/tests/tests/compiler/bugs/b29223_fail.leo
+++ b/tests/tests/compiler/bugs/b29223_fail.leo
@@ -1,0 +1,11 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29223
+// The compiler should emit a type error, not panic, when a non-tuple variable
+// is accessed with a tuple field index inside a `final` block.
+program test.aleo {
+    fn foo(p: u32) -> Final {
+        let f = final {
+            p.0 = 1u32;
+        };
+        return f;
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a panic in `BlockToFunctionRewriter` when a `final` block contains a tuple field assignment on a non-tuple variable (e.g., `p.0 = 1u32` where `p: u32`).
- The type checker correctly emits a diagnostic for this case, but the rewriter ran unconditionally afterward and hit an invariant-violation `panic!`. Now it returns `vec![]` and lets compilation finish, reporting all diagnostics cleanly.
- Adds a regression test (`tests/tests/compiler/bugs/b29223.leo`) that reproduces the MRE from the issue.

Closes #29223.