### PR TITLE
Fix compiler panic when destructuring a non-tuple value

### DIFF
--- a/crates/errors/src/errors/type_checker/type_checker_error.rs
+++ b/crates/errors/src/errors/type_checker/type_checker_error.rs
@@ -1523,4 +1523,11 @@ create_messages!(
         msg: format!("Vector types can only be used in storage declarations."),
         help: None,
     }
+
+    @formatted
+    multi_identifier_definition_requires_tuple {
+        args: (type_: impl Display),
+        msg: format!("A definition with multiple identifiers requires a tuple on the right-hand side, but found type `{type_}`."),
+        help: Some("Use a tuple expression, e.g. `let (a, b) = (x, y);`.".to_string()),
+    }
 );

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -2189,7 +2189,13 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                     (Some(Type::Tuple(tuple_type)), _) => tuple_type.clone(),
                     (None, Type::Tuple(tuple_type)) => tuple_type.clone(),
                     _ => {
-                        // This is an error but should have been emitted earlier. Just exit here.
+                        // This is a type error: no tuple type could be determined for this binding.
+                        // An error should have been emitted by the expression visitor. Set all
+                        // identifiers to `Type::Err` to uphold the invariant that every variable has
+                        // a known type after type checking, preventing downstream panics.
+                        for identifier in identifiers {
+                            self.set_local_type(Some(Type::Err), identifier, Type::Err);
+                        }
                         return;
                     }
                 };

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -2188,6 +2188,21 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                 let tuple_type = match (&input.type_, inferred_type.clone()) {
                     (Some(Type::Tuple(tuple_type)), _) => tuple_type.clone(),
                     (None, Type::Tuple(tuple_type)) => tuple_type.clone(),
+                    (None, rhs_type) => {
+                        // No annotation and the RHS is not a tuple. Emit a diagnostic and set all
+                        // identifiers to `Type::Err` to uphold the invariant that every variable has
+                        // a known type after type checking, preventing downstream panics.
+                        if !matches!(rhs_type, Type::Err) {
+                            self.emit_err(TypeCheckerError::multi_identifier_definition_requires_tuple(
+                                rhs_type,
+                                input.span(),
+                            ));
+                        }
+                        for identifier in identifiers {
+                            self.set_local_type(Some(Type::Err), identifier, Type::Err);
+                        }
+                        return;
+                    }
                     _ => {
                         // This is a type error: no tuple type could be determined for this binding.
                         // An error should have been emitted by the expression visitor. Set all

--- a/tests/expectations/compiler/bugs/b29305_fail.out
+++ b/tests/expectations/compiler/bugs/b29305_fail.out
@@ -1,0 +1,7 @@
+Error [ETYC0372190]: A definition with multiple identifiers requires a tuple on the right-hand side, but found type `u32`.
+    --> compiler-test:6:9
+     |
+   6 |         let (a, b) = 42u32;
+     |         ^^^^^^^^^^^^^^^^^^^
+     |
+     = Use a tuple expression, e.g. `let (a, b) = (x, y);`.

--- a/tests/expectations/compiler/bugs/b29307_fail.out
+++ b/tests/expectations/compiler/bugs/b29307_fail.out
@@ -1,0 +1,5 @@
+Error [ETYC0372117]: Expected u32 but type `(u32, u32)` was found.
+    --> compiler-test:7:27
+     |
+   7 |         let (a, b): u32 = (1u32, 2u32);
+     |                           ^^^^^^^^^^^^

--- a/tests/tests/compiler/bugs/b29305_fail.leo
+++ b/tests/tests/compiler/bugs/b29305_fail.leo
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29305
+// The compiler should emit a type error, not panic, when a multi-identifier
+// definition's RHS is not a tuple type.
+program test.aleo {
+    fn main() -> u32 {
+        let (a, b) = 42u32;
+        return a;
+    }
+}

--- a/tests/tests/compiler/bugs/b29307_fail.leo
+++ b/tests/tests/compiler/bugs/b29307_fail.leo
@@ -1,0 +1,10 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29307
+// The compiler should emit a diagnostic error, not panic, when a `let` binding
+// uses a non-tuple type annotation for a multi-variable destructuring and one of
+// the resulting variables is referenced inside a `final { ... }` block.
+program test.aleo {
+    fn main() -> (u32, Final) {
+        let (a, b): u32 = (1u32, 2u32);
+        return (a, final { let _ = b; });
+    }
+}


### PR DESCRIPTION
Fixes two compiler panics in multi-identifier \`let\` destructuring.

- **#29305**: When the RHS is not a tuple and no type annotation is present (e.g. \`let (a, b) = 42u32;\`), the compiler now emits a proper type error instead of panicking.
- **#29307**: When a non-tuple type annotation is used (e.g. \`let (a, b): u32 = ...;\`), the compiler fell through to an early return without registering variable types, causing downstream panics (e.g. when the variables were referenced in a \`final {}\` block).

In both cases, all bound identifiers are now registered as \`Type::Err\` to uphold the invariant that every variable has a known type after type checking, preventing downstream panics.

Closes #29305
Closes #29307