### PR TITLE
Accept dyn record arguments by looking up interface records (not program records)

### DIFF
--- a/crates/ast/src/interface/mod.rs
+++ b/crates/ast/src/interface/mod.rs
@@ -48,6 +48,17 @@ impl Interface {
     pub fn name(&self) -> Symbol {
         self.identifier.name
     }
+
+    /// Returns `true` if `ty` is a composite type whose name matches a record declared in this interface.
+    pub fn is_record_type(&self, ty: &Type) -> bool {
+        if let Type::Composite(ct) = ty
+            && let Some(loc) = ct.path.try_global_location()
+            && let Some(&name) = loc.path.first()
+        {
+            return self.records.iter().any(|(n, _)| *n == name);
+        }
+        false
+    }
 }
 
 impl PartialEq for Interface {

--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -625,7 +625,7 @@ impl CodeGeneratingVisitor<'_> {
             .iter()
             .map(|inp| {
                 let viz = AleoVisibility::maybe_from(inp.mode()).or(Some(AleoVisibility::Private));
-                self.dynamic_call_input_type(&inp.type_, viz)
+                self.dynamic_call_input_type(&inp.type_, viz, Some(&interface))
             })
             .collect();
 
@@ -648,8 +648,11 @@ impl CodeGeneratingVisitor<'_> {
 
         // Determine output types from the function prototype.
         // call.dynamic requires explicit visibility on every type; default Mode::None to Private.
-        let output_types: Vec<(AleoType, Option<AleoVisibility>)> =
-            func_proto.output.iter().map(|out| self.dynamic_call_output_type(&out.type_, out.mode)).collect();
+        let output_types: Vec<(AleoType, Option<AleoVisibility>)> = func_proto
+            .output
+            .iter()
+            .map(|out| self.dynamic_call_output_type(&out.type_, out.mode, Some(&interface)))
+            .collect();
 
         // Emit CallDynamic instruction.
         instructions.push(AleoStmt::CallDynamic(
@@ -695,7 +698,7 @@ impl CodeGeneratingVisitor<'_> {
                 .iter()
                 .map(|(mode, type_, _)| {
                     let viz = AleoVisibility::maybe_from(*mode).or(Some(AleoVisibility::Private));
-                    self.dynamic_call_input_type(type_, viz)
+                    self.dynamic_call_input_type(type_, viz, None)
                 })
                 .collect()
         } else {
@@ -711,7 +714,7 @@ impl CodeGeneratingVisitor<'_> {
                         .get(&arg.id())
                         .expect("Type checking guarantees argument types are in the type table");
                     let viz = Some(AleoVisibility::Private);
-                    self.dynamic_call_input_type(&ty, viz)
+                    self.dynamic_call_input_type(&ty, viz, None)
                 })
                 .collect()
         };
@@ -724,8 +727,11 @@ impl CodeGeneratingVisitor<'_> {
         }
 
         // Determine output types with visibility annotations.
-        let output_types: Vec<(AleoType, Option<AleoVisibility>)> =
-            input.return_types.iter().map(|(mode, type_, _)| self.dynamic_call_output_type(type_, *mode)).collect();
+        let output_types: Vec<(AleoType, Option<AleoVisibility>)> = input
+            .return_types
+            .iter()
+            .map(|(mode, type_, _)| self.dynamic_call_output_type(type_, *mode, None))
+            .collect();
 
         instructions.push(AleoStmt::CallDynamic(
             prog,

--- a/crates/passes/src/code_generation/type_.rs
+++ b/crates/passes/src/code_generation/type_.rs
@@ -16,7 +16,7 @@
 
 use super::*;
 
-use leo_ast::{IntegerType, Mode, Type};
+use leo_ast::{IntegerType, Interface, Mode, Type};
 
 impl CodeGeneratingVisitor<'_> {
     pub fn visit_type(&self, input: &Type) -> AleoType {
@@ -117,46 +117,34 @@ impl CodeGeneratingVisitor<'_> {
         (self.visit_type(type_), visibility)
     }
 
-    /// Maps a dynamic call input type and mode to an AVM type with visibility.
-    /// Record types (both concrete and `dyn record`) become `DynamicRecord` (no visibility).
-    /// All others use the provided visibility (defaulting to Private).
+    /// Maps a dynamic call input type to an AVM type. `dyn record` and interface record types
+    /// become `DynamicRecord`; all others use the provided visibility.
     pub fn dynamic_call_input_type(
         &self,
         type_: &Type,
         visibility: Option<AleoVisibility>,
+        interface: Option<&Interface>,
     ) -> (AleoType, Option<AleoVisibility>) {
-        if matches!(type_, Type::DynRecord) {
+        if matches!(type_, Type::DynRecord) || interface.is_some_and(|i| i.is_record_type(type_)) {
             return (AleoType::DynamicRecord, None);
-        }
-        if let Type::Composite(composite) = type_ {
-            let composite_location = composite.path.expect_global_location();
-            let this_program_name = self.program_id.unwrap().as_symbol();
-            if self.state.symbol_table.lookup_record(this_program_name, composite_location).is_some() {
-                return (AleoType::DynamicRecord, None);
-            }
         }
         (self.visit_type(type_), visibility)
     }
 
-    /// Maps a dynamic call output type and mode to an AVM type with visibility.
-    /// Futures become `DynamicFuture` (no visibility), record types (both concrete
-    /// and `dyn record`) become `DynamicRecord` (no visibility), all others use the
-    /// provided mode (defaulting to Private).
-    pub fn dynamic_call_output_type(&self, type_: &Type, mode: Mode) -> (AleoType, Option<AleoVisibility>) {
+    /// Maps a dynamic call output type to an AVM type. Futures become `DynamicFuture`, `dyn record`
+    /// and interface record types become `DynamicRecord`; all others use the provided mode.
+    pub fn dynamic_call_output_type(
+        &self,
+        type_: &Type,
+        mode: Mode,
+        interface: Option<&Interface>,
+    ) -> (AleoType, Option<AleoVisibility>) {
         if matches!(type_, Type::Future(..)) {
             (AleoType::DynamicFuture, None)
-        } else if matches!(type_, Type::DynRecord) {
+        } else if matches!(type_, Type::DynRecord) || interface.is_some_and(|i| i.is_record_type(type_)) {
             (AleoType::DynamicRecord, None)
         } else {
             let viz = AleoVisibility::maybe_from(mode).or(Some(AleoVisibility::Private));
-            // Check if this is a concrete record type — those also become DynamicRecord.
-            if let Type::Composite(composite) = type_ {
-                let composite_location = composite.path.expect_global_location();
-                let this_program_name = self.program_id.unwrap().as_symbol();
-                if self.state.symbol_table.lookup_record(this_program_name, composite_location).is_some() {
-                    return (AleoType::DynamicRecord, None);
-                }
-            }
             self.visit_type_with_visibility(type_, viz)
         }
     }

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1087,8 +1087,9 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         // Check argument types. Record-typed parameters require `dyn record` at the call site.
         for (expected_input, argument) in func_proto.input.iter().zip(input.arguments.iter()) {
             let proto_type = expected_input.type_().clone();
-            if self.is_record_type(&proto_type) {
-                let actual_type = self.visit_expression(argument, &Some(Type::DynRecord));
+            if interface.is_record_type(&proto_type) {
+                // Visit without an expected type so only the explicit error below fires.
+                let actual_type = self.visit_expression(argument, &None);
                 if !matches!(actual_type, Type::DynRecord | Type::Err) {
                     self.emit_err(TypeCheckerError::dynamic_call_record_arg_requires_dyn_record(
                         &proto_type,
@@ -1100,9 +1101,8 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
             }
         }
 
-        // If the output type contains a Future, mark it as coming from a dynamic call.
-        // Replace any record types in the output with `dyn record`.
-        let output_type = self.replace_records_with_dyn_record(&func_proto.output_type);
+        // Replace interface record types in the output with `dyn record`, then check for futures.
+        let output_type = self.replace_records_with_dyn_record(&func_proto.output_type, &interface);
         let contains_future = match &output_type {
             Type::Future(..) => true,
             Type::Tuple(tuple) => tuple.elements().iter().any(|t| matches!(t, Type::Future(..))),

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -2256,26 +2256,15 @@ impl TypeCheckingVisitor<'_> {
         comp.cloned()
     }
 
-    /// Returns `true` if `ty` is a composite type whose underlying definition is a record.
-    pub fn is_record_type(&mut self, ty: &Type) -> bool {
-        if let Type::Composite(ct) = ty
-            && let Some(comp) = self.lookup_composite(ct.path.expect_global_location())
-        {
-            return comp.is_record;
-        }
-        false
-    }
-
-    /// Replaces any record-typed composites with `Type::DynRecord`.
-    /// Only recurses into tuples — records cannot be nested inside structs or arrays.
-    pub fn replace_records_with_dyn_record(&mut self, ty: &Type) -> Type {
+    /// Replaces interface record types with `Type::DynRecord`. Only recurses into tuples — records cannot be nested inside structs or arrays.
+    pub fn replace_records_with_dyn_record(&mut self, ty: &Type, interface: &Interface) -> Type {
         match ty {
             Type::DynRecord => Type::DynRecord,
             Type::Tuple(tuple) => Type::Tuple(TupleType::new(
-                tuple.elements().iter().map(|t| self.replace_records_with_dyn_record(t)).collect(),
+                tuple.elements().iter().map(|t| self.replace_records_with_dyn_record(t, interface)).collect(),
             )),
             other => {
-                if self.is_record_type(other) {
+                if interface.is_record_type(other) {
                     Type::DynRecord
                 } else {
                     other.clone()

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_interface_dyn_record_arg.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_interface_dyn_record_arg.out
@@ -1,0 +1,8 @@
+program foo.aleo;
+
+function main:
+    input r0 as identifier.private;
+    input r1 as dynamic.record;
+    input r2 as address.private;
+    call.dynamic r0 'aleo' 'transfer_private' with r1 r2 (as dynamic.record address.private) into r3 (as dynamic.record);
+    output r3 as dynamic.record;

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_interface_record_arg_cast_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_interface_record_arg_cast_fail.out
@@ -1,12 +1,17 @@
-Error [ETYC0372117]: Expected type `dyn record` but type `test.aleo::Token` was found.
-    --> compiler-test:17:55
+Error [ETYC0372187]: Dynamic call argument has record type `vault.aleo::Token`, but dynamic calls require `dyn record`.
+    --> compiler-test:7:56
      |
-  17 |         return test.aleo::TokenOps@(target)::transfer(t);
-     |                                                       ^
-Error [ETYC0372187]: Dynamic call argument has record type `test.aleo::Token`, but dynamic calls require `dyn record`.
-    --> compiler-test:17:55
-     |
-  17 |         return test.aleo::TokenOps@(target)::transfer(t);
-     |                                                       ^
+   7 |         return vault.aleo::TokenOps@(target)::transfer(t);
+     |                                                        ^
      |
      = Cast your record value with `my_arg as dyn record`.
+
+
+---
+Note: Treating dependencies as Aleo produces different results:
+
+Error [ETYC0372005]: Unknown interface `vault.aleo::TokenOps`
+    --> compiler-test:7:16
+     |
+   7 |         return vault.aleo::TokenOps@(target)::transfer(t);
+     |                ^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_interface_record_cast.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_interface_record_cast.out
@@ -1,20 +1,7 @@
-program test.aleo;
+program router.aleo;
 
-record Token:
-    owner as address.private;
-    amount as u64.private;
-
-function transfer:
-    input r0 as Token.record;
-    cast r0.owner r0.amount into r1 as Token.record;
-    output r1 as Token.record;
-
-function main:
+function dispatch:
     input r0 as field.private;
-    input r1 as Token.record;
-    cast r1 into r2 as dynamic.record;
-    call.dynamic r0 'aleo' 'transfer' with r2 (as dynamic.record) into r3 (as dynamic.record);
-    output r3 as dynamic.record;
-
-constructor:
-    assert.eq edition 0u16;
+    input r1 as dynamic.record;
+    call.dynamic r0 'aleo' 'transfer' with r1 (as dynamic.record) into r2 (as dynamic.record);
+    output r2 as dynamic.record;

--- a/tests/expectations/execution/dynamic_call_record_interface.out
+++ b/tests/expectations/execution/dynamic_call_record_interface.out
@@ -1,4 +1,4 @@
-program token_impl.aleo;
+program vault.aleo;
 
 record Token:
     owner as address.private;
@@ -10,7 +10,7 @@ function double_balance:
     cast r0.owner r1 into r2 as Token.record;
     output r2 as Token.record;
 
-function get_initial:
+function mint:
     input r0 as u64.private;
     cast self.signer r0 into r1 as Token.record;
     output r1 as Token.record;
@@ -18,17 +18,16 @@ function get_initial:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import token_impl.aleo;
-program caller.aleo;
+import vault.aleo;
+program router.aleo;
 
-function main:
-    input r0 as address.private;
-    input r1 as u64.private;
-    call token_impl.aleo/get_initial r1 into r2;
-    cast r2 into r3 as dynamic.record;
-    call.dynamic 'token_impl' 'aleo' 'double_balance' with r3 (as dynamic.record) into r4 (as dynamic.record);
-    get.record.dynamic r4.balance into r5 as u64;
-    output r5 as u64.private;
+function dispatch:
+    input r0 as u64.private;
+    call vault.aleo/mint r0 into r1;
+    cast r1 into r2 as dynamic.record;
+    call.dynamic 'vault' 'aleo' 'double_balance' with r2 (as dynamic.record) into r3 (as dynamic.record);
+    get.record.dynamic r3.balance into r4 as u64;
+    output r4 as u64.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_interface_dyn_record_arg.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_interface_dyn_record_arg.leo
@@ -1,0 +1,14 @@
+// OK: Dynamic call passing `dyn record` where the interface function expects a record type.
+// The calling program does not implement the interface, so the record type is not in the
+// program's symbol table. A `dyn record` argument should be accepted for any record-typed
+// interface parameter.
+interface ARC20 {
+    record Token;
+    fn transfer_private(token: Token, to: address) -> Token;
+}
+
+program foo.aleo {
+    fn main(target: identifier, token: dyn record, to: address) -> dyn record {
+        return ARC20@(target)::transfer_private(token, to);
+    }
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_interface_record_arg_cast_fail.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_interface_record_arg_cast_fail.leo
@@ -1,9 +1,11 @@
-// FAIL: Dynamic call with interface passes concrete record instead of dyn record.
+// FAIL: A non-implementing caller passes a concrete record to a dynamic call.
+// Record arguments to interface dynamic calls must always be dyn record.
 interface TokenOps {
+    record Token;
     fn transfer(t: Token) -> Token;
 }
 
-program test.aleo: TokenOps {
+program vault.aleo: TokenOps {
     record Token {
         owner: address,
         amount: u64,
@@ -13,8 +15,21 @@ program test.aleo: TokenOps {
         return t;
     }
 
-    fn main(target: field, t: Token) -> dyn record {
-        return test.aleo::TokenOps@(target)::transfer(t);
+    fn mint(owner: address, amount: u64) -> Token {
+        return Token { owner, amount };
+    }
+
+    @noupgrade
+    constructor() {}
+}
+
+// --- Next Program --- //
+import vault.aleo;
+
+program caller.aleo {
+    fn route(target: field, owner: address, amount: u64) -> dyn record {
+        let t: vault.aleo::Token = vault.aleo::mint(owner, amount);
+        return vault.aleo::TokenOps@(target)::transfer(t);
     }
 
     @noupgrade

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_interface_record_cast.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_interface_record_cast.leo
@@ -1,22 +1,12 @@
-// OK: Dynamic call with interface casts record to dyn record.
+// OK: A router program accepts a dyn record and dispatches it via interface dynamic call.
+// The router does not implement the interface — it acts purely as a dispatcher.
 interface TokenOps {
+    record Token;
     fn transfer(t: Token) -> Token;
 }
 
-program test.aleo: TokenOps {
-    record Token {
-        owner: address,
-        amount: u64,
+program router.aleo {
+    fn dispatch(target: field, token: dyn record) -> dyn record {
+        return router.aleo::TokenOps@(target)::transfer(token);
     }
-
-    fn transfer(t: Token) -> Token {
-        return t;
-    }
-
-    fn main(target: field, t: Token) -> dyn record {
-        return test.aleo::TokenOps@(target)::transfer(t as dyn record);
-    }
-
-    @noupgrade
-    constructor() {}
 }

--- a/tests/tests/execution/dynamic_call_record_interface.leo
+++ b/tests/tests/execution/dynamic_call_record_interface.leo
@@ -2,16 +2,17 @@
 seed = 123456789
 
 [case]
-program = "caller.aleo"
-function = "main"
-input = ["aleo14lskz87tkqwwkyt2z44h64ave5gcwqs6yyfdztus37nupxsj8ypsmqsqcs", "50u64"]
+program = "router.aleo"
+function = "dispatch"
+input = ["50u64"]
 */
 
 interface TokenOps {
+    record Token;
     fn double_balance(t: Token) -> Token;
 }
 
-program token_impl.aleo: TokenOps {
+program vault.aleo: TokenOps {
     record Token {
         owner: address,
         balance: u64,
@@ -21,7 +22,8 @@ program token_impl.aleo: TokenOps {
         return Token { owner: t.owner, balance: t.balance * 2u64 };
     }
 
-    fn get_initial(balance: u64) -> Token {
+    // Mints a token owned by the transaction signer.
+    fn mint(balance: u64) -> Token {
         return Token { owner: self.signer, balance };
     }
 
@@ -30,15 +32,16 @@ program token_impl.aleo: TokenOps {
 }
 
 // --- Next Program --- //
-import token_impl.aleo;
+import vault.aleo;
 
-program caller.aleo {
+// router.aleo does not implement TokenOps — it is a pure dispatcher that routes
+// dyn record tokens to any program that implements the interface at runtime.
+program router.aleo {
 
-    fn main(owner: address, balance: u64) -> u64 {
-        let t: token_impl.aleo::Token = token_impl.aleo::get_initial(balance);
-        let result: dyn record = token_impl.aleo::TokenOps@('token_impl')::double_balance(t as dyn record);
-        let b: u64 = result.balance;
-        return b;
+    fn dispatch(balance: u64) -> u64 {
+        let token: dyn record = vault.aleo::mint(balance) as dyn record;
+        let result: dyn record = vault.aleo::TokenOps@('vault')::double_balance(token);
+        return result.balance;
     }
 
     @noupgrade


### PR DESCRIPTION
Closes #29295

## Summary

When a program calls an interface function via dynamic dispatch, the type checker incorrectly rejected `dyn record` arguments even though that is the only valid type to pass. This happened because record-type detection relied on the calling program's symbol table, which has no entry for records declared in an interface the program does not implement.

The fix makes the interface itself the sole authority on what constitutes a record type in a dynamic call. Record types are now detected by checking the interface's own `record` declarations rather than looking up the calling program's symbol table. The same fix is applied in code generation, ensuring `dynamic.record` is emitted in Aleo bytecode for interface record parameters and return types regardless of whether the calling program implements the interface.

## Changes

- **Type checker** (`visit_dynamic_call`): detect record-typed parameters via `is_interface_record_type`, which checks the interface's declared records — no symbol table lookup of the calling program
- **Type checker**: replace record types in the output with `dyn record` using the same interface-aware check
- **Code generation** (`dynamic_call_input_type`, `dynamic_call_output_type`): emit `dynamic.record` for interface record types even when the calling program does not implement the interface
- **Tests**: updated compiler and execution tests so interfaces explicitly declare their record types with `record Foo;`, and rewrote the dynamic dispatch compiler tests to use a proper router/dispatcher pattern instead of a program calling its own interface