### PR TITLE
fix array in mapping issue

### DIFF
--- a/crates/ast/src/passes/visitor.rs
+++ b/crates/ast/src/passes/visitor.rs
@@ -363,6 +363,7 @@ pub trait ProgramVisitor: AstVisitor {
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.composites.iter().for_each(|(_, c)| self.visit_composite(c));
+        input.interfaces.iter().for_each(|(_, c)| self.visit_interface(c));
         input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
         input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
@@ -374,6 +375,7 @@ pub trait ProgramVisitor: AstVisitor {
     fn visit_module(&mut self, input: &Module) {
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.composites.iter().for_each(|(_, c)| self.visit_composite(c));
+        input.interfaces.iter().for_each(|(_, c)| self.visit_interface(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
     }
 
@@ -402,6 +404,8 @@ pub trait ProgramVisitor: AstVisitor {
     fn visit_interface(&mut self, input: &Interface) {
         input.functions.iter().for_each(|(_, f)| self.visit_function_prototype(f));
         input.records.iter().for_each(|(_, r)| self.visit_record_prototype(r));
+        input.mappings.iter().for_each(|m| self.visit_mapping(m));
+        input.storages.iter().for_each(|s| self.visit_storage_variable(s));
     }
 
     fn visit_function_prototype(&mut self, input: &FunctionPrototype) {

--- a/crates/passes/src/const_propagation/program.rs
+++ b/crates/passes/src/const_propagation/program.rs
@@ -51,6 +51,7 @@ impl ProgramReconstructor for ConstPropagationVisitor<'_> {
         }
 
         input.composites = input.composites.into_iter().map(|(i, c)| (i, self.reconstruct_composite(c))).collect();
+        input.interfaces = input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect();
         input.mappings =
             input.mappings.into_iter().map(|(id, mapping)| (id, self.reconstruct_mapping(mapping))).collect();
         input.storage_variables =

--- a/crates/passes/src/name_validation/program.rs
+++ b/crates/passes/src/name_validation/program.rs
@@ -31,11 +31,13 @@ impl ProgramVisitor for NameValidationVisitor<'_> {
         self.is_not_keyword(program_name, "program", &[]);
 
         input.composites.iter().for_each(|(_, function)| self.visit_composite(function));
+        input.interfaces.iter().for_each(|(_, interface)| self.visit_interface(interface));
         input.functions.iter().for_each(|(_, function)| self.visit_function(function));
     }
 
     fn visit_module(&mut self, input: &Module) {
         input.composites.iter().for_each(|(_, function)| self.visit_composite(function));
+        input.interfaces.iter().for_each(|(_, interface)| self.visit_interface(interface));
         input.functions.iter().for_each(|(_, function)| self.visit_function(function));
     }
 

--- a/crates/passes/src/static_analysis/program.rs
+++ b/crates/passes/src/static_analysis/program.rs
@@ -26,6 +26,7 @@ impl ProgramVisitor for StaticAnalyzingVisitor<'_> {
         // Do the default implementation for visiting the program scope.
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.composites.iter().for_each(|(_, c)| self.visit_composite(c));
+        input.interfaces.iter().for_each(|(_, c)| self.visit_interface(c));
         input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
         input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -88,6 +88,11 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
             ));
         }
 
+        // Typecheck each interface definition.
+        for (_, interface) in input.interfaces.iter() {
+            self.visit_interface(interface);
+        }
+
         // Typecheck each mapping definition.
         let mut mapping_count = 0;
         for (_, mapping) in input.mappings.iter() {
@@ -157,6 +162,9 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
         // Typecheck each composite definition.
         input.composites.iter().for_each(|(_, function)| self.visit_composite(function));
+
+        // Typecheck each interface definition.
+        input.interfaces.iter().for_each(|(_, interface)| self.visit_interface(interface));
 
         for (_, function) in input.functions.iter() {
             self.visit_function(function);

--- a/tests/expectations/compiler/mappings/array_key_mapping.out
+++ b/tests/expectations/compiler/mappings/array_key_mapping.out
@@ -1,0 +1,16 @@
+program test.aleo;
+
+mapping allowances:
+    key as [address; 2u32].public;
+    value as u128.public;
+
+function foo:
+    input r0 as address.private;
+    input r1 as address.private;
+    cast r0 r1 into r2 as [address; 2u32];
+    async foo r2 into r3;
+    output r3 as test.aleo/foo.future;
+
+finalize foo:
+    input r0 as [address; 2u32].public;
+    get.or_use allowances[r0] 0u128 into r1;

--- a/tests/expectations/compiler/mappings/interface_array_key_mapping.out
+++ b/tests/expectations/compiler/mappings/interface_array_key_mapping.out
@@ -1,0 +1,16 @@
+program test.aleo;
+
+mapping allowances:
+    key as [address; 2u32].public;
+    value as u128.public;
+
+function foo:
+    input r0 as address.private;
+    input r1 as address.private;
+    cast r0 r1 into r2 as [address; 2u32];
+    async foo r2 into r3;
+    output r3 as test.aleo/foo.future;
+
+finalize foo:
+    input r0 as [address; 2u32].public;
+    get.or_use allowances[r0] 0u128 into r1;

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/interface_array_key_mapping.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/interface_array_key_mapping.out
@@ -1,0 +1,7 @@
+program test.aleo {
+    const N: u32 = 2u32;
+    mapping allowances: [address; 2] => u128;
+    fn foo() {
+    }
+}
+

--- a/tests/expectations/passes/ssa_const_propagation/array_key_in_mapping.out
+++ b/tests/expectations/passes/ssa_const_propagation/array_key_in_mapping.out
@@ -1,0 +1,6 @@
+program test.aleo {
+    mapping allowances: [address; 2] => u128;
+    fn foo() {
+    }
+}
+

--- a/tests/expectations/passes/ssa_const_propagation/interface_array_key_mapping.out
+++ b/tests/expectations/passes/ssa_const_propagation/interface_array_key_mapping.out
@@ -1,0 +1,6 @@
+program test.aleo {
+    mapping allowances: [address; 2] => u128;
+    fn foo() {
+    }
+}
+

--- a/tests/expectations/passes/ssa_const_propagation/library_module_interface_array_key.out
+++ b/tests/expectations/passes/ssa_const_propagation/library_module_interface_array_key.out
@@ -1,0 +1,9 @@
+Error [ETYC0372186]: Interface definitions are not allowed inside library modules.
+    --> token_types.leo:2:1
+     |
+   2 | interface TokenStorage {
+     | ^^^^^^^^^^^^^^^^^^^^^^^^
+   3 |     mapping allowances: [address; 2] => u128;
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   4 | }
+     | ^

--- a/tests/tests/compiler/mappings/array_key_mapping.leo
+++ b/tests/tests/compiler/mappings/array_key_mapping.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    mapping allowances: [address; 2] => u128;
+
+    fn foo(key0: address, key1: address) -> Final {
+        let key: [address; 2] = [key0, key1];
+        return final { fin_foo(key); };
+    }
+}
+
+final fn fin_foo(key: [address; 2]) {
+    let val: u128 = allowances.get_or_use(key, 0u128);
+}

--- a/tests/tests/compiler/mappings/interface_array_key_mapping.leo
+++ b/tests/tests/compiler/mappings/interface_array_key_mapping.leo
@@ -1,0 +1,19 @@
+// Test: interface with array mapping key compiles end-to-end.
+// Exercises name_validation and static_analysis passes for interface mappings.
+
+interface TokenStorage {
+    mapping allowances: [address; 2] => u128;
+}
+
+program test.aleo: TokenStorage {
+    mapping allowances: [address; 2] => u128;
+
+    fn foo(key0: address, key1: address) -> Final {
+        let key: [address; 2] = [key0, key1];
+        return final { fin_foo(key); };
+    }
+}
+
+final fn fin_foo(key: [address; 2]) {
+    let val: u128 = allowances.get_or_use(key, 0u128);
+}

--- a/tests/tests/passes/const_prop_unroll_and_morphing/interface_array_key_mapping.leo
+++ b/tests/tests/passes/const_prop_unroll_and_morphing/interface_array_key_mapping.leo
@@ -1,0 +1,16 @@
+// Test: const propagation reconstructs interfaces in program scopes, including
+// array lengths that reference const variables. Without the fix to
+// reconstruct_program_scope, the interface mapping key would retain the unfolded
+// const variable instead of the concrete value.
+
+const N: u32 = 2u32;
+
+interface TokenStorage {
+    mapping allowances: [address; N] => u128;
+}
+
+program test.aleo: TokenStorage {
+    mapping allowances: [address; N] => u128;
+
+    fn foo() {}
+}

--- a/tests/tests/passes/ssa_const_propagation/array_key_in_mapping.leo
+++ b/tests/tests/passes/ssa_const_propagation/array_key_in_mapping.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    mapping allowances: [address; 2] => u128;
+
+    fn foo() {}
+}

--- a/tests/tests/passes/ssa_const_propagation/interface_array_key_mapping.leo
+++ b/tests/tests/passes/ssa_const_propagation/interface_array_key_mapping.leo
@@ -1,0 +1,13 @@
+// Test: An interface declaring a mapping with an array key type does not panic in
+// const propagation passes. The interface's array length literal must be visited
+// by the type checker so its NodeID is in the type table.
+
+interface TokenStorage {
+    mapping allowances: [address; 2] => u128;
+}
+
+program test.aleo: TokenStorage {
+    mapping allowances: [address; 2] => u128;
+
+    fn foo() {}
+}

--- a/tests/tests/passes/ssa_const_propagation/library_module_interface_array_key.leo
+++ b/tests/tests/passes/ssa_const_propagation/library_module_interface_array_key.leo
@@ -1,0 +1,21 @@
+// Test: interface with array mapping key in a library submodule does not panic.
+// The type checker must visit interface mappings inside library submodules so that
+// the type table is populated for the array length literal. Without the fix to
+// visit_module, SSA const propagation panics when reconstructing the interface.
+
+// --- library: token_lib --- //
+
+// --- Next Module: token_types.leo --- //
+
+interface TokenStorage {
+    mapping allowances: [address; 2] => u128;
+}
+
+// --- Next Program --- //
+
+program test.aleo {
+    fn foo() {}
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
Closes #29287

- Programs implementing an interface with an array-keyed mapping (e.g. `mapping allowances: [address; 2] => u128`) panicked with "Expected type information to be available" during SSA const propagation.
- Root cause: `visit_interface` — and by extension `visit_program_scope` and `visit_module` — never traversed `Interface.mappings` or `Interface.storages`, so the type checker never inserted array-length literal NodeIDs into the type table for interface definitions. The reconstructor passes (`reconstruct_interface`) did traverse them, causing a lookup of an absent NodeID → panic.
- Fix: made `visit_interface` traverse `mappings` and `storages`; added `visit_interface` calls to `visit_program_scope` and `visit_module` in the default visitor and in all passes that override those methods (type checking, name validation, static analysis). Also corrected an inconsistency in `const_propagation/program.rs` where `reconstruct_program_scope` was not reconstructing interfaces (unlike `reconstruct_module`, which already did).