### PR TITLE
feat(cli): Add workspace support MVP (Phase 1)

### DIFF
--- a/crates/errors/src/errors/package/package_errors.rs
+++ b/crates/errors/src/errors/package/package_errors.rs
@@ -478,4 +478,40 @@ create_messages!(
         ),
         help: Some("Remove either the program entry file or the library entry file.".to_string()),
     }
+
+    /// For when a workspace member directory is missing or lacks a manifest.
+    @backtraced
+    workspace_member_not_found {
+        args: (member: impl Display, workspace_root: impl Display),
+        msg: format!(
+            "Workspace member '{member}' not found. Expected a Leo package at '{workspace_root}/{member}'."
+        ),
+        help: Some("Ensure the member directory exists and contains a `program.json` manifest.".to_string()),
+    }
+
+    /// For when --package names a member not listed in workspace.json.
+    @backtraced
+    workspace_package_not_found {
+        args: (name: impl Display, workspace_root: impl Display),
+        msg: format!(
+            "No workspace member named '{name}' found in workspace at '{workspace_root}'."
+        ),
+        help: Some("Check the `members` list in `workspace.json`.".to_string()),
+    }
+
+    /// For when --package is used outside a workspace.
+    @backtraced
+    workspace_no_workspace {
+        args: (),
+        msg: "The `--package` flag requires a workspace, but no `workspace.json` was found.".to_string(),
+        help: Some("Create a `workspace.json` in the project root, or run the command from within a Leo package.".to_string()),
+    }
+
+    /// For when workspace.json cannot be read or parsed.
+    @backtraced
+    workspace_manifest_error {
+        args: (path: impl Display, error: impl Display),
+        msg: format!("Failed to read workspace manifest at '{path}': {error}"),
+        help: None,
+    }
 );

--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -44,6 +44,9 @@ pub struct CLI {
 
     #[clap(long, global = true, help = "Path to aleo program registry")]
     pub home: Option<PathBuf>,
+
+    #[clap(short = 'p', long = "package", global = true, help = "Target a specific workspace member by name")]
+    pub package: Option<String>,
 }
 
 ///Leo compiler and package manager
@@ -228,7 +231,7 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
 
     // Get custom root folder and create context for it.
     // If not specified, default context will be created in cwd.
-    let context = handle_error(Context::new(cli.path.clone(), cli.home, false));
+    let context = handle_error(Context::new(cli.path.clone(), cli.home, false, cli.package.clone()));
 
     let command_name = cli.command.name();
     let mut command_output: Option<JsonOutput> = None;
@@ -342,6 +345,7 @@ mod tests {
             },
             path: Some(project_directory.clone()),
             home: Some(temp_dir.join(".aleo")),
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -390,6 +394,7 @@ mod tests {
             },
             path: Some(project_directory.clone()),
             home: None,
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -433,6 +438,7 @@ mod tests {
             },
             path: Some(project_directory.clone()),
             home: None,
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -473,6 +479,7 @@ mod tests {
             },
             path: Some(project_directory.clone()),
             home: None,
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -503,6 +510,7 @@ mod tests {
             },
             path: Some(lib_directory.clone()),
             home: None,
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -552,6 +560,7 @@ mod test_helpers {
             command: Commands::New { command: LeoNew { name: name.to_string(), library: false } },
             path: Some(project_directory.clone()),
             home: None,
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -628,6 +637,7 @@ function external_nested_function:
             },
             path: Some(project_directory.clone()),
             home: None,
+            package: None,
         };
 
         create_session_if_not_set_then(|_| {
@@ -669,6 +679,7 @@ function external_nested_function:
             command: Commands::New { command: LeoNew { name: "grandparent".to_string(), library: false } },
             path: Some(grandparent_directory.clone()),
             home: None,
+            package: None,
         };
 
         let create_parent_project = CLI {
@@ -679,6 +690,7 @@ function external_nested_function:
             command: Commands::New { command: LeoNew { name: "parent".to_string(), library: false } },
             path: Some(parent_directory.clone()),
             home: None,
+            package: None,
         };
 
         let create_child_project = CLI {
@@ -689,6 +701,7 @@ function external_nested_function:
             command: Commands::New { command: LeoNew { name: "child".to_string(), library: false } },
             path: Some(child_directory.clone()),
             home: None,
+            package: None,
         };
 
         // Add source files `grandparent/src/main.leo`, `grandparent/parent/src/main.leo`, and `grandparent/parent/child/src/main.leo`
@@ -748,6 +761,7 @@ program child.aleo {
             },
             path: Some(grandparent_directory.clone()),
             home: None,
+            package: None,
         };
 
         let add_grandparent_dependency_2 = CLI {
@@ -765,6 +779,7 @@ program child.aleo {
             },
             path: Some(grandparent_directory.clone()),
             home: None,
+            package: None,
         };
 
         let add_parent_dependency = CLI {
@@ -782,6 +797,7 @@ program child.aleo {
             },
             path: Some(parent_directory.clone()),
             home: None,
+            package: None,
         };
 
         // Execute all commands
@@ -821,6 +837,7 @@ program child.aleo {
             command: Commands::New { command: LeoNew { name: "outer".to_string(), library: false } },
             path: Some(outer_directory.clone()),
             home: None,
+            package: None,
         };
 
         let create_inner_1_project = CLI {
@@ -831,6 +848,7 @@ program child.aleo {
             command: Commands::New { command: LeoNew { name: "inner_1".to_string(), library: false } },
             path: Some(inner_1_directory.clone()),
             home: None,
+            package: None,
         };
 
         let create_inner_2_project = CLI {
@@ -841,6 +859,7 @@ program child.aleo {
             command: Commands::New { command: LeoNew { name: "inner_2".to_string(), library: false } },
             path: Some(inner_2_directory.clone()),
             home: None,
+            package: None,
         };
 
         // Add source files `outer/src/main.leo` and `outer/inner/src/main.leo`
@@ -923,6 +942,7 @@ program inner_2.aleo {
             },
             path: Some(outer_directory.clone()),
             home: None,
+            package: None,
         };
 
         let add_outer_dependency_2 = CLI {
@@ -940,6 +960,7 @@ program inner_2.aleo {
             },
             path: Some(outer_directory.clone()),
             home: None,
+            package: None,
         };
 
         // Execute all commands
@@ -978,6 +999,7 @@ program inner_2.aleo {
             command: Commands::New { command: LeoNew { name: "outer_2".to_string(), library: false } },
             path: Some(outer_directory.clone()),
             home: None,
+            package: None,
         };
 
         let create_inner_1_project = CLI {
@@ -988,6 +1010,7 @@ program inner_2.aleo {
             command: Commands::New { command: LeoNew { name: "inner_1".to_string(), library: false } },
             path: Some(inner_1_directory.clone()),
             home: None,
+            package: None,
         };
 
         let create_inner_2_project = CLI {
@@ -998,6 +1021,7 @@ program inner_2.aleo {
             command: Commands::New { command: LeoNew { name: "inner_2".to_string(), library: false } },
             path: Some(inner_2_directory.clone()),
             home: None,
+            package: None,
         };
 
         // Add source files `outer_2/src/main.leo` and `outer_2/inner/src/main.leo`
@@ -1114,6 +1138,7 @@ program inner_2.aleo {
             },
             path: Some(outer_directory.clone()),
             home: None,
+            package: None,
         };
 
         let add_outer_dependency_2 = CLI {
@@ -1131,6 +1156,7 @@ program inner_2.aleo {
             },
             path: Some(outer_directory.clone()),
             home: None,
+            package: None,
         };
 
         // Execute all commands

--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -534,13 +534,355 @@ mod tests {
         // by the OS, so we ignore errors here rather than failing an otherwise-passing test.
         let _ = std::fs::remove_dir_all(&lib_directory);
     }
+
+    #[test]
+    #[serial]
+    fn workspace_build_from_root_test() {
+        let temp_dir = temp_dir();
+        let ws_root = test_helpers::sample_workspace(&temp_dir, "build_root");
+
+        let build = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Build {
+                command: crate::cli::commands::LeoBuild {
+                    options: Default::default(),
+                    env_override: crate::cli::commands::EnvOptions {
+                        network: Some(NetworkName::TestnetV0),
+                        ..Default::default()
+                    },
+                },
+            },
+            path: Some(ws_root.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(build).expect("workspace build should succeed");
+        });
+
+        assert!(ws_root.join("token/build/main.aleo").exists(), "token should be built");
+        assert!(ws_root.join("swap/build/main.aleo").exists(), "swap should be built");
+
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_build_single_member_test() {
+        let temp_dir = temp_dir();
+        let ws_root = test_helpers::sample_workspace(&temp_dir, "build_single");
+
+        let build = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Build {
+                command: crate::cli::commands::LeoBuild {
+                    options: Default::default(),
+                    env_override: crate::cli::commands::EnvOptions {
+                        network: Some(NetworkName::TestnetV0),
+                        ..Default::default()
+                    },
+                },
+            },
+            path: Some(ws_root.join("token")),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(build).expect("single member build should succeed");
+        });
+
+        assert!(ws_root.join("token/build/main.aleo").exists(), "token should be built");
+        assert!(!ws_root.join("swap/build/main.aleo").exists(), "swap should NOT be built");
+
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_package_flag_test() {
+        let temp_dir = temp_dir();
+        let ws_root = test_helpers::sample_workspace(&temp_dir, "pkg_flag");
+
+        let build = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Build {
+                command: crate::cli::commands::LeoBuild {
+                    options: Default::default(),
+                    env_override: crate::cli::commands::EnvOptions {
+                        network: Some(NetworkName::TestnetV0),
+                        ..Default::default()
+                    },
+                },
+            },
+            path: Some(ws_root.clone()),
+            home: None,
+            package: Some("token".to_string()),
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(build).expect("--package build should succeed");
+        });
+
+        assert!(ws_root.join("token/build/main.aleo").exists(), "token should be built");
+        assert!(!ws_root.join("swap/build/main.aleo").exists(), "swap should NOT be built");
+
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_package_flag_not_found_test() {
+        let temp_dir = temp_dir();
+        let ws_root = test_helpers::sample_workspace(&temp_dir, "pkg_not_found");
+
+        let build = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Build {
+                command: crate::cli::commands::LeoBuild {
+                    options: Default::default(),
+                    env_override: Default::default(),
+                },
+            },
+            path: Some(ws_root.clone()),
+            home: None,
+            package: Some("nonexistent".to_string()),
+        };
+
+        create_session_if_not_set_then(|_| {
+            let result = run_with_args(build);
+            assert!(result.is_err(), "--package with unknown member should error");
+        });
+
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_clean_test() {
+        let temp_dir = temp_dir();
+        let ws_root = test_helpers::sample_workspace(&temp_dir, "clean");
+
+        // Build first.
+        let build = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Build {
+                command: crate::cli::commands::LeoBuild {
+                    options: Default::default(),
+                    env_override: crate::cli::commands::EnvOptions {
+                        network: Some(NetworkName::TestnetV0),
+                        ..Default::default()
+                    },
+                },
+            },
+            path: Some(ws_root.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(build).expect("build should succeed");
+        });
+
+        assert!(ws_root.join("token/build").exists(), "token build dir should exist");
+        assert!(ws_root.join("swap/build").exists(), "swap build dir should exist");
+
+        // Clean.
+        let clean = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Clean { command: crate::cli::commands::LeoClean {} },
+            path: Some(ws_root.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(clean).expect("workspace clean should succeed");
+        });
+
+        assert!(!ws_root.join("token/build").exists(), "token build dir should be cleaned");
+        assert!(!ws_root.join("swap/build").exists(), "swap build dir should be cleaned");
+
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
+    fn workspace_backward_compat_test() {
+        let temp_dir = temp_dir();
+        let pkg_name = "standalone_pkg";
+        let pkg_dir = temp_dir.join(pkg_name);
+
+        if pkg_dir.exists() {
+            std::fs::remove_dir_all(&pkg_dir).unwrap();
+        }
+
+        let new_cmd = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::New {
+                command: crate::cli::commands::LeoNew { name: pkg_name.to_string(), library: false },
+            },
+            path: Some(pkg_dir.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(new_cmd).expect("leo new should succeed");
+        });
+
+        let build = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Build {
+                command: crate::cli::commands::LeoBuild {
+                    options: Default::default(),
+                    env_override: crate::cli::commands::EnvOptions {
+                        network: Some(NetworkName::TestnetV0),
+                        ..Default::default()
+                    },
+                },
+            },
+            path: Some(pkg_dir.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(build).expect("standalone build should succeed");
+        });
+
+        assert!(pkg_dir.join("build/main.aleo").exists(), "build artifact should exist");
+
+        let _ = std::fs::remove_dir_all(&pkg_dir);
+    }
 }
 
 #[cfg(test)]
 mod test_helpers {
     use crate::cli::{CLI, DependencySource, LeoAdd, LeoNew, cli::Commands, run_with_args};
     use leo_span::create_session_if_not_set_then;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
+
+    /// Create a workspace with two members: `token` (no deps) and `swap` (depends on token).
+    ///
+    /// Returns the workspace root directory. Each caller should pass a unique
+    /// `name` to avoid temp-directory collisions under parallel test runners.
+    pub(crate) fn sample_workspace(temp_dir: &Path, name: &str) -> PathBuf {
+        let ws_root = temp_dir.join(format!("ws_{name}"));
+
+        if ws_root.exists() {
+            std::fs::remove_dir_all(&ws_root).unwrap();
+        }
+        std::fs::create_dir_all(&ws_root).unwrap();
+
+        let token_dir = ws_root.join("token");
+        let swap_dir = ws_root.join("swap");
+
+        // Create token package.
+        std::fs::create_dir_all(token_dir.join("src")).unwrap();
+        std::fs::write(
+            token_dir.join("src/main.leo"),
+            "\
+program token.aleo {
+    fn mint(owner: address, amount: u32) -> u32 {
+        return amount;
+    }
+
+    @noupgrade
+    constructor() {}
+}
+",
+        )
+        .unwrap();
+        std::fs::write(
+            token_dir.join(leo_package::MANIFEST_FILENAME),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "program": "token.aleo",
+                "version": "0.1.0",
+                "description": "",
+                "license": "MIT",
+                "leo": env!("CARGO_PKG_VERSION"),
+                "dependencies": null,
+                "dev_dependencies": null
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Create swap package (depends on token via local path).
+        std::fs::create_dir_all(swap_dir.join("src")).unwrap();
+        std::fs::write(
+            swap_dir.join("src/main.leo"),
+            "\
+import token.aleo;
+program swap.aleo {
+    fn do_swap(owner: address, amount: u32) -> u32 {
+        return token.aleo::mint(owner, amount);
+    }
+
+    @noupgrade
+    constructor() {}
+}
+",
+        )
+        .unwrap();
+        std::fs::write(
+            swap_dir.join(leo_package::MANIFEST_FILENAME),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "program": "swap.aleo",
+                "version": "0.1.0",
+                "description": "",
+                "license": "MIT",
+                "leo": env!("CARGO_PKG_VERSION"),
+                "dependencies": [{
+                    "name": "token.aleo",
+                    "location": "local",
+                    "path": "../token",
+                    "edition": null
+                }],
+                "dev_dependencies": null
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        // Write workspace.json.
+        std::fs::write(
+            ws_root.join(leo_package::WORKSPACE_MANIFEST_FILENAME),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "members": ["token", "swap"]
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        ws_root
+    }
 
     pub(crate) fn sample_nested_package(temp_dir: &Path) {
         let name = "nested";

--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -77,8 +77,21 @@ impl Command for LeoBuild {
     }
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
-        // Build the program.
-        handle_build(&self, context)
+        match context.resolve_targets()? {
+            Some(targets) => {
+                let mut last_package = None;
+                for target in &targets {
+                    let member_name = target.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                    if targets.len() > 1 {
+                        println!("\n--- workspace member '{member_name}' ---");
+                    }
+                    let member_ctx = context.with_path(target.clone());
+                    last_package = Some(handle_build(&self, member_ctx)?);
+                }
+                last_package.ok_or_else(|| leo_errors::CliError::custom("No workspace members found.").into())
+            }
+            None => handle_build(&self, context),
+        }
     }
 }
 

--- a/crates/leo/src/cli/commands/clean.rs
+++ b/crates/leo/src/cli/commands/clean.rs
@@ -67,13 +67,13 @@ fn clean_package(context: Context) -> Result<()> {
     // Removes the outputs/ directory.
     let outputs_path = path.join(leo_package::OUTPUTS_DIRECTORY);
     if std::fs::remove_dir_all(&outputs_path).is_ok() {
-        tracing::info!("Cleaned the outputs directory {}", outputs_path.display().to_string().dimmed());
+        tracing::info!("🧹 Cleaned the outputs directory {}", outputs_path.display().to_string().dimmed());
     }
 
     // Removes the build/ directory.
     let build_path = path.join(leo_package::BUILD_DIRECTORY);
     if std::fs::remove_dir_all(&build_path).is_ok() {
-        tracing::info!("Cleaned the build directory {}", build_path.display().to_string().dimmed());
+        tracing::info!("🧹 Cleaned the build directory {}", build_path.display().to_string().dimmed());
     }
 
     Ok(())

--- a/crates/leo/src/cli/commands/clean.rs
+++ b/crates/leo/src/cli/commands/clean.rs
@@ -35,30 +35,46 @@ impl Command for LeoClean {
     }
 
     fn apply(self, context: Context, _: Self::Input) -> Result<Self::Output> {
-        let path = context.dir()?;
-
-        let manifest_path = path.join(leo_package::MANIFEST_FILENAME);
-
-        if !manifest_path.exists() {
-            return Err(anyhow!(
-                "{} doesn't exist - this doesn't appear to be a Leo package.",
-                leo_package::MANIFEST_FILENAME
-            )
-            .into());
+        match context.resolve_targets()? {
+            Some(targets) => {
+                for target in &targets {
+                    let member_name = target.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                    if targets.len() > 1 {
+                        println!("\n--- workspace member '{member_name}' ---");
+                    }
+                    clean_package(context.with_path(target.clone()))?;
+                }
+                Ok(())
+            }
+            None => clean_package(context),
         }
-
-        // Removes the outputs/ directory.
-        let outputs_path = path.join(leo_package::OUTPUTS_DIRECTORY);
-        if std::fs::remove_dir_all(&outputs_path).is_ok() {
-            tracing::info!("🧹 Cleaned the outputs directory {}", outputs_path.display().to_string().dimmed());
-        }
-
-        // Removes the build/ directory.
-        let build_path = path.join(leo_package::BUILD_DIRECTORY);
-        if std::fs::remove_dir_all(&build_path).is_ok() {
-            tracing::info!("🧹 Cleaned the build directory {}", build_path.display().to_string().dimmed());
-        }
-
-        Ok(())
     }
+}
+
+fn clean_package(context: Context) -> Result<()> {
+    let path = context.dir()?;
+
+    let manifest_path = path.join(leo_package::MANIFEST_FILENAME);
+
+    if !manifest_path.exists() {
+        return Err(anyhow!(
+            "{} doesn't exist - this doesn't appear to be a Leo package.",
+            leo_package::MANIFEST_FILENAME
+        )
+        .into());
+    }
+
+    // Removes the outputs/ directory.
+    let outputs_path = path.join(leo_package::OUTPUTS_DIRECTORY);
+    if std::fs::remove_dir_all(&outputs_path).is_ok() {
+        tracing::info!("Cleaned the outputs directory {}", outputs_path.display().to_string().dimmed());
+    }
+
+    // Removes the build/ directory.
+    let build_path = path.join(leo_package::BUILD_DIRECTORY);
+    if std::fs::remove_dir_all(&build_path).is_ok() {
+        tracing::info!("Cleaned the build directory {}", build_path.display().to_string().dimmed());
+    }
+
+    Ok(())
 }

--- a/crates/leo/src/cli/commands/common/query.rs
+++ b/crates/leo/src/cli/commands/common/query.rs
@@ -46,7 +46,7 @@ pub fn get_public_balance<N: Network>(
             },
         },
     }
-    .execute(Context::new(context.path.clone(), context.home.clone(), true)?)?;
+    .execute(Context::new(context.path.clone(), context.home.clone(), true, None)?)?;
     // Remove the last 3 characters since they represent the `u64` suffix.
     public_balance.truncate(public_balance.len() - 3);
     // Make sure the balance is valid.
@@ -81,7 +81,7 @@ pub fn get_latest_block_height(
             },
         },
     }
-    .execute(Context::new(context.path.clone(), context.home.clone(), true)?)?;
+    .execute(Context::new(context.path.clone(), context.home.clone(), true, None)?)?;
     // Parse the height.
     let height = height.parse::<u32>().map_err(CliError::string_parse_error)?;
     Ok(height)

--- a/crates/leo/src/cli/commands/test.rs
+++ b/crates/leo/src/cli/commands/test.rs
@@ -62,6 +62,51 @@ impl Command for LeoTest {
     fn apply(self, _: Context, input: Self::Input) -> Result<Self::Output> {
         handle_test(self, input)
     }
+
+    fn execute(self, context: Context) -> Result<Self::Output> {
+        // Check for workspace mode before falling through to the default
+        // prelude+apply flow, because test needs to build and test each
+        // member independently.
+        match context.resolve_targets()? {
+            Some(targets) if targets.len() > 1 => {
+                let mut aggregate = TestOutput::default();
+                for target in &targets {
+                    let member_name = target.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                    println!("\n--- workspace member '{member_name}' ---");
+
+                    let member_ctx = context.with_path(target.clone());
+
+                    // Build with tests.
+                    let mut opts = self.compiler_options.clone();
+                    opts.build_tests = true;
+                    let package =
+                        (LeoBuild { env_override: self.env_override.clone(), options: opts }).execute(member_ctx)?;
+
+                    // Run tests for this member.
+                    let member_test = LeoTest {
+                        test_name: self.test_name.clone(),
+                        prove: self.prove,
+                        compiler_options: self.compiler_options.clone(),
+                        env_override: self.env_override.clone(),
+                    };
+                    let result = handle_test(member_test, package)?;
+                    aggregate.passed += result.passed;
+                    aggregate.failed += result.failed;
+                    aggregate.tests.extend(result.tests);
+                }
+                Ok(aggregate)
+            }
+            _ => {
+                // Single target or no workspace - use the normal flow.
+                let input = self.prelude(context.clone())?;
+                let span = self.log_span();
+                let span = span.enter();
+                let out = self.apply(context, input);
+                drop(span);
+                out
+            }
+        }
+    }
 }
 
 struct TestFunction {
@@ -177,7 +222,7 @@ fn handle_test(command: LeoTest, package: Package) -> Result<TestOutput> {
             if unit.name == credits {
                 return None;
             }
-            // Libraries have no bytecode — their consts are inlined into the main program.
+            // Libraries have no bytecode - their consts are inlined into the main program.
             if unit.kind.is_library() {
                 return None;
             }

--- a/crates/leo/src/cli/helpers/context.rs
+++ b/crates/leo/src/cli/helpers/context.rs
@@ -15,8 +15,8 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use aleo_std;
-use leo_errors::{CliError, Result};
-use leo_package::Manifest;
+use leo_errors::{CliError, PackageError, Result};
+use leo_package::{Manifest, Workspace};
 
 use aleo_std::aleo_dir;
 use std::{env::current_dir, path::PathBuf};
@@ -33,11 +33,18 @@ pub struct Context {
     /// Recursive flag.
     // TODO: Shift from callee to caller by including display method
     pub recursive: bool,
+    /// If set, target this specific workspace member.
+    pub package_filter: Option<String>,
 }
 
 impl Context {
-    pub fn new(path: Option<PathBuf>, home: Option<PathBuf>, recursive: bool) -> Result<Context> {
-        Ok(Context { path, home, recursive })
+    pub fn new(
+        path: Option<PathBuf>,
+        home: Option<PathBuf>,
+        recursive: bool,
+        package_filter: Option<String>,
+    ) -> Result<Context> {
+        Ok(Context { path, home, recursive, package_filter })
     }
 
     /// Returns the path of the parent directory to the Leo package.
@@ -74,5 +81,52 @@ impl Context {
         let manifest_path = path.join(leo_package::MANIFEST_FILENAME);
         let manifest = Manifest::read_from_file(manifest_path)?;
         Ok(manifest)
+    }
+
+    /// Returns the ordered list of member directories to operate on, respecting
+    /// `--package` filtering and workspace discovery.
+    ///
+    /// - At workspace root without `--package`: all members in dependency order.
+    /// - At workspace root with `--package`: just that member.
+    /// - Inside a member directory: just that member.
+    /// - No workspace found: `None` (caller falls through to single-package behavior).
+    pub fn resolve_targets(&self) -> Result<Option<Vec<PathBuf>>> {
+        let dir = self.dir()?;
+
+        let workspace = match Workspace::discover(&dir)? {
+            Some(ws) => ws,
+            None => {
+                if self.package_filter.is_some() {
+                    return Err(PackageError::workspace_no_workspace().into());
+                }
+                return Ok(None);
+            }
+        };
+
+        if let Some(ref filter) = self.package_filter {
+            match workspace.find_member(filter) {
+                Some(path) => Ok(Some(vec![path.clone()])),
+                None => {
+                    Err(PackageError::workspace_package_not_found(filter, workspace.root_directory.display()).into())
+                }
+            }
+        } else {
+            let canonical = dir.canonicalize().unwrap_or_else(|_| dir.clone());
+            if canonical == workspace.root_directory {
+                // At workspace root - operate on all members.
+                Ok(Some(workspace.member_paths))
+            } else if workspace.is_member(&canonical) {
+                // Inside a member - operate on just this member.
+                Ok(Some(vec![canonical]))
+            } else {
+                // Inside the workspace tree but not in a member directory.
+                Ok(None)
+            }
+        }
+    }
+
+    /// Create a new `Context` pointing at a specific directory.
+    pub fn with_path(&self, path: PathBuf) -> Self {
+        Context { path: Some(path), home: self.home.clone(), recursive: self.recursive, package_filter: None }
     }
 }

--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -88,6 +88,9 @@ pub use package::*;
 mod compilation_unit;
 pub use compilation_unit::*;
 
+mod workspace;
+pub use workspace::*;
+
 pub const SOURCE_DIRECTORY: &str = "src";
 
 pub const MAIN_FILENAME: &str = "main.leo";

--- a/crates/package/src/workspace.rs
+++ b/crates/package/src/workspace.rs
@@ -1,0 +1,384 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Location, MANIFEST_FILENAME, Manifest};
+
+use leo_ast::DiGraph;
+use leo_errors::{PackageError, Result};
+
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+pub const WORKSPACE_MANIFEST_FILENAME: &str = "workspace.json";
+
+/// The contents of a `workspace.json` manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkspaceManifest {
+    pub members: Vec<String>,
+}
+
+impl WorkspaceManifest {
+    pub fn read_from_file<P: AsRef<Path>>(path: P) -> std::result::Result<Self, PackageError> {
+        let contents = std::fs::read_to_string(&path)
+            .map_err(|e| PackageError::workspace_manifest_error(path.as_ref().display(), e))?;
+        serde_json::from_str(&contents).map_err(|e| PackageError::workspace_manifest_error(path.as_ref().display(), e))
+    }
+
+    pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> std::result::Result<(), PackageError> {
+        let mut contents = serde_json::to_string_pretty(self)
+            .map_err(|e| PackageError::workspace_manifest_error(path.as_ref().display(), e))?;
+        contents.push('\n');
+        std::fs::write(&path, contents).map_err(|e| PackageError::workspace_manifest_error(path.as_ref().display(), e))
+    }
+}
+
+/// A Leo workspace - a collection of member packages under a single root.
+#[derive(Debug, Clone)]
+pub struct Workspace {
+    /// The canonicalized root directory containing `workspace.json`.
+    pub root_directory: PathBuf,
+    /// The workspace manifest.
+    pub manifest: WorkspaceManifest,
+    /// Member directories in dependency order, each an absolute path.
+    pub member_paths: Vec<PathBuf>,
+    /// Member program names (from each member's `program.json`), in the same order.
+    pub member_names: Vec<String>,
+}
+
+impl Workspace {
+    /// Read the workspace at `path`, if a `workspace.json` exists there.
+    ///
+    /// Returns `Ok(None)` if no manifest exists.
+    /// Returns `Err` if the manifest exists but is malformed, or if members are missing.
+    pub fn from_directory(path: &Path) -> Result<Option<Self>> {
+        let manifest_path = path.join(WORKSPACE_MANIFEST_FILENAME);
+        if !manifest_path.exists() {
+            return Ok(None);
+        }
+
+        let root_directory =
+            path.canonicalize().map_err(|e| PackageError::workspace_manifest_error(manifest_path.display(), e))?;
+
+        let manifest = WorkspaceManifest::read_from_file(&manifest_path)?;
+
+        // Resolve and validate each member.
+        let mut dir_to_name: Vec<(PathBuf, String)> = Vec::with_capacity(manifest.members.len());
+        for member in &manifest.members {
+            let member_dir = root_directory.join(member);
+            if !member_dir.is_dir() {
+                return Err(PackageError::workspace_member_not_found(member, root_directory.display()).into());
+            }
+            let member_manifest_path = member_dir.join(MANIFEST_FILENAME);
+            if !member_manifest_path.exists() {
+                return Err(PackageError::workspace_member_not_found(member, root_directory.display()).into());
+            }
+            let member_manifest = Manifest::read_from_file(&member_manifest_path)?;
+            let canonical = member_dir
+                .canonicalize()
+                .map_err(|e| PackageError::workspace_manifest_error(member_dir.display(), e))?;
+            dir_to_name.push((canonical, member_manifest.program.clone()));
+        }
+
+        // Build a dependency graph to determine the correct build order.
+        let ordered = order_members(&dir_to_name)?;
+
+        let member_paths = ordered.iter().map(|(p, _)| p.clone()).collect();
+        let member_names = ordered.into_iter().map(|(_, n)| n).collect();
+
+        Ok(Some(Workspace { root_directory, manifest, member_paths, member_names }))
+    }
+
+    /// Walk up from `start_dir` looking for `workspace.json`.
+    ///
+    /// Returns `Ok(None)` if no workspace root is found.
+    pub fn discover(start_dir: &Path) -> Result<Option<Self>> {
+        let start =
+            start_dir.canonicalize().map_err(|e| PackageError::workspace_manifest_error(start_dir.display(), e))?;
+        let mut dir = start.as_path();
+        loop {
+            if let Some(ws) = Self::from_directory(dir)? {
+                return Ok(Some(ws));
+            }
+            match dir.parent() {
+                Some(parent) => dir = parent,
+                None => return Ok(None),
+            }
+        }
+    }
+
+    /// Find a member by directory name or program name (with or without `.aleo` suffix).
+    pub fn find_member(&self, name: &str) -> Option<&PathBuf> {
+        // Try matching by directory basename.
+        if let Some(pos) = self.member_paths.iter().position(|p| p.file_name().and_then(|n| n.to_str()) == Some(name)) {
+            return Some(&self.member_paths[pos]);
+        }
+        // Try matching by program name (exact or with/without .aleo).
+        let name_with_aleo = if name.ends_with(".aleo") { name.to_string() } else { format!("{name}.aleo") };
+        let name_without_aleo = name.strip_suffix(".aleo").unwrap_or(name);
+        self.member_names.iter().zip(self.member_paths.iter()).find_map(|(prog_name, path)| {
+            if prog_name == name || prog_name == &name_with_aleo || prog_name == name_without_aleo {
+                Some(path)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Check whether a given canonicalized path is one of the member directories.
+    pub fn is_member(&self, path: &Path) -> bool {
+        let Ok(canonical) = path.canonicalize() else {
+            return false;
+        };
+        self.member_paths.iter().any(|p| p == &canonical)
+    }
+}
+
+/// Determine the build order for workspace members by analysing cross-member
+/// local dependencies.
+///
+/// Each member's `Manifest` is read to find `Location::Local` dependencies
+/// whose paths resolve to other workspace member directories. Edges are added
+/// to a `DiGraph` from dependent to dependency, and the graph is topologically
+/// sorted so that dependencies appear before the members that depend on them.
+fn order_members(members: &[(PathBuf, String)]) -> Result<Vec<(PathBuf, String)>> {
+    // If there are 0 or 1 members, no ordering is needed.
+    if members.len() <= 1 {
+        return Ok(members.to_vec());
+    }
+
+    let mut graph = DiGraph::<String>::new(Default::default());
+
+    // Index members by canonical path for quick lookup.
+    let path_to_dir_name: std::collections::HashMap<&Path, &str> = members
+        .iter()
+        .filter_map(|(path, _)| {
+            let dir_name = path.file_name()?.to_str()?;
+            Some((path.as_path(), dir_name))
+        })
+        .collect();
+
+    // Add all members as nodes.
+    for (path, _) in members {
+        let dir_name = path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        graph.add_node(dir_name.to_string());
+    }
+
+    // Scan each member's manifest for local dependencies pointing to other members.
+    for (member_path, _) in members {
+        let member_dir_name = member_path.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        let manifest_path = member_path.join(MANIFEST_FILENAME);
+        let manifest = Manifest::read_from_file(&manifest_path)?;
+
+        for dep in manifest.dependencies.iter().flatten() {
+            if dep.location != Location::Local {
+                continue;
+            }
+            let Some(dep_path) = &dep.path else {
+                continue;
+            };
+            // Resolve relative paths against the member directory.
+            let resolved = if dep_path.is_absolute() { dep_path.clone() } else { member_path.join(dep_path) };
+            let Ok(canonical) = resolved.canonicalize() else {
+                continue;
+            };
+            // If this dependency points to another workspace member, add an edge.
+            if let Some(&dep_dir_name) = path_to_dir_name.get(canonical.as_path()) {
+                graph.add_edge(member_dir_name.to_string(), dep_dir_name.to_string());
+            }
+        }
+    }
+
+    let ordered = graph.post_order().map_err(|_| {
+        PackageError::workspace_manifest_error("workspace.json", "circular dependency between workspace members")
+    })?;
+
+    // Map the ordered directory names back to (path, program_name) pairs.
+    let name_to_member: std::collections::HashMap<&str, &(PathBuf, String)> = members
+        .iter()
+        .filter_map(|entry| {
+            let dir_name = entry.0.file_name()?.to_str()?;
+            Some((dir_name, entry))
+        })
+        .collect();
+
+    Ok(ordered
+        .iter()
+        .filter_map(|dir_name| name_to_member.get(dir_name.as_str()).map(|e| (e.0.clone(), e.1.clone())))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::env::temp_dir;
+
+    fn create_member(workspace_dir: &Path, name: &str, deps: &[(&str, &Path)]) {
+        let member_dir = workspace_dir.join(name);
+        std::fs::create_dir_all(member_dir.join("src")).unwrap();
+
+        let program_name = format!("{name}.aleo");
+        let dependencies: Vec<_> = deps
+            .iter()
+            .map(|(dep_name, dep_path)| crate::Dependency {
+                name: format!("{dep_name}.aleo"),
+                location: Location::Local,
+                path: Some(dep_path.to_path_buf()),
+                edition: None,
+            })
+            .collect();
+
+        let manifest = Manifest {
+            program: program_name,
+            version: "0.1.0".to_string(),
+            description: String::new(),
+            license: "MIT".to_string(),
+            leo: "0.0.0".to_string(),
+            dependencies: if dependencies.is_empty() { None } else { Some(dependencies) },
+            dev_dependencies: None,
+        };
+
+        manifest.write_to_file(member_dir.join(MANIFEST_FILENAME)).unwrap();
+
+        // Write a minimal source file so the package is valid.
+        std::fs::write(
+            member_dir.join("src/main.leo"),
+            format!("program {name}.aleo {{\n    @noupgrade\n    constructor() {{}}\n}}\n"),
+        )
+        .unwrap();
+    }
+
+    fn create_workspace(dir: &Path, members: &[&str]) {
+        let manifest = WorkspaceManifest { members: members.iter().map(|s| s.to_string()).collect() };
+        manifest.write_to_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+    }
+
+    #[test]
+    fn workspace_manifest_round_trip() {
+        let dir = temp_dir().join("ws_test_roundtrip");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let manifest = WorkspaceManifest { members: vec!["alpha".into(), "beta".into()] };
+        let path = dir.join(WORKSPACE_MANIFEST_FILENAME);
+        manifest.write_to_file(&path).unwrap();
+
+        let loaded = WorkspaceManifest::read_from_file(&path).unwrap();
+        assert_eq!(loaded.members, vec!["alpha", "beta"]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_from_directory_valid() {
+        let dir = temp_dir().join("ws_test_valid");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        create_member(&dir, "beta", &[]);
+        create_workspace(&dir, &["alpha", "beta"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        assert_eq!(ws.member_paths.len(), 2);
+        assert_eq!(ws.member_names.len(), 2);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_from_directory_missing_member() {
+        let dir = temp_dir().join("ws_test_missing");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        // "beta" is listed but not created.
+        create_workspace(&dir, &["alpha", "beta"]);
+
+        let result = Workspace::from_directory(&dir);
+        assert!(result.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_discover_from_subdirectory() {
+        let dir = temp_dir().join("ws_test_discover");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        create_workspace(&dir, &["alpha"]);
+
+        let member_dir = dir.join("alpha");
+        let ws = Workspace::discover(&member_dir).unwrap().unwrap();
+        assert_eq!(ws.root_directory, dir.canonicalize().unwrap());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_discover_none() {
+        let dir = temp_dir().join("ws_test_no_workspace");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let result = Workspace::discover(&dir).unwrap();
+        assert!(result.is_none());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_dependency_ordering() {
+        let dir = temp_dir().join("ws_test_ordering");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let alpha_dir = dir.join("alpha");
+
+        // alpha has no deps, beta depends on alpha.
+        create_member(&dir, "alpha", &[]);
+        create_member(&dir, "beta", &[("alpha", &alpha_dir)]);
+        create_workspace(&dir, &["beta", "alpha"]); // intentionally wrong order
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        // alpha should come before beta regardless of manifest order.
+        let names: Vec<&str> = ws.member_names.iter().map(|s| s.as_str()).collect();
+        let alpha_pos = names.iter().position(|n| *n == "alpha.aleo").unwrap();
+        let beta_pos = names.iter().position(|n| *n == "beta.aleo").unwrap();
+        assert!(alpha_pos < beta_pos, "alpha should be ordered before beta");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_find_member() {
+        let dir = temp_dir().join("ws_test_find");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        create_workspace(&dir, &["alpha"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        assert!(ws.find_member("alpha").is_some());
+        assert!(ws.find_member("alpha.aleo").is_some());
+        assert!(ws.find_member("nonexistent").is_none());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}


### PR DESCRIPTION
Add initial support for cargo-like workspaces to leo.

Part of #29140 

## Phase 1

Introduce a `workspace.json` manifest that groups related Leo packages under a single root directory. Running `leo build`, `leo test`, or `leo clean` from the workspace root applies the command to every member in dependency order.

- Add `Workspace` and `WorkspaceManifest` types to `leo-package` with discovery (walk-up), cross-member dependency ordering via `DiGraph`, and member lookup.
- Extend `Context` with `resolve_targets()` for workspace-aware dispatch.
- Add global `--package`/`-p` flag to target a single workspace member.
- Workspace iteration in `LeoBuild`, `LeoTest`, and `LeoClean` commands.
- Running from inside a member directory operates on that member only.
- No workspace present: behavior is unchanged.

## To-Do

- [x] Phase 1 - `workspace.json` parsing, workspace discovery, leo build/test/fmt/clean iterate over members, `--package` flag.

## Follow-up

- Phase 2 - Workspace deps
- Phase 3 - Deployment: `leo deploy` with workspace-aware ordering and shared fee estimation.
- Phase 4 - Ergonomics: glob members, leo new --workspace, auto-add member on leo new inside workspace, shared build directory.