### PR TITLE
Fix intrinsic type parameter reconstruction across all passes

### DIFF
--- a/crates/ast/src/passes/reconstructor.rs
+++ b/crates/ast/src/passes/reconstructor.rs
@@ -198,21 +198,14 @@ pub trait AstReconstructor {
 
     fn reconstruct_intrinsic(
         &mut self,
-        input: IntrinsicExpression,
+        mut input: IntrinsicExpression,
         _additional: &Self::AdditionalInput,
     ) -> (Expression, Self::AdditionalOutput) {
-        (
-            IntrinsicExpression {
-                arguments: input
-                    .arguments
-                    .into_iter()
-                    .map(|arg| self.reconstruct_expression(arg, &Default::default()).0)
-                    .collect(),
-                ..input
-            }
-            .into(),
-            Default::default(),
-        )
+        input.type_parameters =
+            input.type_parameters.into_iter().map(|(ty, span)| (self.reconstruct_type(ty).0, span)).collect();
+        input.arguments =
+            input.arguments.into_iter().map(|arg| self.reconstruct_expression(arg, &Default::default()).0).collect();
+        (input.into(), Default::default())
     }
 
     fn reconstruct_tuple_access(

--- a/crates/ast/src/passes/visitor.rs
+++ b/crates/ast/src/passes/visitor.rs
@@ -192,6 +192,9 @@ pub trait AstVisitor {
     }
 
     fn visit_intrinsic(&mut self, input: &IntrinsicExpression, _additional: &Self::AdditionalInput) -> Self::Output {
+        for (ty, _) in &input.type_parameters {
+            self.visit_type(ty);
+        }
         input.arguments.iter().for_each(|arg| {
             self.visit_expression(arg, &Default::default());
         });

--- a/crates/ast/src/types/array.rs
+++ b/crates/ast/src/types/array.rs
@@ -74,8 +74,12 @@ impl ArrayType {
     pub fn to_snarkvm<N: Network>(&self) -> anyhow::Result<ConsoleArrayType<N>> {
         let length = if let Expression::Literal(literal) = &*self.length {
             match &literal.variant {
-                LiteralVariant::Integer(_, s) => s.parse::<u32>().unwrap(),
-                LiteralVariant::Unsuffixed(s) => s.parse::<u32>().unwrap(),
+                LiteralVariant::Integer(_, s) => {
+                    s.parse::<u32>().map_err(|e| anyhow::anyhow!("Array length is not a valid u32: {e}"))?
+                }
+                LiteralVariant::Unsuffixed(s) => {
+                    s.parse::<u32>().map_err(|e| anyhow::anyhow!("Array length is not a valid u32: {e}"))?
+                }
                 _ => anyhow::bail!("Array length must be an integer literal"),
             }
         } else {

--- a/crates/passes/src/const_propagation/ast.rs
+++ b/crates/passes/src/const_propagation/ast.rs
@@ -198,6 +198,13 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
             }
         }
 
+        // Reconstruct type parameters so that const identifiers inside array lengths are
+        // replaced with their evaluated values. This ensures, for example, `[u32; N]` where
+        // `const N: u32 = 5;` becomes `[u32; 5]`, and that unresolved lengths are
+        // reported via `array_length_not_evaluated` at the fixed point.
+        input.type_parameters =
+            input.type_parameters.into_iter().map(|(ty, span)| (self.reconstruct_type(ty).0, span)).collect();
+
         let intrinsic = Intrinsic::from_symbol(input.name, &input.type_parameters)
             .expect("Type checking guarantees this is valid.");
 

--- a/crates/passes/src/disambiguate.rs
+++ b/crates/passes/src/disambiguate.rs
@@ -62,6 +62,8 @@ impl AstReconstructor for DisambiguateVisitor<'_> {
         mut input: IntrinsicExpression,
         _additional: &Self::AdditionalInput,
     ) -> (Expression, Self::AdditionalOutput) {
+        input.type_parameters =
+            input.type_parameters.into_iter().map(|(ty, span)| (self.reconstruct_type(ty).0, span)).collect();
         input.arguments = input.arguments.into_iter().map(|arg| self.reconstruct_expression(arg, &()).0).collect();
 
         if input.name == Symbol::intern("__unresolved_get") {

--- a/crates/passes/src/option_lowering/ast.rs
+++ b/crates/passes/src/option_lowering/ast.rs
@@ -235,6 +235,8 @@ impl leo_ast::AstReconstructor for OptionLoweringVisitor<'_> {
                 (ternary_expr.into(), stmts1)
             }
             _ => {
+                input.type_parameters =
+                    input.type_parameters.into_iter().map(|(ty, span)| (self.reconstruct_type(ty).0, span)).collect();
                 let statements: Vec<_> = input
                     .arguments
                     .iter_mut()

--- a/crates/passes/src/storage_lowering/ast.rs
+++ b/crates/passes/src/storage_lowering/ast.rs
@@ -491,7 +491,10 @@ impl leo_ast::AstReconstructor for StorageLoweringVisitor<'_> {
             }
 
             _ => {
-                // Default: reconstruct all arguments recursively and return the (possibly updated) original call
+                // Default: reconstruct all arguments and type parameters recursively and return the (possibly updated)
+                // original call.
+                input.type_parameters =
+                    input.type_parameters.into_iter().map(|(ty, span)| (self.reconstruct_type(ty).0, span)).collect();
                 let statements: Vec<_> = input
                     .arguments
                     .iter_mut()

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -529,6 +529,13 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_intrinsic(&mut self, input: &IntrinsicExpression, expected: &Self::AdditionalInput) -> Self::Output {
+        // Visit type parameters so that array length expressions are properly checked and any
+        // literal lengths (e.g., the `2` in `[u32; 2]`) are added to the type table. This mirrors
+        // how `visit_definition` and `visit_const` call `visit_type` for their type annotations.
+        for (tp, _) in &input.type_parameters {
+            self.visit_type(tp);
+        }
+
         // Check core struct name and function.
         let Some(intrinsic) = self.get_intrinsic(input) else {
             return Type::Err;

--- a/crates/passes/src/write_transforming/ast.rs
+++ b/crates/passes/src/write_transforming/ast.rs
@@ -161,6 +161,8 @@ impl AstReconstructor for WriteTransformingVisitor<'_> {
         mut input: IntrinsicExpression,
         _additional: &Self::AdditionalInput,
     ) -> (Expression, Self::AdditionalOutput) {
+        input.type_parameters =
+            input.type_parameters.into_iter().map(|(ty, span)| (self.reconstruct_type(ty).0, span)).collect();
         let mut statements = Vec::new();
         for arg in input.arguments.iter_mut() {
             let (expr, statements2) = self.reconstruct_expression(std::mem::take(arg), &());

--- a/tests/expectations/compiler/bugs/b29219_fail.out
+++ b/tests/expectations/compiler/bugs/b29219_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372008]: The value 4294967300 is not a valid `u32`
+    --> compiler-test:6:46
+     |
+   6 |         return Deserialize::from_bits::[[u8; 4294967300]](bits);
+     |                                              ^^^^^^^^^^

--- a/tests/expectations/compiler/bugs/b29221_const.out
+++ b/tests/expectations/compiler/bugs/b29221_const.out
@@ -1,0 +1,6 @@
+program test.aleo;
+
+function main:
+    input r0 as [boolean; 182u32].private;
+    deserialize.bits r0 ([boolean; 182u32]) into r1 ([u32; 2u32]);
+    output r1 as [u32; 2u32].private;

--- a/tests/expectations/compiler/bugs/b29221_fail.out
+++ b/tests/expectations/compiler/bugs/b29221_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372005]: Unknown variable `N`
+    --> compiler-test:6:63
+     |
+   6 |         let result: [u32; 2] = Deserialize::from_bits::[[u32; N]](bits);
+     |                                                               ^

--- a/tests/expectations/compiler/bugs/b29221_loop.out
+++ b/tests/expectations/compiler/bugs/b29221_loop.out
@@ -1,0 +1,8 @@
+program test.aleo;
+
+function main:
+    input r0 as [boolean; 182u32].private;
+    deserialize.bits r0 ([boolean; 182u32]) into r1 ([u32; 2u32]);
+    add 0u32 r1[0u32] into r2;
+    add r2 r1[1u32] into r3;
+    output r3 as u32.private;

--- a/tests/expectations/compiler/bugs/b29221_non_const_fail.out
+++ b/tests/expectations/compiler/bugs/b29221_non_const_fail.out
@@ -1,0 +1,5 @@
+Error [ECMP0376013]: This array length could not be determined at compile time.
+    --> compiler-test:8:63
+     |
+   8 |         let result: [u32; 2] = Deserialize::from_bits::[[u32; n]](bits);
+     |                                                               ^

--- a/tests/expectations/compiler/bugs/b29221_raw.out
+++ b/tests/expectations/compiler/bugs/b29221_raw.out
@@ -1,0 +1,6 @@
+program test.aleo;
+
+function main:
+    input r0 as [boolean; 64u32].private;
+    deserialize.bits.raw r0 ([boolean; 64u32]) into r1 ([u32; 2u32]);
+    output r1 as [u32; 2u32].private;

--- a/tests/tests/compiler/bugs/b29219_fail.leo
+++ b/tests/tests/compiler/bugs/b29219_fail.leo
@@ -1,0 +1,8 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29219
+// The compiler should emit a diagnostic error, not panic, when Deserialize::from_bits
+// is called with an array type parameter whose length exceeds u32::MAX.
+program test.aleo {
+    fn main(bits: [bool; 8]) -> [u8; 1] {
+        return Deserialize::from_bits::[[u8; 4294967300]](bits);
+    }
+}

--- a/tests/tests/compiler/bugs/b29221_const.leo
+++ b/tests/tests/compiler/bugs/b29221_const.leo
@@ -1,0 +1,12 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29221
+// Using a defined constant as the array length in a Deserialize type parameter
+// must compile successfully and not panic or emit a false error.
+
+program test.aleo {
+    const N: u32 = 2u32;
+
+    fn main(bits: [bool; 182]) -> [u32; 2] {
+        let result: [u32; 2] = Deserialize::from_bits::[[u32; N]](bits);
+        return result;
+    }
+}

--- a/tests/tests/compiler/bugs/b29221_fail.leo
+++ b/tests/tests/compiler/bugs/b29221_fail.leo
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29221
+// The compiler should emit a diagnostic error, not panic, when Deserialize::from_bits
+// is called with an array type parameter whose length is an unresolved identifier.
+program test.aleo {
+    fn main(bits: [bool; 182]) -> [u32; 2] {
+        let result: [u32; 2] = Deserialize::from_bits::[[u32; N]](bits);
+        return result;
+    }
+}

--- a/tests/tests/compiler/bugs/b29221_loop.leo
+++ b/tests/tests/compiler/bugs/b29221_loop.leo
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29221
+// Using a const N as both the loop bound and the array length in a Deserialize
+// type parameter verifies that loop unrolling and const propagation cooperate
+// correctly when N appears in an intrinsic type parameter.
+
+program test.aleo {
+    const N: u32 = 2u32;
+
+    fn main(bits: [bool; 182]) -> u32 {
+        let arr: [u32; N] = Deserialize::from_bits::[[u32; N]](bits);
+        let total: u32 = 0u32;
+        for i: u32 in 0u32..N {
+            total += arr[i];
+        }
+        return total;
+    }
+}

--- a/tests/tests/compiler/bugs/b29221_non_const_fail.leo
+++ b/tests/tests/compiler/bugs/b29221_non_const_fail.leo
@@ -1,0 +1,11 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29221
+// Using a runtime (non-const) variable as the array length in a Deserialize
+// type parameter must fail with a clear error, not a panic.
+
+program test.aleo {
+    fn main(bits: [bool; 182]) -> [u32; 2] {
+        let n: u32 = 2u32;
+        let result: [u32; 2] = Deserialize::from_bits::[[u32; n]](bits);
+        return result;
+    }
+}

--- a/tests/tests/compiler/bugs/b29221_raw.leo
+++ b/tests/tests/compiler/bugs/b29221_raw.leo
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29221
+// Using a const N as the array length in a Deserialize::from_bits_raw type
+// parameter must compile successfully — verifying the fix covers both
+// Deserialize variants.
+
+program test.aleo {
+    const N: u32 = 2u32;
+
+    fn main(bits: [bool; 64]) -> [u32; 2] {
+        let result: [u32; N] = Deserialize::from_bits_raw::[[u32; N]](bits);
+        return result;
+    }
+}


### PR DESCRIPTION
Fixes panics when `Deserialize::from_bits` or `Deserialize::from_bits_raw` is called with an invalid array type parameter.

Closes #29221.
Closes #29219.

---

### Root cause — three interacting gaps

1. **Default `visit_intrinsic`** never called `visit_type` on type parameters, so the type checker never visited intrinsic type parameters. Literal lengths (e.g. `4294967300` in `[u8; 4294967300]`) were never validated against `u32`, and const-identifier lengths (e.g. `N` in `[u32; N]`) were never resolved.

2. **Default `reconstruct_intrinsic`** used `..input` spread for `type_parameters`, so type parameters were silently passed through unchanged by every pass that did not explicitly override the method. Without propagation, const propagation could not substitute resolved values into array lengths, and code generation would later panic with `length should be known at this point`.

3. **Type checker's `visit_intrinsic`** never visited type parameters at all, so the two problems above compounded: neither literal overflow nor unresolved identifiers produced a diagnostic — the compiler continued past type checking and panicked deeper in the pipeline.

