### PR TITLE
Fix panic on unsuffixed integer literal in dynamic intrinsic arguments

### DIFF
--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -1545,7 +1545,7 @@ impl TypeCheckingVisitor<'_> {
         }
         for (i, arg) in input.arguments.iter().skip(3).enumerate() {
             let expected = input.input_types.get(i).map(|(_, t, _)| t.clone());
-            self.visit_expression(arg, &expected);
+            self.visit_expression_reject_numeric(arg, &expected);
         }
 
         // Reject `constant` visibility on input and return types.
@@ -1627,9 +1627,9 @@ impl TypeCheckingVisitor<'_> {
             }
         }
 
-        // Arg 4 (key): any type.
+        // Arg 4 (key): any type, but must be fully typed (unsuffixed literals are rejected).
         if input.arguments.len() > 3 {
-            self.visit_expression(&input.arguments[3], &None);
+            self.visit_expression_reject_numeric(&input.arguments[3], &None);
         }
 
         // Determine return type.

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_fail.out
@@ -1,0 +1,7 @@
+Error [ETYC0372004]: Could not determine the type of `1`
+    --> compiler-test:6:55
+     |
+   6 |         return _dynamic_call::[u64]('a', 'aleo', 'b', 1);
+     |                                                       ^
+     |
+     = Consider using explicit type annotations.

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_inferred.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_inferred.out
@@ -1,0 +1,5 @@
+program test.aleo;
+
+function main:
+    call.dynamic 'a' 'aleo' 'b' with 1u64 (as u64.public) into r0 (as u64.private);
+    output r0 as u64.private;

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_contains_unsuffixed_key_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_contains_unsuffixed_key_fail.out
@@ -1,0 +1,7 @@
+Error [ETYC0372004]: Could not determine the type of `1`
+    --> compiler-test:11:62
+     |
+  11 |     let _: bool = _dynamic_contains(prog, net, mapping_name, 1);
+     |                                                              ^
+     |
+     = Consider using explicit type annotations.

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_default_inferred.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_default_inferred.out
@@ -1,0 +1,16 @@
+program test.aleo;
+
+function get:
+    input r0 as field.private;
+    input r1 as field.private;
+    input r2 as field.private;
+    input r3 as u64.private;
+    async get r0 r1 r2 r3 into r4;
+    output r4 as test.aleo/get.future;
+
+finalize get:
+    input r0 as field.public;
+    input r1 as field.public;
+    input r2 as field.public;
+    input r3 as u64.public;
+    get.or_use.dynamic r0 r1 r2[r3] 1u64 into r4 as u64;

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_key_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_key_fail.out
@@ -1,0 +1,7 @@
+Error [ETYC0372004]: Could not determine the type of `1`
+    --> compiler-test:11:70
+     |
+  11 |     let _: u64 = _dynamic_get_or_use::[u64](prog, net, mapping_name, 1, 0u64);
+     |                                                                      ^
+     |
+     = Consider using explicit type annotations.

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_get_unsuffixed_key_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_get_unsuffixed_key_fail.out
@@ -1,0 +1,7 @@
+Error [ETYC0372004]: Could not determine the type of `1`
+    --> compiler-test:11:63
+     |
+  11 |     let _: u64 = _dynamic_get::[u64](prog, net, mapping_name, 1);
+     |                                                               ^
+     |
+     = Consider using explicit type annotations.

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_fail.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_fail.leo
@@ -1,0 +1,8 @@
+// FAIL: unsuffixed integer literal as _dynamic_call argument without input_types annotation.
+// The literal `1` has no expected type (input_types is absent), so type inference fails.
+// Fix: annotate the call with _dynamic_call::[public u64, u64](...) or suffix the literal (1u64).
+program test.aleo {
+    fn main() -> u64 {
+        return _dynamic_call::[u64]('a', 'aleo', 'b', 1);
+    }
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_inferred.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_call_unsuffixed_arg_inferred.leo
@@ -1,0 +1,7 @@
+// PASS: unsuffixed integer literal as _dynamic_call argument, inferred from explicit input_types.
+// The literal `1` resolves to u64 because input_types provides the expected type.
+program test.aleo {
+    fn main() -> u64 {
+        return _dynamic_call::[public u64, u64]('a', 'aleo', 'b', 1);
+    }
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_contains_unsuffixed_key_fail.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_contains_unsuffixed_key_fail.leo
@@ -1,0 +1,12 @@
+// FAIL: unsuffixed integer literal as _dynamic_contains key argument.
+// The key `1` has no expected type; type inference fails.
+// Fix: use a suffixed literal such as 1u64.
+program test.aleo {
+    fn check(prog: field, net: field, mapping_name: field) -> Final {
+        return final { finalize_check(prog, net, mapping_name); };
+    }
+}
+
+final fn finalize_check(prog: field, net: field, mapping_name: field) {
+    let _: bool = _dynamic_contains(prog, net, mapping_name, 1);
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_default_inferred.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_default_inferred.leo
@@ -1,0 +1,11 @@
+// PASS: unsuffixed integer literal as _dynamic_get_or_use default argument, inferred from type parameter.
+// The default `1` resolves to u64 because the type parameter provides the expected type.
+program test.aleo {
+    fn get(prog: field, net: field, mapping_name: field, key: u64) -> Final {
+        return final { finalize_get(prog, net, mapping_name, key); };
+    }
+}
+
+final fn finalize_get(prog: field, net: field, mapping_name: field, key: u64) {
+    let _: u64 = _dynamic_get_or_use::[u64](prog, net, mapping_name, key, 1);
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_key_fail.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_get_or_use_unsuffixed_key_fail.leo
@@ -1,0 +1,12 @@
+// FAIL: unsuffixed integer literal as _dynamic_get_or_use key argument.
+// The key `1` has no expected type; type inference fails.
+// Fix: use a suffixed literal such as 1u64.
+program test.aleo {
+    fn check(prog: field, net: field, mapping_name: field) -> Final {
+        return final { finalize_check(prog, net, mapping_name); };
+    }
+}
+
+final fn finalize_check(prog: field, net: field, mapping_name: field) {
+    let _: u64 = _dynamic_get_or_use::[u64](prog, net, mapping_name, 1, 0u64);
+}

--- a/tests/tests/compiler/dynamic_dispatch/dynamic_get_unsuffixed_key_fail.leo
+++ b/tests/tests/compiler/dynamic_dispatch/dynamic_get_unsuffixed_key_fail.leo
@@ -1,0 +1,12 @@
+// FAIL: unsuffixed integer literal as _dynamic_get key argument.
+// The key `1` has no expected type; type inference fails.
+// Fix: use a suffixed literal such as 1u64.
+program test.aleo {
+    fn check(prog: field, net: field, mapping_name: field) -> Final {
+        return final { finalize_check(prog, net, mapping_name); };
+    }
+}
+
+final fn finalize_check(prog: field, net: field, mapping_name: field) {
+    let _: u64 = _dynamic_get::[u64](prog, net, mapping_name, 1);
+}


### PR DESCRIPTION
## Summary

Fixes #29316 — compiler panic (`Unexpected type for unsuffixed integer literal. This should have been caught by the type checker`) when an unsuffixed integer literal (e.g. `1` instead of `1u64`) is passed as an argument to any of the four dynamic intrinsics.

- **Root cause**: `check_dynamic_call` and `check_dynamic_mapping_op` visited untyped argument positions with `visit_expression(..., &None)`. An unsuffixed literal then resolves to `Type::Numeric`, which is stored in the `type_table`. Codegen later reads `Type::Numeric` and panics because it only handles `Integer`/`Field`/`Group`/`Scalar`.
- **Fix**: Use `visit_expression_reject_numeric` at both sites so `Type::Numeric` emits `ETYC0372004` ("Could not determine the type") and stores `Type::Err` instead, stopping compilation before codegen.
- **Inference preserved**: When `input_types` covers an argument (e.g. `_dynamic_call::[public u64, u64](..., 1)`), the expected type flows through and the unsuffixed literal is correctly resolved to `u64`. The `_dynamic_get_or_use` default value already had an expected type from the type parameter and is unaffected.