### PR TITLE
Add WASM ABI generation from Aleo bytecode

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,38 @@
+name: WASM
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - crates/abi/**
+      - crates/ast/**
+      - crates/disassembler/**
+      - crates/errors/**
+      - crates/leo-aleo-abi-wasm/**
+      - crates/span/**
+      - .github/workflows/wasm.yml
+
+permissions:
+  contents: read
+
+jobs:
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
+      - name: Install clippy
+        run: rustup component add clippy
+      - name: Test leo-aleo-abi-wasm
+        run: cargo test -p leo-aleo-abi-wasm --locked
+      - name: Check leo-aleo-abi-wasm for wasm32
+        run: cargo check -p leo-aleo-abi-wasm --target wasm32-unknown-unknown --locked
+      - name: Clippy leo-aleo-abi-wasm for wasm32
+        run: cargo clippy -p leo-aleo-abi-wasm --target wasm32-unknown-unknown --locked -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1235,6 +1235,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2158,7 +2222,9 @@ dependencies = [
  "indexmap",
  "leo-abi-types",
  "leo-ast",
+ "leo-disassembler",
  "leo-span",
+ "serde_json",
 ]
 
 [[package]]
@@ -2169,10 +2235,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "leo-aleo-abi-wasm"
+version = "4.0.2"
+dependencies = [
+ "leo-abi",
+ "leo-ast",
+ "serde_json",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leo-ast"
 version = "4.0.2"
 dependencies = [
  "anyhow",
+ "getrandom 0.2.17",
  "indexmap",
  "itertools 0.14.0",
  "leo-errors",
@@ -2180,6 +2257,8 @@ dependencies = [
  "serde",
  "serde_json",
  "snarkvm",
+ "snarkvm-console",
+ "snarkvm-synthesizer-program",
 ]
 
 [[package]]
@@ -2233,10 +2312,13 @@ dependencies = [
 name = "leo-disassembler"
 version = "4.0.2"
 dependencies = [
+ "getrandom 0.2.17",
  "leo-ast",
  "leo-errors",
  "leo-span",
  "snarkvm",
+ "snarkvm-console",
+ "snarkvm-synthesizer-program",
 ]
 
 [[package]]
@@ -4750,7 +4832,9 @@ dependencies = [
  "anyhow",
  "cfg-if",
  "colored 3.1.1",
+ "encoding",
  "hex",
+ "js-sys",
  "lazy_static",
  "parking_lot",
  "paste",
@@ -4761,6 +4845,7 @@ dependencies = [
  "snarkvm-curves",
  "snarkvm-utilities",
  "thiserror 2.0.18",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/abi/Cargo.toml
+++ b/crates/abi/Cargo.toml
@@ -17,14 +17,27 @@ include = [ "Cargo.toml", "src", "README.md", "LICENSE.md" ]
 license = "GPL-3.0"
 edition = "2024"
 
+[features]
+default = [ ]
+aleo-bytecode = [
+  "dep:leo-disassembler",
+]
+
 [dependencies.leo-abi-types]
 workspace = true
 
 [dependencies.leo-ast]
 workspace = true
 
+[dependencies.leo-disassembler]
+workspace = true
+optional = true
+
 [dependencies.leo-span]
 workspace = true
 
 [dependencies.indexmap]
+workspace = true
+
+[dev-dependencies.serde_json]
 workspace = true

--- a/crates/abi/src/aleo.rs
+++ b/crates/abi/src/aleo.rs
@@ -31,6 +31,33 @@ use leo_span::Symbol;
 
 use std::collections::HashSet;
 
+#[cfg(feature = "aleo-bytecode")]
+use leo_span::create_session_if_not_set_then;
+#[cfg(feature = "aleo-bytecode")]
+use std::fmt;
+
+/// Error returned when generating ABI data from Aleo bytecode fails.
+#[cfg(feature = "aleo-bytecode")]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BytecodeAbiError(String);
+
+#[cfg(feature = "aleo-bytecode")]
+impl BytecodeAbiError {
+    fn new(error: impl ToString) -> Self {
+        Self(error.to_string())
+    }
+}
+
+#[cfg(feature = "aleo-bytecode")]
+impl fmt::Display for BytecodeAbiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+#[cfg(feature = "aleo-bytecode")]
+impl std::error::Error for BytecodeAbiError {}
+
 /// Generates ABI from an Aleo program (pre-compiled bytecode dependency).
 ///
 /// Unlike Leo programs, Aleo programs do not have modules, so type paths in the
@@ -71,6 +98,20 @@ pub fn generate(aleo: &ast::AleoProgram) -> abi::Program {
     prune_non_interface_types(&mut program);
 
     program
+}
+
+/// Generates ABI from Aleo bytecode for the requested network.
+#[cfg(feature = "aleo-bytecode")]
+pub fn generate_from_bytecode(
+    name: impl fmt::Display,
+    bytecode: &str,
+    network: ast::NetworkName,
+) -> Result<abi::Program, BytecodeAbiError> {
+    create_session_if_not_set_then(|_| {
+        let aleo = leo_disassembler::disassemble_from_str_for_network(name, bytecode, network)
+            .map_err(BytecodeAbiError::new)?;
+        Ok(generate(&aleo))
+    })
 }
 
 /// Converts a function stub to an ABI function.
@@ -125,5 +166,25 @@ fn convert_function_output(ty: &ast::Type, record_names: &HashSet<Symbol>) -> ab
             abi::FunctionOutput::Plaintext(convert_plaintext(ty))
         }
         _ => abi::FunctionOutput::Plaintext(convert_plaintext(ty)),
+    }
+}
+
+#[cfg(all(test, feature = "aleo-bytecode"))]
+mod tests {
+    use super::*;
+
+    use serde_json::Value;
+
+    const SIMPLE_ALEO: &str = include_str!("../../../tests/tests/cli/test_abi_from_aleo/contents/simple.aleo");
+    const SIMPLE_ABI: &str =
+        include_str!("../../../tests/expectations/cli/test_abi_from_aleo/contents/simple.abi.json");
+
+    #[test]
+    fn generate_from_bytecode_matches_existing_cli_fixture() {
+        let abi = generate_from_bytecode("simple.aleo", SIMPLE_ALEO, ast::NetworkName::TestnetV0)
+            .expect("expected ABI generation to succeed");
+        let abi = serde_json::to_value(&abi).expect("expected generated ABI to serialize");
+        let expected: Value = serde_json::from_str(SIMPLE_ABI).expect("expected fixture ABI JSON to parse");
+        assert_eq!(abi, expected);
     }
 }

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -31,4 +31,18 @@ indexmap        = { workspace = true }
 itertools       = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 snarkvm         = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = [ "js" ] }
+snarkvm-console = { version = "=4.6.1", default-features = false, features = [
+  "account",
+  "program",
+  "types",
+  "dev_skip_checks",
+  "test_consensus_heights",
+  "test_targets",
+  "wasm",
+] }
+snarkvm-synthesizer-program = { version = "=4.6.1", features = [ "wasm" ] }

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -22,6 +22,17 @@
 
 #![allow(ambiguous_glob_reexports)]
 
+#[cfg(target_arch = "wasm32")]
+extern crate self as snarkvm;
+
+// Preserve this crate's existing `snarkvm::...` imports on WASM without pulling
+// in the full native-oriented `snarkvm` dependency graph.
+#[cfg(target_arch = "wasm32")]
+mod snarkvm_wasm;
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub use snarkvm_wasm::{console, prelude, synthesizer};
+
 mod composite;
 pub use self::composite::*;
 

--- a/crates/ast/src/snarkvm_wasm.rs
+++ b/crates/ast/src/snarkvm_wasm.rs
@@ -1,0 +1,34 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Minimal `snarkvm::...` facade used by this crate on WASM targets.
+//!
+//! The full `snarkvm` crate pulls in native-oriented ledger and package paths.
+//! This module preserves the existing crate-local imports while exposing only
+//! the console and program-parsing surface needed by ABI-from-bytecode builds.
+
+pub use snarkvm_console as console;
+
+pub mod prelude {
+    pub use snarkvm_console::{network::prelude::*, program::*, types::prelude::*};
+    pub use snarkvm_synthesizer_program::{Mapping, Program};
+}
+
+pub mod synthesizer {
+    pub mod program {
+        pub use snarkvm_synthesizer_program::*;
+    }
+}

--- a/crates/disassembler/Cargo.toml
+++ b/crates/disassembler/Cargo.toml
@@ -26,4 +26,19 @@ leo-ast    = { workspace = true }
 leo-errors = { workspace = true }
 leo-span   = { workspace = true }
 # third party dependencies
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 snarkvm    = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = [ "js" ] }
+snarkvm-console = { version = "=4.6.1", default-features = false, features = [
+  "account",
+  "program",
+  "types",
+  "dev_skip_checks",
+  "test_consensus_heights",
+  "test_targets",
+  "wasm",
+] }
+snarkvm-synthesizer-program = { version = "=4.6.1", features = [ "wasm" ] }

--- a/crates/disassembler/src/lib.rs
+++ b/crates/disassembler/src/lib.rs
@@ -14,7 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{AleoProgram, Composite, FunctionStub, Identifier, Mapping, ProgramId};
+#[cfg(target_arch = "wasm32")]
+extern crate self as snarkvm;
+
+// Preserve this crate's existing `snarkvm::...` imports on WASM without pulling
+// in the full native-oriented `snarkvm` dependency graph.
+#[cfg(target_arch = "wasm32")]
+mod snarkvm_wasm;
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub use snarkvm_wasm::{prelude, synthesizer};
+
+use leo_ast::{AleoProgram, Composite, FunctionStub, Identifier, Mapping, NetworkName, ProgramId};
 use leo_errors::UtilError;
 use leo_span::Symbol;
 
@@ -86,6 +97,19 @@ pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) 
     match Program::<N>::from_str(program) {
         Ok(p) => Ok(disassemble(p)),
         Err(_) => Err(UtilError::snarkvm_parsing_error(name)),
+    }
+}
+
+/// Disassembles Aleo bytecode using the snarkVM network selected by `network`.
+pub fn disassemble_from_str_for_network(
+    name: impl fmt::Display,
+    program: &str,
+    network: NetworkName,
+) -> Result<AleoProgram, UtilError> {
+    match network {
+        NetworkName::MainnetV0 => disassemble_from_str::<snarkvm::prelude::MainnetV0>(name, program),
+        NetworkName::TestnetV0 => disassemble_from_str::<snarkvm::prelude::TestnetV0>(name, program),
+        NetworkName::CanaryV0 => disassemble_from_str::<snarkvm::prelude::CanaryV0>(name, program),
     }
 }
 

--- a/crates/disassembler/src/snarkvm_wasm.rs
+++ b/crates/disassembler/src/snarkvm_wasm.rs
@@ -1,0 +1,31 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Minimal `snarkvm::...` facade used by this crate on WASM targets.
+//!
+//! The full `snarkvm` crate pulls in native-oriented ledger and package paths.
+//! This module preserves the existing crate-local imports while exposing only
+//! the network and program-parsing surface needed by ABI-from-bytecode builds.
+
+pub mod prelude {
+    pub use snarkvm_console::network::prelude::*;
+}
+
+pub mod synthesizer {
+    pub mod program {
+        pub use snarkvm_synthesizer_program::{Program, ProgramCore};
+    }
+}

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -22,10 +22,12 @@ edition = "2024"
 leo-span         = { workspace = true }
 # third party dependencies
 anyhow           = { workspace = true }
-backtrace        = { workspace = true }
 colored          = { workspace = true }
-color-backtrace  = { workspace = true }
 derivative       = { workspace = true }
 itertools        = { workspace = true }
 serde            = { workspace = true }
 thiserror        = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+backtrace        = { workspace = true }
+color-backtrace  = { workspace = true }

--- a/crates/errors/src/common/backtraced.rs
+++ b/crates/errors/src/common/backtraced.rs
@@ -16,11 +16,13 @@
 
 use std::fmt;
 
-use backtrace::Backtrace;
-use color_backtrace::{BacktracePrinter, Verbosity};
+use crate::Backtrace;
 use colored::Colorize;
 use derivative::Derivative;
 use leo_span::source_map::is_color;
+
+#[cfg(not(target_arch = "wasm32"))]
+use color_backtrace::{BacktracePrinter, Verbosity};
 
 /// The indent for an error message.
 pub(crate) const INDENT: &str = "    ";
@@ -44,9 +46,9 @@ pub struct Backtraced {
     pub type_: String,
     /// Is this Backtrace a warning or error?
     pub error: bool,
+    /// The backtrace representing where the error occurred in Leo.
     #[derivative(PartialEq = "ignore")]
     #[derivative(Hash = "ignore")]
-    /// The backtrace representing where the error occurred in Leo.
     pub backtrace: Backtrace,
 }
 
@@ -127,21 +129,24 @@ impl fmt::Display for Backtraced {
             )?;
         }
 
-        let leo_backtrace = std::env::var("LEO_BACKTRACE").unwrap_or_default().trim().to_owned();
-        match leo_backtrace.as_ref() {
-            "1" => {
-                let mut printer = BacktracePrinter::default();
-                printer = printer.lib_verbosity(Verbosity::Medium);
-                let trace = printer.format_trace_to_string(&self.backtrace).map_err(|_| fmt::Error)?;
-                write!(f, "{trace}")?;
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let leo_backtrace = std::env::var("LEO_BACKTRACE").unwrap_or_default().trim().to_owned();
+            match leo_backtrace.as_ref() {
+                "1" => {
+                    let mut printer = BacktracePrinter::default();
+                    printer = printer.lib_verbosity(Verbosity::Medium);
+                    let trace = printer.format_trace_to_string(&self.backtrace).map_err(|_| fmt::Error)?;
+                    write!(f, "{trace}")?;
+                }
+                "full" => {
+                    let mut printer = BacktracePrinter::default();
+                    printer = printer.lib_verbosity(Verbosity::Full);
+                    let trace = printer.format_trace_to_string(&self.backtrace).map_err(|_| fmt::Error)?;
+                    write!(f, "{trace}")?;
+                }
+                _ => {}
             }
-            "full" => {
-                let mut printer = BacktracePrinter::default();
-                printer = printer.lib_verbosity(Verbosity::Full);
-                let trace = printer.format_trace_to_string(&self.backtrace).map_err(|_| fmt::Error)?;
-                write!(f, "{trace}")?;
-            }
-            _ => {}
         }
 
         Ok(())

--- a/crates/errors/src/common/formatted.rs
+++ b/crates/errors/src/common/formatted.rs
@@ -14,15 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Backtraced, INDENT};
+use crate::{Backtrace, Backtraced, INDENT};
 
 use leo_span::{Span, source_map::LineContents, with_session_globals};
 
-use backtrace::Backtrace;
-use color_backtrace::{BacktracePrinter, Verbosity};
 use colored::Colorize;
 use itertools::Itertools;
 use std::fmt;
+
+#[cfg(not(target_arch = "wasm32"))]
+use color_backtrace::{BacktracePrinter, Verbosity};
 
 /// Represents available colors for error labels.
 #[derive(Default, Clone, Debug, Hash, PartialEq, Eq)]
@@ -399,23 +400,26 @@ impl fmt::Display for Formatted {
             )?;
         }
 
-        let leo_backtrace = std::env::var("LEO_BACKTRACE").unwrap_or_default().trim().to_owned();
-        match leo_backtrace.as_ref() {
-            "1" => {
-                let mut printer = BacktracePrinter::default();
-                printer = printer.verbosity(Verbosity::Medium);
-                printer = printer.lib_verbosity(Verbosity::Medium);
-                let trace = printer.format_trace_to_string(&self.backtrace.backtrace).map_err(|_| fmt::Error)?;
-                write!(f, "\n{trace}")?;
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let leo_backtrace = std::env::var("LEO_BACKTRACE").unwrap_or_default().trim().to_owned();
+            match leo_backtrace.as_ref() {
+                "1" => {
+                    let mut printer = BacktracePrinter::default();
+                    printer = printer.verbosity(Verbosity::Medium);
+                    printer = printer.lib_verbosity(Verbosity::Medium);
+                    let trace = printer.format_trace_to_string(&self.backtrace.backtrace).map_err(|_| fmt::Error)?;
+                    write!(f, "\n{trace}")?;
+                }
+                "full" => {
+                    let mut printer = BacktracePrinter::default();
+                    printer = printer.verbosity(Verbosity::Full);
+                    printer = printer.lib_verbosity(Verbosity::Full);
+                    let trace = printer.format_trace_to_string(&self.backtrace.backtrace).map_err(|_| fmt::Error)?;
+                    write!(f, "\n{trace}")?;
+                }
+                _ => {}
             }
-            "full" => {
-                let mut printer = BacktracePrinter::default();
-                printer = printer.verbosity(Verbosity::Full);
-                printer = printer.lib_verbosity(Verbosity::Full);
-                let trace = printer.format_trace_to_string(&self.backtrace.backtrace).map_err(|_| fmt::Error)?;
-                write!(f, "\n{trace}")?;
-            }
-            _ => {}
         }
 
         Ok(())

--- a/crates/errors/src/common/macros.rs
+++ b/crates/errors/src/common/macros.rs
@@ -28,9 +28,7 @@ macro_rules! create_messages {
     };
     ($(#[$error_type_docs:meta])* $type_:ident, code_mask: $code_mask:expr, code_prefix: $code_prefix:expr, $($(#[$docs:meta])* @$formatted_or_backtraced_list:ident $names:ident { args: ($($arg_names:ident: $arg_types:ty$(,)?)*), msg: $messages:expr, help: $helps:expr, })*) => {
         #[allow(unused_imports)] // Allow unused for errors that only use formatted or backtraced errors.
-        use $crate::{Backtraced, Formatted, LeoMessageCode};
-
-        use backtrace::Backtrace;
+        use $crate::{Backtrace, Backtraced, Formatted, LeoMessageCode};
 
         // Generates the enum and implements from FormattedError and BacktracedErrors.
         #[derive(Clone, Debug, Error)]

--- a/crates/errors/src/common/mod.rs
+++ b/crates/errors/src/common/mod.rs
@@ -14,6 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use backtrace::Backtrace;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Debug, Default)]
+pub struct Backtrace;
+
+#[cfg(target_arch = "wasm32")]
+impl Backtrace {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
 /// This module contains a backtraced error and its methods.
 pub mod backtraced;
 pub use self::backtraced::*;

--- a/crates/leo-aleo-abi-wasm/Cargo.toml
+++ b/crates/leo-aleo-abi-wasm/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "leo-aleo-abi-wasm"
+version = "4.0.2"
+authors = [ "The Leo Team <leo@provable.com>" ]
+description = "WASM bindings for ABI generation from Aleo bytecode"
+homepage = "https://leo-lang.org"
+repository = "https://github.com/ProvableHQ/leo"
+keywords = [ "aleo", "leo", "wasm" ]
+categories = [ "compilers", "cryptography", "wasm" ]
+include = [ "Cargo.toml", "src", "LICENSE.md" ]
+license = "GPL-3.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+crate-type = [ "cdylib", "rlib" ]
+
+[dependencies]
+leo-abi = { workspace = true, features = [ "aleo-bytecode" ] }
+leo-ast = { workspace = true }
+serde_json = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"

--- a/crates/leo-aleo-abi-wasm/src/lib.rs
+++ b/crates/leo-aleo-abi-wasm/src/lib.rs
@@ -1,0 +1,63 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+#![forbid(unsafe_code)]
+#![cfg_attr(not(any(test, target_arch = "wasm32")), allow(dead_code))]
+
+//! WASM bindings for ABI generation from Aleo bytecode.
+//!
+//! This crate intentionally exposes only the ABI-from-compiled-`.aleo` path.
+
+use leo_ast::NetworkName;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm_bindings {
+    use super::generate_abi_from_aleo_json;
+
+    use wasm_bindgen::prelude::*;
+
+    /// Generates pretty-printed ABI JSON from compiled Aleo bytecode for the requested network.
+    ///
+    /// This binding accepts an existing `.aleo` artifact. It does not parse or
+    /// compile `.leo` source.
+    #[wasm_bindgen]
+    pub fn generate_abi_from_aleo(bytecode: &str, network: &str) -> Result<String, JsValue> {
+        generate_abi_from_aleo_json(bytecode, network).map_err(|error| JsValue::from_str(&error))
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm_bindings::generate_abi_from_aleo;
+
+// Keep the implementation target-neutral so native unit tests exercise the
+// same parsing, ABI generation, and JSON serialization path as the WASM export.
+fn generate_abi_from_aleo_json(bytecode: &str, network: &str) -> Result<String, String> {
+    let network = network.parse::<NetworkName>().map_err(|error| error.to_string())?;
+    let abi =
+        leo_abi::aleo::generate_from_bytecode("program.aleo", bytecode, network).map_err(|error| error.to_string())?;
+    serde_json::to_string_pretty(&abi).map_err(|error| error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::generate_abi_from_aleo_json;
+
+    #[test]
+    fn generate_abi_from_aleo_rejects_unknown_network() {
+        let error = generate_abi_from_aleo_json("", "unknown").expect_err("expected unknown network to fail");
+        assert!(error.contains("Invalid network name"), "unexpected error: {error}");
+    }
+}

--- a/crates/leo/Cargo.toml
+++ b/crates/leo/Cargo.toml
@@ -49,7 +49,7 @@ only_testnet = [ ]
 
 [dependencies]
 # leo dependencies
-leo-abi           = { workspace = true }
+leo-abi           = { workspace = true, features = [ "aleo-bytecode" ] }
 leo-ast           = { workspace = true }
 leo-compiler      = { workspace = true }
 leo-disassembler  = { workspace = true }

--- a/crates/leo/src/cli/commands/abi.rs
+++ b/crates/leo/src/cli/commands/abi.rs
@@ -19,8 +19,6 @@ use super::*;
 use leo_ast::NetworkName;
 use leo_errors::CliError;
 
-use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
-
 use std::path::PathBuf;
 
 /// Generate ABI from an Aleo bytecode file.
@@ -75,16 +73,9 @@ impl Command for LeoAbi {
         // Get the file name for error messages.
         let file_name = self.file.file_name().and_then(|s| s.to_str()).unwrap_or("unknown");
 
-        // Disassemble and generate ABI based on network type.
-        let aleo_program = match self.network {
-            NetworkName::MainnetV0 => leo_disassembler::disassemble_from_str::<MainnetV0>(file_name, &content),
-            NetworkName::TestnetV0 => leo_disassembler::disassemble_from_str::<TestnetV0>(file_name, &content),
-            NetworkName::CanaryV0 => leo_disassembler::disassemble_from_str::<CanaryV0>(file_name, &content),
-        }
-        .map_err(|e| CliError::failed_to_parse_aleo_file(file_name, e))?;
-
-        // Generate ABI from the disassembled program.
-        let abi = leo_abi::aleo::generate(&aleo_program);
+        // Disassemble the Aleo bytecode and generate its ABI.
+        let abi = leo_abi::aleo::generate_from_bytecode(file_name, &content, self.network)
+            .map_err(|e| CliError::failed_to_parse_aleo_file(file_name, e))?;
 
         // Serialize to JSON.
         let json = serde_json::to_string_pretty(&abi).map_err(|e| CliError::failed_to_serialize_abi(e.to_string()))?;


### PR DESCRIPTION
## Summary

- add `leo-aleo-abi-wasm`, a narrow `wasm-bindgen` wrapper for generating ABI JSON from compiled Aleo bytecode
- expose only `generate_abi_from_aleo(bytecode, network)` from the WASM binding
- keep `leo_abi::aleo` typed: the optional `aleo-bytecode` helper returns `leo_abi::Program`, while JSON serialization stays at the WASM boundary
- replace the standalone `leo-snarkvm-wasm-compat` crate with private wasm-only `snarkvm::...` facades inside `leo-ast` and `leo-disassembler`
- use direct wasm-only dependencies on `snarkvm-console` and `snarkvm-synthesizer-program` so the supported path avoids full `snarkvm`, ledger/query, `ureq`, `ring`, and `rustls`
- route `leo abi` through the same typed bytecode helper used by the WASM binding
- add focused WASM CI for test, check, and clippy of the supported crate

This intentionally stops short of parse/typecheck, package resolution, or full `leo build` support in WASM. The supported API in this PR is only `generate_abi_from_aleo(bytecode, network)` for an existing compiled `.aleo` artifact.

Broader Leo WASM support is tracked separately in #29371.

## TypeScript SDK usage

The SDK exposes network-specific entrypoints like `@provablehq/sdk/testnet.js` and re-exports wasm bindings from `@provablehq/wasm/testnet.js`. Once this binding is re-exported through the SDK, the minimal usage looks like:

```ts
import { readFile } from "node:fs/promises";
import { generate_abi_from_aleo } from "@provablehq/sdk/testnet.js";

const bytecode = await readFile("build/main.aleo", "utf8");
const abi = JSON.parse(generate_abi_from_aleo(bytecode, "testnet"));

console.log(abi);
```

Note: `bytecode` here is the compiled Aleo program artifact, for example `build/main.aleo`. This MVP does not compile `.leo` source in WASM; callers should pass an existing `.aleo` artifact.

## Validation

- `cargo +stable check -p leo-aleo-abi-wasm --target wasm32-unknown-unknown --locked`
- `cargo +stable clippy -p leo-aleo-abi-wasm --target wasm32-unknown-unknown --locked -- -D warnings`
- `cargo +stable test -p leo-aleo-abi-wasm --locked`
- `cargo +stable test -p leo-abi --features aleo-bytecode --locked`
- `cargo check -p leo-lang --locked`
- `git diff --check`
- `cargo +stable tree -p leo-aleo-abi-wasm --target wasm32-unknown-unknown --locked | rg "(^|[[:space:]])(leo-snarkvm|snarkvm v4|snarkvm-ledger|ureq v|ring v|rustls v)"` returns no matches
