### PR TITLE
Fix compiler panic after tuple destructuring size mismatch

### DIFF
--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1595,7 +1595,12 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         let var = self.state.symbol_table.lookup_path(current_program, input);
 
         if let Some(var) = var {
-            let ty = var.type_.expect("must be known at this point");
+            // The type may be `None` if a prior error (e.g. a tuple size mismatch) prevented the
+            // variable's type from being set during `visit_definition`. Return `Type::Err` to
+            // signal that an error has already been emitted rather than panicking.
+            let Some(ty) = var.type_ else {
+                return Type::Err;
+            };
             if var.declaration == VariableType::Storage && !ty.is_vector() && !ty.is_mapping() {
                 self.check_access_allowed("storage access", true, input.span());
             }

--- a/tests/expectations/compiler/bugs/b29184_fail.out
+++ b/tests/expectations/compiler/bugs/b29184_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372072]: Expected a tuple with 3 elements, found one with 2 elements
+    --> compiler-test:7:9
+     |
+   7 |         let (a, b) = (1u8, 2u8, 3u8);
+     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/tests/compiler/bugs/b29184_fail.leo
+++ b/tests/tests/compiler/bugs/b29184_fail.leo
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29184
+// The compiler should emit a diagnostic error, not panic, when a tuple
+// destructuring has fewer identifiers than the tuple has elements, and
+// those variables are subsequently used in an expression.
+program b29184.aleo {
+    fn foo() -> (u8, u8) {
+        let (a, b) = (1u8, 2u8, 3u8);
+        return (a, b);
+    }
+}


### PR DESCRIPTION
## Summary

When a tuple destructuring statement had fewer identifiers than the RHS tuple had elements, the type checker correctly emitted `ETYC0372072` but then panicked instead of continuing gracefully.

**Root cause:** `visit_definition` returns early on a size mismatch without setting the types of the declared variables in the symbol table (`type_` stays `None`). Later, when those variables are referenced (e.g. in a `return` expression), `visit_path` called `.expect("must be known at this point")` on a `None` type, causing the panic.

**Fix:** Replace the `.expect()` in `visit_path` with a `let Some(ty) = var.type_ else { return Type::Err; }` guard. When a variable's type was never populated due to a prior error, the visitor now returns `Type::Err` — signalling that an error has already been reported — instead of panicking.

Closes #29184