### PR TITLE
fix(passes): do not require parameter names to match in interface conformance

### DIFF
--- a/crates/errors/src/errors/check_interfaces.rs
+++ b/crates/errors/src/errors/check_interfaces.rs
@@ -66,7 +66,7 @@ create_messages!(
              Found:\n\
              {found}"
         ),
-        help: Some("Function signatures must match exactly: same parameter names, types, modes, order, and return type.".to_string()),
+        help: Some("Function signatures must match exactly: same parameter types, modes, order, and return type.".to_string()),
     }
 
     @formatted

--- a/crates/passes/src/check_interfaces/visitor.rs
+++ b/crates/passes/src/check_interfaces/visitor.rs
@@ -493,8 +493,6 @@ impl<'a> CheckInterfacesVisitor<'a> {
         // Input parameters must match exactly.
         a.input.len() == b.input.len() &&
         a.input.iter().zip(b.input.iter()).all(|(input_a, input_b)| {
-            // Parameter names must match.
-            input_a.identifier.name == input_b.identifier.name &&
             // Parameter types must match.
             Self::proto_type_eq(&input_a.type_, &input_b.type_, prototype_record_locations) &&
             // Parameter modes must match.
@@ -599,8 +597,6 @@ impl<'a> CheckInterfacesVisitor<'a> {
         func.input.len() == proto.input.len() &&
 
         func.input.iter().zip(proto.input.iter()).all(|(func_input, proto_input)| {
-            // Parameter names must match.
-            func_input.identifier.name == proto_input.identifier.name &&
             // Parameter types must match.
             self.concrete_type_matches_proto(&func_input.type_, &proto_input.type_, prototype_record_locations) &&
             // Parameter modes must match.

--- a/tests/expectations/compiler/interfaces/abstract_and_external_same_name_wrong_external_fail.out
+++ b/tests/expectations/compiler/interfaces/abstract_and_external_same_name_wrong_external_fail.out
@@ -12,7 +12,7 @@ fn external_transfer(t: test.aleo::Token) -> test.aleo::Token
   17 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> compiler-test:5:1
      |

--- a/tests/expectations/compiler/interfaces/diamond_two_programs_wrong_concrete_fail.out
+++ b/tests/expectations/compiler/interfaces/diamond_two_programs_wrong_concrete_fail.out
@@ -12,7 +12,7 @@ fn transfer(t: lib1.aleo::Token) -> lib1.aleo::Token
   13 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Error [ECHI03712004]: Function `stake` does not match the signature required by interface `lib2.aleo/IRight`.
 Expected:
 fn stake(t: lib2.aleo::Token) -> lib2.aleo::Token
@@ -27,7 +27,7 @@ fn stake(t: lib1.aleo::Token) -> lib1.aleo::Token
   17 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> compiler-test:11:1
      |

--- a/tests/expectations/compiler/interfaces/generic_struct_mismatch_fail.out
+++ b/tests/expectations/compiler/interfaces/generic_struct_mismatch_fail.out
@@ -12,4 +12,4 @@ fn store(s: test.aleo::Slot::[16u32]) -> u32
   16 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/compiler/interfaces/grandparent_cross_program_wrong_concrete_fail.out
+++ b/tests/expectations/compiler/interfaces/grandparent_cross_program_wrong_concrete_fail.out
@@ -12,7 +12,7 @@ fn fn2(t: other.aleo::Token) -> other.aleo::Token
   18 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Error [ECHI03712004]: Function `fn1` does not match the signature required by interface `parent.aleo/IP`.
 Expected:
 fn fn1(t: grandparent.aleo::Token) -> grandparent.aleo::Token
@@ -27,7 +27,7 @@ fn fn1(t: other.aleo::Token) -> other.aleo::Token
   14 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> compiler-test:12:1
      |

--- a/tests/expectations/compiler/interfaces/library_record_param_name_mismatch_valid.out
+++ b/tests/expectations/compiler/interfaces/library_record_param_name_mismatch_valid.out
@@ -1,0 +1,11 @@
+program test.aleo;
+
+record Token:
+    owner as address.private;
+    amount as u128.private;
+
+function transfer_private:
+    input r0 as Token.record;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/interfaces/mismatch_fail.out
+++ b/tests/expectations/compiler/interfaces/mismatch_fail.out
@@ -12,22 +12,7 @@ fn foo() -> u32
   10 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
-Error [ECHI03712004]: Function `bar` does not match the signature required by interface `test.aleo/AbstractProgram`.
-Expected:
-fn bar(a: u64) -> ()
-Found:
-fn bar(b: u64) -> ()
-    --> compiler-test:12:5
-     |
-  12 |     fn bar(b: u64) {
-     |     ^^^^^^^^^^^^^^^^
-  13 |         return 0;
-     |         ^^^^^^^^^
-  14 |     }
-     |     ^
-     |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Error [ECHI03712004]: Function `baz` does not match the signature required by interface `test.aleo/AbstractProgram`.
 Expected:
 fn baz(a: u64, b: u8, c: u32) -> Final<Fn()>
@@ -38,4 +23,4 @@ fn baz(a: u32, b: u8, c: u32) -> ()
   16 |     fn baz(a: u32, b: u8, c: u32) {}
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/compiler/interfaces/module_interface_inherited_record_wrong_program_fail.out
+++ b/tests/expectations/compiler/interfaces/module_interface_inherited_record_wrong_program_fail.out
@@ -12,7 +12,7 @@ fn f1(t: other.aleo::Token) -> other.aleo::Token
   11 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> interfaces.leo:3:1
      |

--- a/tests/expectations/compiler/interfaces/module_interface_record_wrong_program_fail.out
+++ b/tests/expectations/compiler/interfaces/module_interface_record_wrong_program_fail.out
@@ -12,7 +12,7 @@ fn transfer(t: other.aleo::Token) -> other.aleo::Token
   11 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> interfaces.leo:3:1
      |

--- a/tests/expectations/compiler/interfaces/module_record_uses_interface_token_fail.out
+++ b/tests/expectations/compiler/interfaces/module_record_uses_interface_token_fail.out
@@ -12,7 +12,7 @@ fn transfer(t: lib.aleo::Token) -> lib.aleo::Token
   12 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> compiler-test:13:1
      |

--- a/tests/expectations/compiler/interfaces/module_record_wrong_program_fail.out
+++ b/tests/expectations/compiler/interfaces/module_record_wrong_program_fail.out
@@ -12,7 +12,7 @@ fn transfer(t: other.aleo::Token) -> other.aleo::Token
    8 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Error [ECHI03712003]: Program `test.aleo` implements interface `lib.aleo/HasToken` but is missing the required record `Token`.
     --> compiler-test:5:1
      |

--- a/tests/expectations/compiler/libraries/lib_interface_implements_missing_inherited_fail.out
+++ b/tests/expectations/compiler/libraries/lib_interface_implements_missing_inherited_fail.out
@@ -12,7 +12,7 @@ fn process(v: u64) -> u32
   14 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Error [ECHI03712002]: Program `main.aleo` implements interface `top_lib/Top` but is missing the required function `fetch`.
     --> compiler-test:7:1
      |

--- a/tests/expectations/passes/check_interfaces/cross_module_record_wrong_name_fail.out
+++ b/tests/expectations/passes/check_interfaces/cross_module_record_wrong_name_fail.out
@@ -12,7 +12,7 @@ fn mint(owner: address) -> test.aleo::Coin
    9 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Error [ECHI03712003]: Program `test.aleo` implements interface `token_lib/itoken::TokenInterface` but is missing the required record `Token`.
     --> test:1:1
      |

--- a/tests/expectations/passes/check_interfaces/interface_array_length_mismatch_fail.out
+++ b/tests/expectations/passes/check_interfaces/interface_array_length_mismatch_fail.out
@@ -12,4 +12,4 @@ fn hash(input: [u8; 16]) -> [u8; 32]
   13 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/multiple_inheritance_conflict_fail.out
+++ b/tests/expectations/passes/check_interfaces/multiple_inheritance_conflict_fail.out
@@ -12,4 +12,4 @@ fn get_value() -> u64
   14 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/signature_mismatch_fail.out
+++ b/tests/expectations/passes/check_interfaces/signature_mismatch_fail.out
@@ -2,14 +2,14 @@ Error [ECHI03712004]: Function `process` does not match the signature required b
 Expected:
 fn process(value: u64, multiplier: u64) -> u64
 Found:
-fn process(value: u64, mult: u64) -> u64
+fn process(value: u64, multiplier: u32) -> u64
     --> test:9:5
      |
-   9 |     fn process(value: u64, mult: u64) -> u64 {
-     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  10 |         return value * mult;
-     |         ^^^^^^^^^^^^^^^^^^^^
+   9 |     fn process(value: u64, multiplier: u32) -> u64 {
+     |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  10 |         return value;
+     |         ^^^^^^^^^^^^^
   11 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/signature_mismatch_mode_fail.out
+++ b/tests/expectations/passes/check_interfaces/signature_mismatch_mode_fail.out
@@ -12,4 +12,4 @@ fn transfer(amount: u64) -> u64
   13 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/signature_mismatch_return_fail.out
+++ b/tests/expectations/passes/check_interfaces/signature_mismatch_return_fail.out
@@ -12,4 +12,4 @@ fn convert(value: u64) -> u64
   11 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.

--- a/tests/expectations/passes/check_interfaces/signature_param_name_mismatch_valid.out
+++ b/tests/expectations/passes/check_interfaces/signature_param_name_mismatch_valid.out
@@ -1,0 +1,8 @@
+program test.aleo {
+    fn transfer(sender: address, qty: u64) -> u64 {
+        return qty;
+    }
+    fn main() {
+    }
+}
+

--- a/tests/expectations/passes/check_interfaces/tuple_return_mismatch_fail.out
+++ b/tests/expectations/passes/check_interfaces/tuple_return_mismatch_fail.out
@@ -12,7 +12,7 @@ fn split(t: test.aleo::Token) -> (test.aleo::Token, u64)
   21 |     }
      |     ^
      |
-     = Function signatures must match exactly: same parameter names, types, modes, order, and return type.
+     = Function signatures must match exactly: same parameter types, modes, order, and return type.
 Warning [WPAR0370002]: Record prototype `Token` does not constrain any fields beyond the implicit `owner: address`. Consider simplifying to `record Token;`.
     --> test:6:1
      |

--- a/tests/tests/compiler/interfaces/library_record_param_name_mismatch_valid.leo
+++ b/tests/tests/compiler/interfaces/library_record_param_name_mismatch_valid.leo
@@ -1,0 +1,30 @@
+// Test: a library-based interface that requires a record type in a function parameter
+// compiles correctly when the implementing function uses a different parameter name.
+// Regression test for https://github.com/ProvableHQ/leo/issues/29327.
+
+// --- library: test_lib --- //
+
+interface Foo {
+    record Token {
+        owner: address,
+        amount: u128,
+        ..
+    }
+
+    fn transfer_private(token: Token);
+}
+
+// --- Next Program --- //
+
+program test.aleo: test_lib::Foo {
+    record Token {
+        owner: address,
+        amount: u128,
+    }
+
+    // `input` differs from the prototype's `token` — must compile without error.
+    fn transfer_private(input: Token) {}
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/check_interfaces/signature_mismatch_fail.leo
+++ b/tests/tests/passes/check_interfaces/signature_mismatch_fail.leo
@@ -5,12 +5,12 @@ interface Processor {
 }
 
 program test.aleo: Processor {
-    // Wrong parameter name: 'mult' instead of 'multiplier'
-    fn process(value: u64, mult: u64) -> u64 {
-        return value * mult;
+    // Wrong parameter type: `u32` instead of `u64`
+    fn process(value: u64, multiplier: u32) -> u64 {
+        return value;
     }
 
     fn main(x: u64) -> u64 {
-        return process(x, 2u64);
+        return process(x, 2u32);
     }
 }

--- a/tests/tests/passes/check_interfaces/signature_param_name_mismatch_valid.leo
+++ b/tests/tests/passes/check_interfaces/signature_param_name_mismatch_valid.leo
@@ -1,0 +1,16 @@
+// Test: parameter names do not need to match between an interface prototype and the
+// implementing function. Only types, modes, order, and return type are significant.
+// Regression test for https://github.com/ProvableHQ/leo/issues/29327.
+
+interface Transferable {
+    fn transfer(from: address, amount: u64) -> u64;
+}
+
+program test.aleo: Transferable {
+    // Different parameter names (`sender` and `qty` vs `from` and `amount`) — must compile.
+    fn transfer(sender: address, qty: u64) -> u64 {
+        return qty;
+    }
+
+    fn main() {}
+}


### PR DESCRIPTION
## Summary

- Removes the parameter-name equality check from `function_matches_prototype` and `prototypes_match` in the `check_interfaces` pass.
- Parameter names are local aliases and are not part of a function's ABI contract. Only types, modes, order, and return type are significant.
- Updates the signature-mismatch help text accordingly and adds two regression tests.

Closes #29327