### PR TITLE
refactor: rename "program" identifiers to "unit" (compilation unit)

### DIFF
--- a/crates/ast/src/module/mod.rs
+++ b/crates/ast/src/module/mod.rs
@@ -18,7 +18,7 @@
 //! typically corresponding to a file or logical unit of code. It stores all
 //! relevant definitions associated with a module, including:
 //!
-//! - The name of the program the module belongs to (`program_name`)
+//! - The name of the program the module belongs to (`unit_name`)
 //! - The hierarchical path identifying the module (`path`)
 //! - A list of constant declarations (`consts`)
 //! - A list of composite type definitions (`composites`)
@@ -37,8 +37,8 @@ use serde::{Deserialize, Serialize};
 /// Stores the abstract syntax tree of a Leo module.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Module {
-    /// The name of the program that this module belongs to.
-    pub program_name: Symbol,
+    /// The name of the compilation unit (program or library) that this module belongs to.
+    pub unit_name: Symbol,
     /// The path to the module.
     pub path: Vec<Symbol>,
     /// A vector of const definitions.

--- a/crates/ast/src/passes/reconstructor.rs
+++ b/crates/ast/src/passes/reconstructor.rs
@@ -571,8 +571,8 @@ pub trait AstReconstructor {
     }
 }
 
-/// A Reconstructor trait for the program represented by the AST.
-pub trait ProgramReconstructor: AstReconstructor {
+/// A Reconstructor trait for a compilation unit (program or library) represented by the AST.
+pub trait UnitReconstructor: AstReconstructor {
     fn reconstruct_program(&mut self, input: Program) -> Program {
         let stubs = input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect();
         let program_scopes =
@@ -653,7 +653,7 @@ pub trait ProgramReconstructor: AstReconstructor {
 
     fn reconstruct_module(&mut self, input: Module) -> Module {
         Module {
-            program_name: input.program_name,
+            unit_name: input.unit_name,
             path: input.path,
             consts: input
                 .consts

--- a/crates/ast/src/passes/visitor.rs
+++ b/crates/ast/src/passes/visitor.rs
@@ -22,7 +22,7 @@ use crate::*;
 
 // TODO: The Visitor and Reconstructor patterns need a redesign so that the default implementation can easily be invoked though its implemented in an overriding trait.
 // Here is a pattern that seems to work
-// trait ProgramVisitor {
+// trait UnitVisitor {
 //     // The trait method that can be overridden
 //     fn visit_program_scope(&mut self);
 //
@@ -34,7 +34,7 @@ use crate::*;
 //
 // struct YourStruct;
 //
-// impl ProgramVisitor for YourStruct {
+// impl UnitVisitor for YourStruct {
 //     fn visit_program_scope(&mut self) {
 //         println!("Do custom stuff.");
 //         // Call the default implementation
@@ -343,8 +343,8 @@ pub trait AstVisitor {
     }
 }
 
-/// A Visitor trait for the program represented by the AST.
-pub trait ProgramVisitor: AstVisitor {
+/// A Visitor trait for a compilation unit (program or library) represented by the AST.
+pub trait UnitVisitor: AstVisitor {
     fn visit_program(&mut self, input: &Program) {
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
         input.modules.values().for_each(|module| self.visit_module(module));

--- a/crates/compiler/benchmarks/src/lib.rs
+++ b/crates/compiler/benchmarks/src/lib.rs
@@ -270,10 +270,10 @@ pub fn load_source_fixture(source_path: &Path) -> Result<FixtureData, String> {
 
 /// Creates a fresh [`Compiler`] with all fixture dependencies pre-loaded.
 pub fn create_compiler(fixture: &FixtureData) -> Compiler {
-    let expected_program_name = if fixture.program_name.is_empty() { None } else { Some(fixture.program_name.clone()) };
+    let expected_unit_name = if fixture.program_name.is_empty() { None } else { Some(fixture.program_name.clone()) };
 
     Compiler::new(
-        expected_program_name,
+        expected_unit_name,
         false,
         Handler::default(),
         Rc::new(NodeBuilder::default()),
@@ -286,10 +286,10 @@ pub fn create_compiler(fixture: &FixtureData) -> Compiler {
 
 /// Creates a lightweight [`Compiler`] with no import stubs for parse-only benchmarks.
 pub fn create_parse_only_compiler(fixture: &FixtureData) -> Compiler {
-    let expected_program_name = if fixture.program_name.is_empty() { None } else { Some(fixture.program_name.clone()) };
+    let expected_unit_name = if fixture.program_name.is_empty() { None } else { Some(fixture.program_name.clone()) };
 
     Compiler::new(
-        expected_program_name,
+        expected_unit_name,
         false,
         Handler::default(),
         Rc::new(NodeBuilder::default()),

--- a/crates/compiler/src/compiler.rs
+++ b/crates/compiler/src/compiler.rs
@@ -62,8 +62,8 @@ pub struct Compiled {
 pub struct Compiler {
     /// The path to where the compiler outputs all generated files.
     output_directory: PathBuf,
-    /// The program name,
-    pub program_name: Option<String>,
+    /// The name of the compilation unit (program or library).
+    pub unit_name: Option<String>,
     /// Options configuring compilation.
     compiler_options: CompilerOptions,
     /// State.
@@ -112,8 +112,8 @@ impl Compiler {
         // Check that the name of its program scope matches the expected name.
         // Note that parsing enforces that there is exactly one program scope in a file.
         let program_scope = program.program_scopes.values().next().unwrap();
-        if let Some(program_name) = &self.program_name {
-            if program_name != &program_scope.program_id.as_symbol().to_string() {
+        if let Some(unit_name) = &self.unit_name {
+            if unit_name != &program_scope.program_id.as_symbol().to_string() {
                 return Err(CompilerError::program_name_should_match_file_name(
                     program_scope.program_id.as_symbol(),
                     // If this is a test, use the filename as the expected name.
@@ -123,14 +123,14 @@ impl Compiler {
                             filename.to_string().split("/").last().expect("Could not get file name")
                         )
                     } else {
-                        format!("`{program_name}` (specified in `program.json`)")
+                        format!("`{unit_name}` (specified in `program.json`)")
                     },
                     program_scope.program_id.span(),
                 )
                 .into());
             }
         } else {
-            self.program_name = Some(program_scope.program_id.as_symbol().to_string());
+            self.unit_name = Some(program_scope.program_id.as_symbol().to_string());
         }
 
         self.state.ast = Ast::Program(program);
@@ -203,11 +203,11 @@ impl Compiler {
             self.state.network,
         )?);
 
-        // Downstream passes (e.g. `add_import_stubs`) read `program_name` to identify the
+        // Downstream passes (e.g. `add_import_stubs`) read `unit_name` to identify the
         // current compilation target. Libraries don't embed their own name in the source the
         // way programs do, so adopt the name supplied by the caller if none was pre-set.
-        if self.program_name.is_none() {
-            self.program_name = Some(library_name.to_string());
+        if self.unit_name.is_none() {
+            self.unit_name = Some(library_name.to_string());
         }
 
         Ok(())
@@ -216,7 +216,7 @@ impl Compiler {
     /// Returns a new Leo compiler.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        expected_program_name: Option<String>,
+        expected_unit_name: Option<String>,
         is_test: bool,
         handler: Handler,
         node_builder: Rc<NodeBuilder>,
@@ -234,7 +234,7 @@ impl Compiler {
                 ..Default::default()
             },
             output_directory,
-            program_name: expected_program_name,
+            unit_name: expected_unit_name,
             compiler_options: compiler_options.unwrap_or_default(),
             import_stubs,
             statements_before_dce: 0,
@@ -384,7 +384,7 @@ impl Compiler {
 
         // Build the primary compiled program.
         let primary = CompiledProgram {
-            name: self.program_name.clone().unwrap(),
+            name: self.unit_name.clone().unwrap(),
             bytecode: bytecodes.primary_bytecode,
             abi: primary_abi,
         };
@@ -546,12 +546,12 @@ impl Compiler {
                 if self.compiler_options.ast_spans_enabled {
                     program.to_json_file(
                         self.output_directory.clone(),
-                        &format!("{}.{file_suffix}", self.program_name.as_ref().unwrap()),
+                        &format!("{}.{file_suffix}", self.unit_name.as_ref().unwrap()),
                     )?;
                 } else {
                     program.to_json_file_without_keys(
                         self.output_directory.clone(),
-                        &format!("{}.{file_suffix}", self.program_name.as_ref().unwrap()),
+                        &format!("{}.{file_suffix}", self.unit_name.as_ref().unwrap()),
                         &["_span", "span"],
                     )?;
                 }
@@ -565,7 +565,7 @@ impl Compiler {
 
     /// Writes the AST to a file (Leo syntax, not JSON).
     fn write_ast(&self, file_suffix: &str) -> Result<()> {
-        let filename = format!("{}.{file_suffix}", self.program_name.as_ref().unwrap());
+        let filename = format!("{}.{file_suffix}", self.unit_name.as_ref().unwrap());
         let full_filename = self.output_directory.join(&filename);
 
         let contents = match &self.state.ast {
@@ -606,7 +606,7 @@ impl Compiler {
                 // Add any libraries that have this program as a parent
                 for (stub_name, stub) in &self.import_stubs {
                     if matches!(stub, Stub::FromLibrary { .. })
-                        && stub.parents().contains(&Symbol::intern(self.program_name.as_ref().unwrap()))
+                        && stub.parents().contains(&Symbol::intern(self.unit_name.as_ref().unwrap()))
                     {
                         map.insert(
                             *stub_name,
@@ -620,7 +620,7 @@ impl Compiler {
                 // Libraries have no explicit `imports` field; their dependencies are expressed
                 // indirectly through parent relations on the stubs map. A stub is a dep of this
                 // library iff its parent set contains the library's own name.
-                let library_name = Symbol::intern(self.program_name.as_ref().unwrap());
+                let library_name = Symbol::intern(self.unit_name.as_ref().unwrap());
                 self.import_stubs
                     .iter()
                     .filter(|(_, stub)| stub.parents().contains(&library_name))
@@ -633,7 +633,7 @@ impl Compiler {
         let mut to_explore: Vec<(Symbol, Span)> = initial_imports.iter().map(|(sym, span)| (*sym, *span)).collect();
 
         // If this is a named program, set the main program as the parent of its direct imports.
-        if let Some(main_program_name) = self.program_name.clone() {
+        if let Some(main_program_name) = self.unit_name.clone() {
             let main_symbol = Symbol::intern(&main_program_name);
             for import in initial_imports.keys() {
                 if let Some(child_stub) = self.import_stubs.get_mut(import) {
@@ -650,7 +650,7 @@ impl Compiler {
             // Look up the corresponding stub.
             let Some(stub) = self.import_stubs.get(&import_symbol) else {
                 return Err(CompilerError::imported_program_not_found(
-                    self.program_name.as_ref().unwrap(),
+                    self.unit_name.as_ref().unwrap(),
                     import_symbol,
                     span,
                 )

--- a/crates/compiler/src/test_utils.rs
+++ b/crates/compiler/src/test_utils.rs
@@ -65,7 +65,7 @@ pub fn whole_compile(
     let filename = FileName::Custom("compiler-test".into());
     let bytecodes = compiler.compile(&main_source, filename, &module_refs)?;
 
-    Ok((bytecodes, compiler.program_name.unwrap()))
+    Ok((bytecodes, compiler.unit_name.unwrap()))
 }
 
 /// Parses a Leo source string into an AST `Program` without generating bytecode.
@@ -103,7 +103,7 @@ pub fn parse_program(
     let filename = FileName::Custom("compiler-test".into());
     let program = compiler.parse_and_return_program(&main_source, filename, &module_refs)?;
 
-    Ok((program, compiler.program_name.unwrap()))
+    Ok((program, compiler.unit_name.unwrap()))
 }
 
 /// Parses a Leo library from the given source for use in compiler tests.

--- a/crates/parser/src/rowan.rs
+++ b/crates/parser/src/rowan.rs
@@ -2040,7 +2040,7 @@ impl<'a> ConversionContext<'a> {
         // Sort functions: entry points first
         functions.sort_by_key(|func| if func.1.variant.is_entry() { 0u8 } else { 1u8 });
 
-        Ok(leo_ast::Module { program_name, path, consts, composites, functions, interfaces })
+        Ok(leo_ast::Module { unit_name: program_name, path, consts, composites, functions, interfaces })
     }
 
     /// Convert a syntax node to a program (main file).

--- a/crates/passes/src/check_interfaces/mod.rs
+++ b/crates/passes/src/check_interfaces/mod.rs
@@ -19,7 +19,7 @@ use visitor::*;
 
 use crate::{CompilerState, Pass};
 
-use leo_ast::{Ast, ProgramVisitor};
+use leo_ast::{Ast, UnitVisitor};
 use leo_errors::Result;
 
 /// A pass to validate interface inheritance soundness.

--- a/crates/passes/src/check_interfaces/visitor.rs
+++ b/crates/passes/src/check_interfaces/visitor.rs
@@ -29,10 +29,10 @@ use leo_ast::{
     Member,
     Program,
     ProgramScope,
-    ProgramVisitor,
     RecordPrototype,
     StorageVariablePrototype,
     Type,
+    UnitVisitor,
 };
 use leo_errors::{CheckInterfacesError, Color, Label};
 use leo_span::{Span, Symbol, sym};
@@ -54,7 +54,7 @@ struct FlattenedInterface {
 pub struct CheckInterfacesVisitor<'a> {
     pub state: &'a mut CompilerState,
     /// Current program name being processed.
-    current_program: Symbol,
+    current_unit: Symbol,
     /// Cache of flattened interfaces (with all inherited members).
     flattened_interfaces: IndexMap<Location, FlattenedInterface>,
     /// Interface inheritance graph — used for cycle detection and ancestor lookup.
@@ -65,7 +65,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
     pub fn new(state: &'a mut CompilerState) -> Self {
         Self {
             state,
-            current_program: Symbol::intern(""),
+            current_unit: Symbol::intern(""),
             flattened_interfaces: IndexMap::new(),
             inheritance_graph: DiGraph::default(),
         }
@@ -83,7 +83,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
             return Some(flattened.clone());
         }
 
-        let Some(interface) = self.state.symbol_table.lookup_interface(self.current_program, location) else {
+        let Some(interface) = self.state.symbol_table.lookup_interface(self.current_unit, location) else {
             self.state.handler.emit_err(CheckInterfacesError::interface_not_found(location, location_span));
             return None;
         };
@@ -131,7 +131,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
 
         for ancestor_location in &all_ancestors {
             let Some(ancestor_interface) =
-                self.state.symbol_table.lookup_interface(self.current_program, ancestor_location)
+                self.state.symbol_table.lookup_interface(self.current_unit, ancestor_location)
             else {
                 self.state
                     .handler
@@ -523,14 +523,14 @@ impl<'a> CheckInterfacesVisitor<'a> {
     }
 
     /// Compare a concrete type against a prototype type. If the prototype names a prototype record,
-    /// the concrete type must have the same name and belong to `self.current_program`.
+    /// the concrete type must have the same name and belong to `self.current_unit`.
     fn concrete_type_matches_proto(
         &self,
         concrete: &Type,
         proto: &Type,
         prototype_record_locations: &IndexSet<Location>,
     ) -> bool {
-        Self::record_type_eq(concrete, proto, prototype_record_locations, Some(self.current_program))
+        Self::record_type_eq(concrete, proto, prototype_record_locations, Some(self.current_unit))
     }
 
     /// Core type comparison with prototype-record awareness.
@@ -710,7 +710,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
         let mut processed: IndexSet<Location> = IndexSet::new();
         for (prefix, interface) in interfaces {
             let path: Vec<Symbol> = prefix.iter().cloned().chain(std::iter::once(interface.identifier.name)).collect();
-            let location = Location::new(self.current_program, path);
+            let location = Location::new(self.current_unit, path);
             let span = interface.identifier.span;
             queue.insert((location, span));
         }
@@ -727,7 +727,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
             }
             self.inheritance_graph.add_node(location.clone());
 
-            let interface = match self.state.symbol_table.lookup_interface(self.current_program, &location) {
+            let interface = match self.state.symbol_table.lookup_interface(self.current_unit, &location) {
                 Some(p) => p.clone(),
                 None => {
                     // Skip silently; `flatten_interface` is the authoritative source for this error.
@@ -761,7 +761,7 @@ impl AstVisitor for CheckInterfacesVisitor<'_> {
     type Output = ();
 }
 
-impl ProgramVisitor for CheckInterfacesVisitor<'_> {
+impl UnitVisitor for CheckInterfacesVisitor<'_> {
     fn visit_program(&mut self, input: &Program) {
         // Visit stubs first so that library interface caches are fully populated
         // before check_program_implements_interface runs in visit_program_scope.
@@ -775,7 +775,7 @@ impl ProgramVisitor for CheckInterfacesVisitor<'_> {
         // before cycle detection and flattening run below.
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
 
-        self.current_program = input.name;
+        self.current_unit = input.name;
         // Reset the inheritance graph for this new scope.
         self.inheritance_graph = DiGraph::default();
 
@@ -805,13 +805,13 @@ impl ProgramVisitor for CheckInterfacesVisitor<'_> {
         // prefixed paths so the Location matches the symbol table entries.
         for (prefix, interface) in &prefixed {
             let path: Vec<Symbol> = prefix.iter().cloned().chain(std::iter::once(interface.identifier.name)).collect();
-            let location = Location::new(self.current_program, path);
+            let location = Location::new(self.current_unit, path);
             self.flatten_interface(&location, interface.identifier.span);
         }
     }
 
     fn visit_program_scope(&mut self, input: &ProgramScope) {
-        self.current_program = input.program_id.as_symbol();
+        self.current_unit = input.program_id.as_symbol();
         // Reset the inheritance graph for this new scope.
         self.inheritance_graph = DiGraph::default();
 
@@ -848,7 +848,7 @@ impl ProgramVisitor for CheckInterfacesVisitor<'_> {
 
         // Flatten all interfaces in this program scope.
         for (_, interface) in &input.interfaces {
-            let location = Location::new(self.current_program, vec![interface.identifier.name]);
+            let location = Location::new(self.current_unit, vec![interface.identifier.name]);
             // This will validate inheritance and cache the result.
             self.flatten_interface(&location, interface.identifier.span);
         }

--- a/crates/passes/src/common/block_to_function_rewriter.rs
+++ b/crates/passes/src/common/block_to_function_rewriter.rs
@@ -76,12 +76,12 @@ use indexmap::IndexMap;
 
 pub struct BlockToFunctionRewriter<'a> {
     state: &'a mut CompilerState,
-    current_program: Symbol,
+    current_unit: Symbol,
 }
 
 impl<'a> BlockToFunctionRewriter<'a> {
-    pub fn new(state: &'a mut CompilerState, current_program: Symbol) -> Self {
-        Self { state, current_program }
+    pub fn new(state: &'a mut CompilerState, current_unit: Symbol) -> Self {
+        Self { state, current_unit }
     }
 }
 
@@ -321,7 +321,7 @@ impl BlockToFunctionRewriter<'_> {
         // Create the call expression to invoke the function.
         let call_to_function = CallExpression {
             function: Path::from(make_identifier(self, function_name))
-                .to_global(Location::new(self.current_program, vec![function_name])),
+                .to_global(Location::new(self.current_unit, vec![function_name])),
             const_arguments: vec![],
             arguments,
             span: input.span,

--- a/crates/passes/src/common/replacer/mod.rs
+++ b/crates/passes/src/common/replacer/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use leo_ast::{AstReconstructor, Block, Expression, IterationStatement, Node as _, ProgramReconstructor, Statement};
+use leo_ast::{AstReconstructor, Block, Expression, IterationStatement, Node as _, Statement, UnitReconstructor};
 
 use crate::CompilerState;
 
@@ -131,4 +131,4 @@ where
     }
 }
 
-impl<F> ProgramReconstructor for Replacer<'_, F> where F: Fn(&Expression) -> Expression {}
+impl<F> UnitReconstructor for Replacer<'_, F> where F: Fn(&Expression) -> Expression {}

--- a/crates/passes/src/common/stub_walk.rs
+++ b/crates/passes/src/common/stub_walk.rs
@@ -112,7 +112,7 @@ fn module_functions<'a>(
 ) -> impl Iterator<Item = (Location, &'a Function)> {
     m.functions.iter().map(move |(name, f)| {
         let full: Vec<Symbol> = path.iter().copied().chain(std::iter::once(*name)).collect();
-        (Location::new(m.program_name, full), f)
+        (Location::new(m.unit_name, full), f)
     })
 }
 
@@ -121,6 +121,6 @@ fn module_composites<'a>(
 ) -> impl Iterator<Item = (Location, &'a Composite)> {
     m.composites.iter().map(move |(name, c)| {
         let full: Vec<Symbol> = path.iter().copied().chain(std::iter::once(*name)).collect();
-        (Location::new(m.program_name, full), c)
+        (Location::new(m.unit_name, full), c)
     })
 }

--- a/crates/passes/src/common/symbol_access_collector.rs
+++ b/crates/passes/src/common/symbol_access_collector.rs
@@ -22,7 +22,7 @@
 
 use crate::CompilerState;
 
-use leo_ast::{AstVisitor, Expression, Node as _, Path, ProgramVisitor, TupleAccess, Type};
+use leo_ast::{AstVisitor, Expression, Node as _, Path, TupleAccess, Type, UnitVisitor};
 
 use indexmap::IndexSet;
 
@@ -61,4 +61,4 @@ impl AstVisitor for SymbolAccessCollector<'_> {
     }
 }
 
-impl ProgramVisitor for SymbolAccessCollector<'_> {}
+impl UnitVisitor for SymbolAccessCollector<'_> {}

--- a/crates/passes/src/common/symbol_table/mod.rs
+++ b/crates/passes/src/common/symbol_table/mod.rs
@@ -268,57 +268,57 @@ impl SymbolTable {
         self.interfaces.iter()
     }
 
-    /// Access a struct by this location if it exists and is accessible from program named `current_program`.
-    pub fn lookup_struct(&self, current_program: Symbol, loc: &Location) -> Option<&Composite> {
-        if self.is_visible(current_program, &loc.program) { self.structs.get(loc) } else { None }
+    /// Access a struct by this location if it exists and is accessible from the compilation unit `current_unit`.
+    pub fn lookup_struct(&self, current_unit: Symbol, loc: &Location) -> Option<&Composite> {
+        if self.is_visible(current_unit, &loc.program) { self.structs.get(loc) } else { None }
     }
 
-    /// Access a record at this location if it exists and is accessible from program named `current_program`.
-    pub fn lookup_record(&self, current_program: Symbol, location: &Location) -> Option<&Composite> {
-        if self.is_visible(current_program, &location.program) { self.records.get(location) } else { None }
+    /// Access a record at this location if it exists and is accessible from the compilation unit `current_unit`.
+    pub fn lookup_record(&self, current_unit: Symbol, location: &Location) -> Option<&Composite> {
+        if self.is_visible(current_unit, &location.program) { self.records.get(location) } else { None }
     }
 
-    /// Access a function by this name if it exists and is accessible from program named `current_program`.
-    pub fn lookup_function(&self, current_program: Symbol, location: &Location) -> Option<&FunctionSymbol> {
-        if self.is_visible(current_program, &location.program) { self.functions.get(location) } else { None }
+    /// Access a function by this name if it exists and is accessible from the compilation unit `current_unit`.
+    pub fn lookup_function(&self, current_unit: Symbol, location: &Location) -> Option<&FunctionSymbol> {
+        if self.is_visible(current_unit, &location.program) { self.functions.get(location) } else { None }
     }
 
-    /// Returns true if `location` refers to an entry point in a different program than
-    /// `current_program`. Cross-program entry-point calls must be emitted as direct Aleo `call`
-    /// instructions — inlining an entry-point body into a different program would lose its
-    /// transition semantics (record creation, signing, finalize scheduling).
-    pub fn is_cross_program_entry(&self, current_program: Symbol, location: &Location) -> bool {
-        location.program != current_program
+    /// Returns true if `location` refers to an entry point in a different compilation unit than
+    /// `current_unit`. Cross-unit entry-point calls must be emitted as direct Aleo `call`
+    /// instructions — inlining an entry-point body into a different compilation unit would lose
+    /// its transition semantics (record creation, signing, finalize scheduling).
+    pub fn is_cross_program_entry(&self, current_unit: Symbol, location: &Location) -> bool {
+        location.program != current_unit
             && self
-                .lookup_function(current_program, location)
+                .lookup_function(current_unit, location)
                 .expect("the symbol table must know about every callee at this stage")
                 .function
                 .variant
                 .is_entry()
     }
 
-    /// Access an interface by this name if it exists and is accessible from program named `current_program`.
-    pub fn lookup_interface(&self, current_program: Symbol, location: &Location) -> Option<&Interface> {
-        if self.is_visible(current_program, &location.program) { self.interfaces.get(location) } else { None }
+    /// Access an interface by this name if it exists and is accessible from the compilation unit `current_unit`.
+    pub fn lookup_interface(&self, current_unit: Symbol, location: &Location) -> Option<&Interface> {
+        if self.is_visible(current_unit, &location.program) { self.interfaces.get(location) } else { None }
     }
 
-    /// Attempts to look up a variable by a path from program named `current_program`.
+    /// Attempts to look up a variable by a path from the compilation unit `current_unit`.
     ///
-    /// First, it tries to resolve the symbol as a global using the full path under the given program.
+    /// First, it tries to resolve the symbol as a global using the full path under the given compilation unit.
     /// If that fails and the path is non-empty, it falls back to resolving the last component
     /// of the path as a local symbol.
     ///
     /// # Arguments
     ///
-    /// * `program` - The root symbol representing the program or module context.
+    /// * `current_unit` - The root symbol representing the compilation unit context.
     /// * `path` - A `Path`.
     ///
     /// # Returns
     ///
     /// An `Option<VariableSymbol>` containing the resolved symbol if found, otherwise `None`.
-    pub fn lookup_path(&self, current_program: Symbol, path: &Path) -> Option<VariableSymbol> {
+    pub fn lookup_path(&self, current_unit: Symbol, path: &Path) -> Option<VariableSymbol> {
         if let Some(loc) = path.try_global_location() {
-            self.lookup_global(current_program, loc).cloned()
+            self.lookup_global(current_unit, loc).cloned()
         } else if let Some(sym) = path.try_local_symbol() {
             self.lookup_local(sym)
         } else {
@@ -486,12 +486,8 @@ impl SymbolTable {
         None
     }
 
-    pub fn lookup_global_const(&self, current_program: Symbol, location: &Location) -> Option<Expression> {
-        if self.is_visible(current_program, &location.program) {
-            self.global_consts.get(location).cloned()
-        } else {
-            None
-        }
+    pub fn lookup_global_const(&self, current_unit: Symbol, location: &Location) -> Option<Expression> {
+        if self.is_visible(current_unit, &location.program) { self.global_consts.get(location).cloned() } else { None }
     }
 
     /// Insert a struct at this location.
@@ -530,9 +526,9 @@ impl SymbolTable {
     }
 
     /// Access the global variable at this location if it exists and is visible
-    /// from the given `current_program`.
-    pub fn lookup_global(&self, current_program: Symbol, location: &Location) -> Option<&VariableSymbol> {
-        if self.is_visible(current_program, &location.program) { self.globals.get(location) } else { None }
+    /// from the given `current_unit`.
+    pub fn lookup_global(&self, current_unit: Symbol, location: &Location) -> Option<&VariableSymbol> {
+        if self.is_visible(current_unit, &location.program) { self.globals.get(location) } else { None }
     }
 
     /// Sets the type of a local using its name. Returns `false` if the local is not found.

--- a/crates/passes/src/common_subexpression_elimination/mod.rs
+++ b/crates/passes/src/common_subexpression_elimination/mod.rs
@@ -42,7 +42,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 use leo_errors::Result;
 
 mod ast;

--- a/crates/passes/src/common_subexpression_elimination/program.rs
+++ b/crates/passes/src/common_subexpression_elimination/program.rs
@@ -16,9 +16,9 @@
 
 use super::CommonSubexpressionEliminatingVisitor;
 
-use leo_ast::{AstReconstructor, Constructor, Function, Library, Module, ProgramReconstructor};
+use leo_ast::{AstReconstructor, Constructor, Function, Library, Module, UnitReconstructor};
 
-impl ProgramReconstructor for CommonSubexpressionEliminatingVisitor<'_> {
+impl UnitReconstructor for CommonSubexpressionEliminatingVisitor<'_> {
     fn reconstruct_library(&mut self, input: Library) -> Library {
         // Library function bodies are no longer relevant after function inlining and may not
         // satisfy CSE's invariants (e.g. expression type-table entries for raw function bodies).

--- a/crates/passes/src/const_propagation/mod.rs
+++ b/crates/passes/src/const_propagation/mod.rs
@@ -16,7 +16,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 use leo_errors::Result;
 use leo_span::{Span, Symbol};
 

--- a/crates/passes/src/const_propagation/program.rs
+++ b/crates/passes/src/const_propagation/program.rs
@@ -26,12 +26,12 @@ use leo_ast::{
     Module,
     Node,
     Output,
-    ProgramReconstructor,
     ProgramScope,
     Statement,
+    UnitReconstructor,
 };
 
-impl ProgramReconstructor for ConstPropagationVisitor<'_> {
+impl UnitReconstructor for ConstPropagationVisitor<'_> {
     fn reconstruct_program_scope(&mut self, mut input: ProgramScope) -> ProgramScope {
         self.program = input.program_id.as_symbol();
 
@@ -61,7 +61,7 @@ impl ProgramReconstructor for ConstPropagationVisitor<'_> {
     }
 
     fn reconstruct_module(&mut self, input: Module) -> Module {
-        self.program = input.program_name;
+        self.program = input.unit_name;
         self.in_module_scope(&input.path.clone(), |slf| {
             Module {
                 // Reconstruct consts firsts
@@ -73,7 +73,7 @@ impl ProgramReconstructor for ConstPropagationVisitor<'_> {
                         _ => panic!("`reconstruct_const` can only return `Statement::Const`"),
                     })
                     .collect(),
-                program_name: input.program_name,
+                unit_name: input.unit_name,
                 path: input.path,
                 // Skip generic composites (those with const parameters): their types cannot be
                 // fully evaluated until they are monomorphized into the consuming program's scope.

--- a/crates/passes/src/dead_code_elimination/mod.rs
+++ b/crates/passes/src/dead_code_elimination/mod.rs
@@ -51,7 +51,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 use leo_errors::Result;
 
 mod ast;
@@ -80,7 +80,7 @@ impl Pass for DeadCodeEliminating {
         let mut visitor = DeadCodeEliminatingVisitor {
             state,
             used_variables: Default::default(),
-            program_name: Default::default(),
+            unit_name: Default::default(),
             statements_before: 0,
             statements_after: 0,
         };

--- a/crates/passes/src/dead_code_elimination/program.rs
+++ b/crates/passes/src/dead_code_elimination/program.rs
@@ -16,18 +16,18 @@
 
 use super::DeadCodeEliminatingVisitor;
 
-use leo_ast::{AstReconstructor, Constructor, Function, Location, ProgramReconstructor, UpgradeVariant};
+use leo_ast::{AstReconstructor, Constructor, Function, Location, UnitReconstructor, UpgradeVariant};
 use leo_errors::StaticAnalyzerError;
 
-impl ProgramReconstructor for DeadCodeEliminatingVisitor<'_> {
+impl UnitReconstructor for DeadCodeEliminatingVisitor<'_> {
     fn reconstruct_program_scope(&mut self, mut input: leo_ast::ProgramScope) -> leo_ast::ProgramScope {
-        self.program_name = input.program_id.as_symbol();
+        self.unit_name = input.program_id.as_symbol();
         input.functions = input
             .functions
             .into_iter()
             .filter(|(name, fun)| {
                 use leo_ast::Variant::*;
-                let location = Location::new(self.program_name, vec![*name]);
+                let location = Location::new(self.unit_name, vec![*name]);
                 let call_count = *self.state.call_count.get(&location).unwrap();
 
                 match fun.variant {

--- a/crates/passes/src/dead_code_elimination/visitor.rs
+++ b/crates/passes/src/dead_code_elimination/visitor.rs
@@ -28,7 +28,7 @@ pub struct DeadCodeEliminatingVisitor<'a> {
     pub used_variables: IndexSet<Symbol>,
 
     /// The name of the program currently being processed.
-    pub program_name: Symbol,
+    pub unit_name: Symbol,
 
     /// How many statements were in the AST before DCE?
     pub statements_before: u32,

--- a/crates/passes/src/destructuring/mod.rs
+++ b/crates/passes/src/destructuring/mod.rs
@@ -19,7 +19,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 
 use leo_errors::Result;
 

--- a/crates/passes/src/destructuring/program.rs
+++ b/crates/passes/src/destructuring/program.rs
@@ -16,9 +16,9 @@
 
 use super::DestructuringVisitor;
 
-use leo_ast::{AstReconstructor, Constructor, Function, ProgramReconstructor};
+use leo_ast::{AstReconstructor, Constructor, Function, UnitReconstructor};
 
-impl ProgramReconstructor for DestructuringVisitor<'_> {
+impl UnitReconstructor for DestructuringVisitor<'_> {
     fn reconstruct_function(&mut self, input: Function) -> Function {
         // Set the `is_onchain` flag before reconstructing the block.
         // Note: There is no need to reset this flag as it is appropriately assigned before visiting a function or constructor.

--- a/crates/passes/src/disambiguate.rs
+++ b/crates/passes/src/disambiguate.rs
@@ -51,7 +51,7 @@ pub struct DisambiguateVisitor<'state> {
     pub state: &'state mut CompilerState,
 }
 
-impl ProgramReconstructor for DisambiguateVisitor<'_> {}
+impl UnitReconstructor for DisambiguateVisitor<'_> {}
 
 impl AstReconstructor for DisambiguateVisitor<'_> {
     type AdditionalInput = ();

--- a/crates/passes/src/flattening/mod.rs
+++ b/crates/passes/src/flattening/mod.rs
@@ -53,7 +53,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 use leo_errors::Result;
 use leo_span::Symbol;
 

--- a/crates/passes/src/flattening/program.rs
+++ b/crates/passes/src/flattening/program.rs
@@ -22,13 +22,13 @@ use leo_ast::{
     Expression,
     Function,
     Library,
-    ProgramReconstructor,
     ProgramScope,
     ReturnStatement,
     Statement,
+    UnitReconstructor,
 };
 
-impl ProgramReconstructor for FlatteningVisitor<'_> {
+impl UnitReconstructor for FlatteningVisitor<'_> {
     fn reconstruct_library(&mut self, input: Library) -> Library {
         let prev_program = self.program;
         self.program = input.name;

--- a/crates/passes/src/function_inlining/analysis.rs
+++ b/crates/passes/src/function_inlining/analysis.rs
@@ -17,7 +17,7 @@
 //! Analysis phase of the ForceInlineConversion pass.
 
 use indexmap::IndexSet;
-use leo_ast::{AstVisitor, AsyncExpression, CallExpression, ErrExpression, Function, ProgramVisitor, Variant};
+use leo_ast::{AstVisitor, AsyncExpression, CallExpression, ErrExpression, Function, UnitVisitor, Variant};
 use leo_span::Symbol;
 
 #[derive(Debug)]
@@ -67,7 +67,7 @@ impl AstVisitor for AnalysisVisitor {
     }
 }
 
-impl ProgramVisitor for AnalysisVisitor {
+impl UnitVisitor for AnalysisVisitor {
     fn visit_function(&mut self, input: &Function) {
         // Save previous variant
         let prev_variant = self.current_variant;

--- a/crates/passes/src/function_inlining/mod.rs
+++ b/crates/passes/src/function_inlining/mod.rs
@@ -106,7 +106,7 @@ use crate::Pass;
 
 use analysis::AnalysisVisitor;
 use indexmap::IndexMap;
-use leo_ast::{ProgramReconstructor, ProgramVisitor};
+use leo_ast::{UnitReconstructor, UnitVisitor};
 use leo_errors::Result;
 use leo_span::Symbol;
 use transform::TransformVisitor;

--- a/crates/passes/src/function_inlining/transform.rs
+++ b/crates/passes/src/function_inlining/transform.rs
@@ -55,7 +55,7 @@ impl<'a> TransformVisitor<'a> {
     }
 }
 
-impl ProgramReconstructor for TransformVisitor<'_> {
+impl UnitReconstructor for TransformVisitor<'_> {
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         let top_level_program = input.program_id.as_symbol();
         self.program = top_level_program;
@@ -459,7 +459,7 @@ impl TransformVisitor<'_> {
     /// Assembles a Module for a FromLeo stub from reconstructed_functions.
     fn assemble_module(&self, input: Module) -> Module {
         Module {
-            functions: items_at_path(&self.reconstructed_functions, input.program_name, &input.path).collect(),
+            functions: items_at_path(&self.reconstructed_functions, input.unit_name, &input.path).collect(),
             ..input
         }
     }

--- a/crates/passes/src/global_items_collection.rs
+++ b/crates/passes/src/global_items_collection.rs
@@ -50,9 +50,9 @@ use leo_ast::{
     Module,
     OptionalType,
     ProgramScope,
-    ProgramVisitor,
     StorageVariable,
     Type,
+    UnitVisitor,
 };
 use leo_errors::Result;
 use leo_span::Symbol;
@@ -70,7 +70,7 @@ impl Pass for GlobalItemsCollection {
 
     fn do_pass(_input: Self::Input, state: &mut CompilerState) -> Result<Self::Output> {
         let ast = std::mem::take(&mut state.ast);
-        let mut visitor = GlobalItemsCollectionVisitor { state, program_name: Symbol::intern(""), module: vec![] };
+        let mut visitor = GlobalItemsCollectionVisitor { state, unit_name: Symbol::intern(""), module: vec![] };
 
         match &ast {
             Ast::Program(program) => visitor.visit_program(program),
@@ -87,7 +87,7 @@ struct GlobalItemsCollectionVisitor<'a> {
     /// The state of the compiler.
     state: &'a mut CompilerState,
     /// The current program name.
-    program_name: Symbol,
+    unit_name: Symbol,
     /// The current module name.
     module: Vec<Symbol>,
 }
@@ -110,14 +110,14 @@ impl AstVisitor for GlobalItemsCollectionVisitor<'_> {
     fn visit_const(&mut self, input: &ConstDeclaration) {
         // Just set the type of the const in the symbol table.
         let const_path: Vec<Symbol> = self.module.iter().cloned().chain(std::iter::once(input.place.name)).collect();
-        self.state.symbol_table.set_global_type(&Location::new(self.program_name, const_path), input.type_.clone());
+        self.state.symbol_table.set_global_type(&Location::new(self.unit_name, const_path), input.type_.clone());
     }
 }
 
-impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
+impl UnitVisitor for GlobalItemsCollectionVisitor<'_> {
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set current program name
-        self.program_name = input.program_id.as_symbol();
+        self.unit_name = input.program_id.as_symbol();
 
         // Visit the program scope
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
@@ -132,7 +132,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
     }
 
     fn visit_module(&mut self, input: &Module) {
-        self.program_name = input.program_name;
+        self.unit_name = input.unit_name;
         self.in_module_scope(&input.path.clone(), |slf| {
             input.composites.iter().for_each(|(_, c)| slf.visit_composite(c));
             input.functions.iter().for_each(|(_, c)| slf.visit_function(c));
@@ -148,12 +148,12 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
             // While records are not allowed in submodules, we stll use their full name in the records table.
             // We don't expect the full name to have more than a single Symbol though.
             if let Err(err) =
-                self.state.symbol_table.insert_record(Location::new(self.program_name, full_name), input.clone())
+                self.state.symbol_table.insert_record(Location::new(self.unit_name, full_name), input.clone())
             {
                 self.state.handler.emit_err(err);
             }
         } else if let Err(err) =
-            self.state.symbol_table.insert_struct(Location::new(self.program_name, full_name.clone()), input.clone())
+            self.state.symbol_table.insert_struct(Location::new(self.unit_name, full_name.clone()), input.clone())
         {
             self.state.handler.emit_err(err);
         }
@@ -162,7 +162,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
     fn visit_mapping(&mut self, input: &Mapping) {
         // Set the type of the variable associated with the mapping in the symbol table.
         self.state.symbol_table.set_global_type(
-            &Location::new(self.program_name, vec![input.identifier.name]),
+            &Location::new(self.unit_name, vec![input.identifier.name]),
             Type::Mapping(MappingType {
                 key: Box::new(input.key_type.clone()),
                 value: Box::new(input.value_type.clone()),
@@ -179,12 +179,12 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
             _ => Type::Optional(OptionalType { inner: Box::new(input.type_.clone()) }),
         };
 
-        self.state.symbol_table.set_global_type(&Location::new(self.program_name, vec![input.identifier.name]), type_);
+        self.state.symbol_table.set_global_type(&Location::new(self.unit_name, vec![input.identifier.name]), type_);
     }
 
     fn visit_function(&mut self, input: &Function) {
         let full_name = self.module.iter().cloned().chain(std::iter::once(input.name())).collect::<Vec<Symbol>>();
-        let loc = Location::new(self.program_name, full_name);
+        let loc = Location::new(self.unit_name, full_name);
         if let Err(err) = self.state.symbol_table.insert_function(loc, input.clone()) {
             self.state.handler.emit_err(err);
         }
@@ -193,14 +193,14 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
     fn visit_interface(&mut self, input: &Interface) {
         let full_name = self.module.iter().cloned().chain(std::iter::once(input.name())).collect::<Vec<Symbol>>();
         if let Err(err) =
-            self.state.symbol_table.insert_interface(Location::new(self.program_name, full_name), input.clone())
+            self.state.symbol_table.insert_interface(Location::new(self.unit_name, full_name), input.clone())
         {
             self.state.handler.emit_err(err);
         }
     }
 
     fn visit_library(&mut self, input: &Library) {
-        self.program_name = input.name;
+        self.unit_name = input.name;
 
         input.interfaces.iter().for_each(|(_, i)| self.visit_interface(i));
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
@@ -213,7 +213,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
     }
 
     fn visit_aleo_program(&mut self, input: &AleoProgram) {
-        self.program_name = input.stub_id.as_symbol();
+        self.unit_name = input.stub_id.as_symbol();
 
         input.functions.iter().for_each(|(_, c)| self.visit_function_stub(c));
         input.composites.iter().for_each(|(_, c)| self.visit_composite_stub(c));
@@ -222,7 +222,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
 
     fn visit_function_stub(&mut self, input: &FunctionStub) {
         // Construct the location for the function.
-        let location = Location::new(self.program_name, vec![input.name()]);
+        let location = Location::new(self.unit_name, vec![input.name()]);
         // Initialize the function symbol.
         if let Err(err) = self.state.symbol_table.insert_function(location.clone(), Function::from(input.clone())) {
             self.state.handler.emit_err(err);
@@ -237,7 +237,7 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
             let name = Symbol::intern(&format!("finalize/{}", input.name()));
             if let Err(err) = self.state.symbol_table.attach_finalizer(
                 location,
-                Location::new(self.program_name, vec![name]),
+                Location::new(self.unit_name, vec![name]),
                 Vec::new(),
                 Vec::new(),
             ) {
@@ -248,15 +248,13 @@ impl ProgramVisitor for GlobalItemsCollectionVisitor<'_> {
 
     fn visit_composite_stub(&mut self, input: &Composite) {
         if input.is_record {
-            if let Err(err) = self
-                .state
-                .symbol_table
-                .insert_record(Location::new(self.program_name, vec![input.name()]), input.clone())
+            if let Err(err) =
+                self.state.symbol_table.insert_record(Location::new(self.unit_name, vec![input.name()]), input.clone())
             {
                 self.state.handler.emit_err(err);
             }
         } else if let Err(err) =
-            self.state.symbol_table.insert_struct(Location::new(self.program_name, vec![input.name()]), input.clone())
+            self.state.symbol_table.insert_struct(Location::new(self.unit_name, vec![input.name()]), input.clone())
         {
             self.state.handler.emit_err(err);
         }

--- a/crates/passes/src/global_vars_collection.rs
+++ b/crates/passes/src/global_vars_collection.rs
@@ -52,9 +52,9 @@ use leo_ast::{
     Mapping,
     Module,
     ProgramScope,
-    ProgramVisitor,
     StorageVariable,
     Stub,
+    UnitVisitor,
 };
 use leo_errors::Result;
 use leo_span::Symbol;
@@ -73,7 +73,7 @@ impl Pass for GlobalVarsCollection {
         let ast = std::mem::take(&mut state.ast);
         let mut visitor = GlobalVarsCollectionVisitor {
             state,
-            program_name: Symbol::intern(""),
+            unit_name: Symbol::intern(""),
             module: vec![],
             parents: IndexSet::new(),
         };
@@ -93,7 +93,7 @@ struct GlobalVarsCollectionVisitor<'a> {
     /// The state of the compiler.
     state: &'a mut CompilerState,
     /// The current program name.
-    program_name: Symbol,
+    unit_name: Symbol,
     /// The current module name.
     module: Vec<Symbol>,
     /// The set of programs that import the program we're visiting.
@@ -119,7 +119,7 @@ impl AstVisitor for GlobalVarsCollectionVisitor<'_> {
         // Just add the const to the symbol table without validating it; that will happen later
         // in type checking.
         let const_path: Vec<Symbol> = self.module.iter().cloned().chain(std::iter::once(input.place.name)).collect();
-        if let Err(err) = self.state.symbol_table.insert_variable(self.program_name, &const_path, VariableSymbol {
+        if let Err(err) = self.state.symbol_table.insert_variable(self.unit_name, &const_path, VariableSymbol {
             type_: None,
             span: input.place.span,
             declaration: VariableType::Const,
@@ -129,13 +129,13 @@ impl AstVisitor for GlobalVarsCollectionVisitor<'_> {
     }
 }
 
-impl ProgramVisitor for GlobalVarsCollectionVisitor<'_> {
+impl UnitVisitor for GlobalVarsCollectionVisitor<'_> {
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set current program name
-        self.program_name = input.program_id.as_symbol();
+        self.unit_name = input.program_id.as_symbol();
 
         // Update the `imports` map in the symbol table.
-        self.state.symbol_table.add_imported_by(self.program_name, &self.parents);
+        self.state.symbol_table.add_imported_by(self.unit_name, &self.parents);
 
         // Visit the program scope
         input.parents.iter().for_each(|(_, c)| self.visit_type(c));
@@ -145,7 +145,7 @@ impl ProgramVisitor for GlobalVarsCollectionVisitor<'_> {
     }
 
     fn visit_module(&mut self, input: &Module) {
-        self.program_name = input.program_name;
+        self.unit_name = input.unit_name;
         self.in_module_scope(&input.path.clone(), |slf| {
             input.consts.iter().for_each(|(_, c)| slf.visit_const(c));
         })
@@ -153,7 +153,7 @@ impl ProgramVisitor for GlobalVarsCollectionVisitor<'_> {
 
     fn visit_mapping(&mut self, input: &Mapping) {
         if let Err(err) = self.state.symbol_table.insert_global(
-            Location::new(self.program_name, vec![input.identifier.name]),
+            Location::new(self.unit_name, vec![input.identifier.name]),
             VariableSymbol { type_: None, span: input.span, declaration: VariableType::Storage },
         ) {
             self.state.handler.emit_err(err);
@@ -162,7 +162,7 @@ impl ProgramVisitor for GlobalVarsCollectionVisitor<'_> {
 
     fn visit_storage_variable(&mut self, input: &StorageVariable) {
         if let Err(err) = self.state.symbol_table.insert_global(
-            Location::new(self.program_name, vec![input.identifier.name]),
+            Location::new(self.unit_name, vec![input.identifier.name]),
             VariableSymbol { type_: None, span: input.span, declaration: VariableType::Storage },
         ) {
             self.state.handler.emit_err(err);
@@ -187,12 +187,12 @@ impl ProgramVisitor for GlobalVarsCollectionVisitor<'_> {
     }
 
     fn visit_library(&mut self, input: &Library) {
-        self.program_name = input.name;
+        self.unit_name = input.name;
 
         // Update the `imports` map in the symbol table.
-        self.state.symbol_table.add_imported_by(self.program_name, &self.parents);
+        self.state.symbol_table.add_imported_by(self.unit_name, &self.parents);
 
-        self.state.symbol_table.add_as_library(self.program_name);
+        self.state.symbol_table.add_as_library(self.unit_name);
 
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.modules.values().for_each(|m| self.visit_module(m));
@@ -200,10 +200,10 @@ impl ProgramVisitor for GlobalVarsCollectionVisitor<'_> {
     }
 
     fn visit_aleo_program(&mut self, input: &AleoProgram) {
-        self.program_name = input.stub_id.as_symbol();
+        self.unit_name = input.stub_id.as_symbol();
 
         // Update the `imports` map in the symbol table.
-        self.state.symbol_table.add_imported_by(self.program_name, &self.parents);
+        self.state.symbol_table.add_imported_by(self.unit_name, &self.parents);
 
         input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
     }

--- a/crates/passes/src/loop_unrolling/mod.rs
+++ b/crates/passes/src/loop_unrolling/mod.rs
@@ -16,7 +16,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor;
+use leo_ast::UnitReconstructor;
 use leo_errors::Result;
 use leo_span::{Span, Symbol};
 

--- a/crates/passes/src/loop_unrolling/program.rs
+++ b/crates/passes/src/loop_unrolling/program.rs
@@ -18,7 +18,7 @@ use leo_ast::*;
 
 use super::UnrollingVisitor;
 
-impl ProgramReconstructor for UnrollingVisitor<'_> {
+impl UnitReconstructor for UnrollingVisitor<'_> {
     fn reconstruct_aleo_program(&mut self, input: AleoProgram) -> AleoProgram {
         // Set the current program.
         self.program = input.stub_id.as_symbol();

--- a/crates/passes/src/monomorphization/ast.rs
+++ b/crates/passes/src/monomorphization/ast.rs
@@ -26,8 +26,8 @@ use leo_ast::{
     Expression,
     Identifier,
     Node as _,
-    ProgramReconstructor as _,
     Type,
+    UnitReconstructor as _,
 };
 
 use indexmap::IndexMap;

--- a/crates/passes/src/monomorphization/mod.rs
+++ b/crates/passes/src/monomorphization/mod.rs
@@ -67,7 +67,7 @@
 
 use crate::Pass;
 
-use leo_ast::{CompositeExpression, CompositeType, ProgramReconstructor as _};
+use leo_ast::{CompositeExpression, CompositeType, UnitReconstructor as _};
 use leo_errors::Result;
 use leo_span::Symbol;
 

--- a/crates/passes/src/monomorphization/program.rs
+++ b/crates/passes/src/monomorphization/program.rs
@@ -16,10 +16,10 @@
 
 use super::MonomorphizationVisitor;
 use crate::common::{items_at_path, program_composites, program_functions, stub_composites, stub_functions};
-use leo_ast::{AstReconstructor, Library, Program, ProgramReconstructor, ProgramScope, Statement, Stub, Variant};
+use leo_ast::{AstReconstructor, Library, Program, ProgramScope, Statement, Stub, UnitReconstructor, Variant};
 use leo_span::sym;
 
-impl ProgramReconstructor for MonomorphizationVisitor<'_> {
+impl UnitReconstructor for MonomorphizationVisitor<'_> {
     fn reconstruct_library(&mut self, input: Library) -> Library {
         // Unreached library functions are dropped: code generation skips library stubs
         // entirely, and nothing downstream reads un-inlined library bodies. Only functions

--- a/crates/passes/src/monomorphization/visitor.rs
+++ b/crates/passes/src/monomorphization/visitor.rs
@@ -30,9 +30,9 @@ use leo_ast::{
     Module,
     Path,
     Program,
-    ProgramReconstructor,
     ProgramScope,
     Statement,
+    UnitReconstructor,
 };
 use leo_span::Symbol;
 
@@ -161,13 +161,13 @@ impl MonomorphizationVisitor<'_> {
 
     /// Assembles a `Module` from the already-populated `reconstructed_*` maps. Interfaces are
     /// reconstructed because they may reference composites that have been monomorphized.
-    /// `input.program_name` is used (not `self.program`) because a nested `reconstruct_program`
+    /// `input.unit_name` is used (not `self.program`) because a nested `reconstruct_program`
     /// call on a `Stub::FromLeo` dependency may have moved `self.program` off the module's own
-    /// program.
+    /// compilation unit.
     pub(super) fn assemble_module(&mut self, input: Module) -> Module {
         Module {
-            composites: items_at_path(&self.reconstructed_composites, input.program_name, &input.path).collect(),
-            functions: items_at_path(&self.reconstructed_functions, input.program_name, &input.path).collect(),
+            composites: items_at_path(&self.reconstructed_composites, input.unit_name, &input.path).collect(),
+            functions: items_at_path(&self.reconstructed_functions, input.unit_name, &input.path).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
             ..input
         }

--- a/crates/passes/src/name_validation/mod.rs
+++ b/crates/passes/src/name_validation/mod.rs
@@ -23,7 +23,7 @@ use visitor::*;
 
 use crate::{CompilerState, Pass};
 
-use leo_ast::{Ast, ProgramVisitor};
+use leo_ast::{Ast, UnitVisitor};
 use leo_errors::Result;
 
 /// A pass to validate names.

--- a/crates/passes/src/name_validation/program.rs
+++ b/crates/passes/src/name_validation/program.rs
@@ -18,7 +18,7 @@ use super::NameValidationVisitor;
 
 use leo_ast::*;
 
-impl ProgramVisitor for NameValidationVisitor<'_> {
+impl UnitVisitor for NameValidationVisitor<'_> {
     fn visit_program(&mut self, input: &Program) {
         input.stubs.iter().for_each(|(_symbol, stub)| self.visit_stub(stub));
         input.modules.values().for_each(|module| self.visit_module(module));

--- a/crates/passes/src/option_lowering/mod.rs
+++ b/crates/passes/src/option_lowering/mod.rs
@@ -67,7 +67,7 @@ use crate::{
     TypeCheckingInput,
 };
 
-use leo_ast::{ArrayType, CompositeType, ProgramReconstructor as _, Type};
+use leo_ast::{ArrayType, CompositeType, Type, UnitReconstructor as _};
 use leo_errors::Result;
 use leo_span::Symbol;
 

--- a/crates/passes/src/option_lowering/program.rs
+++ b/crates/passes/src/option_lowering/program.rs
@@ -25,13 +25,13 @@ use leo_ast::{
     Module,
     Output,
     Program,
-    ProgramReconstructor,
     ProgramScope,
     Statement,
+    UnitReconstructor,
 };
 use leo_span::Symbol;
 
-impl ProgramReconstructor for OptionLoweringVisitor<'_> {
+impl UnitReconstructor for OptionLoweringVisitor<'_> {
     fn reconstruct_library(&mut self, input: Library) -> Library {
         let prev_program = self.program;
         self.program = input.name;
@@ -81,12 +81,11 @@ impl ProgramReconstructor for OptionLoweringVisitor<'_> {
             }
         }
         for (module_path, module) in &input.modules {
-            self.program = module.program_name;
+            self.program = module.unit_name;
             for (_, c) in &module.composites {
                 let full_name = module_path.iter().cloned().chain(std::iter::once(c.name())).collect::<Vec<Symbol>>();
                 let new_composite = self.reconstruct_composite(c.clone());
-                self.reconstructed_composites
-                    .insert(Location::new(module.program_name, full_name), new_composite.clone());
+                self.reconstructed_composites.insert(Location::new(module.unit_name, full_name), new_composite.clone());
             }
         }
 
@@ -150,7 +149,7 @@ impl ProgramReconstructor for OptionLoweringVisitor<'_> {
     }
 
     fn reconstruct_module(&mut self, input: Module) -> Module {
-        self.program = input.program_name;
+        self.program = input.unit_name;
         self.in_module_scope(&input.path.clone(), |slf| Module {
             consts: input
                 .consts

--- a/crates/passes/src/path_resolution/mod.rs
+++ b/crates/passes/src/path_resolution/mod.rs
@@ -42,7 +42,7 @@
 
 use crate::Pass;
 
-use leo_ast::{Ast, ProgramReconstructor as _};
+use leo_ast::{Ast, UnitReconstructor as _};
 use leo_errors::Result;
 use leo_span::Symbol;
 

--- a/crates/passes/src/path_resolution/program.rs
+++ b/crates/passes/src/path_resolution/program.rs
@@ -29,12 +29,12 @@ use leo_ast::{
     Member,
     Module,
     Output,
-    ProgramReconstructor,
     ProgramScope,
     Statement,
+    UnitReconstructor,
 };
 
-impl ProgramReconstructor for PathResolutionVisitor<'_> {
+impl UnitReconstructor for PathResolutionVisitor<'_> {
     fn reconstruct_aleo_program(&mut self, input: AleoProgram) -> AleoProgram {
         self.program = input.stub_id.as_symbol();
         AleoProgram {
@@ -99,9 +99,9 @@ impl ProgramReconstructor for PathResolutionVisitor<'_> {
     }
 
     fn reconstruct_module(&mut self, input: Module) -> Module {
-        self.program = input.program_name;
+        self.program = input.unit_name;
         self.in_module_scope(&input.path.clone(), |slf| Module {
-            program_name: input.program_name,
+            unit_name: input.unit_name,
             path: input.path,
             composites: input.composites.into_iter().map(|(i, c)| (i, slf.reconstruct_composite(c))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),

--- a/crates/passes/src/processing_async/ast.rs
+++ b/crates/passes/src/processing_async/ast.rs
@@ -29,7 +29,7 @@ impl AstReconstructor for ProcessingAsyncVisitor<'_> {
         let finalize_fn_name = self.state.assigner.unique_symbol(self.current_function, "$");
 
         // Convert the block into a function and a function call.
-        let mut block_to_function_rewriter = BlockToFunctionRewriter::new(self.state, self.current_program);
+        let mut block_to_function_rewriter = BlockToFunctionRewriter::new(self.state, self.current_unit);
         let (function, call_to_finalize) =
             block_to_function_rewriter.rewrite_block(&input.block, finalize_fn_name, Variant::Finalize);
 

--- a/crates/passes/src/processing_async/mod.rs
+++ b/crates/passes/src/processing_async/mod.rs
@@ -57,7 +57,7 @@ use crate::{
     TypeCheckingInput,
 };
 
-use leo_ast::{Ast, ProgramReconstructor as _};
+use leo_ast::{Ast, UnitReconstructor as _};
 use leo_errors::Result;
 use leo_span::Symbol;
 
@@ -81,7 +81,7 @@ impl Pass for ProcessingAsync {
         let mut visitor = ProcessingAsyncVisitor {
             state,
             max_inputs: input.max_inputs,
-            current_program: Symbol::intern(""),
+            current_unit: Symbol::intern(""),
             current_function: Symbol::intern(""),
             new_async_functions: Vec::new(),
             modified: false,

--- a/crates/passes/src/processing_async/program.rs
+++ b/crates/passes/src/processing_async/program.rs
@@ -22,12 +22,12 @@ use leo_ast::{
     Input,
     Node,
     Output,
-    ProgramReconstructor,
     ProgramScope,
     Statement,
+    UnitReconstructor,
 };
 
-impl ProgramReconstructor for ProcessingAsyncVisitor<'_> {
+impl UnitReconstructor for ProcessingAsyncVisitor<'_> {
     /// Reconstructs a `ProgramScope` by rewriting all contained elements:
     /// - Updates the current program context.
     /// - Reconstructs all functions using `reconstruct_function`.
@@ -39,7 +39,7 @@ impl ProgramReconstructor for ProcessingAsyncVisitor<'_> {
     /// components have gone through transformation.
     fn reconstruct_program_scope(&mut self, input: ProgramScope) -> ProgramScope {
         // Set the current program context
-        self.current_program = input.program_id.as_symbol();
+        self.current_unit = input.program_id.as_symbol();
 
         // Reconstruct all functions and store them temporarily. This process also populates
         // `new_async_functions`.

--- a/crates/passes/src/processing_async/visitor.rs
+++ b/crates/passes/src/processing_async/visitor.rs
@@ -25,7 +25,7 @@ pub struct ProcessingAsyncVisitor<'a> {
     /// on the number of variables captured by an `async` block.
     pub max_inputs: usize,
     /// The name of the current program being processed
-    pub current_program: Symbol,
+    pub current_unit: Symbol,
     /// The name of the current function being processed
     pub current_function: Symbol,
     /// A map of reconstructed functions in the current program scope.

--- a/crates/passes/src/remove_unreachable.rs
+++ b/crates/passes/src/remove_unreachable.rs
@@ -55,7 +55,7 @@ pub struct RemoveUnreachableVisitor<'state> {
     pub has_return: bool,
 }
 
-impl ProgramReconstructor for RemoveUnreachableVisitor<'_> {
+impl UnitReconstructor for RemoveUnreachableVisitor<'_> {
     fn reconstruct_function(&mut self, input: Function) -> Function {
         self.has_return = false;
         let res = Function {

--- a/crates/passes/src/ssa_const_propagation/mod.rs
+++ b/crates/passes/src/ssa_const_propagation/mod.rs
@@ -22,7 +22,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 use leo_errors::Result;
 use leo_span::Symbol;
 

--- a/crates/passes/src/ssa_const_propagation/program.rs
+++ b/crates/passes/src/ssa_const_propagation/program.rs
@@ -16,9 +16,9 @@
 
 use super::SsaConstPropagationVisitor;
 
-use leo_ast::{AstReconstructor, Constructor, Function, Library, ProgramReconstructor, ProgramScope, Statement};
+use leo_ast::{AstReconstructor, Constructor, Function, Library, ProgramScope, Statement, UnitReconstructor};
 
-impl ProgramReconstructor for SsaConstPropagationVisitor<'_> {
+impl UnitReconstructor for SsaConstPropagationVisitor<'_> {
     fn reconstruct_library(&mut self, input: Library) -> Library {
         // Library functions have already been inlined into the consuming program by the
         // function-inlining pass. Pass the library stub through unchanged.

--- a/crates/passes/src/static_analysis/mod.rs
+++ b/crates/passes/src/static_analysis/mod.rs
@@ -26,7 +26,7 @@ use visitor::*;
 
 use crate::Pass;
 
-use leo_ast::{Ast, ProgramVisitor};
+use leo_ast::{Ast, UnitVisitor};
 use leo_errors::Result;
 use leo_span::Symbol;
 
@@ -44,7 +44,7 @@ impl Pass for StaticAnalyzing {
         let mut visitor = StaticAnalyzingVisitor {
             state,
             await_checker: AwaitChecker::new(),
-            current_program: Symbol::intern(""),
+            current_unit: Symbol::intern(""),
             variant: None,
             non_async_external_call_seen: false,
         };

--- a/crates/passes/src/static_analysis/program.rs
+++ b/crates/passes/src/static_analysis/program.rs
@@ -19,10 +19,10 @@ use super::StaticAnalyzingVisitor;
 use leo_ast::{Type, *};
 use leo_errors::{StaticAnalyzerError, StaticAnalyzerWarning};
 
-impl ProgramVisitor for StaticAnalyzingVisitor<'_> {
+impl UnitVisitor for StaticAnalyzingVisitor<'_> {
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Set the current program name.
-        self.current_program = input.program_id.as_symbol();
+        self.current_unit = input.program_id.as_symbol();
         // Do the default implementation for visiting the program scope.
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.composites.iter().for_each(|(_, c)| self.visit_composite(c));
@@ -126,7 +126,7 @@ impl ProgramVisitor for StaticAnalyzingVisitor<'_> {
     }
 
     fn visit_library(&mut self, input: &leo_ast::Library) {
-        self.current_program = input.name;
+        self.current_unit = input.name;
 
         // The rest is identical to the default implementation
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));

--- a/crates/passes/src/static_analysis/visitor.rs
+++ b/crates/passes/src/static_analysis/visitor.rs
@@ -25,7 +25,7 @@ pub struct StaticAnalyzingVisitor<'a> {
     /// Struct to store the state relevant to checking all futures are awaited.
     pub await_checker: AwaitChecker,
     /// The current program name.
-    pub current_program: Symbol,
+    pub current_unit: Symbol,
     /// The variant of the function that we are currently traversing.
     pub variant: Option<Variant>,
     /// Whether or not a non-async external call has been seen in this function.
@@ -79,7 +79,7 @@ impl StaticAnalyzingVisitor<'_> {
         let func_symbol = self
             .state
             .symbol_table
-            .lookup_function(self.current_program, function_path.expect_global_location())
+            .lookup_function(self.current_unit, function_path.expect_global_location())
             .expect("Type checking guarantees functions are present.");
 
         // If it is not an async transition, return.
@@ -95,7 +95,7 @@ impl StaticAnalyzingVisitor<'_> {
         let async_function = self
             .state
             .symbol_table
-            .lookup_function(self.current_program, &finalizer.location)
+            .lookup_function(self.current_unit, &finalizer.location)
             .expect("Type checking guarantees functions are present.");
 
         // If the async function takes a future as an argument, emit an error.
@@ -119,7 +119,7 @@ impl AstVisitor for StaticAnalyzingVisitor<'_> {
 
     fn visit_call(&mut self, input: &CallExpression, _: &Self::AdditionalInput) -> Self::Output {
         let function_location = input.function.expect_global_location();
-        let caller_program = self.current_program;
+        let caller_program = self.current_unit;
         let callee_program = function_location.program;
 
         // If the function call is an external async transition, then for all async calls that follow a non-async call,
@@ -134,7 +134,7 @@ impl AstVisitor for StaticAnalyzingVisitor<'_> {
         let func_symbol = self
             .state
             .symbol_table
-            .lookup_function(self.current_program, input.function.expect_global_location())
+            .lookup_function(self.current_unit, input.function.expect_global_location())
             .expect("Type checking guarantees functions exist.");
 
         if func_symbol.function.variant == Variant::EntryPoint && !func_symbol.function.has_final_output() {

--- a/crates/passes/src/static_single_assignment/program.rs
+++ b/crates/passes/src/static_single_assignment/program.rs
@@ -200,10 +200,10 @@ impl ModuleConsumer for SsaFormingVisitor<'_> {
     type Output = Module;
 
     fn consume_module(&mut self, input: Module) -> Self::Output {
-        self.program = input.program_name;
+        self.program = input.unit_name;
         Module {
             path: input.path,
-            program_name: self.program,
+            unit_name: self.program,
             composites: input.composites.into_iter().map(|(i, s)| (i, self.consume_composite(s))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
             interfaces: input.interfaces,

--- a/crates/passes/src/storage_lowering/mod.rs
+++ b/crates/passes/src/storage_lowering/mod.rs
@@ -105,7 +105,7 @@ use crate::{
     TypeCheckingInput,
 };
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 use leo_errors::Result;
 use leo_span::Symbol;
 

--- a/crates/passes/src/storage_lowering/program.rs
+++ b/crates/passes/src/storage_lowering/program.rs
@@ -22,16 +22,16 @@ use leo_ast::{
     Library,
     Location,
     Mapping,
-    ProgramReconstructor,
     ProgramScope,
     Statement,
     StorageVariable,
     Type,
+    UnitReconstructor,
     VectorType,
 };
 use leo_span::Symbol;
 
-impl ProgramReconstructor for StorageLoweringVisitor<'_> {
+impl UnitReconstructor for StorageLoweringVisitor<'_> {
     fn reconstruct_library(&mut self, input: Library) -> Library {
         let prev_program = self.program;
         self.program = input.name;

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -261,7 +261,7 @@ impl TypeCheckingVisitor<'_> {
     /// - assignments in async functions or async blocks outside the allowed conditional scope,
     /// - assignments to variables outside an async block’s scope.
     pub fn visit_path_assign(&mut self, input: &Path) -> AssignTargetInfo {
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
 
         // Lookup the variable in the symbol table
         let Some(var) = self.state.symbol_table.lookup_path(current_program, input) else {
@@ -609,7 +609,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         // just inspect how the async block would look like as an async function in order to
         // populate the map `async_function_input_types`.
         let mut block_to_function_rewriter =
-            BlockToFunctionRewriter::new(self.state, self.scope_state.program_name.unwrap());
+            BlockToFunctionRewriter::new(self.state, self.scope_state.unit_name.unwrap());
         let (new_function, _) =
             block_to_function_rewriter.rewrite_block(&input.block, Symbol::intern("unused"), Variant::Finalize);
 
@@ -625,7 +625,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
 
         let input_types = new_function.input.iter().map(|Input { type_, .. }| type_.clone()).collect();
         self.async_function_input_types.insert(
-            Location::new(self.scope_state.program_name.unwrap(), vec![Symbol::intern(&format!(
+            Location::new(self.scope_state.unit_name.unwrap(), vec![Symbol::intern(&format!(
                 "finalize/{}",
                 self.scope_state.function.unwrap(),
             ))]),
@@ -1037,7 +1037,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_dynamic_call(&mut self, input: &DynamicCallExpression, expected: &Self::AdditionalInput) -> Self::Output {
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
 
         // Look up the interface in the symbol table.
         let Type::Composite(CompositeType { path: interface_path, .. }) = &input.interface else {
@@ -1120,7 +1120,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_call(&mut self, input: &CallExpression, expected: &Self::AdditionalInput) -> Self::Output {
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
         let callee_location = input.function.expect_global_location();
         let callee_program = callee_location.program;
         let callee_path = callee_location.path.clone();
@@ -1144,7 +1144,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
             ),
             Variant::EntryPoint
                 if matches!(func.variant, Variant::EntryPoint)
-                    && callee_program == self.scope_state.program_name.unwrap() =>
+                    && callee_program == self.scope_state.unit_name.unwrap() =>
             {
                 self.emit_err(TypeCheckerError::cannot_invoke_call_to_local_entry_point_fn(input.span))
             }
@@ -1271,7 +1271,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         }
 
         let caller_program =
-            self.scope_state.program_name.expect("`program_name` is always set before traversing a program scope");
+            self.scope_state.unit_name.expect("`unit_name` is always set before traversing a compilation unit");
         // Note: Constructors are added to the call graph under the `constructor` symbol.
         // This is safe since `constructor` is a reserved token and cannot be used as a function name.
         let caller_function = if self.scope_state.is_constructor {
@@ -1348,7 +1348,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                 .expect("Failed to attach finalizer");
             // Create expectation for finalize inputs that will be checked when checking corresponding finalize function signature.
             self.async_function_callers
-                .entry(Location::new(self.scope_state.program_name.unwrap(), callee_path.clone()))
+                .entry(Location::new(self.scope_state.unit_name.unwrap(), callee_path.clone()))
                 .or_default()
                 .insert(self.scope_state.location());
 
@@ -1515,7 +1515,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                     None => {
                         // If `expression` is None, then the member uses the identifier shorthand, e.g. `Foo { a }`.
                         // Therefore, lookup a local or a global in the symbol table with the member name.
-                        let current_program = self.scope_state.program_name.unwrap();
+                        let current_program = self.scope_state.unit_name.unwrap();
                         let var = self.state.symbol_table.lookup_local(actual.identifier.name).or_else(|| {
                             self.state
                                 .symbol_table
@@ -1555,7 +1555,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
 
         if composite.is_record {
             // Ensure that we're not instantating an external record
-            if composite_location.program != self.scope_state.program_name.unwrap() {
+            if composite_location.program != self.scope_state.unit_name.unwrap() {
                 self.state
                     .handler
                     .emit_err(TypeCheckerError::cannot_instantiate_external_record(composite_location, input.span()));
@@ -1595,7 +1595,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_path(&mut self, input: &Path, expected: &Self::AdditionalInput) -> Self::Output {
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
         let var = self.state.symbol_table.lookup_path(current_program, input);
 
         if let Some(var) = var {
@@ -2324,7 +2324,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         let caller_path =
             self.scope_state.module_name.iter().cloned().chain(std::iter::once(caller_name)).collect::<Vec<Symbol>>();
 
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
 
         let func_symbol = self
             .state

--- a/crates/passes/src/type_checking/mod.rs
+++ b/crates/passes/src/type_checking/mod.rs
@@ -26,7 +26,7 @@ use visitor::*;
 use self::scope_state::ScopeState;
 use crate::{CompilerState, Pass};
 
-use leo_ast::{Ast, CallGraph, CompositeGraph, NetworkName, ProgramVisitor};
+use leo_ast::{Ast, CallGraph, CompositeGraph, NetworkName, UnitVisitor};
 use leo_errors::Result;
 
 use snarkvm::prelude::{CanaryV0, MainnetV0, Network, TestnetV0};

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 use std::collections::{BTreeMap, HashMap};
 
-impl ProgramVisitor for TypeCheckingVisitor<'_> {
+impl UnitVisitor for TypeCheckingVisitor<'_> {
     fn visit_program(&mut self, input: &Program) {
         // Typecheck the program's stubs.
         input.stubs.iter().for_each(|(symbol, stub)| {
@@ -51,10 +51,10 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_program_scope(&mut self, input: &ProgramScope) {
-        let program_name = input.program_id.as_symbol();
+        let unit_name = input.program_id.as_symbol();
 
         // Set the current program name.
-        self.scope_state.program_name = Some(program_name);
+        self.scope_state.unit_name = Some(unit_name);
 
         // Collect a map from record names to their spans
         let record_info: BTreeMap<String, leo_span::Span> = input
@@ -154,7 +154,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
     fn visit_module(&mut self, input: &Module) {
         let parent_module = self.scope_state.module_name.clone();
         // Set the current program name.
-        self.scope_state.program_name = Some(input.program_name);
+        self.scope_state.unit_name = Some(input.unit_name);
         self.scope_state.module_name = input.path.clone();
 
         // Typecheck each const definition, and append to symbol table.
@@ -175,7 +175,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
     fn visit_library(&mut self, input: &Library) {
         // Set the scope state.
-        self.scope_state.program_name = Some(input.name);
+        self.scope_state.unit_name = Some(input.name);
 
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
@@ -206,7 +206,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
 
     fn visit_aleo_program(&mut self, input: &AleoProgram) {
         // Set the scope state.
-        self.scope_state.program_name = Some(input.stub_id.as_symbol());
+        self.scope_state.unit_name = Some(input.stub_id.as_symbol());
         self.scope_state.is_stub = true;
 
         // Cannot have constant declarations in stubs.
@@ -338,7 +338,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
                     .cloned()
                     .chain(std::iter::once(input.identifier.name))
                     .collect::<Vec<Symbol>>();
-                let this_program = self.scope_state.program_name.unwrap();
+                let this_program = self.scope_state.unit_name.unwrap();
                 let composite_location = Location::new(this_program, composite_path);
                 if let Type::Composite(composite_member_type) = type_ {
                     // Note that since there are no cycles in the program dependency graph, there are no cycles in the
@@ -590,7 +590,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
         if let UpgradeVariant::Checksum { mapping, key, key_type } = &upgrade_variant {
             // Look up the mapping type.
             let Some(VariableSymbol { type_: Some(Type::Mapping(mapping_type)), .. }) =
-                self.state.symbol_table.lookup_global(self.scope_state.program_name.unwrap(), mapping)
+                self.state.symbol_table.lookup_global(self.scope_state.unit_name.unwrap(), mapping)
             else {
                 self.emit_err(TypeCheckerError::custom(
                     format!("The mapping '{mapping}' does not exist. Please ensure that it is imported or defined in your program."),
@@ -672,7 +672,7 @@ impl ProgramVisitor for TypeCheckingVisitor<'_> {
                 .collect();
 
             finalize_input_map.insert(
-                Location::new(self.scope_state.program_name.unwrap(), vec![input.identifier.name]),
+                Location::new(self.scope_state.unit_name.unwrap(), vec![input.identifier.name]),
                 resolved_inputs,
             );
         }

--- a/crates/passes/src/type_checking/scope_state.rs
+++ b/crates/passes/src/type_checking/scope_state.rs
@@ -26,7 +26,7 @@ pub struct ScopeState {
     /// Whether or not the function that we are currently traversing has a return statement.
     pub(crate) has_return: bool,
     /// Current program name.
-    pub(crate) program_name: Option<Symbol>,
+    pub(crate) unit_name: Option<Symbol>,
     /// Current module name.
     pub(crate) module_name: Vec<Symbol>,
     /// Whether or not we are currently traversing a stub.
@@ -53,7 +53,7 @@ impl ScopeState {
             function: None,
             variant: None,
             has_return: false,
-            program_name: None,
+            unit_name: None,
             module_name: vec![],
             is_stub: false,
             futures: IndexMap::new(),
@@ -91,7 +91,7 @@ impl ScopeState {
             .collect::<Vec<Symbol>>();
 
         Location::new(
-            self.program_name.expect("Only call ScopeState::location when visiting a function or function stub."),
+            self.unit_name.expect("Only call ScopeState::location when visiting a function or function stub."),
             function_path,
         )
     }

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -536,7 +536,7 @@ impl TypeCheckingVisitor<'_> {
             bail!("structs are not supported")
         }
 
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
         // Returns true if the given expression is a local path in the current program.
         let is_local_path = |expr: &Expression| -> bool {
             matches!(expr, Expression::Path(path)
@@ -2010,13 +2010,13 @@ impl TypeCheckingVisitor<'_> {
             // this async function.
             let mut caller_finalizers = self
                 .async_function_callers
-                .get(&Location::new(self.scope_state.program_name.unwrap(), function_path))
+                .get(&Location::new(self.scope_state.unit_name.unwrap(), function_path))
                 .map(|callers| {
                     callers
                         .iter()
                         .flat_map(|caller| {
                             let caller = Location::new(caller.program, caller.path.clone());
-                            self.state.symbol_table.lookup_function(self.scope_state.program_name.unwrap(), &caller)
+                            self.state.symbol_table.lookup_function(self.scope_state.unit_name.unwrap(), &caller)
                         })
                         .flat_map(|fn_symbol| fn_symbol.finalizer.clone())
                 })
@@ -2269,13 +2269,13 @@ impl TypeCheckingVisitor<'_> {
     /// Wrapper around lookup_struct and lookup_record that additionally records all structs and records that are
     /// used in the program.
     pub fn lookup_composite(&mut self, loc: &Location) -> Option<Composite> {
-        let current_program = self.scope_state.program_name.unwrap();
+        let current_program = self.scope_state.unit_name.unwrap();
         let record_comp = self.state.symbol_table.lookup_record(current_program, loc);
         let comp = record_comp.or_else(|| self.state.symbol_table.lookup_struct(current_program, loc));
         // Record the usage.
         if let Some(s) = comp {
             // If it's a struct or internal record, mark it used.
-            if !s.is_record || Some(loc.program) == self.scope_state.program_name {
+            if !s.is_record || Some(loc.program) == self.scope_state.unit_name {
                 self.used_composites.insert(loc.clone());
             }
         }
@@ -2349,7 +2349,7 @@ impl TypeCheckingVisitor<'_> {
 
     pub fn is_external_record(&self, ty: &Type) -> bool {
         if let Type::Composite(typ) = &ty {
-            let this_program = self.scope_state.program_name.unwrap();
+            let this_program = self.scope_state.unit_name.unwrap();
             let composite_location = typ.path.expect_global_location();
             composite_location.program != this_program
                 && self.state.symbol_table.lookup_record(this_program, composite_location).is_some()

--- a/crates/passes/src/write_transforming/mod.rs
+++ b/crates/passes/src/write_transforming/mod.rs
@@ -16,7 +16,7 @@
 
 use crate::Pass;
 
-use leo_ast::ProgramReconstructor as _;
+use leo_ast::UnitReconstructor as _;
 
 use leo_errors::Result;
 

--- a/crates/passes/src/write_transforming/program.rs
+++ b/crates/passes/src/write_transforming/program.rs
@@ -16,9 +16,9 @@
 
 use super::WriteTransformingVisitor;
 
-use leo_ast::{AstReconstructor as _, Constructor, Function, ProgramReconstructor};
+use leo_ast::{AstReconstructor as _, Constructor, Function, UnitReconstructor};
 
-impl ProgramReconstructor for WriteTransformingVisitor<'_> {
+impl UnitReconstructor for WriteTransformingVisitor<'_> {
     fn reconstruct_function(&mut self, input: Function) -> Function {
         // Since the input parameters may be composites or arrays that are written to,
         // we may need to define variable members.

--- a/crates/passes/src/write_transforming/visitor.rs
+++ b/crates/passes/src/write_transforming/visitor.rs
@@ -267,7 +267,7 @@ impl WriteTransformingFiller<'_> {
             }
         }
         for (_, module) in program.modules.iter() {
-            self.0.program = module.program_name;
+            self.0.program = module.unit_name;
             for (_, function) in module.functions.iter() {
                 self.visit_block(&function.block);
             }


### PR DESCRIPTION
Rename compiler-internal identifiers that say "program" but actually mean "the current compilation target" (which can be either a program or a library). This aligns with the existing `CompilationUnit` type and reduces confusion for contributors.

- `ProgramVisitor` -> `UnitVisitor`
- `ProgramReconstructor` -> `UnitReconstructor`
- `Compiler::program_name` -> `Compiler::unit_name`
- `Module::program_name` -> `Module::unit_name`
- Various visitor `program_name`/`current_program` fields -> `unit_name`/`current_unit`

Closes #29346