### PR TITLE
Allow `signature` type in storage

### DIFF
--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -1844,9 +1844,6 @@ impl TypeCheckingVisitor<'_> {
             Type::DynRecord => {
                 self.emit_err(TypeCheckerError::invalid_storage_type("dyn record", span));
             }
-            Type::Signature => {
-                self.emit_err(TypeCheckerError::invalid_storage_type("signature", span));
-            }
             Type::Future(_) => {
                 self.emit_err(TypeCheckerError::invalid_storage_type("future", span));
             }
@@ -1896,7 +1893,7 @@ impl TypeCheckingVisitor<'_> {
                 self.assert_storage_type_is_valid(element_ty, span);
             }
 
-            // Everything else (integers, bool, group, etc.)
+            // Everything else (integers, bool, group, signature, etc.)
             Type::Address
             | Type::Boolean
             | Type::Field
@@ -1904,6 +1901,7 @@ impl TypeCheckingVisitor<'_> {
             | Type::Ident(_)
             | Type::Integer(_)
             | Type::Scalar
+            | Type::Signature
             | Type::Numeric
             | Type::Err => {} // valid
             Type::Vector(vector_type) => {

--- a/tests/expectations/compiler/storage/bad_storage_types_fail.out
+++ b/tests/expectations/compiler/storage/bad_storage_types_fail.out
@@ -13,123 +13,108 @@ Error [ETYC0372166]: string is an invalid storage type
      |
    4 |     storage string_storage: string;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: signature is an invalid storage type
+Error [ETYC0372166]: future is an invalid storage type
     --> compiler-test:5:5
      |
-   5 |     storage signature_storage: signature;
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: future is an invalid storage type
-    --> compiler-test:6:5
-     |
-   6 |     storage future_storage: Final;
+   5 |     storage future_storage: Final;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: optional is an invalid storage type
-    --> compiler-test:7:5
+    --> compiler-test:6:5
      |
-   7 |     storage optional_storage: u32?;
+   6 |     storage optional_storage: u32?;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: tuple is an invalid storage type
-    --> compiler-test:8:5
+    --> compiler-test:7:5
      |
-   8 |     storage tuple_storage: (u32, u32);
+   7 |     storage tuple_storage: (u32, u32);
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: record is an invalid storage type
-    --> compiler-test:15:5
+    --> compiler-test:14:5
      |
-  15 |     storage record_storage: MyRecord;
+  14 |     storage record_storage: MyRecord;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: A zero sized type is an invalid storage type
-    --> compiler-test:18:5
+    --> compiler-test:17:5
      |
-  18 |     storage array_unit: [(); 2];
+  17 |     storage array_unit: [(); 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: unit is an invalid storage type
-    --> compiler-test:18:5
+    --> compiler-test:17:5
      |
-  18 |     storage array_unit: [(); 2];
+  17 |     storage array_unit: [(); 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: string is an invalid storage type
+    --> compiler-test:18:5
+     |
+  18 |     storage array_string: [string; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: future is an invalid storage type
     --> compiler-test:19:5
      |
-  19 |     storage array_string: [string; 2];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: signature is an invalid storage type
+  19 |     storage array_future: [Final; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: future is an invalid storage type
+    --> compiler-test:19:5
+     |
+  19 |     storage array_future: [Final; 2];
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Error [ETYC0372166]: optional is an invalid storage type
     --> compiler-test:20:5
      |
-  20 |     storage array_signature: [signature; 2];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: future is an invalid storage type
-    --> compiler-test:21:5
-     |
-  21 |     storage array_future: [Final; 2];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: future is an invalid storage type
-    --> compiler-test:21:5
-     |
-  21 |     storage array_future: [Final; 2];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: optional is an invalid storage type
-    --> compiler-test:22:5
-     |
-  22 |     storage array_optional: [u32?; 2];
+  20 |     storage array_optional: [u32?; 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: optional is an invalid storage type
-    --> compiler-test:22:5
+    --> compiler-test:20:5
      |
-  22 |     storage array_optional: [u32?; 2];
+  20 |     storage array_optional: [u32?; 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: tuple is an invalid storage type
-    --> compiler-test:23:5
+    --> compiler-test:21:5
      |
-  23 |     storage array_tuple: [(u32, u32); 2];
+  21 |     storage array_tuple: [(u32, u32); 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: tuple is an invalid storage type
-    --> compiler-test:23:5
+    --> compiler-test:21:5
      |
-  23 |     storage array_tuple: [(u32, u32); 2];
+  21 |     storage array_tuple: [(u32, u32); 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: record is an invalid storage type
-    --> compiler-test:24:5
+    --> compiler-test:22:5
      |
-  24 |     storage array_record: [MyRecord; 2];
+  22 |     storage array_record: [MyRecord; 2];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: A zero sized type is an invalid storage type
-    --> compiler-test:27:5
+    --> compiler-test:25:5
      |
-  27 |     storage vec_unit: [()];
+  25 |     storage vec_unit: [()];
      |     ^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: unit is an invalid storage type
-    --> compiler-test:27:5
+    --> compiler-test:25:5
      |
-  27 |     storage vec_unit: [()];
+  25 |     storage vec_unit: [()];
      |     ^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: string is an invalid storage type
-    --> compiler-test:28:5
+    --> compiler-test:26:5
      |
-  28 |     storage vec_string: [string];
+  26 |     storage vec_string: [string];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Error [ETYC0372166]: signature is an invalid storage type
-    --> compiler-test:29:5
-     |
-  29 |     storage vec_signature: [signature];
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: future is an invalid storage type
-    --> compiler-test:30:5
+    --> compiler-test:27:5
      |
-  30 |     storage vec_future: [Final];
+  27 |     storage vec_future: [Final];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: optional is an invalid storage type
-    --> compiler-test:31:5
+    --> compiler-test:28:5
      |
-  31 |     storage vec_optional: [u32?];
+  28 |     storage vec_optional: [u32?];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: tuple is an invalid storage type
-    --> compiler-test:32:5
+    --> compiler-test:29:5
      |
-  32 |     storage vec_tuple: [(u32, u32)];
+  29 |     storage vec_tuple: [(u32, u32)];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372166]: record is an invalid storage type
-    --> compiler-test:33:5
+    --> compiler-test:30:5
      |
-  33 |     storage vec_record: [MyRecord];
+  30 |     storage vec_record: [MyRecord];
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/expectations/compiler/storage/good_storage_types.out
+++ b/tests/expectations/compiler/storage/good_storage_types.out
@@ -25,6 +25,10 @@ mapping address_storage__:
     key as boolean.public;
     value as address.public;
 
+mapping signature_storage__:
+    key as boolean.public;
+    value as signature.public;
+
 mapping u32_storage__:
     key as boolean.public;
     value as u32.public;
@@ -48,6 +52,10 @@ mapping array_bool__:
 mapping array_address__:
     key as boolean.public;
     value as [address; 2u32].public;
+
+mapping array_signature__:
+    key as boolean.public;
+    value as [signature; 2u32].public;
 
 mapping array_struct__:
     key as boolean.public;

--- a/tests/expectations/compiler/storage/signature_storage.out
+++ b/tests/expectations/compiler/storage/signature_storage.out
@@ -1,0 +1,19 @@
+program signature_storage.aleo;
+
+mapping sig__:
+    key as boolean.public;
+    value as signature.public;
+
+mapping sig_array__:
+    key as boolean.public;
+    value as [signature; 2u32].public;
+
+mapping sig_vec__:
+    key as u32.public;
+    value as signature.public;
+
+mapping sig_vec__len__:
+    key as boolean.public;
+    value as u32.public;
+
+function foo:

--- a/tests/tests/compiler/storage/bad_storage_types_fail.leo
+++ b/tests/tests/compiler/storage/bad_storage_types_fail.leo
@@ -2,7 +2,6 @@ program negative_storage_tests.aleo {
     // --- Top-level illegal types ---
     storage unit_storage: ();
     storage string_storage: string;
-    storage signature_storage: signature;
     storage future_storage: Final;
     storage optional_storage: u32?;
     storage tuple_storage: (u32, u32);
@@ -17,7 +16,6 @@ program negative_storage_tests.aleo {
     // --- Arrays of illegal types ---
     storage array_unit: [(); 2];
     storage array_string: [string; 2];
-    storage array_signature: [signature; 2];
     storage array_future: [Final; 2];
     storage array_optional: [u32?; 2];
     storage array_tuple: [(u32, u32); 2];
@@ -26,7 +24,6 @@ program negative_storage_tests.aleo {
     // --- Vectors of illegal types ---
     storage vec_unit: [()];
     storage vec_string: [string];
-    storage vec_signature: [signature];
     storage vec_future: [Final];
     storage vec_optional: [u32?];
     storage vec_tuple: [(u32, u32)];

--- a/tests/tests/compiler/storage/good_storage_types.leo
+++ b/tests/tests/compiler/storage/good_storage_types.leo
@@ -12,6 +12,7 @@ program good_storage_tests.aleo {
     storage field_storage: field;
     storage group_storage: group;
     storage address_storage: address;
+    storage signature_storage: signature;
     storage u32_storage: u32;
     storage i8_storage: i8;
 
@@ -21,6 +22,7 @@ program good_storage_tests.aleo {
     storage array_u32: [u32; 3];
     storage array_bool: [bool; 2];
     storage array_address: [address; 2];
+    storage array_signature: [signature; 2];
     storage array_struct: [MyStruct; 2];
 
     // --- Vectors ---

--- a/tests/tests/compiler/storage/signature_storage.leo
+++ b/tests/tests/compiler/storage/signature_storage.leo
@@ -1,0 +1,12 @@
+program signature_storage.aleo {
+    // signature as a plain storage variable
+    storage sig: signature;
+
+    // signature inside a fixed-size array
+    storage sig_array: [signature; 2];
+
+    // signature inside a vector
+    storage sig_vec: [signature];
+
+    fn foo() {}
+}


### PR DESCRIPTION
## Summary

- Removes the explicit rejection of `Type::Signature` from `assert_storage_type_is_valid` in the type checker
- `signature`, `[signature; N]`, and `[signature]` are now valid storage types
- Adds `tests/tests/compiler/storage/signature_storage.leo` covering all three forms

Closes #29112