### PR TITLE
fix(package): update from_directory doctest for new network_retries param

### DIFF
--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -50,7 +50,7 @@
 //! ```no_run
 //! # use leo_ast::NetworkName;
 //! use leo_package::Package;
-//! let package = Package::from_directory("path/to/package", "/home/me/.aleo", false, false, Some(NetworkName::TestnetV0), Some("http://localhost:3030")).unwrap();
+//! let package = Package::from_directory("path/to/package", "/home/me/.aleo", false, false, Some(NetworkName::TestnetV0), Some("http://localhost:3030"), 0).unwrap();
 //! ```
 //! This will read the manifest and keep their data in `package.manifest`.
 //! It will also process dependencies and store them in topological order in `package.compilation_units`. This processing


### PR DESCRIPTION
The leo-package doctest for `Package::from_directory` is missing the `network_retries: u32` argument, causing `cargo test --doc` to fail. Adds the missing argument.