### PR TITLE
fix(compiler): bail out before passes when the parser found errors

### DIFF
--- a/crates/compiler/src/compiler.rs
+++ b/crates/compiler/src/compiler.rs
@@ -253,6 +253,10 @@ impl Compiler {
 
     /// Runs all frontend passes: NameValidation through StaticAnalyzing.
     pub fn frontend_passes(&mut self) -> Result<()> {
+        // Bail out if the parser already found errors.  The error-recovering parser may have
+        // produced ErrExpression nodes in the AST, which would cause panics in later passes.
+        self.state.handler.last_err()?;
+
         self.do_pass::<NameValidation>(())?;
         self.do_pass::<GlobalVarsCollection>(())?;
         self.do_pass::<PathResolution>(())?;

--- a/tests/expectations/compiler/bugs/b29302_fail.out
+++ b/tests/expectations/compiler/bugs/b29302_fail.out
@@ -1,0 +1,5 @@
+Error [EPAR0370021]: The type of `2u32` has no associated function `exp` that takes 1 argument(s).
+    --> compiler-test:9:20
+     |
+   9 |     fn main(x: S::[2u32.exp(2u32)]);
+     |                    ^^^^^^^^^^^^^^

--- a/tests/tests/compiler/bugs/b29302_fail.leo
+++ b/tests/tests/compiler/bugs/b29302_fail.leo
@@ -1,0 +1,14 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29302
+// The compiler should emit a diagnostic error, not panic, when an invalid
+// method call appears as a const type argument to a struct in an interface.
+struct S::[N: u32] {
+    x: u32,
+}
+
+interface Foo {
+    fn main(x: S::[2u32.exp(2u32)]);
+}
+
+program bad_op.aleo {
+    fn main() {}
+}


### PR DESCRIPTION
## Summary

- The error-recovering parser can emit errors to the handler while still returning `Ok` with `ErrExpression` nodes in the AST
- Without a guard, frontend passes (starting with `NameValidation`) would encounter those nodes and panic — as reported in #29302
- Adds `handler.last_err()?` at the top of `frontend_passes` so any parser-recorded error stops compilation before any pass runs
- This mirrors the guard already present in `build.rs` for the library parsing path

Closes #29302.