### PR TITLE
Fix panic on out-of-bounds tuple access in final block

### DIFF
--- a/crates/passes/src/common/block_to_function_rewriter.rs
+++ b/crates/passes/src/common/block_to_function_rewriter.rs
@@ -146,6 +146,12 @@ impl BlockToFunctionRewriter<'_> {
                             return vec![];
                         };
 
+                        // The type checker has already emitted an error for this out-of-bounds access;
+                        // return no inputs so compilation can continue to report all diagnostics.
+                        if index >= elements.len() {
+                            return vec![];
+                        }
+
                         let synthetic_name = format!("\"{symbol}.{index}\"");
                         let synthetic_symbol = Symbol::intern(&synthetic_name);
                         let identifier = make_identifier(slf, synthetic_symbol);

--- a/tests/expectations/compiler/bugs/b29309_fail.out
+++ b/tests/expectations/compiler/bugs/b29309_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372024]: Tuple index `8` out of range for a tuple with length `3`
+    --> compiler-test:7:32
+     |
+   7 |         return final { let _ = y.8; };
+     |                                ^^^

--- a/tests/tests/compiler/bugs/b29309_fail.leo
+++ b/tests/tests/compiler/bugs/b29309_fail.leo
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29309
+// The compiler should emit a diagnostic error, not panic, when a tuple element
+// access inside a `final { }` block uses an out-of-bounds index.
+program test.aleo {
+    fn foo() -> Final {
+        let y = (1u32, 2u8, 3u16);
+        return final { let _ = y.8; };
+    }
+}


### PR DESCRIPTION
  BlockToFunctionRewriter panicked with an index-out-of-bounds when a final { } block contained a tuple access with an out-of-range index (e.g. y.8 on a 3-element tuple). The type checker correctly emitted a diagnostic, but the rewriter then indexed elements[index] without a bounds check, crashing the compiler. Added a guard that mirrors the existing one for non-tuple types: when index >= elements.len(), return no inputs and let the already-emitted error surface cleanly. Added a regression test that confirms the compiler now produces Error [ETYC0372024] instead of panicking.

Closes #29309 