### PR TITLE
block_to_function_rewriter: soft-fail when local var has no inferred type

### DIFF
--- a/crates/passes/src/common/block_to_function_rewriter.rs
+++ b/crates/passes/src/common/block_to_function_rewriter.rs
@@ -273,7 +273,15 @@ impl BlockToFunctionRewriter<'_> {
 
                 // All other variables become parameters to the function being built.
                 let var = self.state.symbol_table.lookup_local(local_var_name)?;
-                Some(make_inputs_and_arguments(self, local_var_name, &var.type_.expect("must be known by now"), *index))
+                // The variable's type can be unset when an earlier diagnostic
+                // in the same pass invalidated the binding (#29391:
+                // `let (a, b, c): (u32, u32) = (1u32, 2u32);` produces a
+                // type-mismatch error and `c` never gets a type before the
+                // async-block rewriter visits it). Soft-fail with `None` —
+                // the surrounding flat_map drops the entry and the user keeps
+                // the original diagnostic instead of an ICE.
+                let ty = var.type_.as_ref()?;
+                Some(make_inputs_and_arguments(self, local_var_name, ty, *index))
             })
             .flatten()
             .unzip();


### PR DESCRIPTION
Fixes #29391.

`rewrite_block` collected the parameters of the synthesized async function via `var.type_.expect("must be known by now")`. The reproducer (`let (a, b, c): (u32, u32) = (1u32, 2u32);`) emits a tuple-arity mismatch diagnostic in the same pass, and `c` never gets a type before the rewriter visits the surrounding async block — the expect ICE'd the compiler.

Use `var.type_.as_ref()?` so the surrounding flat_map drops untyped entries; the original diagnostic still lands and `leo build` exits non-zero, just without the "this is a bug" panic-handler noise. Same shape as the sibling fix in #29392.