### PR TITLE
fix(passes): prevent panics and cascading errors in visit_async

### DIFF
--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -576,25 +576,28 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_async(&mut self, input: &AsyncExpression, _additional: &Self::AdditionalInput) -> Self::Output {
-        // Step into an async block
-        self.async_block_id = Some(input.block.id);
-
         // A few restrictions
         if self.scope_state.is_conditional {
             self.emit_err(TypeCheckerError::final_block_in_conditional(input.span));
+            return Type::Err;
         }
 
         if !matches!(self.scope_state.variant, Some(Variant::EntryPoint)) {
             self.emit_err(TypeCheckerError::illegal_final_block_location(input.span));
+            return Type::Err;
         }
 
         if self.scope_state.already_contains_an_async_block {
             self.emit_err(TypeCheckerError::multiple_final_blocks_not_allowed(input.span));
+            return Type::Err;
         }
 
         if self.scope_state.has_called_finalize {
             panic!("Finalize has been called before this final block");
         }
+
+        // Step into the async block only after all validation checks pass.
+        self.async_block_id = Some(input.block.id);
 
         self.visit_block(&input.block);
 

--- a/tests/expectations/compiler/async_blocks/final_block_in_conditional_no_cascade_fail.out
+++ b/tests/expectations/compiler/async_blocks/final_block_in_conditional_no_cascade_fail.out
@@ -1,0 +1,7 @@
+Error [ETYC0372151]: `final` blocks are not allowed inside conditional blocks.
+    --> compiler-test:10:34
+     |
+  10 |             let ignored: Final = final { };
+     |                                  ^^^^^^^^^
+     |
+     = Refactor your code to move the `final` block outside of the conditional block.

--- a/tests/expectations/compiler/async_blocks/multiple_final_blocks_no_cascade_fail.out
+++ b/tests/expectations/compiler/async_blocks/multiple_final_blocks_no_cascade_fail.out
@@ -1,0 +1,11 @@
+Error [ETYC0372150]: An entry point fn cannot contain more than one `final` block.
+    --> compiler-test:9:25
+     |
+   9 |         let f2: Final = final {
+     |                         ^^^^^^^
+  10 |             let bad: u32 = true;
+     |             ^^^^^^^^^^^^^^^^^^^^
+  11 |         };
+     |         ^
+     |
+     = Combine the logic into a single `final` block, or restructure your code to avoid multiple final blocks within the same entry point fn.

--- a/tests/expectations/compiler/bugs/b29324_fail.out
+++ b/tests/expectations/compiler/bugs/b29324_fail.out
@@ -1,0 +1,12 @@
+Error [ETYC0372148]: `final` blocks are only allowed inside an entry point fn returning `Final` or a script function.
+    --> compiler-test:5:22
+     |
+   5 |     const F: Final = final { };
+     |                      ^^^^^^^^^
+     |
+     = Try moving this `final` block into an entry point fn or a script function.
+Error [ETYC0372083]: A program must have at least one entry point fn.
+    --> compiler-test:4:9
+     |
+   4 | program test.aleo {
+     |         ^^^^^^^^^

--- a/tests/expectations/compiler/finalize/closure_with_finalize_fail.out
+++ b/tests/expectations/compiler/finalize/closure_with_finalize_fail.out
@@ -40,11 +40,6 @@ Error [ETYC0372148]: `final` blocks are only allowed inside an entry point fn re
      |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      |
      = Try moving this `final` block into an entry point fn or a script function.
-Error [ETYC0372042]: Only regular fns can be called from a regular function or constructor.
-    --> compiler-test:18:20
-     |
-  18 |     return final { finalize_mint(receiver, amount); };
-     |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Error [ETYC0372083]: A program must have at least one entry point fn.
     --> compiler-test:1:9
      |

--- a/tests/tests/compiler/async_blocks/final_block_in_conditional_no_cascade_fail.leo
+++ b/tests/tests/compiler/async_blocks/final_block_in_conditional_no_cascade_fail.leo
@@ -1,0 +1,16 @@
+// Regression test: early return after `final_block_in_conditional` error must prevent
+// `already_contains_an_async_block` from being set, so that a subsequent valid `final`
+// block in the same entry point fn does not spuriously trigger
+// `multiple_final_blocks_not_allowed`.
+program test.aleo {
+    fn foo() -> Final {
+        let x: bool = true;
+        if x {
+            // Invalid: final block inside a conditional.
+            let ignored: Final = final { };
+        }
+        // Valid: this is the only final block at the function level.
+        let f: Final = final { };
+        return f;
+    }
+}

--- a/tests/tests/compiler/async_blocks/multiple_final_blocks_no_cascade_fail.leo
+++ b/tests/tests/compiler/async_blocks/multiple_final_blocks_no_cascade_fail.leo
@@ -1,0 +1,14 @@
+// Regression test: early return after `multiple_final_blocks_not_allowed` error must
+// prevent `visit_block` from running on the invalid second `final` block, so that type
+// errors inside its body do not cascade.
+program test.aleo {
+    fn foo() -> Final {
+        let f1: Final = final { };
+        // Second final block is already invalid (multiple not allowed).
+        // Its body contains a type error (bool assigned to u32) that must be suppressed.
+        let f2: Final = final {
+            let bad: u32 = true;
+        };
+        return f1;
+    }
+}

--- a/tests/tests/compiler/bugs/b29324_fail.leo
+++ b/tests/tests/compiler/bugs/b29324_fail.leo
@@ -1,0 +1,9 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29324
+// The compiler should emit a diagnostic error, not panic, when `final { }` is
+// used as a `const` initializer at program scope.
+program test.aleo {
+    const F: Final = final { };
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
Fixes a panic in the type checker when a `final { }` block is used as a `const` initializer at program scope, and also addresses three related issues in `visit_async`:

**1. `const` initializer panic (the original bug)**
`visit_async` would unwrap `scope_state.program_name` and `scope_state.function` — both `None` at program scope — after the `illegal_final_block_location` error was emitted but execution continued. Fixed by adding an early `return Type::Err` after the error.

**2. `is_conditional` — early return added**
Without it, `already_contains_an_async_block` was set and `async_function_input_types` was populated for an invalid block, causing a spurious `multiple_final_blocks_not_allowed` error for any subsequent valid `final {}` in the same entry point fn.

**3. `already_contains_an_async_block` — early return added**
Without it, `visit_block` ran on the invalid second block, type-checking its body and producing cascading errors that shouldn't appear.

**4. `async_block_id` assignment moved after validation**
`async_block_id` was set at the top of `visit_async` before any checks. On any early return it was left set, causing `visit_return` to misidentify function-level `return` statements as being inside a `final` block (`ETYC0372153`). It is now assigned only after all validation passes. This also corrects a stale expectation in `closure_with_finalize_fail.out`.

closes #29324