### PR TITLE
Fix panic on repeat/array expressions with oversized const lengths (#29220)

### DIFF
--- a/crates/errors/src/errors/compiler/compiler_errors.rs
+++ b/crates/errors/src/errors/compiler/compiler_errors.rs
@@ -132,4 +132,5 @@ create_messages!(
         msg: "This repeat count could not be determined at compile time.".to_string(),
         help: None,
     }
+
 );

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -514,12 +514,14 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         // a `U32` as the default type.
         self.visit_expression_infer_default_u32(&input.count);
 
-        // If we can already evaluate the repeat count as a `u32`, then make sure it's not 0 or  greater than the array
-        // size limit.
-        if let Some(count) = input.count.as_u32()
-            && count > self.limits.max_array_elements as u32
-        {
-            self.emit_err(TypeCheckerError::array_too_large(count, self.limits.max_array_elements, input.span()));
+        // If we can already evaluate the repeat count as a `u32`, then make sure it's not greater than the array
+        // size limit. If the count is a literal but exceeds u32::MAX, report that separately.
+        if let Some(count) = input.count.as_u32() {
+            if count > self.limits.max_array_elements as u32 {
+                self.emit_err(TypeCheckerError::array_too_large(count, self.limits.max_array_elements, input.span()));
+            }
+        } else if let Expression::Literal(_) = &input.count {
+            self.emit_err(TypeCheckerError::array_too_large_for_u32(input.span()));
         }
 
         let type_ = Type::Array(ArrayType::new(inferred_element_type, input.count.clone()));

--- a/tests/expectations/compiler/array/bad_repeat_count_fail.out
+++ b/tests/expectations/compiler/array/bad_repeat_count_fail.out
@@ -3,11 +3,21 @@ Error [ETYC0372008]: The value 111111111111111 is not a valid `u8`
      |
    3 |         let a = [1u32; 111111111111111u8]; // overflow
      |                        ^^^^^^^^^^^^^^^^^
+Error [ETYC0372144]: An array length must be small enough to fit in a `u32`
+    --> compiler-test:3:17
+     |
+   3 |         let a = [1u32; 111111111111111u8]; // overflow
+     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372008]: The value 111111111111111 is not a valid `u32`
     --> compiler-test:4:24
      |
    4 |         let b = [1u32; 111111111111111]; // overflow
      |                        ^^^^^^^^^^^^^^^
+Error [ETYC0372144]: An array length must be small enough to fit in a `u32`
+    --> compiler-test:4:17
+     |
+   4 |         let b = [1u32; 111111111111111]; // overflow
+     |                 ^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372077]: An array cannot have more than 2048 elements, found one with 2049 elements
     --> compiler-test:6:17
      |

--- a/tests/expectations/compiler/bugs/b29220_array_fail.out
+++ b/tests/expectations/compiler/bugs/b29220_array_fail.out
@@ -1,0 +1,10 @@
+Error [ETYC0372144]: An array length must be small enough to fit in a `u32`
+    --> compiler-test:9:9
+     |
+   9 |         let x: [u32; COUNT * 9223372036854775807] = [0u32; COUNT * 9223372036854775807];
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372144]: An array length must be small enough to fit in a `u32`
+    --> compiler-test:9:53
+     |
+   9 |         let x: [u32; COUNT * 9223372036854775807] = [0u32; COUNT * 9223372036854775807];
+     |                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/bugs/b29220_fail.out
+++ b/tests/expectations/compiler/bugs/b29220_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372144]: An array length must be small enough to fit in a `u32`
+    --> compiler-test:6:12
+     |
+   6 |     return [val; COUNT * 9223372036854775807];
+     |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/tests/compiler/bugs/b29220_array_fail.leo
+++ b/tests/tests/compiler/bugs/b29220_array_fail.leo
@@ -1,0 +1,12 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29220
+// The compiler should emit a diagnostic error, not panic, when an array type's
+// length evaluates to a value that exceeds u32::MAX.
+
+program test.aleo {
+    const COUNT: u128 = 2u128;
+
+    fn main(public a: u32, b: u32) -> u32 {
+        let x: [u32; COUNT * 9223372036854775807] = [0u32; COUNT * 9223372036854775807];
+        return x[0u32];
+    }
+}

--- a/tests/tests/compiler/bugs/b29220_fail.leo
+++ b/tests/tests/compiler/bugs/b29220_fail.leo
@@ -1,0 +1,13 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29220
+// The compiler should emit a diagnostic error, not panic, when a repeat
+// expression's count evaluates to a value that exceeds u32::MAX.
+
+fn repeat_value::[COUNT: u128](val: u32) -> [u32; COUNT * 2] {
+    return [val; COUNT * 9223372036854775807];
+}
+
+program test.aleo {
+    fn main() -> [u32; 6] {
+        return repeat_value::[3](42u32);
+    }
+}


### PR DESCRIPTION
When a repeat count or array length evaluated to a `u128` value exceeding `u32::MAX`, the compiler
would panic in code generation instead of emitting a diagnostic.

The type checker already caught this for array length types (via `array_too_large_for_u32`), but
`visit_repeat` only checked `count.as_u32()` — which returns `None` for both unevaluated expressions
*and* literals exceeding `u32::MAX` — so oversized repeat counts slipped through silently.

**Fix:** add the missing `else if let Expression::Literal(_)` branch in `visit_repeat`, mirroring
the existing check in `assert_type_is_valid` for array types. Const propagation now simply
substitutes the evaluated literal and lets type checking catch the size violation uniformly.

Closes #29220 