### PR TITLE
Fix panics when comparing unit-type expressions

### DIFF
--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -199,8 +199,21 @@ impl CodeGeneratingVisitor<'_> {
     fn visit_binary(&mut self, input: &BinaryExpression) -> (AleoExpr, Vec<AleoStmt>) {
         let (left, left_instructions) = self.visit_expression(&input.left);
         let (right, right_instructions) = self.visit_expression(&input.right);
-        let left = left.expect("Trying to operate on an empty expression");
-        let right = right.expect("Trying to operate on an empty expression");
+
+        let (left, right) = match (left, right) {
+            (Some(l), Some(r)) => (l, r),
+            (None, None) => {
+                // Both operands are Unit type. Only equality comparisons are valid; the result is constant.
+                let mut instructions = left_instructions;
+                instructions.extend(right_instructions);
+                return match input.op {
+                    BinaryOperation::Eq => (AleoExpr::Bool(true), instructions),
+                    BinaryOperation::Neq => (AleoExpr::Bool(false), instructions),
+                    _ => panic!("Non-equality binary operations cannot have Unit-type operands."),
+                };
+            }
+            _ => panic!("Both operands of a binary expression must have the same type."),
+        };
 
         let dest_reg = self.next_register();
 

--- a/crates/passes/src/code_generation/statement.rs
+++ b/crates/passes/src/code_generation/statement.rs
@@ -64,27 +64,27 @@ impl CodeGeneratingVisitor<'_> {
             AssertVariant::AssertEq(left, right) => {
                 let (left, left_stmts) = self.visit_expression(left);
                 let (right, right_stmts) = self.visit_expression(right);
-                let left = left.expect("Trying to assert an empty expression.");
-                let right = right.expect("Trying to assert an empty expression.");
-                let assert_instruction = AleoStmt::AssertEq(left, right);
-
-                // Concatenate the instructions.
                 let mut instructions = left_stmts;
                 instructions.extend(right_stmts);
-                instructions.push(assert_instruction);
+                match (left, right) {
+                    (Some(left), Some(right)) => instructions.push(AleoStmt::AssertEq(left, right)),
+                    // Unit == Unit is trivially true; no instruction is needed.
+                    (None, None) => {}
+                    _ => panic!("Both operands of assert_eq must have the same type."),
+                }
                 instructions
             }
             AssertVariant::AssertNeq(left, right) => {
                 let (left, left_stmts) = self.visit_expression(left);
                 let (right, right_stmts) = self.visit_expression(right);
-                let left = left.expect("Trying to assert an empty expression.");
-                let right = right.expect("Trying to assert an empty expression.");
-                let assert_instruction = AleoStmt::AssertNeq(left, right);
-
-                // Concatenate the instructions.
                 let mut instructions = left_stmts;
                 instructions.extend(right_stmts);
-                instructions.push(assert_instruction);
+                match (left, right) {
+                    (Some(left), Some(right)) => instructions.push(AleoStmt::AssertNeq(left, right)),
+                    // Unit != Unit is trivially false; emit an instruction that always fails.
+                    (None, None) => instructions.push(AleoStmt::AssertEq(AleoExpr::Bool(false), AleoExpr::Bool(true))),
+                    _ => panic!("Both operands of assert_neq must have the same type."),
+                }
                 instructions
             }
         }

--- a/crates/passes/src/flattening/visitor.rs
+++ b/crates/passes/src/flattening/visitor.rs
@@ -351,10 +351,11 @@ impl FlatteningVisitor<'_> {
         }
         // Otherwise, push a dummy return statement to the end of the block.
         else {
+            let unit_id = self.state.node_builder.next_id();
+            self.state.type_table.insert(unit_id, Type::Unit);
             block.statements.push(
                 ReturnStatement {
-                    expression: UnitExpression { span: Default::default(), id: self.state.node_builder.next_id() }
-                        .into(),
+                    expression: UnitExpression { span: Default::default(), id: unit_id }.into(),
                     span: Default::default(),
                     id: self.state.node_builder.next_id(),
                 }

--- a/tests/expectations/compiler/bugs/b29314.out
+++ b/tests/expectations/compiler/bugs/b29314.out
@@ -1,0 +1,16 @@
+program test.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.public;
+    async main r0 into r1;
+    output r1 as test.aleo/main.future;
+
+finalize main:
+    input r0 as u32.public;
+    set r0 into values[r0];
+    set r0 into values[r0];
+    assert.eq true true;

--- a/tests/expectations/compiler/bugs/b29314_assert_eq_direct.out
+++ b/tests/expectations/compiler/bugs/b29314_assert_eq_direct.out
@@ -1,0 +1,15 @@
+program test.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.public;
+    async main r0 into r1;
+    output r1 as test.aleo/main.future;
+
+finalize main:
+    input r0 as u32.public;
+    set r0 into values[r0];
+    set r0 into values[r0];

--- a/tests/expectations/compiler/bugs/b29314_assert_neq.out
+++ b/tests/expectations/compiler/bugs/b29314_assert_neq.out
@@ -1,0 +1,16 @@
+program test.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.public;
+    async main r0 into r1;
+    output r1 as test.aleo/main.future;
+
+finalize main:
+    input r0 as u32.public;
+    set r0 into values[r0];
+    set r0 into values[r0];
+    assert.eq false true;

--- a/tests/expectations/compiler/bugs/b29315.out
+++ b/tests/expectations/compiler/bugs/b29315.out
@@ -1,0 +1,13 @@
+program test.aleo;
+
+mapping m:
+    key as u32.public;
+    value as u32.public;
+
+function foo:
+    async foo into r0;
+    output r0 as test.aleo/foo.future;
+
+finalize foo:
+    set 0u32 into m[0u32];
+    set 0u32 into m[0u32];

--- a/tests/expectations/compiler/bugs/b29315_assert_neq.out
+++ b/tests/expectations/compiler/bugs/b29315_assert_neq.out
@@ -1,0 +1,14 @@
+program test.aleo;
+
+mapping m:
+    key as u32.public;
+    value as u32.public;
+
+function foo:
+    async foo into r0;
+    output r0 as test.aleo/foo.future;
+
+finalize foo:
+    set 0u32 into m[0u32];
+    set 0u32 into m[0u32];
+    assert.eq false true;

--- a/tests/expectations/compiler/bugs/b29315_eq_binary.out
+++ b/tests/expectations/compiler/bugs/b29315_eq_binary.out
@@ -1,0 +1,14 @@
+program test.aleo;
+
+mapping m:
+    key as u32.public;
+    value as u32.public;
+
+function foo:
+    async foo into r0;
+    output r0 as test.aleo/foo.future;
+
+finalize foo:
+    set 0u32 into m[0u32];
+    set 0u32 into m[0u32];
+    assert.eq true true;

--- a/tests/expectations/execution/unit_assert_eq.out
+++ b/tests/expectations/execution/unit_assert_eq.out
@@ -1,0 +1,48 @@
+program test.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.public;
+    async main r0 into r1;
+    output r1 as test.aleo/main.future;
+
+finalize main:
+    input r0 as u32.public;
+    set r0 into values[r0];
+    set r0 into values[r0];
+
+constructor:
+    assert.eq edition 0u16;
+verified: true
+status: accepted
+{
+  "transitions": [
+    {
+      "id": "au1jfcjz7yerg0k8lvey2mc6sfq022263sng9kunmngs3wszezkqv8snlkucd",
+      "program": "test.aleo",
+      "function": "main",
+      "inputs": [
+        {
+          "type": "public",
+          "id": "7773034874610117133230516208382923742290004600358329673188095387730767902690field",
+          "value": "5u32"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "future",
+          "id": "6507007117229272484477344824608470491166824174191595712441883272056843115716field",
+          "value": "{\n  program_id: test.aleo,\n  function_name: main,\n  arguments: [\n    5u32\n  ]\n}"
+        }
+      ],
+      "tpk": "3692622213593196582239088403386301302928630797329676351131222279372480359426group",
+      "tcm": "3696696342970920102486901480960985333336648147126379294698152091542749337271field",
+      "scm": "4396256668744344446249151407765855403536642777056702396775934577520814761469field"
+    }
+  ],
+  "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
+}
+

--- a/tests/expectations/execution/unit_assert_neq.out
+++ b/tests/expectations/execution/unit_assert_neq.out
@@ -1,0 +1,49 @@
+program test.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function main:
+    input r0 as u32.public;
+    async main r0 into r1;
+    output r1 as test.aleo/main.future;
+
+finalize main:
+    input r0 as u32.public;
+    set r0 into values[r0];
+    set r0 into values[r0];
+    assert.eq false true;
+
+constructor:
+    assert.eq edition 0u16;
+verified: true
+status: rejected
+{
+  "transitions": [
+    {
+      "id": "au1jfcjz7yerg0k8lvey2mc6sfq022263sng9kunmngs3wszezkqv8snlkucd",
+      "program": "test.aleo",
+      "function": "main",
+      "inputs": [
+        {
+          "type": "public",
+          "id": "7773034874610117133230516208382923742290004600358329673188095387730767902690field",
+          "value": "5u32"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "future",
+          "id": "6507007117229272484477344824608470491166824174191595712441883272056843115716field",
+          "value": "{\n  program_id: test.aleo,\n  function_name: main,\n  arguments: [\n    5u32\n  ]\n}"
+        }
+      ],
+      "tpk": "3692622213593196582239088403386301302928630797329676351131222279372480359426group",
+      "tcm": "3696696342970920102486901480960985333336648147126379294698152091542749337271field",
+      "scm": "4396256668744344446249151407765855403536642777056702396775934577520814761469field"
+    }
+  ],
+  "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
+}
+

--- a/tests/tests/compiler/bugs/b29314.leo
+++ b/tests/tests/compiler/bugs/b29314.leo
@@ -1,0 +1,13 @@
+program test.aleo {
+    mapping values: u32 => u32;
+
+    fn main(public a: u32) -> Final {
+        return final {
+            assert(fin_foo(a) == fin_foo(a));
+        };
+    }
+}
+
+final fn fin_foo(a: u32) {
+    Mapping::set(values, a, a);
+}

--- a/tests/tests/compiler/bugs/b29314_assert_eq_direct.leo
+++ b/tests/tests/compiler/bugs/b29314_assert_eq_direct.leo
@@ -1,0 +1,13 @@
+program test.aleo {
+    mapping values: u32 => u32;
+
+    fn main(public a: u32) -> Final {
+        return final {
+            assert_eq(fin_foo(a), fin_foo(a));
+        };
+    }
+}
+
+final fn fin_foo(a: u32) {
+    Mapping::set(values, a, a);
+}

--- a/tests/tests/compiler/bugs/b29314_assert_neq.leo
+++ b/tests/tests/compiler/bugs/b29314_assert_neq.leo
@@ -1,0 +1,13 @@
+program test.aleo {
+    mapping values: u32 => u32;
+
+    fn main(public a: u32) -> Final {
+        return final {
+            assert(fin_foo(a) != fin_foo(a));
+        };
+    }
+}
+
+final fn fin_foo(a: u32) {
+    Mapping::set(values, a, a);
+}

--- a/tests/tests/compiler/bugs/b29315.leo
+++ b/tests/tests/compiler/bugs/b29315.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    mapping m: u32 => u32;
+
+    fn foo() -> Final {
+        return final { assert_eq(Mapping::set(m, 0u32, 0u32), Mapping::set(m, 0u32, 0u32)); };
+    }
+}

--- a/tests/tests/compiler/bugs/b29315_assert_neq.leo
+++ b/tests/tests/compiler/bugs/b29315_assert_neq.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    mapping m: u32 => u32;
+
+    fn foo() -> Final {
+        return final { assert_neq(Mapping::set(m, 0u32, 0u32), Mapping::set(m, 0u32, 0u32)); };
+    }
+}

--- a/tests/tests/compiler/bugs/b29315_eq_binary.leo
+++ b/tests/tests/compiler/bugs/b29315_eq_binary.leo
@@ -1,0 +1,7 @@
+program test.aleo {
+    mapping m: u32 => u32;
+
+    fn foo() -> Final {
+        return final { assert(Mapping::set(m, 0u32, 0u32) == Mapping::set(m, 0u32, 0u32)); };
+    }
+}

--- a/tests/tests/execution/unit_assert_eq.leo
+++ b/tests/tests/execution/unit_assert_eq.leo
@@ -1,0 +1,29 @@
+/*
+seed = 123456789
+min_height = 16
+
+[case]
+program = "test.aleo"
+function = "main"
+input = ["5u32"]
+*/
+
+// Tests that assert_eq on two unit-returning expressions compiles to no
+// assertion instruction (Unit == Unit is trivially true) and the finalize
+// still succeeds.
+program test.aleo {
+    mapping values: u32 => u32;
+
+    fn main(public a: u32) -> Final {
+        return final {
+            assert_eq(fin_foo(a), fin_foo(a));
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}
+
+final fn fin_foo(a: u32) {
+    Mapping::set(values, a, a);
+}

--- a/tests/tests/execution/unit_assert_neq.leo
+++ b/tests/tests/execution/unit_assert_neq.leo
@@ -1,0 +1,29 @@
+/*
+seed = 123456789
+min_height = 16
+
+[case]
+program = "test.aleo"
+function = "main"
+input = ["5u32"]
+*/
+
+// Tests that assert_neq on two unit-returning expressions compiles to an
+// instruction that always fails (Unit != Unit is trivially false), so the
+// finalize is always rejected.
+program test.aleo {
+    mapping values: u32 => u32;
+
+    fn main(public a: u32) -> Final {
+        return final {
+            assert_neq(fin_foo(a), fin_foo(a));
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}
+
+final fn fin_foo(a: u32) {
+    Mapping::set(values, a, a);
+}


### PR DESCRIPTION
Fix panics when comparing unit-type expressions (`assert_eq`/`assert_neq`/`==`/`!=`) rather than rejecting them at the type-checking level.

**Root causes:**
- Flattening: dummy `return ()` inserted for void functions wasn't registered in the type table, causing a later SSA pass to panic.
- Code generation: `visit_binary` and `visit_assert` didn't handle the `(None, None)` case that arises when both operands are unit-type.

**Behavior:**
- `() == ()` → trivially true, no assert instruction emitted.
- `() != ()` → trivially false, emits `assert.eq false true` (always fails at runtime).

Closes #29314
Closes #29315