### PR TITLE
type_checking: soft-fail when finalize entry is missing for already-rejected callee

### DIFF
--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1155,7 +1155,14 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                     input.function.identifier().name
                 ))]))
             else {
-                panic!("Finalization not found: {} {}", input.function.clone(), input.span);
+                // The callee's finalize entry can be missing when an earlier
+                // diagnostic in the same pass already rejected the callee
+                // (see #29390: `finish` was rejected with ETYC0372043 before
+                // its finalize symbol could be recorded). The orchestrator
+                // does not abort between diagnostic-emitting visitors and
+                // visitors that depend on a complete type table, so soft-fail
+                // here rather than ICE the compiler.
+                return Type::Err;
             };
 
             let future_type = Type::Future(FutureType::new(inputs.clone(), Some(callee_location.clone()), true));

--- a/tests/expectations/compiler/async_blocks/finalize_after_rejected_callee_no_ice.out
+++ b/tests/expectations/compiler/async_blocks/finalize_after_rejected_callee_no_ice.out
@@ -1,0 +1,5 @@
+[ETYC0372043] Error: Cannot call a local entry point fn from an entry point fn.
+   ╭─[ compiler-test:9:16 ]
+   │
+ 9 │         return finish();
+───╯

--- a/tests/tests/compiler/async_blocks/finalize_after_rejected_callee_no_ice.leo
+++ b/tests/tests/compiler/async_blocks/finalize_after_rejected_callee_no_ice.leo
@@ -1,0 +1,15 @@
+// Regression for #29390. When a callee like `finish` is rejected with
+// ETYC0372043 ("Cannot call a local entry point fn from an entry point
+// fn") its finalize-table entry is not recorded. The visitor that fans
+// out to those call sites used to look up the missing entry with a
+// hard `panic!` and ICE the compiler. The fix soft-fails to Type::Err
+// so the user sees the real diagnostic instead of an internal panic.
+program test.aleo {
+    fn caller() -> Final {
+        return finish();
+    }
+
+    fn finish() -> Final {
+        return final {};
+    }
+}


### PR DESCRIPTION
Fixes #29390.

`visit_call` panicked with `panic!("Finalization not found: ...")` when the callee's finalize entry was absent from `async_function_input_types`. The entry can be missing while the same pass is running because an earlier diagnostic (e.g. `ETYC0372043` rejecting the callee's call site) prevented the symbol from being recorded; the orchestrator does not call `abort_if_errors()` between the diagnostic-emitting visitor and visitors that depend on a complete type table.

Soft-fail by returning `Type::Err` instead of ICE'ing the compiler. The user still gets the original `ETYC0372043` diagnostics and `leo build` exits non-zero — just without the "this is a bug" panic-handler noise.