### PR TITLE
feat(LSP) Implement go to definition.

### DIFF
--- a/crates/compiler/src/compiler.rs
+++ b/crates/compiler/src/compiler.rs
@@ -99,6 +99,7 @@ pub struct Compiler {
 }
 
 impl Compiler {
+    /// Return the network selected for this compiler instance.
     pub fn network(&self) -> NetworkName {
         self.state.network
     }
@@ -326,6 +327,7 @@ impl Compiler {
         }
     }
 
+    /// Run a compiler pass without an external cancellation check.
     pub fn do_pass<P: Pass>(&mut self, input: P::Input) -> Result<P::Output> {
         self.do_pass_with_check::<P, _>(input, &mut || Ok(()))
     }
@@ -884,6 +886,20 @@ impl Compiler {
 /// change the stub set. Editor caches can hash or stat those paths to know when
 /// dependency-backed semantic state must be rebuilt.
 pub fn load_import_stubs_for_package(package_root: &Path, network: NetworkName) -> Result<LoadedImportStubs> {
+    load_import_stubs_for_package_with_file_source(package_root, network, &DiskFileSource)
+}
+
+/// Load local dependency stubs using an explicit file source for Leo source reads.
+///
+/// This variant lets editor integrations serve unsaved overlays and record the
+/// exact disk bytes used for dependency source stubs. Manifest discovery still
+/// reads the real filesystem because dependencies are package-level metadata,
+/// but every parsed Leo source file flows through `file_source`.
+pub fn load_import_stubs_for_package_with_file_source(
+    package_root: &Path,
+    network: NetworkName,
+    file_source: &impl FileSource,
+) -> Result<LoadedImportStubs> {
     create_session_if_not_set_then(|_| {
         let package_root =
             package_root.canonicalize().map_err(|error| PackageError::failed_path(package_root.display(), error))?;
@@ -901,15 +917,19 @@ pub fn load_import_stubs_for_package(package_root: &Path, network: NetworkName) 
                 CompilationUnit::from_aleo_path(*name, path, &declared_dependencies)?
             } else {
                 let unit = CompilationUnit::from_package_path(*name, path)?;
-                watch_paths.extend(unit_watch_paths(&unit)?);
+                watch_paths.extend(unit_watch_paths(&unit, file_source)?);
                 unit
             };
 
             let stub = match &unit.data {
                 ProgramData::Bytecode(bytecode) => disassemble_dependency_bytecode(unit.name, bytecode, network)?,
-                ProgramData::SourcePath { directory, source } => {
-                    load_source_dependency_stub(&unit, source, dependency_source_directory(directory, source), network)?
-                }
+                ProgramData::SourcePath { directory, source } => load_source_dependency_stub(
+                    &unit,
+                    source,
+                    dependency_source_directory(directory, source),
+                    network,
+                    file_source,
+                )?,
             };
             import_stubs.insert(unit.name, stub);
         }
@@ -984,7 +1004,7 @@ fn normalize_local_dependency(base_path: &Path, mut dependency: Dependency) -> R
 }
 
 /// Return the manifest and source files whose metadata should invalidate one stubbed unit.
-fn unit_watch_paths(unit: &CompilationUnit) -> Result<Vec<PathBuf>> {
+fn unit_watch_paths(unit: &CompilationUnit, file_source: &impl FileSource) -> Result<Vec<PathBuf>> {
     let ProgramData::SourcePath { directory, source } = &unit.data else {
         return Ok(Vec::new());
     };
@@ -992,13 +1012,30 @@ fn unit_watch_paths(unit: &CompilationUnit) -> Result<Vec<PathBuf>> {
     let source_directory = dependency_source_directory(directory, source);
     let mut watch_paths = vec![directory.join(MANIFEST_FILENAME), source_directory.clone(), source.clone()];
     if source_directory.is_dir() {
-        let mut modules = DiskFileSource
+        collect_source_directories(&source_directory, &mut watch_paths)?;
+        let mut modules = file_source
             .list_leo_files(&source_directory, source)
             .map_err(|error| CompilerError::file_read_error(source_directory.display().to_string(), error))?;
         watch_paths.append(&mut modules);
     }
 
     Ok(watch_paths)
+}
+
+/// Collect source directories whose mtimes signal nested module creation/removal.
+fn collect_source_directories(dir: &Path, watch_paths: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).map_err(|error| CompilerError::file_read_error(dir.display().to_string(), error))? {
+        let entry = entry.map_err(|error| CompilerError::file_read_error(dir.display().to_string(), error))?;
+        let path = entry.path();
+        if path.is_dir() {
+            // Watching only existing `.leo` files misses the first file added to
+            // an already-existing nested module directory. Include directories
+            // so LSP-side cache revisions notice those create/remove events.
+            watch_paths.push(path.clone());
+            collect_source_directories(&path, watch_paths)?;
+        }
+    }
+    Ok(())
 }
 
 /// Parse a local dependency just far enough to recover the public interface
@@ -1008,6 +1045,7 @@ fn load_source_dependency_stub(
     source: &Path,
     source_directory: PathBuf,
     network: NetworkName,
+    file_source: &impl FileSource,
 ) -> Result<Stub> {
     let handler = Handler::default();
     let node_builder = Rc::new(NodeBuilder::default());
@@ -1029,18 +1067,19 @@ fn load_source_dependency_stub(
                 library_name,
                 source,
                 &source_directory,
-                &DiskFileSource,
+                file_source,
             )?;
             Ok(library.into())
         }
         PackageKind::Program | PackageKind::Test => {
             let program =
-                compiler.parse_program_from_directory_with_file_source(source, &source_directory, &DiskFileSource)?;
+                compiler.parse_program_from_directory_with_file_source(source, &source_directory, file_source)?;
             Ok(extract_program_interface_stub(unit.name, &program))
         }
     }
 }
 
+/// Build the public interface stub for a source dependency program.
 fn extract_program_interface_stub(_program_name: Symbol, program: &Program) -> Stub {
     let scope = program.program_scopes.values().next().expect("program AST should contain one program scope");
 
@@ -1126,6 +1165,7 @@ mod tests {
 
     use indexmap::IndexMap;
 
+    /// Verifies library parsing can read every source file from an in-memory source.
     #[test]
     fn parse_library_from_directory_in_memory() {
         create_session_if_not_set_then(|_| {
@@ -1170,6 +1210,7 @@ mod tests {
         });
     }
 
+    /// Verifies in-memory library builds still reject type errors.
     #[test]
     fn build_library_from_directory_in_memory_rejects_type_error() {
         create_session_if_not_set_then(|_| {
@@ -1207,6 +1248,7 @@ mod tests {
         });
     }
 
+    /// Verifies in-memory program parsing can load sibling modules.
     #[test]
     fn parse_program_from_directory_in_memory_with_module() {
         create_session_if_not_set_then(|_| {

--- a/crates/lsp/src/compiler_bridge.rs
+++ b/crates/lsp/src/compiler_bridge.rs
@@ -14,19 +14,24 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::mutable_key_type)]
+
 //! Compiler-backed semantic analysis for `leo-lsp`.
 //!
 //! The worker always produces a syntax-derived token stream so highlighting can
-//! stay responsive for malformed or unmanaged files. When the snapshot belongs
-//! to a resolvable Leo package, this module reruns the compiler frontend against
-//! the current in-memory text and upgrades those syntax tokens with stable
-//! symbol identities and more accurate token kinds.
+//! stay responsive for malformed files. When a snapshot belongs to a resolvable
+//! Leo package, or when it is a standalone `.leo` program buffer, this module
+//! reruns the compiler frontend against the current in-memory text and upgrades
+//! those syntax tokens with stable symbol identities and more accurate token
+//! kinds.
 
 use crate::{
-    document_store::DocumentSnapshot,
+    document_store::{AnalysisBucket, DocumentSnapshot, DocumentViewSnapshot, OpenFileOverlay},
     features::semantic_tokens::encode_tokens,
     project_model::ProjectContext,
     semantics::{
+        CachedDocumentView,
+        CachedPackageAnalysis,
         FileRange,
         OccurrenceRole,
         SemanticIndex,
@@ -34,6 +39,7 @@ use crate::{
         SemanticSnapshot,
         SemanticSource,
         SemanticTokenOccurrence,
+        SourceFingerprint,
         SymbolIdentity,
         SymbolOccurrence,
         merge_occurrences,
@@ -69,37 +75,54 @@ use leo_ast::{
     Node,
     Path,
     Program,
+    ProgramId,
     ProgramScope,
     RecordPrototype,
     StorageVariable,
     StorageVariablePrototype,
+    Stub,
     Type,
     UnitVisitor,
 };
-use leo_compiler::{Compiler, FrontendAnalysis, load_import_stubs_for_package};
+use leo_compiler::{Compiler, FrontendAnalysis, load_import_stubs_for_package_with_file_source};
 use leo_errors::Handler;
 use leo_passes::{SymbolTable, TypeTable, VariableType};
 use leo_span::{
     Symbol,
     create_session_if_not_set_then,
-    file_source::{DiskFileSource, OverlayFileSource},
+    file_source::{DiskFileSource, FileSource},
     source_map::FileName,
     with_session_globals,
 };
 use std::{
-    collections::HashMap,
+    cell::RefCell,
+    collections::{HashMap, HashSet, VecDeque},
     fs::Metadata,
     hash::{DefaultHasher, Hash, Hasher},
+    io,
     path::{Path as StdPath, PathBuf},
     rc::Rc,
     sync::{Arc, atomic::Ordering},
     time::UNIX_EPOCH,
 };
 
+/// Maximum worker-local dependency-stub packages retained at once.
+const MAX_PACKAGE_ANALYSIS_CACHE_ENTRIES: usize = 8;
+
+/// Worker result for a package-analysis job.
+#[derive(Debug, Clone)]
+pub struct PackageWorkerAnalysis {
+    /// Shared package analysis cached by package key on the routing thread.
+    pub package: Arc<CachedPackageAnalysis>,
+    /// Encoded semantic-token view for the document that triggered the job.
+    pub document_view: CachedDocumentView,
+}
+
 /// Worker-local cache of package dependency stubs.
 #[derive(Debug, Default)]
 pub struct PackageAnalysisCache {
     entries: HashMap<PathBuf, PackageAnalysisCacheEntry>,
+    order: VecDeque<PathBuf>,
 }
 
 /// One cached package entry, including both the imported stubs and the
@@ -108,12 +131,32 @@ pub struct PackageAnalysisCache {
 struct PackageAnalysisCacheEntry {
     /// Package-wide import stubs reused across snapshots from the same root.
     import_stubs: Arc<IndexMap<Symbol, leo_ast::Stub>>,
+    /// Compact source fingerprints recorded while parsing dependency stubs.
+    ///
+    /// The cache stores these as a sorted slice instead of a `HashMap` because
+    /// they live as long as the package entry. We only need map lookup while
+    /// lowering one worker result, so `fingerprints_with` builds that transient
+    /// map at the boundary where it is actually useful.
+    fingerprints: Arc<[(PathBuf, SourceFingerprint)]>,
     /// Filesystem inputs whose metadata changes invalidate `import_stubs`.
     watch_paths: Arc<[PathBuf]>,
     /// Per-path revision memo reused to avoid rehashing unchanged watched inputs.
     watch_state: HashMap<PathBuf, CachedWatchedPathRevision>,
-    /// Hash of the last observed metadata for `watch_paths`.
+    /// Aggregate watched-path revision for the cached stub set.
+    ///
+    /// Each path revision hashes the actual file bytes or recursive directory
+    /// listing, while `watch_state` lets unchanged metadata stamps reuse those
+    /// full revisions between checks.
     revision: u64,
+}
+
+/// Cached import stubs plus the dependency source fingerprints captured when
+/// those stubs were parsed.
+#[derive(Debug, Clone)]
+struct CachedImportStubs {
+    import_stubs: Arc<IndexMap<Symbol, leo_ast::Stub>>,
+    /// Sorted slice instead of a cached hash table to keep package caches lean.
+    fingerprints: Arc<[(PathBuf, SourceFingerprint)]>,
 }
 
 /// Memoized revision for one watched path.
@@ -139,58 +182,140 @@ enum WatchedPathStamp {
     Directory { modified_nanos: u128 },
 }
 
-/// Build the latest semantic snapshot for one committed document generation.
+/// Compiler occurrences plus source fingerprints captured by the file source.
+#[derive(Debug)]
+struct CompilerOutput {
+    occurrences: Vec<SymbolOccurrence>,
+    fingerprints: HashMap<PathBuf, SourceFingerprint>,
+}
+
+/// Build the latest package analysis plus the trigger document's token view.
 ///
 /// Syntax analysis always runs first so the server can return a best-effort
 /// token stream even when package discovery, dependency loading, or compiler
 /// analysis fail. Compiler-backed occurrences then replace matching syntax
-/// ranges when available so later features can reuse a richer semantic index.
-pub fn analyze_snapshot(snapshot: &DocumentSnapshot, package_cache: &mut PackageAnalysisCache) -> SemanticSnapshot {
+/// ranges when available so navigation reuses the same semantic truth as
+/// highlighting.
+pub fn analyze_package_snapshot(
+    snapshot: &DocumentSnapshot,
+    package_cache: &mut PackageAnalysisCache,
+) -> PackageWorkerAnalysis {
     let syntax = syntax_semantics::collect(snapshot);
     if snapshot_is_cancelled(snapshot) {
-        return semantic_snapshot(snapshot, syntax.occurrences, syntax.tokens, SemanticSource::SyntaxOnly);
+        return package_analysis(
+            snapshot,
+            syntax.occurrences,
+            syntax.tokens,
+            SemanticSource::SyntaxOnly,
+            HashMap::new(),
+        );
     }
 
     let compiler_occurrences = compiler_occurrences(snapshot, package_cache);
     if snapshot_is_cancelled(snapshot) {
-        return semantic_snapshot(snapshot, syntax.occurrences, syntax.tokens, SemanticSource::SyntaxOnly);
+        return package_analysis(
+            snapshot,
+            syntax.occurrences,
+            syntax.tokens,
+            SemanticSource::SyntaxOnly,
+            HashMap::new(),
+        );
     }
 
-    let (occurrences, source) = match compiler_occurrences {
-        Some(compiler_occurrences) => {
-            (merge_occurrences(syntax.occurrences, compiler_occurrences), SemanticSource::CompilerEnhanced)
+    let (occurrences, lexical_tokens, source, fingerprints) = match compiler_occurrences {
+        Some(CompilerOutput { occurrences, fingerprints }) => {
+            let mut merged_fingerprints = syntax.fingerprints;
+            merged_fingerprints.extend(fingerprints);
+            (
+                merge_occurrences(syntax.occurrences, occurrences),
+                syntax.tokens,
+                SemanticSource::CompilerEnhanced,
+                merged_fingerprints,
+            )
         }
-        None => (syntax.occurrences, SemanticSource::SyntaxOnly),
+        None => {
+            let syntax = syntax_semantics::collect_package_fallback(snapshot);
+            (syntax.occurrences, syntax.tokens, SemanticSource::SyntaxOnly, syntax.fingerprints)
+        }
     };
 
-    semantic_snapshot(snapshot, occurrences, syntax.tokens, source)
+    package_analysis(snapshot, occurrences, lexical_tokens, source, fingerprints)
 }
 
-/// Encode one semantic occurrence set into the cached snapshot returned to the main thread.
-fn semantic_snapshot(
+/// Compatibility helper retained for PR 2 tests and callers.
+#[allow(dead_code)]
+pub fn analyze_snapshot(snapshot: &DocumentSnapshot, package_cache: &mut PackageAnalysisCache) -> SemanticSnapshot {
+    let analysis = analyze_package_snapshot(snapshot, package_cache);
+    SemanticSnapshot {
+        encoded_tokens: analysis.document_view.encoded_tokens,
+        index: Arc::clone(&analysis.package.index),
+        source: analysis.package.source,
+    }
+}
+
+/// Build a document token view from a cached package analysis.
+pub fn build_document_view(snapshot: &DocumentViewSnapshot, package: Arc<CachedPackageAnalysis>) -> CachedDocumentView {
+    let syntax = syntax_semantics::collect_view(snapshot);
+    let package_tokens = snapshot
+        .file_path
+        .as_deref()
+        .map(|path| package.index.token_occurrences_for_file(path.as_ref()))
+        .unwrap_or_default();
+    let tokens = semantic_token_occurrences(&package_tokens, syntax.occurrences, syntax.tokens);
+    let encoded_tokens = encode_tokens(&tokens, snapshot.file_path.as_deref(), snapshot.line_index.as_ref());
+    CachedDocumentView { key: snapshot.key.clone(), encoded_tokens }
+}
+
+/// Lower merged occurrences into a shared package index and trigger-document view.
+fn package_analysis(
     snapshot: &DocumentSnapshot,
     occurrences: Vec<SymbolOccurrence>,
     lexical_tokens: Vec<SemanticTokenOccurrence>,
     source: SemanticSource,
-) -> SemanticSnapshot {
-    let semantic_tokens = semantic_token_occurrences(&occurrences, lexical_tokens);
-    let encoded_tokens = encode_tokens(&semantic_tokens, snapshot.file_path.as_deref(), snapshot.line_index.as_ref());
+    recorded_fingerprints: HashMap<PathBuf, SourceFingerprint>,
+) -> PackageWorkerAnalysis {
+    let (index, analyzed_files) = SemanticIndex::build(
+        &occurrences,
+        |path| {
+            recorded_fingerprints
+                .get(path)
+                .cloned()
+                .or_else(|| open_buffer_fingerprint(snapshot.open_overlays.as_ref(), path))
+                .unwrap_or(SourceFingerprint::Volatile)
+        },
+        |path| open_line_index(snapshot.open_overlays.as_ref(), path),
+    );
+    let index = Arc::new(index);
+    let package = Arc::new(CachedPackageAnalysis {
+        key: snapshot.package_key.clone(),
+        index: Arc::clone(&index),
+        analyzed_files: Arc::new(analyzed_files),
+        source,
+    });
 
-    SemanticSnapshot { encoded_tokens, index: Arc::new(SemanticIndex { occurrences }), source }
+    let package_tokens =
+        snapshot.file_path.as_deref().map(|path| index.token_occurrences_for_file(path.as_ref())).unwrap_or_default();
+    let semantic_tokens = semantic_token_occurrences(&package_tokens, Vec::new(), lexical_tokens);
+    let encoded_tokens = encode_tokens(&semantic_tokens, snapshot.file_path.as_deref(), snapshot.line_index.as_ref());
+    let document_view = CachedDocumentView { key: snapshot.view_key.clone(), encoded_tokens };
+
+    PackageWorkerAnalysis { package, document_view }
 }
 
 /// Merge symbol occurrences with highlighting-only lexical tokens for encoding.
 fn semantic_token_occurrences(
-    occurrences: &[SymbolOccurrence],
+    package_tokens: &[SemanticTokenOccurrence],
+    syntax_occurrences: Vec<SymbolOccurrence>,
     mut lexical_tokens: Vec<SemanticTokenOccurrence>,
 ) -> Vec<SemanticTokenOccurrence> {
-    let mut tokens = Vec::with_capacity(occurrences.len() + lexical_tokens.len());
-    tokens.extend(occurrences.iter().map(SemanticTokenOccurrence::from_symbol));
+    let mut tokens = Vec::with_capacity(package_tokens.len() + syntax_occurrences.len() + lexical_tokens.len());
+    tokens.extend(package_tokens.iter().cloned());
+    tokens.extend(syntax_occurrences.iter().map(SemanticTokenOccurrence::from_symbol));
     tokens.append(&mut lexical_tokens);
     sort_token_occurrences(&mut tokens);
 
-    // Symbol tokens are inserted before lexical tokens, so exact range ties keep
-    // the navigation-grade semantic classification.
+    // Package tokens are inserted before syntax and lexical tokens, so exact
+    // range ties keep navigation-grade compiler classifications.
     tokens.dedup_by(|left, right| left.range == right.range);
     tokens
 }
@@ -202,58 +327,73 @@ fn semantic_token_occurrences(
 fn compiler_occurrences(
     snapshot: &DocumentSnapshot,
     package_cache: &mut PackageAnalysisCache,
-) -> Option<Vec<SymbolOccurrence>> {
+) -> Option<CompilerOutput> {
     if snapshot_is_cancelled(snapshot) {
         return None;
     }
 
-    let (file_path, project) = compiler_inputs(snapshot)?;
-    let overlay_path = file_path.as_ref().clone();
-    let overlay_text = snapshot.text.to_string();
-    let project = Arc::clone(project);
+    let input = compiler_input(snapshot)?;
 
     let result = create_session_if_not_set_then(|_| {
         // Dependency resolution and parsing intern symbols, so the worker must
         // enter a Leo session before it asks the compiler for frontend state.
-        let import_stubs = package_cache.import_stubs_for(project.as_ref()).map_err(|error| {
-            tracing::debug!(
-                package = project.package_root.display().to_string(),
-                error,
-                "dependency stub loading failed"
-            );
-            error
-        })?;
+        let file_source = RecordingFileSource::new(Arc::clone(&snapshot.open_overlays));
+        match input {
+            CompilerInput::ManagedPackage { project } => {
+                let import_stubs = package_cache.import_stubs_for(project.as_ref(), &file_source).map_err(|error| {
+                    tracing::debug!(
+                        package = project.package_root.display().to_string(),
+                        error,
+                        "dependency stub loading failed"
+                    );
+                    error
+                })?;
 
-        // Run the compiler against the unsaved editor buffer while reading all
-        // other package files from disk.
-        let overlay_source = OverlayFileSource::new(overlay_path, overlay_text, &DiskFileSource);
-        let mut compiler = Compiler::new(
-            Some(project.program_name.to_string()),
-            false,
-            Handler::default(),
-            Rc::new(leo_ast::NodeBuilder::default()),
-            PathBuf::default(),
-            Some(leo_compiler::CompilerOptions::default()),
-            import_stubs.as_ref().clone(),
-            leo_ast::NetworkName::TestnetV0,
-        );
+                // Run the compiler against every open same-package editor
+                // buffer while recording fingerprints for disk files at the
+                // exact read boundary.
+                let output = run_compiler_analysis(
+                    Some(project.program_name.to_string()),
+                    project.entry_file.as_ref(),
+                    project.source_directory.as_ref(),
+                    &file_source,
+                    import_stubs.import_stubs.as_ref().clone(),
+                    || check_snapshot_current(snapshot),
+                )
+                .map_err(|error| error.to_string())?;
 
-        let frontend = compiler
-            .analyze_frontend_from_directory_with_file_source_and_check(
-                project.entry_file.as_ref(),
-                project.source_directory.as_ref(),
-                &overlay_source,
-                || check_snapshot_current(snapshot),
-            )
-            .map_err(|error| error.to_string())?;
+                check_snapshot_current(snapshot).map_err(|error| error.to_string())?;
+                Ok::<_, String>(CompilerOutput {
+                    occurrences: output,
+                    fingerprints: file_source.fingerprints_with(import_stubs.fingerprints.as_ref()),
+                })
+            }
+            CompilerInput::StandaloneProgram { file_path, source_directory } => {
+                let single_file_source = SingleFileSource::new(&file_source);
+                // Loose editor buffers should be analyzed as exactly one file.
+                // Scanning the parent directory would accidentally treat
+                // formatter fixtures or unrelated scratch files as Leo modules.
+                let output = run_compiler_analysis(
+                    None,
+                    file_path.as_ref(),
+                    source_directory.as_ref(),
+                    &single_file_source,
+                    IndexMap::new(),
+                    || check_snapshot_current(snapshot),
+                )
+                .map_err(|error| error.to_string())?;
 
-        let FrontendAnalysis { ast, symbol_table, type_table } = frontend;
-        check_snapshot_current(snapshot).map_err(|error| error.to_string())?;
-        Ok::<_, String>(CompilerSemanticCollector::new(symbol_table, type_table).collect(ast))
+                check_snapshot_current(snapshot).map_err(|error| error.to_string())?;
+                Ok::<_, String>(CompilerOutput {
+                    occurrences: output,
+                    fingerprints: file_source.fingerprints_with(&[]),
+                })
+            }
+        }
     });
 
     match result {
-        Ok(occurrences) => Some(occurrences),
+        Ok(output) => Some(output),
         Err(error) => {
             tracing::debug!(uri = snapshot.uri.as_str(), error, "compiler semantic analysis unavailable; falling back");
             None
@@ -261,41 +401,289 @@ fn compiler_occurrences(
     }
 }
 
-/// Return the file and project context required for compiler-backed analysis.
-fn compiler_inputs(snapshot: &DocumentSnapshot) -> Option<(&Arc<PathBuf>, &Arc<ProjectContext>)> {
+/// Compiler frontend input shape selected for a document snapshot.
+enum CompilerInput {
+    /// A document inside a discovered Leo package source tree.
+    ManagedPackage { project: Arc<ProjectContext> },
+    /// A loose `.leo` program buffer analyzed without sibling module discovery.
+    StandaloneProgram { file_path: Arc<PathBuf>, source_directory: PathBuf },
+}
+
+/// Return the compiler analysis mode supported by this snapshot.
+fn compiler_input(snapshot: &DocumentSnapshot) -> Option<CompilerInput> {
     let file_path = snapshot.file_path.as_ref()?;
-    let project = snapshot.project.as_ref()?;
-    // Keep compiler analysis inside the package source tree. Files outside the
-    // source root may still receive syntax tokens, but the compiler pipeline
-    // expects entry/module relationships rooted at the package source dir.
-    file_path.starts_with(project.source_directory.as_ref()).then_some((file_path, project))
+    if let Some(project) = snapshot.project.as_ref()
+        && file_path.starts_with(project.source_directory.as_ref())
+    {
+        return Some(CompilerInput::ManagedPackage { project: Arc::clone(project) });
+    }
+
+    Some(CompilerInput::StandaloneProgram {
+        file_path: Arc::clone(file_path),
+        source_directory: file_path.parent()?.to_path_buf(),
+    })
+}
+
+/// Run frontend analysis and immediately collect semantic occurrences.
+fn run_compiler_analysis(
+    expected_unit_name: Option<String>,
+    entry_file: &StdPath,
+    source_directory: &StdPath,
+    file_source: &impl FileSource,
+    import_stubs: IndexMap<Symbol, leo_ast::Stub>,
+    mut should_continue: impl FnMut() -> leo_errors::Result<()>,
+) -> leo_errors::Result<Vec<SymbolOccurrence>> {
+    let mut compiler = Compiler::new(
+        expected_unit_name,
+        false,
+        Handler::default(),
+        Rc::new(leo_ast::NodeBuilder::default()),
+        PathBuf::default(),
+        Some(leo_compiler::CompilerOptions::default()),
+        import_stubs,
+        leo_ast::NetworkName::TestnetV0,
+    );
+
+    let frontend = compiler.analyze_frontend_from_directory_with_file_source_and_check(
+        entry_file,
+        source_directory,
+        file_source,
+        &mut should_continue,
+    )?;
+
+    let FrontendAnalysis { ast, symbol_table, type_table } = frontend;
+    Ok(CompilerSemanticCollector::new(symbol_table, type_table).collect(ast))
+}
+
+/// File source that serves all open same-package buffers and records read fingerprints.
+///
+/// The compiler's [`FileSource`] trait takes `&self`, but go-to-definition must
+/// know the exact bytes the compiler consumed for every indexed file. This
+/// recorder therefore uses interior mutability to append fingerprints during
+/// `read_file`. It is created per worker job and never shared across threads, so
+/// `RefCell<HashMap<...>>` is the smallest honest tool here: a `Mutex` would add
+/// unnecessary atomic locking/poisoning machinery, and `DashMap` would imply
+/// concurrent writers that cannot exist for this job-local file source.
+struct RecordingFileSource {
+    overlays: Arc<[OpenFileOverlay]>,
+    fingerprints: RefCell<HashMap<PathBuf, SourceFingerprint>>,
+}
+
+impl RecordingFileSource {
+    /// Create a recording file source over the open buffers captured by a snapshot.
+    fn new(overlays: Arc<[OpenFileOverlay]>) -> Self {
+        Self { overlays, fingerprints: RefCell::new(HashMap::new()) }
+    }
+
+    /// Return a compact, deterministic copy of dependency fingerprints for cache storage.
+    fn dependency_fingerprints(&self) -> Arc<[(PathBuf, SourceFingerprint)]> {
+        let mut fingerprints = self
+            .fingerprints
+            .borrow()
+            .iter()
+            .map(|(path, fingerprint)| (path.clone(), fingerprint.clone()))
+            .collect::<Vec<_>>();
+        // Keep cached dependency fingerprints deterministic and compact. The
+        // semantic-index builder can expand this slice into a temporary map
+        // later, but the long-lived package cache does not pay for hash buckets.
+        fingerprints.sort_by(|(left, _), (right, _)| left.cmp(right));
+        Arc::from(fingerprints)
+    }
+
+    /// Merge cached dependency fingerprints with reads performed by this job.
+    fn fingerprints_with(&self, cached: &[(PathBuf, SourceFingerprint)]) -> HashMap<PathBuf, SourceFingerprint> {
+        let recorded = self.fingerprints.borrow();
+        let mut fingerprints = HashMap::with_capacity(cached.len() + recorded.len());
+        fingerprints.extend(cached.iter().cloned());
+        fingerprints.extend(recorded.iter().map(|(path, fingerprint)| (path.clone(), fingerprint.clone())));
+        fingerprints
+    }
+
+    /// Record the fingerprint for bytes returned through this file source.
+    fn record(&self, path: &StdPath, fingerprint: SourceFingerprint) {
+        self.fingerprints.borrow_mut().insert(path.to_path_buf(), fingerprint);
+    }
+}
+
+impl FileSource for RecordingFileSource {
+    /// Read a source file from an open overlay or disk and capture its fingerprint.
+    fn read_file(&self, path: &StdPath) -> io::Result<String> {
+        if let Some(overlay) = self.overlays.iter().find(|overlay| overlay.path.as_ref() == path) {
+            let text = overlay.text.to_string();
+            self.record(path, SourceFingerprint::OpenBuffer);
+            return Ok(text);
+        }
+
+        let before = std::fs::metadata(path).ok().and_then(|metadata| disk_stamp(&metadata));
+        let contents = std::fs::read_to_string(path)?;
+        let after = std::fs::metadata(path).ok().and_then(|metadata| disk_stamp(&metadata));
+        let fingerprint = match (before, after) {
+            // Only disk bytes bracketed by identical metadata are safe to
+            // re-open later for LSP range conversion. If a write races the
+            // read, we mark the file volatile and suppress cross-file targets.
+            (Some(before), Some(after)) if before == after => SourceFingerprint::Disk {
+                modified_nanos: Some(after.modified_nanos),
+                len: after.len,
+                content_hash: content_hash(contents.as_str()),
+            },
+            _ => SourceFingerprint::Volatile,
+        };
+        self.record(path, fingerprint);
+        Ok(contents)
+    }
+
+    /// List package source modules, including unsaved open overlays.
+    fn list_leo_files(&self, dir: &StdPath, exclude: &StdPath) -> io::Result<Vec<PathBuf>> {
+        let mut files = DiskFileSource.list_leo_files(dir, exclude)?;
+        for overlay in self.overlays.iter() {
+            // Include unsaved same-package module buffers in compiler analysis
+            // even if the file has not been flushed to disk yet.
+            if overlay.path.starts_with(dir)
+                && overlay.path.extension().is_some_and(|extension| extension == "leo")
+                && overlay.path.as_ref() != exclude
+                && !files.iter().any(|path| path == overlay.path.as_ref())
+            {
+                files.push(overlay.path.as_ref().clone());
+            }
+        }
+        files.sort();
+        Ok(files)
+    }
+}
+
+/// File source adapter for standalone buffers that must not discover modules.
+struct SingleFileSource<'a> {
+    inner: &'a RecordingFileSource,
+}
+
+impl<'a> SingleFileSource<'a> {
+    /// Create a single-file view over a recording source.
+    fn new(inner: &'a RecordingFileSource) -> Self {
+        Self { inner }
+    }
+}
+
+impl FileSource for SingleFileSource<'_> {
+    /// Read through the recording source so fingerprints stay accurate.
+    fn read_file(&self, path: &StdPath) -> io::Result<String> {
+        self.inner.read_file(path)
+    }
+
+    /// Suppress sibling module discovery for loose, unmanaged files.
+    fn list_leo_files(&self, _dir: &StdPath, _exclude: &StdPath) -> io::Result<Vec<PathBuf>> {
+        Ok(Vec::new())
+    }
+}
+
+/// Cheap filesystem stamp used to prove a disk read was stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiskStamp {
+    /// File length observed in metadata.
+    len: u64,
+    /// Last-modified timestamp converted to nanoseconds since the Unix epoch.
+    modified_nanos: u128,
+}
+
+/// Build a comparable stamp from filesystem metadata.
+fn disk_stamp(metadata: &Metadata) -> Option<DiskStamp> {
+    Some(DiskStamp { len: metadata.len(), modified_nanos: metadata_modified_nanos(metadata)? })
+}
+
+/// Return the current open-buffer fingerprint for an analyzed path.
+fn open_buffer_fingerprint(overlays: &[OpenFileOverlay], path: &StdPath) -> Option<SourceFingerprint> {
+    overlays.iter().any(|overlay| overlay.path.as_ref() == path).then_some(SourceFingerprint::OpenBuffer)
+}
+
+/// Return the line index for an open buffer referenced by compact ranges.
+fn open_line_index(overlays: &[OpenFileOverlay], path: &StdPath) -> Option<Arc<line_index::LineIndex>> {
+    overlays.iter().find(|overlay| overlay.path.as_ref() == path).map(|overlay| Arc::clone(&overlay.line_index))
+}
+
+/// Hash source text for stale-target detection without retaining full text.
+fn content_hash(contents: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    contents.hash(&mut hasher);
+    hasher.finish()
 }
 
 impl PackageAnalysisCache {
+    /// Drop worker-local package stub entries that no longer have open documents.
+    pub fn retain_open_buckets(&mut self, open_buckets: &HashSet<AnalysisBucket>) {
+        self.entries.retain(|package_root, _| {
+            open_buckets
+                .iter()
+                .any(|bucket| matches!(bucket, AnalysisBucket::ManagedPackage { package_root: root } if root.as_ref() == package_root))
+        });
+        self.order.retain(|package_root| self.entries.contains_key(package_root));
+    }
+
     /// Return cached import stubs for the project, reloading them whenever the
     /// watched manifest or source metadata changes.
-    fn import_stubs_for(&mut self, project: &ProjectContext) -> Result<Arc<IndexMap<Symbol, leo_ast::Stub>>, String> {
+    fn import_stubs_for(
+        &mut self,
+        project: &ProjectContext,
+        file_source: &RecordingFileSource,
+    ) -> Result<CachedImportStubs, String> {
         if let Some(entry) = self.entries.get_mut(project.package_root.as_ref())
             && entry.revision == watched_paths_revision_cached(entry.watch_paths.as_ref(), &mut entry.watch_state)
         {
-            return Ok(Arc::clone(&entry.import_stubs));
+            let import_stubs = Arc::clone(&entry.import_stubs);
+            let fingerprints = Arc::clone(&entry.fingerprints);
+            self.touch_entry(project.package_root.as_ref());
+            return Ok(CachedImportStubs { import_stubs, fingerprints });
         }
 
         // Import stubs are package-wide, but they depend on manifest/source
         // metadata. Rebuild the entry when any watched input changes.
-        let loaded = load_import_stubs_for_package(project.package_root.as_ref(), leo_ast::NetworkName::TestnetV0)
-            .map_err(|error| error.to_string())?;
+        let loaded = load_import_stubs_for_package_with_file_source(
+            project.package_root.as_ref(),
+            leo_ast::NetworkName::TestnetV0,
+            file_source,
+        )
+        .map_err(|error| error.to_string())?;
         let watch_paths = Arc::<[PathBuf]>::from(loaded.watch_paths);
         let mut watch_state = HashMap::new();
         let revision = watched_paths_revision_cached(watch_paths.as_ref(), &mut watch_state);
         let import_stubs = Arc::new(loaded.stubs);
-        self.entries.insert(project.package_root.as_ref().clone(), PackageAnalysisCacheEntry {
+        // Capturing dependency fingerprints here is what lets source-dependency
+        // go-to-definition return real disk locations on cache hits. Without
+        // carrying these fingerprints alongside the stubs, dependency targets
+        // would later look volatile and be filtered out as unsafe.
+        let fingerprints = file_source.dependency_fingerprints();
+        let package_root = project.package_root.as_ref().clone();
+        self.entries.insert(package_root.clone(), PackageAnalysisCacheEntry {
             import_stubs: Arc::clone(&import_stubs),
+            fingerprints: Arc::clone(&fingerprints),
             watch_paths,
             watch_state,
             revision,
         });
-        Ok(import_stubs)
+        self.touch_entry(&package_root);
+        self.evict_old_entries(&package_root);
+        Ok(CachedImportStubs { import_stubs, fingerprints })
+    }
+
+    /// Mark a package-root cache entry as most recently used.
+    fn touch_entry(&mut self, package_root: &StdPath) {
+        self.order.retain(|candidate| candidate.as_path() != package_root);
+        self.order.push_back(package_root.to_path_buf());
+    }
+
+    /// Evict old package stub entries while preserving the entry just loaded.
+    fn evict_old_entries(&mut self, protected: &StdPath) {
+        self.order.retain(|package_root| self.entries.contains_key(package_root));
+        let mut attempts = self.order.len();
+        while self.entries.len() > MAX_PACKAGE_ANALYSIS_CACHE_ENTRIES && attempts > 0 {
+            attempts -= 1;
+            let Some(oldest) = self.order.pop_front() else {
+                break;
+            };
+            if oldest.as_path() == protected {
+                self.order.push_back(oldest);
+            } else {
+                self.entries.remove(&oldest);
+            }
+        }
     }
 }
 
@@ -388,15 +776,37 @@ impl<'a> CompilerSemanticCollector<'a> {
         Location::new(self.current_program, path)
     }
 
+    /// Build a nested declaration location under the current semantic owner.
+    fn owned_item_location(&self, name: Symbol) -> Location {
+        if let Some(owner) = self.current_owner() {
+            let mut path = owner.path;
+            path.push(name);
+            Location::new(owner.program, path)
+        } else {
+            self.current_item_location(name)
+        }
+    }
+
     /// Record a program or imported-namespace occurrence.
     fn add_namespace_occurrence(&mut self, identifier: &Identifier, role: OccurrenceRole) {
+        self.add_namespace_occurrence_with_declaration(
+            identifier,
+            role,
+            matches!(role, OccurrenceRole::Declaration).then(|| span_to_file_range(identifier.span)).flatten(),
+        );
+    }
+
+    /// Record a program or imported-namespace occurrence with an explicit target.
+    fn add_namespace_occurrence_with_declaration(
+        &mut self,
+        identifier: &Identifier,
+        role: OccurrenceRole,
+        declaration: Option<FileRange>,
+    ) {
         if let Some(range) = span_to_file_range(identifier.span) {
             self.occurrences.push(SymbolOccurrence {
-                range: range.clone(),
-                identity: SymbolIdentity::Program {
-                    name: identifier.name,
-                    declaration: matches!(role, OccurrenceRole::Declaration).then_some(range.clone()),
-                },
+                range,
+                identity: SymbolIdentity::Program { name: identifier.name, declaration },
                 role,
                 token_kind: SemanticKind::Namespace,
                 readonly: false,
@@ -496,6 +906,16 @@ impl<'a> CompilerSemanticCollector<'a> {
             .or_else(|| self.type_table.get(&input.id).and_then(|type_| self.member_owner_from_type(&type_)))
     }
 
+    /// Record a source import and point it at the imported program when available.
+    fn add_import_occurrence(&mut self, import: &ProgramId, program: &Program) {
+        let declaration = program
+            .stubs
+            .get(&import.as_symbol())
+            .or_else(|| program.stubs.get(&import.name.name))
+            .and_then(stub_program_declaration_range);
+        self.add_namespace_occurrence_with_declaration(&import.name, OccurrenceRole::Reference, declaration);
+    }
+
     /// Resolve a global path through the compiler symbol tables and emit the
     /// most accurate semantic kind available for its target declaration.
     fn visit_global_path(&mut self, path: &Path) {
@@ -507,9 +927,8 @@ impl<'a> CompilerSemanticCollector<'a> {
             self.add_namespace_occurrence(first, OccurrenceRole::Reference);
         }
 
-        let Some(location) = path.try_global_location().cloned() else {
-            return;
-        };
+        let location =
+            path.try_global_location().cloned().unwrap_or_else(|| self.current_item_location(path.identifier().name));
         let Some(range) = span_to_file_range(path.identifier().span) else {
             return;
         };
@@ -572,9 +991,12 @@ impl<'a> CompilerSemanticCollector<'a> {
 }
 
 impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
+    /// Compiler semantic collection does not need caller-supplied visitor state.
     type AdditionalInput = ();
+    /// Visitor methods record occurrences through side effects.
     type Output = ();
 
+    /// Visit a function call and classify the callee as a function reference.
     fn visit_call(&mut self, input: &CallExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         // Regular calls highlight the callee path as a function and then visit
         // all compile-time and runtime arguments as expressions.
@@ -583,6 +1005,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         input.arguments.iter().for_each(|expr| self.visit_expression(expr, &()));
     }
 
+    /// Visit a composite literal, recording field names as member references.
     fn visit_composite_init(
         &mut self,
         input: &CompositeExpression,
@@ -601,6 +1024,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         }
     }
 
+    /// Visit a composite type path and any const-generic arguments.
     fn visit_composite_type(&mut self, input: &CompositeType) {
         // Composite types reuse the same path identity logic as value-level
         // references, plus any const-generic arguments they carry.
@@ -608,6 +1032,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         input.const_arguments.iter().for_each(|expr| self.visit_expression(expr, &()));
     }
 
+    /// Visit dynamic operations whose target identity cannot be fully resolved.
     fn visit_dynamic_op(&mut self, input: &DynamicOpExpression, _additional: &Self::AdditionalInput) -> Self::Output {
         self.visit_type(&input.interface);
         self.visit_expression(&input.target_program, &());
@@ -634,6 +1059,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         }
     }
 
+    /// Visit `receiver.member` expressions and preserve the receiver-derived owner.
     fn visit_member_access(&mut self, input: &MemberAccess, _additional: &Self::AdditionalInput) -> Self::Output {
         // Member access records the receiver first so nested expressions still
         // contribute their own occurrences before the property reference.
@@ -642,6 +1068,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         self.add_member_occurrence(owner, &input.name, OccurrenceRole::Reference, false, None);
     }
 
+    /// Visit a path, preferring lexical bindings before falling back to globals.
     fn visit_path(&mut self, input: &Path, _additional: &Self::AdditionalInput) -> Self::Output {
         if input.is_global() {
             self.visit_global_path(input);
@@ -651,9 +1078,11 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         // Non-global paths only participate in semantic indexing if they can be
         // matched back to a currently bound lexical declaration.
         let Some(symbol) = input.try_local_symbol() else {
+            self.visit_global_path(input);
             return;
         };
         let Some(binding) = self.local_scopes.iter().rev().find_map(|scope| scope.get(&symbol)).cloned() else {
+            self.visit_global_path(input);
             return;
         };
         let Some(range) = span_to_file_range(input.identifier().span) else {
@@ -668,6 +1097,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         });
     }
 
+    /// Visit a block inside a new lexical scope.
     fn visit_block(&mut self, input: &leo_ast::Block) {
         // Blocks introduce lexical scope for definitions created inside them.
         self.push_scope();
@@ -675,6 +1105,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         self.pop_scope();
     }
 
+    /// Visit a constant declaration as either global or scoped readonly state.
     fn visit_const(&mut self, input: &ConstDeclaration) {
         // Constants behave like readonly variable declarations for semantic
         // token purposes, even when they appear at top level.
@@ -698,6 +1129,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         }
     }
 
+    /// Visit a `let` definition and bind every declared local name.
     fn visit_definition(&mut self, input: &DefinitionStatement) {
         if let Some(type_) = &input.type_ {
             self.visit_type(type_);
@@ -713,6 +1145,7 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
         }
     }
 
+    /// Visit a loop while limiting the loop variable to the body scope.
     fn visit_iteration(&mut self, input: &IterationStatement) {
         if let Some(type_) = &input.type_ {
             self.visit_type(type_);
@@ -728,14 +1161,17 @@ impl<'a> AstVisitor for CompilerSemanticCollector<'a> {
 }
 
 impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
+    /// Visit an analyzed program, including imported stubs.
     fn visit_program(&mut self, input: &Program) {
         // Visit both owned source and imported stub graphs so semantic
         // identities remain available across dependency boundaries.
+        input.imports.values().for_each(|import| self.add_import_occurrence(import, input));
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
         input.modules.values().for_each(|module| self.visit_module(module));
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
     }
 
+    /// Visit a library root while preserving the surrounding module context.
     fn visit_library(&mut self, input: &leo_ast::Library) {
         // Libraries reuse the same collector machinery as programs, but their
         // top-level items live directly under the library name.
@@ -752,6 +1188,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.current_module = previous_module;
     }
 
+    /// Visit one program scope and reset module qualifiers for its items.
     fn visit_program_scope(&mut self, input: &ProgramScope) {
         // Reset the module path at each program scope so top-level locations do
         // not accidentally inherit a nested module qualifier.
@@ -775,6 +1212,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.current_module = previous_module;
     }
 
+    /// Visit a module with its fully qualified module path active.
     fn visit_module(&mut self, input: &Module) {
         // Modules replace the current module path wholesale because the AST
         // stores the full module path for each module node.
@@ -791,6 +1229,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.current_module = previous_module;
     }
 
+    /// Visit a struct or record and anchor member declarations to the composite.
     fn visit_composite(&mut self, input: &Composite) {
         // Member identities are anchored to the enclosing composite location, so
         // push that owner before walking members.
@@ -827,6 +1266,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.owner_stack.pop();
     }
 
+    /// Visit a concrete mapping declaration.
     fn visit_mapping(&mut self, input: &Mapping) {
         // Mappings surface to the editor like property-like global declarations.
         if let Some(range) = span_to_file_range(input.identifier.span) {
@@ -843,6 +1283,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.visit_type(&input.value_type);
     }
 
+    /// Visit a concrete storage declaration.
     fn visit_storage_variable(&mut self, input: &StorageVariable) {
         // Storage declarations are highlighted the same way as other
         // property-shaped global state.
@@ -859,13 +1300,14 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.visit_type(&input.type_);
     }
 
+    /// Visit an interface mapping prototype under the active owner.
     fn visit_mapping_prototype(&mut self, input: &MappingPrototype) {
         // Interface mapping prototypes mirror concrete mapping declarations for
         // semantic-token purposes, but without executable bodies.
         if let Some(range) = span_to_file_range(input.identifier.span) {
             self.add_global_occurrence(
                 range.clone(),
-                self.current_item_location(input.identifier.name),
+                self.owned_item_location(input.identifier.name),
                 Some(range),
                 OccurrenceRole::Declaration,
                 SemanticKind::Property,
@@ -876,13 +1318,14 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.visit_type(&input.value_type);
     }
 
+    /// Visit an interface storage prototype under the active owner.
     fn visit_storage_variable_prototype(&mut self, input: &StorageVariablePrototype) {
         // Interface storage prototypes still contribute property declarations
         // even though no backing storage exists in this source file.
         if let Some(range) = span_to_file_range(input.identifier.span) {
             self.add_global_occurrence(
                 range.clone(),
-                self.current_item_location(input.identifier.name),
+                self.owned_item_location(input.identifier.name),
                 Some(range),
                 OccurrenceRole::Declaration,
                 SemanticKind::Property,
@@ -892,6 +1335,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.visit_type(&input.type_);
     }
 
+    /// Visit a concrete function and bind its parameter/body scopes.
     fn visit_function(&mut self, input: &Function) {
         // Function parameters introduce the outermost lexical scope for the
         // function body, before nested blocks add their own scopes.
@@ -921,6 +1365,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.pop_scope();
     }
 
+    /// Visit an interface and use it as the owner for all prototypes.
     fn visit_interface(&mut self, input: &Interface) {
         // Interface members share the interface as their semantic owner even
         // though they are prototype declarations rather than full definitions.
@@ -947,11 +1392,12 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.owner_stack.pop();
     }
 
+    /// Visit an interface function prototype without a body.
     fn visit_function_prototype(&mut self, input: &FunctionPrototype) {
         // Prototype parameters still participate in local binding/highlighting
         // even though there is no executable body to visit.
         if let Some(range) = span_to_file_range(input.identifier.span) {
-            let location = self.current_item_location(input.identifier.name);
+            let location = self.owned_item_location(input.identifier.name);
             self.add_global_occurrence(
                 range.clone(),
                 location,
@@ -976,10 +1422,11 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         self.pop_scope();
     }
 
+    /// Visit an interface record prototype and its owned members.
     fn visit_record_prototype(&mut self, input: &RecordPrototype) {
         // Record members inherit the record prototype as their semantic owner.
         if let Some(range) = span_to_file_range(input.identifier.span) {
-            let location = self.current_item_location(input.identifier.name);
+            let location = self.owned_item_location(input.identifier.name);
             self.add_global_occurrence(
                 range.clone(),
                 location.clone(),
@@ -1016,6 +1463,60 @@ fn variable_symbol_semantics(declaration: VariableType) -> (SemanticKind, bool) 
         VariableType::Mut => (SemanticKind::Variable, false),
         VariableType::Storage => (SemanticKind::Property, false),
     }
+}
+
+/// Return the source declaration range for an imported dependency stub.
+fn stub_program_declaration_range(stub: &Stub) -> Option<FileRange> {
+    match stub {
+        Stub::FromLeo { program, .. } => program.program_scopes.values().find_map(|scope| {
+            span_to_file_range(scope.program_id.name.span)
+                .or_else(|| program_name_range_from_span(scope.span, scope.program_id.name.name.to_string().as_str()))
+        }),
+        Stub::FromAleo { program, .. } => span_to_file_range(program.stub_id.name.span)
+            .or_else(|| program_name_range_from_span(program.span, program.stub_id.name.name.to_string().as_str())),
+        Stub::FromLibrary { .. } => None,
+    }
+}
+
+/// Recover a program-name token from a larger program/stub span.
+fn program_name_range_from_span(span: leo_span::Span, name: &str) -> Option<FileRange> {
+    if span.is_dummy() {
+        return None;
+    }
+
+    with_session_globals(|session| {
+        let source_file = session.source_map.find_source_file(span.lo)?;
+        if span.hi > source_file.absolute_end {
+            return None;
+        }
+        let FileName::Real(path) = &source_file.name else {
+            return None;
+        };
+
+        let span_text = source_file.contents_of_span(span);
+        let name_offset = find_program_name_in_text(span_text, name)?;
+        let start = source_file.relative_offset(span.lo).checked_add(u32::try_from(name_offset).ok()?)?;
+        let end = start.checked_add(u32::try_from(name.len()).ok()?)?;
+        FileRange::new(Arc::new(path.clone()), start, end)
+    })
+}
+
+/// Find the identifier token in a `program name.aleo` source slice.
+fn find_program_name_in_text(text: &str, name: &str) -> Option<usize> {
+    let program_end = text.find("program")?.checked_add("program".len())?;
+    let bytes = text.as_bytes();
+    text[program_end..].match_indices(name).find_map(|(relative, _)| {
+        let start = program_end + relative;
+        let end = start + name.len();
+        let left_boundary = start == 0 || !is_identifier_byte(bytes[start - 1]);
+        let right_boundary = end == bytes.len() || !is_identifier_byte(bytes[end]);
+        (left_boundary && right_boundary).then_some(start)
+    })
+}
+
+/// Return whether a byte can appear inside a Leo identifier.
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 /// Convert a compiler span into a real file-relative range for semantic indexing.
@@ -1167,26 +1668,31 @@ fn collect_leo_files(dir: &StdPath, files: &mut Vec<PathBuf>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{PackageAnalysisCache, analyze_snapshot};
+    use super::{
+        MAX_PACKAGE_ANALYSIS_CACHE_ENTRIES,
+        PackageAnalysisCache,
+        PackageAnalysisCacheEntry,
+        analyze_snapshot,
+    };
     use crate::{
-        document_store::DocumentSnapshot,
+        document_store::{DocumentSnapshot, DocumentStore},
         project_model::ProjectModel,
-        semantics::{OccurrenceRole, SemanticSource, SymbolIdentity},
+        semantics::{OccurrenceRole, SemanticSource, SourceFingerprint},
     };
     use leo_ast::NetworkName;
     use leo_compiler::load_import_stubs_for_package;
-    use line_index::LineIndex;
     use lsp_types::Uri;
     use serde_json::json;
     use std::{
         fs,
-        path::Path,
-        sync::{Arc, atomic::AtomicU64},
+        path::{Path, PathBuf},
+        sync::Arc,
         thread,
         time::Duration,
     };
     use tempfile::tempdir;
 
+    /// Build a test `file:` URI from a native path.
     fn file_uri(path: &Path) -> Uri {
         #[cfg(target_os = "windows")]
         let path = {
@@ -1201,10 +1707,12 @@ mod tests {
         format!("file://{path}").parse().expect("file uri")
     }
 
+    /// Build the minimal manifest dependency JSON for a local package.
     fn local_dependency_json(path: &Path) -> String {
         json!([{ "name": "helper", "location": "local", "path": path }]).to_string()
     }
 
+    /// Write a package manifest and source directory for dependency-cache tests.
     fn write_manifest(package_root: &Path, program: &str, dependencies: &str) {
         fs::create_dir_all(package_root.join("src")).expect("create source dir");
         fs::write(
@@ -1224,23 +1732,16 @@ mod tests {
         .expect("write manifest");
     }
 
+    /// Build a committed document snapshot for compiler-bridge tests.
     fn snapshot_for(path: &Path, text: &str) -> DocumentSnapshot {
         let uri = file_uri(path);
         let mut projects = ProjectModel::default();
         let (file_path, project) = projects.resolve_document_context(&uri);
-
-        DocumentSnapshot {
-            uri,
-            text: Arc::from(text),
-            line_index: Arc::new(LineIndex::new(text)),
-            version: 1,
-            generation: 1,
-            file_path,
-            project,
-            cancel_token: Arc::new(AtomicU64::new(1)),
-        }
+        let mut documents = DocumentStore::default();
+        documents.commit_open(documents.prepare_open(uri, "leo".to_owned(), 1, text.to_owned(), file_path, project))
     }
 
+    /// Verifies network dependencies are ignored by local stub loading.
     #[test]
     fn import_stub_loader_skips_network_dependencies() {
         let tempdir = tempdir().expect("tempdir");
@@ -1265,6 +1766,7 @@ mod tests {
         assert_eq!(loaded.stubs.len(), 1);
     }
 
+    /// Verifies unchanged watched inputs reuse cached import stubs.
     #[test]
     fn package_cache_reuses_import_stubs_when_watched_inputs_are_unchanged() {
         let tempdir = tempdir().expect("tempdir");
@@ -1278,12 +1780,36 @@ mod tests {
         let project = project.expect("project context");
 
         let mut cache = PackageAnalysisCache::default();
-        let first = cache.import_stubs_for(project.as_ref()).expect("initial cache load");
-        let second = cache.import_stubs_for(project.as_ref()).expect("cached load");
+        let file_source = super::RecordingFileSource::new(Arc::from([]));
+        let first = cache.import_stubs_for(project.as_ref(), &file_source).expect("initial cache load");
+        let second = cache.import_stubs_for(project.as_ref(), &file_source).expect("cached load");
 
-        assert!(Arc::ptr_eq(&first, &second));
+        assert!(Arc::ptr_eq(&first.import_stubs, &second.import_stubs));
     }
 
+    /// Verifies the worker-local package cache evicts old stub entries.
+    #[test]
+    fn package_cache_caps_open_stub_entries() {
+        let mut cache = PackageAnalysisCache::default();
+
+        for index in 0..(MAX_PACKAGE_ANALYSIS_CACHE_ENTRIES + 3) {
+            let package_root = Path::new("/tmp").join(format!("pkg-{index}"));
+            cache.entries.insert(package_root.clone(), PackageAnalysisCacheEntry {
+                import_stubs: Arc::new(Default::default()),
+                fingerprints: Arc::from(Vec::<(PathBuf, SourceFingerprint)>::new()),
+                watch_paths: Arc::from([]),
+                watch_state: Default::default(),
+                revision: index as u64,
+            });
+            cache.touch_entry(&package_root);
+            cache.evict_old_entries(&package_root);
+        }
+
+        assert_eq!(cache.entries.len(), MAX_PACKAGE_ANALYSIS_CACHE_ENTRIES);
+        assert!(cache.entries.contains_key(Path::new("/tmp").join("pkg-10").as_path()));
+    }
+
+    /// Verifies dependency source rewrites invalidate cached stubs.
     #[test]
     fn package_cache_invalidates_when_dependency_sources_change() {
         let tempdir = tempdir().expect("tempdir");
@@ -1303,16 +1829,50 @@ mod tests {
         let project = project.expect("project context");
 
         let mut cache = PackageAnalysisCache::default();
-        let first = cache.import_stubs_for(project.as_ref()).expect("initial cache load");
+        let file_source = super::RecordingFileSource::new(Arc::from([]));
+        let first = cache.import_stubs_for(project.as_ref(), &file_source).expect("initial cache load");
 
         thread::sleep(Duration::from_millis(20));
         fs::write(&helper_source, "const VALUE: u32 = 2u32;\nconst EXTRA: u32 = VALUE + 1u32;\n")
             .expect("update helper source");
 
-        let second = cache.import_stubs_for(project.as_ref()).expect("reloaded cache entry");
-        assert!(!Arc::ptr_eq(&first, &second));
+        let second = cache.import_stubs_for(project.as_ref(), &file_source).expect("reloaded cache entry");
+        assert!(!Arc::ptr_eq(&first.import_stubs, &second.import_stubs));
     }
 
+    /// Verifies new nested dependency modules invalidate cached stubs.
+    #[test]
+    fn package_cache_invalidates_when_nested_dependency_module_is_added() {
+        let tempdir = tempdir().expect("tempdir");
+        let helper_root = tempdir.path().join("helper");
+        write_manifest(&helper_root, "helper", "null");
+        let nested_dir = helper_root.join("src").join("nested");
+        fs::create_dir_all(&nested_dir).expect("create nested module dir");
+        fs::write(helper_root.join("src").join("lib.leo"), "const VALUE: u32 = 1u32;\n").expect("write helper source");
+        let helper_root = helper_root.canonicalize().expect("canonical helper root");
+        let nested_module = nested_dir.join("extra.leo");
+
+        let root = tempdir.path().join("root");
+        write_manifest(&root, "root.aleo", &local_dependency_json(&helper_root));
+        let main_path = root.join("src").join("main.leo");
+        fs::write(&main_path, "program root.aleo {}\n").expect("write root source");
+
+        let mut projects = ProjectModel::default();
+        let (_, project) = projects.resolve_document_context(&file_uri(&main_path));
+        let project = project.expect("project context");
+
+        let mut cache = PackageAnalysisCache::default();
+        let file_source = super::RecordingFileSource::new(Arc::from([]));
+        let first = cache.import_stubs_for(project.as_ref(), &file_source).expect("initial cache load");
+
+        thread::sleep(Duration::from_millis(20));
+        fs::write(nested_module, "const EXTRA: u32 = 2u32;\n").expect("write nested helper module");
+
+        let second = cache.import_stubs_for(project.as_ref(), &file_source).expect("reloaded cache entry");
+        assert!(!Arc::ptr_eq(&first.import_stubs, &second.import_stubs));
+    }
+
+    /// Verifies same-size rewrites still change watched-path revisions.
     #[test]
     fn watched_paths_revision_changes_on_same_size_rewrite() {
         let tempdir = tempdir().expect("tempdir");
@@ -1326,6 +1886,7 @@ mod tests {
         assert_ne!(first, second);
     }
 
+    /// Verifies directory listing changes are part of watched-path revisions.
     #[test]
     fn watched_paths_revision_changes_when_directory_listing_changes() {
         let tempdir = tempdir().expect("tempdir");
@@ -1341,6 +1902,7 @@ mod tests {
         assert_ne!(first, second);
     }
 
+    /// Verifies top-level const references share the declaration identity.
     #[test]
     fn top_level_consts_share_global_identity_with_references() {
         let tempdir = tempdir().expect("tempdir");
@@ -1360,23 +1922,51 @@ mod tests {
             .occurrences
             .iter()
             .filter(|occurrence| {
-                occurrence.range.path.as_ref() == &main_path
+                semantic_snapshot.index.files[occurrence.range.file as usize].as_ref() == &main_path
                     && &source[occurrence.range.start as usize..occurrence.range.end as usize] == "LIMIT"
             })
             .collect::<Vec<_>>();
         assert_eq!(occurrences.len(), 2);
+        assert!(occurrences.iter().all(|occurrence| occurrence.key_id().is_some()));
         assert!(occurrences.iter().any(|occurrence| occurrence.role == OccurrenceRole::Declaration));
         assert!(occurrences.iter().any(|occurrence| occurrence.role == OccurrenceRole::Reference));
-
-        let identities = occurrences.iter().map(|occurrence| &occurrence.identity).collect::<Vec<_>>();
-        match (&identities[0], &identities[1]) {
-            (SymbolIdentity::GlobalItem { location: left, .. }, SymbolIdentity::GlobalItem { location: right, .. }) => {
-                assert_eq!(left, right)
-            }
-            other => panic!("expected shared global identities, got {other:?}"),
-        }
+        assert!(occurrences.iter().all(|occurrence| occurrence.key == occurrences[0].key));
     }
 
+    /// Verifies import names carry a dependency-source definition target.
+    #[test]
+    fn import_names_resolve_to_dependency_program_declarations() {
+        let tempdir = tempdir().expect("tempdir");
+        let helper_root = tempdir.path().join("helper");
+        write_manifest(&helper_root, "helper.aleo", "null");
+        let helper_source = "program helper.aleo {\n    fn double(x: u32) -> u32 { return x + x; }\n}\n";
+        fs::write(helper_root.join("src").join("main.leo"), helper_source).expect("write helper source");
+
+        let root = tempdir.path().join("root");
+        let dependencies = json!([{ "name": "helper.aleo", "location": "local", "path": helper_root }]).to_string();
+        write_manifest(&root, "root.aleo", dependencies.as_str());
+        let source = "import helper.aleo;\n\nprogram root.aleo {\n    fn main() -> u32 { return 1u32; }\n}\n";
+        fs::write(root.join("src").join("main.leo"), source).expect("write root source");
+        let main_path = root.join("src").join("main.leo").canonicalize().expect("canonical main path");
+
+        let snapshot = snapshot_for(&main_path, source);
+        let semantic_snapshot = analyze_snapshot(&snapshot, &mut PackageAnalysisCache::default());
+
+        assert_eq!(semantic_snapshot.source, SemanticSource::CompilerEnhanced);
+        let occurrence = semantic_snapshot
+            .index
+            .occurrences
+            .iter()
+            .find(|occurrence| {
+                semantic_snapshot.index.files[occurrence.range.file as usize].as_ref() == &main_path
+                    && &source[occurrence.range.start as usize..occurrence.range.end as usize] == "helper"
+            })
+            .expect("helper import occurrence");
+        let key = occurrence.key_id().expect("navigation-grade import key");
+        assert!(!semantic_snapshot.index.definitions_for(key).is_empty());
+    }
+
+    /// Verifies member references resolve through the composite owner.
     #[test]
     fn member_references_reuse_resolved_composite_owner() {
         let tempdir = tempdir().expect("tempdir");
@@ -1404,23 +1994,55 @@ mod tests {
             .occurrences
             .iter()
             .filter(|occurrence| {
-                occurrence.range.path.as_ref() == &main_path
+                semantic_snapshot.index.files[occurrence.range.file as usize].as_ref() == &main_path
                     && &source[occurrence.range.start as usize..occurrence.range.end as usize] == "x"
             })
             .collect::<Vec<_>>();
         assert_eq!(x_occurrences.len(), 3);
 
-        let owners = x_occurrences
-            .iter()
-            .map(|occurrence| match &occurrence.identity {
-                SymbolIdentity::Member { owner, .. } => owner.clone(),
-                other => panic!("expected member identity, got {other:?}"),
-            })
-            .collect::<Vec<_>>();
-
-        assert!(owners.iter().all(|owner| owner.is_some()));
-        assert!(owners.windows(2).all(|pair| pair[0] == pair[1]));
+        assert!(x_occurrences.iter().all(|occurrence| occurrence.key_id().is_some()));
+        assert!(x_occurrences.iter().all(|occurrence| occurrence.key == x_occurrences[0].key));
         assert!(x_occurrences.iter().any(|occurrence| occurrence.role == OccurrenceRole::Declaration));
         assert_eq!(x_occurrences.iter().filter(|occurrence| occurrence.role == OccurrenceRole::Reference).count(), 2);
+    }
+
+    /// Verifies same-named interface prototypes stay owner-qualified.
+    #[test]
+    fn interface_prototypes_with_same_name_use_owner_qualified_identities() {
+        let tempdir = tempdir().expect("tempdir");
+        let root = tempdir.path().join("root");
+        write_manifest(&root, "root.aleo", "null");
+        let source = concat!(
+            "interface First {\n",
+            "    fn shared() -> u32;\n",
+            "}\n\n",
+            "interface Second {\n",
+            "    fn shared() -> u32;\n",
+            "}\n\n",
+            "program root.aleo {\n",
+            "    fn main() {}\n",
+            "}\n",
+        );
+        fs::write(root.join("src").join("main.leo"), source).expect("write root source");
+        let main_path = root.join("src").join("main.leo").canonicalize().expect("canonical main path");
+
+        let snapshot = snapshot_for(&main_path, source);
+        let semantic_snapshot = analyze_snapshot(&snapshot, &mut PackageAnalysisCache::default());
+
+        assert_eq!(semantic_snapshot.source, SemanticSource::CompilerEnhanced);
+
+        let shared_occurrences = semantic_snapshot
+            .index
+            .occurrences
+            .iter()
+            .filter(|occurrence| {
+                semantic_snapshot.index.files[occurrence.range.file as usize].as_ref() == &main_path
+                    && &source[occurrence.range.start as usize..occurrence.range.end as usize] == "shared"
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(shared_occurrences.len(), 2);
+        assert!(shared_occurrences.iter().all(|occurrence| occurrence.role == OccurrenceRole::Declaration));
+        assert!(shared_occurrences.iter().all(|occurrence| occurrence.key_id().is_some()));
+        assert_ne!(shared_occurrences[0].key, shared_occurrences[1].key);
     }
 }

--- a/crates/lsp/src/document_store.rs
+++ b/crates/lsp/src/document_store.rs
@@ -14,17 +14,64 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::mutable_key_type)]
+
 use crate::project_model::ProjectContext;
 use line_index::LineIndex;
 use lsp_types::Uri;
 use std::{
-    collections::HashMap,
-    path::PathBuf,
+    collections::{HashMap, HashSet},
+    path::{Path, PathBuf},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
 };
+
+/// Package-sized freshness bucket for semantic analysis.
+///
+/// Managed documents share a bucket by canonical package root so changing one
+/// open sibling invalidates package analysis for every open file in that
+/// package. Unmanaged buffers keep URI-local buckets because they have no
+/// package graph to share.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AnalysisBucket {
+    /// A Leo package rooted at a canonical `program.json` directory.
+    ManagedPackage { package_root: Arc<PathBuf> },
+    /// A scratch or non-file document with no resolved package context.
+    UnmanagedDocument { uri: Uri },
+}
+
+/// Freshness key for package-level semantic analysis.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PackageAnalysisKey {
+    /// Package or unmanaged-document bucket being analyzed.
+    pub bucket: AnalysisBucket,
+    /// Monotonic generation for all open-buffer inputs in the bucket.
+    pub bucket_generation: u64,
+}
+
+/// Freshness key for one document's encoded semantic-token view.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DocumentViewKey {
+    /// Open document URI for the encoded view.
+    pub uri: Uri,
+    /// Per-document generation used for position and lexical-token freshness.
+    pub document_generation: u64,
+    /// Package analysis this document view merges against.
+    pub package: PackageAnalysisKey,
+}
+
+/// Open-buffer overlay supplied to compiler package analysis.
+#[derive(Debug, Clone)]
+pub struct OpenFileOverlay {
+    /// Native path used by compiler file-source lookups.
+    pub path: Arc<PathBuf>,
+    /// Current committed editor text.
+    pub text: Arc<str>,
+    /// Line index for range conversion against this exact text.
+    pub line_index: Arc<LineIndex>,
+}
 
 /// Committed state for an open Leo document tracked by the server.
 ///
@@ -41,6 +88,8 @@ pub struct OpenDocument {
     pub generation: u64,
     pub file_path: Option<Arc<PathBuf>>,
     pub project: Option<Arc<ProjectContext>>,
+    /// Package-sized invalidation bucket this open document contributes to.
+    pub analysis_bucket: AnalysisBucket,
     pub cancel_token: Arc<AtomicU64>,
 }
 
@@ -60,6 +109,24 @@ pub struct DocumentSnapshot {
     #[allow(dead_code)]
     pub file_path: Option<Arc<PathBuf>>,
     #[allow(dead_code)]
+    pub project: Option<Arc<ProjectContext>>,
+    /// Package-analysis key for this snapshot's package-sized inputs.
+    pub package_key: PackageAnalysisKey,
+    /// Document-view key for the trigger document.
+    pub view_key: DocumentViewKey,
+    /// Same-package open buffers visible to compiler analysis.
+    pub open_overlays: Arc<[OpenFileOverlay]>,
+    pub cancel_token: Arc<AtomicU64>,
+}
+
+/// Document-sized worker input for rebuilding one semantic-token view.
+#[derive(Debug, Clone)]
+pub struct DocumentViewSnapshot {
+    pub key: DocumentViewKey,
+    pub uri: Uri,
+    pub text: Arc<str>,
+    pub line_index: Arc<LineIndex>,
+    pub file_path: Option<Arc<PathBuf>>,
     pub project: Option<Arc<ProjectContext>>,
     pub cancel_token: Arc<AtomicU64>,
 }
@@ -82,6 +149,7 @@ pub struct PreparedDocument {
 pub struct DocumentStore {
     documents: HashMap<Uri, OpenDocument>,
     latest_generation: HashMap<Uri, u64>,
+    bucket_generations: HashMap<AnalysisBucket, u64>,
 }
 
 impl DocumentStore {
@@ -104,9 +172,19 @@ impl DocumentStore {
         let text: Arc<str> = Arc::from(text);
         let line_index = Arc::new(LineIndex::new(text.as_ref()));
         let cancel_token = Arc::new(AtomicU64::new(generation));
+        let analysis_bucket = analysis_bucket_for(&uri, project.as_ref());
 
-        let document =
-            OpenDocument { language_id, text, line_index, version, generation, file_path, project, cancel_token };
+        let document = OpenDocument {
+            language_id,
+            text,
+            line_index,
+            version,
+            generation,
+            file_path,
+            project,
+            analysis_bucket,
+            cancel_token,
+        };
 
         PreparedDocument { uri, document }
     }
@@ -116,11 +194,15 @@ impl DocumentStore {
     /// If the URI was already open, the previous document's in-flight work is
     /// invalidated before the new snapshot becomes current.
     pub fn commit_open(&mut self, prepared: PreparedDocument) -> DocumentSnapshot {
-        let (uri, document, snapshot) = prepared.into_parts();
+        let (uri, document) = prepared.into_parts();
         if let Some(previous) = self.documents.insert(uri.clone(), document) {
             previous.cancel_token.store(next_generation(previous.generation), Ordering::SeqCst);
+            self.bump_bucket(&previous.analysis_bucket);
         }
 
+        let bucket = self.documents.get(&uri).expect("document just inserted").analysis_bucket.clone();
+        self.bump_bucket(&bucket);
+        let snapshot = self.snapshot_for_package_analysis(&uri).expect("document just inserted");
         self.latest_generation.insert(uri, snapshot.generation);
         snapshot
     }
@@ -143,6 +225,7 @@ impl DocumentStore {
         let text: Arc<str> = Arc::from(text);
         let line_index = Arc::new(LineIndex::new(text.as_ref()));
         let generation = next_generation(current.generation);
+        let analysis_bucket = analysis_bucket_for(uri, project.as_ref());
 
         let document = OpenDocument {
             language_id: current.language_id.clone(),
@@ -152,6 +235,7 @@ impl DocumentStore {
             generation,
             file_path,
             project,
+            analysis_bucket,
             cancel_token: Arc::clone(&current.cancel_token),
         };
 
@@ -163,9 +247,16 @@ impl DocumentStore {
     /// Committing updates both the visible document state and the shared cancel
     /// token so older snapshots become stale immediately.
     pub fn commit_change(&mut self, prepared: PreparedDocument) -> DocumentSnapshot {
-        let (uri, document, snapshot) = prepared.into_parts();
+        let (uri, document) = prepared.into_parts();
         document.cancel_token.store(document.generation, Ordering::SeqCst);
-        self.documents.insert(uri.clone(), document);
+        if let Some(previous) = self.documents.insert(uri.clone(), document)
+            && previous.analysis_bucket != self.documents.get(&uri).expect("document just inserted").analysis_bucket
+        {
+            self.bump_bucket(&previous.analysis_bucket);
+        }
+        let bucket = self.documents.get(&uri).expect("document just inserted").analysis_bucket.clone();
+        self.bump_bucket(&bucket);
+        let snapshot = self.snapshot_for_package_analysis(&uri).expect("document just inserted");
         self.latest_generation.insert(uri, snapshot.generation);
         snapshot
     }
@@ -180,6 +271,7 @@ impl DocumentStore {
         };
 
         document.cancel_token.store(next_generation(document.generation), Ordering::SeqCst);
+        self.bump_bucket(&document.analysis_bucket);
         true
     }
 
@@ -191,6 +283,68 @@ impl DocumentStore {
         self.documents.get(uri).map(|document| document.generation)
     }
 
+    /// Return the current package-analysis key for an open document.
+    pub fn package_key(&self, uri: &Uri) -> Option<PackageAnalysisKey> {
+        let document = self.documents.get(uri)?;
+        Some(self.package_key_for_bucket(&document.analysis_bucket))
+    }
+
+    /// Return the current document-view key for an open document.
+    pub fn document_view_key(&self, uri: &Uri) -> Option<DocumentViewKey> {
+        let document = self.documents.get(uri)?;
+        Some(DocumentViewKey {
+            uri: uri.clone(),
+            document_generation: document.generation,
+            package: self.package_key_for_bucket(&document.analysis_bucket),
+        })
+    }
+
+    /// Return the committed document for main-thread request handling.
+    pub fn open_document(&self, uri: &Uri) -> Option<&OpenDocument> {
+        self.documents.get(uri)
+    }
+
+    /// Build the latest package-analysis snapshot for an open document.
+    pub fn snapshot_for_package_analysis(&self, uri: &Uri) -> Option<DocumentSnapshot> {
+        let document = self.documents.get(uri)?;
+        Some(document.snapshot(
+            uri.clone(),
+            self.package_key_for_bucket(&document.analysis_bucket),
+            self.open_overlays(&document.analysis_bucket),
+        ))
+    }
+
+    /// Build a document-sized snapshot for a semantic-token view rebuild.
+    pub fn snapshot_for_document_view(&self, uri: &Uri) -> Option<DocumentViewSnapshot> {
+        let document = self.documents.get(uri)?;
+        Some(DocumentViewSnapshot {
+            key: self.document_view_key(uri)?,
+            uri: uri.clone(),
+            text: Arc::clone(&document.text),
+            line_index: Arc::clone(&document.line_index),
+            file_path: document.file_path.clone(),
+            project: document.project.clone(),
+            cancel_token: Arc::clone(&document.cancel_token),
+        })
+    }
+
+    /// Return the line index for an open path captured by current document state.
+    #[allow(dead_code)]
+    pub fn open_line_index_for_path(&self, path: &Path) -> Option<Arc<LineIndex>> {
+        self.documents.values().find_map(|document| {
+            document
+                .file_path
+                .as_deref()
+                .is_some_and(|candidate| candidate.as_path() == path)
+                .then(|| Arc::clone(&document.line_index))
+        })
+    }
+
+    /// Return currently open buckets for worker-side cache eviction.
+    pub fn open_buckets(&self) -> HashSet<AnalysisBucket> {
+        self.documents.values().map(|document| document.analysis_bucket.clone()).collect()
+    }
+
     /// Return the committed document for tests.
     #[cfg(test)]
     pub fn get(&self, uri: &Uri) -> Option<&OpenDocument> {
@@ -199,7 +353,16 @@ impl DocumentStore {
 }
 
 impl OpenDocument {
-    fn snapshot(&self, uri: Uri) -> DocumentSnapshot {
+    /// Capture the current open document plus package context for worker analysis.
+    fn snapshot(
+        &self,
+        uri: Uri,
+        package_key: PackageAnalysisKey,
+        open_overlays: Arc<[OpenFileOverlay]>,
+    ) -> DocumentSnapshot {
+        let view_key =
+            DocumentViewKey { uri: uri.clone(), document_generation: self.generation, package: package_key.clone() };
+
         DocumentSnapshot {
             uri,
             text: Arc::clone(&self.text),
@@ -208,21 +371,79 @@ impl OpenDocument {
             generation: self.generation,
             file_path: self.file_path.clone(),
             project: self.project.clone(),
+            package_key,
+            view_key,
+            open_overlays,
             cancel_token: Arc::clone(&self.cancel_token),
         }
     }
 }
 
 impl PreparedDocument {
-    fn into_parts(self) -> (Uri, OpenDocument, DocumentSnapshot) {
+    /// Split a prepared mutation into its target URI and committed document state.
+    fn into_parts(self) -> (Uri, OpenDocument) {
         let Self { uri, document } = self;
-        // Snapshot before moving the document into the store so the worker sees
-        // the exact committed state, including the shared cancel token.
-        let snapshot = document.snapshot(uri.clone());
-        (uri, document, snapshot)
+        (uri, document)
     }
 }
 
+impl DocumentStore {
+    /// Build the package-analysis freshness key for a bucket.
+    fn package_key_for_bucket(&self, bucket: &AnalysisBucket) -> PackageAnalysisKey {
+        PackageAnalysisKey {
+            bucket: bucket.clone(),
+            bucket_generation: self.bucket_generations.get(bucket).copied().unwrap_or_default(),
+        }
+    }
+
+    /// Advance a bucket generation after any open-buffer input changes.
+    fn bump_bucket(&mut self, bucket: &AnalysisBucket) {
+        let generation = self.bucket_generations.get(bucket).copied().unwrap_or_default();
+        self.bucket_generations.insert(bucket.clone(), next_generation(generation));
+    }
+
+    /// Collect open same-bucket buffers that compiler package analysis may read.
+    fn open_overlays(&self, bucket: &AnalysisBucket) -> Arc<[OpenFileOverlay]> {
+        let overlays = self
+            .documents
+            .values()
+            .filter_map(|document| {
+                if &document.analysis_bucket != bucket {
+                    return None;
+                }
+
+                let path = document.file_path.as_ref()?;
+                if let AnalysisBucket::ManagedPackage { .. } = bucket
+                    && let Some(project) = document.project.as_ref()
+                    && !path.starts_with(project.source_directory.as_ref())
+                {
+                    // Managed package analysis compiles from the package source
+                    // root. Open files outside `src` share the package bucket
+                    // for invalidation, but they must not be offered to the
+                    // compiler as module overlays.
+                    return None;
+                }
+
+                Some(OpenFileOverlay {
+                    path: Arc::clone(path),
+                    text: Arc::clone(&document.text),
+                    line_index: Arc::clone(&document.line_index),
+                })
+            })
+            .collect::<Vec<_>>();
+        Arc::from(overlays)
+    }
+}
+
+/// Choose the invalidation bucket for a document based on project discovery.
+fn analysis_bucket_for(uri: &Uri, project: Option<&Arc<ProjectContext>>) -> AnalysisBucket {
+    match project {
+        Some(project) => AnalysisBucket::ManagedPackage { package_root: Arc::clone(&project.package_root) },
+        None => AnalysisBucket::UnmanagedDocument { uri: uri.clone() },
+    }
+}
+
+/// Return the next monotonic generation, panicking rather than wrapping.
 fn next_generation(generation: u64) -> u64 {
     // Generation reuse would break stale-work detection, so overflow is treated
     // as a hard invariant violation rather than wrapping silently.
@@ -236,10 +457,12 @@ mod tests {
     use lsp_types::Uri;
     use std::sync::{Arc, atomic::Ordering};
 
+    /// Return the canonical URI used by document-store unit tests.
     fn test_uri() -> Uri {
         "file:///tmp/main.leo".parse().expect("valid file uri")
     }
 
+    /// Verifies full-sync edits replace text and advance document generations.
     #[test]
     fn full_sync_replaces_text_and_increments_generation() {
         let mut store = DocumentStore::default();
@@ -258,6 +481,7 @@ mod tests {
         assert!(!Arc::ptr_eq(&first.line_index, &second.line_index));
     }
 
+    /// Verifies prepared-but-uncommitted edits do not mutate visible state.
     #[test]
     fn dropping_prepared_change_preserves_committed_state() {
         let mut store = DocumentStore::default();
@@ -275,6 +499,7 @@ mod tests {
         assert_eq!(current.cancel_token.load(Ordering::SeqCst), 1);
     }
 
+    /// Verifies closing a document invalidates snapshots already sent to workers.
     #[test]
     fn close_invalidates_in_flight_work() {
         let mut store = DocumentStore::default();
@@ -288,6 +513,7 @@ mod tests {
         assert!(store.generation(&uri).is_none());
     }
 
+    /// Verifies reopening a URI cannot reuse its closed generation.
     #[test]
     fn reopen_after_close_advances_generation() {
         let mut store = DocumentStore::default();
@@ -304,6 +530,7 @@ mod tests {
         assert_eq!(second.generation, 2);
     }
 
+    /// Verifies duplicate opens cancel work tied to the replaced document.
     #[test]
     fn duplicate_open_invalidates_previous_in_flight_work() {
         let mut store = DocumentStore::default();
@@ -320,6 +547,7 @@ mod tests {
         assert_eq!(second.cancel_token.load(Ordering::SeqCst), 2);
     }
 
+    /// Verifies line indices preserve UTF-16 columns for multibyte text.
     #[test]
     fn line_index_tracks_utf16_columns_for_multibyte_text() {
         let mut store = DocumentStore::default();

--- a/crates/lsp/src/features/goto_definition.rs
+++ b/crates/lsp/src/features/goto_definition.rs
@@ -1,0 +1,200 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Go-to-definition resolution for Leo LSP.
+//!
+//! This module is intentionally compiler-free. The worker lowers compiler and
+//! syntax state into [`CachedPackageAnalysis`], and this feature module only
+//! answers cursor queries against that compact, snapshot-safe representation.
+//! Keeping this boundary small makes PR 4 references and PR 5 rename able to
+//! reuse the same lookup primitives without learning server or compiler internals.
+
+use crate::{
+    document_store::DocumentViewKey,
+    project_model::path_to_file_uri,
+    semantics::{CachedPackageAnalysis, CompactRange, SourceFingerprint},
+};
+use line_index::{LineIndex, TextSize, WideEncoding, WideLineCol};
+use lsp_types::{GotoDefinitionResponse, Location, LocationLink, Position, Range, Uri};
+use serde_json::Value;
+use std::{
+    hash::{DefaultHasher, Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::UNIX_EPOCH,
+};
+
+/// Cursor query captured before any async package-analysis wait.
+///
+/// The LSP position is converted to a UTF-8 byte offset immediately against the
+/// current open document. Pending requests keep that exact offset so multiple
+/// requests waiting on the same package analysis can still resolve to different
+/// targets.
+#[derive(Debug, Clone)]
+pub struct DefinitionQuery {
+    /// Requesting document URI, retained so pending requests can be cleared on close.
+    pub uri: Uri,
+    /// Native path for the document where the cursor started.
+    pub file_path: Arc<PathBuf>,
+    /// Original LSP position used as a fallback origin range for links.
+    pub position: Position,
+    /// UTF-8 byte offset resolved from `position` before any async wait.
+    pub offset: u32,
+    /// Line index for the exact open-buffer text that produced `offset`.
+    pub line_index: Arc<LineIndex>,
+    /// Freshness key for the document view active when the request arrived.
+    pub view_key: DocumentViewKey,
+    /// Whether the client accepts `LocationLink` responses with origin ranges.
+    pub link_support: bool,
+}
+
+/// Feature-level result before JSON serialization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DefinitionResult {
+    /// No safe navigation target was found.
+    None,
+    /// Plain LSP locations for clients without `LocationLink` support.
+    Locations(Vec<Location>),
+    /// Rich links including the source selection range.
+    Links(Vec<LocationLink>),
+}
+
+/// Convert an LSP UTF-16 position into a byte offset for the current document.
+pub fn position_to_offset(line_index: &LineIndex, position: Position) -> Option<u32> {
+    let wide = WideLineCol { line: position.line, col: position.character };
+    let utf8 = line_index.to_utf8(WideEncoding::Utf16, wide)?;
+    Some(u32::from(line_index.offset(utf8)?))
+}
+
+/// Resolve a go-to-definition query against a fresh package analysis.
+pub fn resolve(query: &DefinitionQuery, package: &CachedPackageAnalysis) -> DefinitionResult {
+    let Some(occurrence) = package.index.occurrence_at(query.file_path.as_ref(), query.offset) else {
+        return DefinitionResult::None;
+    };
+    let Some(key_id) = occurrence.occurrence.key_id() else {
+        return DefinitionResult::None;
+    };
+
+    let origin_range = compact_range_to_open_lsp_range(occurrence.occurrence.range, package, &query.line_index)
+        .unwrap_or_else(|| Range::new(query.position, query.position));
+    let mut locations = Vec::new();
+    let mut links = Vec::new();
+
+    for target in package.index.definitions_for(key_id) {
+        let Some((target_uri, target_range)) = compact_range_to_location_parts(*target, package) else {
+            continue;
+        };
+
+        if query.link_support {
+            links.push(LocationLink {
+                origin_selection_range: Some(origin_range),
+                target_uri,
+                target_range,
+                target_selection_range: target_range,
+            });
+        } else {
+            locations.push(Location { uri: target_uri, range: target_range });
+        }
+    }
+
+    if query.link_support {
+        if links.is_empty() { DefinitionResult::None } else { DefinitionResult::Links(links) }
+    } else if locations.is_empty() {
+        DefinitionResult::None
+    } else {
+        DefinitionResult::Locations(locations)
+    }
+}
+
+/// Serialize a feature result into the standard LSP response payload.
+pub fn response_value(result: DefinitionResult) -> Value {
+    match result {
+        DefinitionResult::None => Value::Null,
+        DefinitionResult::Locations(locations) => serde_json::to_value(GotoDefinitionResponse::Array(locations))
+            .expect("GotoDefinitionResponse::Array should serialize"),
+        DefinitionResult::Links(links) => serde_json::to_value(GotoDefinitionResponse::Link(links))
+            .expect("GotoDefinitionResponse::Link should serialize"),
+    }
+}
+
+/// Convert a source occurrence range in the requesting open buffer to LSP coordinates.
+fn compact_range_to_open_lsp_range(
+    range: CompactRange,
+    package: &CachedPackageAnalysis,
+    line_index: &LineIndex,
+) -> Option<Range> {
+    let file = package.analyzed_files.get(range.file)?;
+    if !matches!(file.fingerprint, SourceFingerprint::OpenBuffer) {
+        return None;
+    }
+    byte_range_to_lsp_range(line_index, range.start, range.end)
+}
+
+/// Convert a compact definition target into a safe external URI/range pair.
+fn compact_range_to_location_parts(range: CompactRange, package: &CachedPackageAnalysis) -> Option<(Uri, Range)> {
+    let file = package.analyzed_files.get(range.file)?;
+    let uri = path_to_file_uri(file.path.as_ref())?;
+    let lsp_range = match &file.fingerprint {
+        SourceFingerprint::OpenBuffer => {
+            byte_range_to_lsp_range(file.open_line_index.as_ref()?, range.start, range.end)?
+        }
+        SourceFingerprint::Disk { .. } => {
+            // Disk-backed targets are only emitted if the file still matches the
+            // exact bytes analyzed by the worker. This avoids returning ranges
+            // into a dependency file that changed after indexing.
+            let text = read_verified_disk_text(file.path.as_ref(), &file.fingerprint)?;
+            let line_index = LineIndex::new(text.as_str());
+            byte_range_to_lsp_range(&line_index, range.start, range.end)?
+        }
+        SourceFingerprint::Volatile => return None,
+    };
+    Some((uri, lsp_range))
+}
+
+/// Convert UTF-8 byte offsets into the UTF-16 positions required by LSP.
+fn byte_range_to_lsp_range(line_index: &LineIndex, start: u32, end: u32) -> Option<Range> {
+    let start = line_index.try_line_col(TextSize::from(start))?;
+    let end = line_index.try_line_col(TextSize::from(end))?;
+    let start = line_index.to_wide(WideEncoding::Utf16, start)?;
+    let end = line_index.to_wide(WideEncoding::Utf16, end)?;
+    Some(Range::new(Position::new(start.line, start.col), Position::new(end.line, end.col)))
+}
+
+/// Re-read disk text only when it still matches the analysis fingerprint.
+fn read_verified_disk_text(path: &Path, expected: &SourceFingerprint) -> Option<String> {
+    let SourceFingerprint::Disk { modified_nanos, len, content_hash } = expected else {
+        return None;
+    };
+    let metadata = std::fs::metadata(path).ok()?;
+    let current_modified = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?.as_nanos();
+    // Size and mtime are cheap rejection tests; the content hash is the final
+    // guard for same-size rewrites or coarse filesystem timestamp behavior.
+    if *len != metadata.len() || *modified_nanos != Some(current_modified) {
+        return None;
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    if *content_hash != hash_text(text.as_str()) {
+        return None;
+    }
+    Some(text)
+}
+
+/// Hash text using the same lightweight process-local hasher as analysis.
+fn hash_text(text: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    text.hash(&mut hasher);
+    hasher.finish()
+}

--- a/crates/lsp/src/features/mod.rs
+++ b/crates/lsp/src/features/mod.rs
@@ -14,5 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+pub mod goto_definition;
 /// Semantic token capability wiring and wire-format encoding helpers.
 pub mod semantic_tokens;

--- a/crates/lsp/src/project_model.rs
+++ b/crates/lsp/src/project_model.rs
@@ -116,6 +116,42 @@ pub(crate) fn uri_to_file_path(uri: &Uri) -> Option<PathBuf> {
     }
 }
 
+/// Convert a native filesystem path into an LSP `file:` URI.
+///
+/// The helper keeps URI construction centralized so editor responses do not
+/// depend on hand-built `file://{path}` strings. It canonicalizes paths when
+/// possible, preserves unresolved paths when necessary, and percent-encodes
+/// bytes that are not safe in a URI path.
+pub(crate) fn path_to_file_uri(path: &Path) -> Option<Uri> {
+    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+
+    #[cfg(target_os = "windows")]
+    let raw = {
+        let display = path.display().to_string();
+        let display = display.strip_prefix(r"\\?\").unwrap_or(display.as_str());
+        format!("/{}", display.replace('\\', "/"))
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let raw = path.display().to_string();
+
+    format!("file://{}", percent_encode_path(&raw)).parse().ok()
+}
+
+/// Percent-encode a native path string for the path component of a `file:` URI.
+fn percent_encode_path(path: &str) -> String {
+    let mut encoded = String::with_capacity(path.len());
+    for byte in path.bytes() {
+        if matches!(byte, b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'/' | b'.' | b'-' | b'_' | b'~' | b':') {
+            encoded.push(byte as char);
+        } else {
+            use std::fmt::Write;
+            let _ = write!(encoded, "%{byte:02X}");
+        }
+    }
+    encoded
+}
+
 /// Find the nearest package root that owns the given document path.
 fn find_package_root(path: &Path) -> Option<PathBuf> {
     let start = if path.is_dir() { Some(path) } else { path.parent() }?;
@@ -197,6 +233,7 @@ mod tests {
     use std::{fs, path::Path};
     use tempfile::tempdir;
 
+    /// Build a test `file:` URI from a native path.
     fn file_uri(path: &Path) -> Uri {
         #[cfg(target_os = "windows")]
         let path = format!("/{}", path.display()).replace('\\', "/");
@@ -207,6 +244,7 @@ mod tests {
         format!("file://{path}").parse().expect("file uri")
     }
 
+    /// Verifies project discovery chooses the nearest manifest ancestor.
     #[test]
     fn resolves_nearest_manifest_ancestor() {
         let tempdir = tempdir().expect("tempdir");
@@ -231,6 +269,7 @@ mod tests {
         assert_eq!(resolved.kind, ProjectKind::Program);
     }
 
+    /// Verifies non-file documents remain unmanaged.
     #[test]
     fn non_file_uris_are_unmanaged() {
         let mut projects = ProjectModel::default();
@@ -241,6 +280,7 @@ mod tests {
         assert!(project.is_none());
     }
 
+    /// Verifies a previous miss can become managed after a manifest appears.
     #[test]
     fn discovers_manifest_added_after_initial_miss() {
         let tempdir = tempdir().expect("tempdir");
@@ -264,6 +304,7 @@ mod tests {
         assert_eq!(resolved.package_root.as_ref(), &package_root.canonicalize().expect("canonical package root"));
     }
 
+    /// Verifies cached project roots are invalidated after manifest removal.
     #[test]
     fn invalidates_cached_root_after_manifest_removal() {
         let tempdir = tempdir().expect("tempdir");
@@ -287,6 +328,7 @@ mod tests {
         assert!(projects.resolve_document_context(&file_uri).1.is_none());
     }
 
+    /// Verifies library packages resolve to library entrypoints.
     #[test]
     fn resolves_library_entrypoints() {
         let tempdir = tempdir().expect("tempdir");
@@ -308,6 +350,7 @@ mod tests {
         assert_eq!(resolved.program_name.as_ref(), "math_lib");
     }
 
+    /// Verifies manifest content changes refresh cached project context.
     #[test]
     fn refreshes_cached_context_after_manifest_content_change() {
         let tempdir = tempdir().expect("tempdir");
@@ -338,6 +381,7 @@ mod tests {
         assert_eq!(refreshed.program_name.as_ref(), "updated.aleo");
     }
 
+    /// Verifies same-size manifest rewrites produce a new revision.
     #[test]
     fn manifest_revision_changes_on_same_size_rewrite() {
         let tempdir = tempdir().expect("tempdir");

--- a/crates/lsp/src/scheduler.rs
+++ b/crates/lsp/src/scheduler.rs
@@ -14,80 +14,177 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::mutable_key_type)]
+
 use crate::{
-    compiler_bridge::{PackageAnalysisCache, analyze_snapshot},
-    document_store::DocumentSnapshot,
+    compiler_bridge::{PackageAnalysisCache, PackageWorkerAnalysis, analyze_package_snapshot, build_document_view},
+    document_store::{AnalysisBucket, DocumentSnapshot, DocumentViewKey, DocumentViewSnapshot, PackageAnalysisKey},
     panic_boundary::{PanicReport, catch_unwind},
-    semantics::SemanticSnapshot,
+    semantics::{CachedDocumentView, CachedPackageAnalysis},
 };
-use crossbeam_channel::{Receiver, Sender, TryRecvError, unbounded};
+use crossbeam_channel::{Receiver, Sender, bounded, unbounded};
 use lsp_types::Uri;
 use std::{
-    collections::HashMap,
-    sync::atomic::AtomicU64,
+    collections::{HashMap, HashSet},
+    sync::{
+        Arc,
+        Mutex,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
     thread::{self, JoinHandle},
 };
 
-type PendingJobs = HashMap<String, PendingJob>;
+/// One wakeup is enough: real work lives in `PendingQueues` and coalesces there.
+const WORKER_CHANNEL_BOUND: usize = 1;
+/// Hard cap for heavy package jobs waiting behind the worker.
+const MAX_PENDING_PACKAGE_JOBS: usize = 16;
+/// Hard cap for lightweight document-view rebuilds waiting behind the worker.
+const MAX_PENDING_VIEW_JOBS: usize = 64;
 
-/// Commands sent from the main thread to the background worker.
-#[derive(Debug)]
-pub enum WorkerCommand {
-    Analyze(DocumentSnapshot),
-    Shutdown,
-}
+/// Pending heavy-analysis jobs keyed by package bucket.
+type PendingPackageJobs = HashMap<AnalysisBucket, PendingPackageJob>;
+/// Pending document-view jobs keyed by exact view freshness.
+type PendingViewJobs = HashMap<DocumentViewKey, PendingViewJob>;
 
 /// Events sent from the background worker back to the main thread.
 #[derive(Debug)]
 pub enum WorkerEvent {
-    Analyzed(DocumentAnalysis),
-    Cancelled { uri: Uri, generation: u64 },
-    Panicked { uri: Uri, generation: u64, report: PanicReport },
+    /// Fresh package analysis and trigger-document view are ready.
+    PackageAnalyzed(PackageAnalysis),
+    /// A semantic-token view was rebuilt from an already cached package.
+    DocumentViewBuilt(CachedDocumentView),
+    /// A package job became stale before or after worker execution.
+    PackageCancelled { key: PackageAnalysisKey, uri: Uri, generation: u64 },
+    /// A document-view job became stale before or after worker execution.
+    DocumentViewCancelled { key: DocumentViewKey },
+    /// Package analysis panicked inside the worker panic boundary.
+    PackagePanicked { key: PackageAnalysisKey, uri: Uri, generation: u64, report: PanicReport },
+    /// Document-view construction panicked inside the worker panic boundary.
+    DocumentViewPanicked { key: DocumentViewKey, report: PanicReport },
 }
 
 /// Worker-produced semantic state for one document generation.
 #[derive(Debug, Clone)]
-pub struct DocumentAnalysis {
+pub struct PackageAnalysis {
+    /// URI whose edit/request triggered this package analysis.
     pub uri: Uri,
+    /// Per-document generation of the triggering URI.
     pub generation: u64,
-    pub semantic_snapshot: SemanticSnapshot,
+    /// Package freshness key that all waiters must match.
+    pub key: PackageAnalysisKey,
+    /// Shared package index plus the trigger document's encoded view.
+    pub result: PackageWorkerAnalysis,
 }
 
 /// A coalesced worker job paired with its arrival order.
 ///
-/// The worker keeps at most one pending snapshot per URI, and `sequence`
-/// preserves global recency so the most recently updated document runs first.
+/// Package jobs are keyed by [`AnalysisBucket`], so the worker keeps at most
+/// one pending heavy-analysis snapshot per package bucket. `sequence` preserves
+/// global recency so the freshest package edit runs first.
 #[derive(Debug)]
-struct PendingJob {
+struct PendingPackageJob {
+    /// Monotonic enqueue order used to pick the freshest job globally.
     sequence: u64,
+    /// Latest package snapshot retained for this bucket.
     snapshot: DocumentSnapshot,
+}
+
+/// A coalesced document-view job paired with its arrival order.
+#[derive(Debug)]
+struct PendingViewJob {
+    /// Monotonic enqueue order used to pick the freshest view job globally.
+    sequence: u64,
+    /// Document snapshot used to rebuild encoded semantic tokens.
+    snapshot: DocumentViewSnapshot,
+    /// Package analysis the document view merges against.
+    package: Arc<CachedPackageAnalysis>,
+}
+
+/// Heavy analysis jobs waiting for the worker.
+///
+/// The routing thread writes snapshots into this short-lived queue and sends a
+/// tiny wakeup over the channel. Keeping package-sized snapshots out of the
+/// channel lets edit storms coalesce in place without blocking LSP request
+/// handling behind compiler work.
+///
+/// The mutex around this queue is intentionally not part of compiler analysis:
+/// it is held only while inserting, dropping, or removing queued jobs. The
+/// expensive worker path starts after the guard is gone, so request handling is
+/// not serialized behind package analysis.
+#[derive(Debug, Default)]
+struct PendingQueues {
+    /// Coalesced package-analysis jobs.
+    packages: PendingPackageJobs,
+    /// Coalesced document-view jobs.
+    views: PendingViewJobs,
+    /// Global sequence counter shared by both queues.
+    sequence: u64,
+    /// Latest open-bucket set supplied by the routing thread for cache eviction.
+    open_buckets: Option<HashSet<AnalysisBucket>>,
+}
+
+/// Bounded worker wake token.
+#[derive(Debug)]
+enum WorkerWake {
+    /// Ask the worker to inspect `PendingQueues`.
+    Wake,
+}
+
+/// Concrete job selected from the coalescing queues.
+enum WorkerJob {
+    /// Rebuild shared package analysis for a snapshot.
+    Package(DocumentSnapshot),
+    /// Rebuild one encoded document view from a cached package.
+    View(DocumentViewSnapshot, Arc<CachedPackageAnalysis>),
 }
 
 /// Background worker owner and communication channels.
 #[derive(Debug)]
 pub struct Scheduler {
-    command_tx: Sender<WorkerCommand>,
+    wake_tx: Sender<WorkerWake>,
+    event_tx: Sender<WorkerEvent>,
     event_rx: Receiver<WorkerEvent>,
+    pending: Arc<Mutex<PendingQueues>>,
+    shutdown_requested: Arc<AtomicBool>,
     worker: Option<JoinHandle<()>>,
 }
 
 impl Scheduler {
     /// Spawn the dedicated analysis worker thread.
     pub fn new(panic_on_worker_job: bool) -> Self {
-        let (command_tx, command_rx) = unbounded();
+        let (wake_tx, wake_rx) = bounded(WORKER_CHANNEL_BOUND);
         let (event_tx, event_rx) = unbounded();
+        let pending = Arc::new(Mutex::new(PendingQueues::default()));
+        let shutdown_requested = Arc::new(AtomicBool::new(false));
+
+        let worker_pending = Arc::clone(&pending);
+        let worker_shutdown = Arc::clone(&shutdown_requested);
+        let worker_event_tx = event_tx.clone();
 
         let worker = thread::Builder::new()
             .name("leo-lsp-worker".to_owned())
-            .spawn(move || worker_loop(command_rx, event_tx, panic_on_worker_job))
+            .spawn(move || worker_loop(wake_rx, worker_event_tx, worker_pending, worker_shutdown, panic_on_worker_job))
             .expect("failed to spawn leo-lsp worker");
 
-        Self { command_tx, event_rx, worker: Some(worker) }
+        Self { wake_tx, event_tx, event_rx, pending, shutdown_requested, worker: Some(worker) }
     }
 
     /// Enqueue a document snapshot for background analysis.
-    pub fn enqueue(&self, snapshot: DocumentSnapshot) {
-        let _ = self.command_tx.send(WorkerCommand::Analyze(snapshot));
+    pub fn enqueue_package(&self, snapshot: DocumentSnapshot) {
+        with_pending_queues(&self.pending, |pending| queue_package(pending, snapshot, self.event_tx.clone()));
+        self.wake_worker();
+    }
+
+    /// Enqueue one document-view rebuild against an already cached package analysis.
+    pub fn enqueue_document_view(&self, snapshot: DocumentViewSnapshot, package: Arc<CachedPackageAnalysis>) {
+        with_pending_queues(&self.pending, |pending| queue_view(pending, snapshot, package, self.event_tx.clone()));
+        self.wake_worker();
+    }
+
+    /// Inform the worker which package buckets still have open documents.
+    pub fn set_open_buckets(&self, buckets: HashSet<AnalysisBucket>) {
+        with_pending_queues(&self.pending, |pending| pending.open_buckets = Some(buckets));
+        self.wake_worker();
     }
 
     /// Return the receiver used to observe worker events.
@@ -97,91 +194,158 @@ impl Scheduler {
 
     /// Shut down the worker thread and wait for it to exit.
     pub fn shutdown(&mut self) {
-        let _ = self.command_tx.send(WorkerCommand::Shutdown);
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+        self.wake_worker();
 
         if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
     }
+
+    /// Wake the worker without queueing duplicate wake tokens.
+    fn wake_worker(&self) {
+        // The bounded wake channel carries no payload beyond "check the queue".
+        // If it is already full, the worker has either been woken or will wake
+        // shortly; another token would not represent another distinct job.
+        let _ = self.wake_tx.try_send(WorkerWake::Wake);
+    }
 }
 
 impl Drop for Scheduler {
+    /// Join the worker thread when callers drop the scheduler without explicit shutdown.
     fn drop(&mut self) {
         self.shutdown();
     }
 }
 
-fn worker_loop(command_rx: Receiver<WorkerCommand>, event_tx: Sender<WorkerEvent>, panic_on_worker_job: bool) {
-    let mut pending = PendingJobs::new();
-    let mut sequence = 0_u64;
+/// Run the worker event loop until shutdown or channel disconnect.
+fn worker_loop(
+    wake_rx: Receiver<WorkerWake>,
+    event_tx: Sender<WorkerEvent>,
+    pending: Arc<Mutex<PendingQueues>>,
+    shutdown_requested: Arc<AtomicBool>,
+    panic_on_worker_job: bool,
+) {
     let mut package_cache = PackageAnalysisCache::default();
 
     loop {
-        // Block only when there is nothing queued locally; otherwise keep
-        // draining and coalescing messages before choosing the next job.
-        if pending.is_empty() {
-            match command_rx.recv() {
-                Ok(command) => {
-                    if absorb_command(command, &mut pending, &mut sequence) {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-
-        if drain_commands(&command_rx, &mut pending, &mut sequence) {
+        if shutdown_requested.load(Ordering::SeqCst) {
             break;
         }
 
-        // Prefer the most recent document edit across the whole queue instead
-        // of processing URIs round-robin. That keeps the actively edited file
-        // feeling responsive when multiple documents are open.
-        let Some(snapshot) = take_latest_pending(&mut pending) else {
-            continue;
-        };
-
-        run_job(snapshot, &event_tx, panic_on_worker_job, &mut package_cache);
-    }
-}
-
-fn absorb_command(command: WorkerCommand, pending: &mut PendingJobs, sequence: &mut u64) -> bool {
-    match command {
-        WorkerCommand::Analyze(snapshot) => {
-            *sequence += 1;
-            // Replacing by URI coalesces bursts of edits down to the latest
-            // snapshot while still remembering when that URI was last touched.
-            pending.insert(snapshot.uri.as_str().to_owned(), PendingJob { sequence: *sequence, snapshot });
-            false
-        }
-        WorkerCommand::Shutdown => true,
-    }
-}
-
-fn drain_commands(command_rx: &Receiver<WorkerCommand>, pending: &mut PendingJobs, sequence: &mut u64) -> bool {
-    // Collapse any burst of pending commands before work starts so the worker
-    // spends time on the freshest snapshots rather than intermediate states.
-    loop {
-        match command_rx.try_recv() {
-            Ok(command) => {
-                if absorb_command(command, pending, sequence) {
-                    return true;
+        if let Some(job) = take_next_job(&pending, &mut package_cache) {
+            match job {
+                WorkerJob::Package(snapshot) => {
+                    run_package_job(snapshot, &event_tx, panic_on_worker_job, &mut package_cache);
                 }
+                WorkerJob::View(snapshot, package) => run_view_job(snapshot, package, &event_tx, panic_on_worker_job),
             }
-            Err(TryRecvError::Empty) => return false,
-            Err(TryRecvError::Disconnected) => return true,
+            continue;
+        }
+
+        match wake_rx.recv() {
+            Ok(WorkerWake::Wake) => {}
+            Err(_) => break,
         }
     }
 }
 
-fn take_latest_pending(pending: &mut PendingJobs) -> Option<DocumentSnapshot> {
-    // Pick the single newest URI update globally, then remove that one pending
-    // entry from the queue.
+/// Mutate pending queue state while keeping the mutex critical section explicit.
+fn with_pending_queues<R>(pending: &Arc<Mutex<PendingQueues>>, f: impl FnOnce(&mut PendingQueues) -> R) -> R {
+    // Keep the critical section explicit and tiny. Callers should mutate queue
+    // metadata here, then do compiler or document-view work after the guard is
+    // dropped by returning from this helper.
+    let mut pending = pending.lock().expect("scheduler pending queue mutex poisoned");
+    f(&mut pending)
+}
+
+/// Insert or replace the pending heavy-analysis job for a package bucket.
+fn queue_package(pending: &mut PendingQueues, snapshot: DocumentSnapshot, event_tx: Sender<WorkerEvent>) {
+    pending.sequence += 1;
+    if pending.packages.len() >= MAX_PENDING_PACKAGE_JOBS
+        && !pending.packages.contains_key(&snapshot.package_key.bucket)
+        && let Some(dropped) = drop_oldest_package(&mut pending.packages)
+    {
+        let _ = event_tx.send(WorkerEvent::PackageCancelled {
+            key: dropped.snapshot.package_key,
+            uri: dropped.snapshot.uri,
+            generation: dropped.snapshot.generation,
+        });
+    }
+
+    // Replacing by bucket, not generation, keeps edit storms to one heavy
+    // overlay snapshot per package while preserving the freshest generation.
+    pending
+        .packages
+        .insert(snapshot.package_key.bucket.clone(), PendingPackageJob { sequence: pending.sequence, snapshot });
+}
+
+/// Insert or replace the pending document-view job for an exact view key.
+fn queue_view(
+    pending: &mut PendingQueues,
+    snapshot: DocumentViewSnapshot,
+    package: Arc<CachedPackageAnalysis>,
+    event_tx: Sender<WorkerEvent>,
+) {
+    // Document views are small, but still bounded because every pending view
+    // retains a package `Arc` and an open-document snapshot.
+    pending.sequence += 1;
+    if pending.views.len() >= MAX_PENDING_VIEW_JOBS
+        && !pending.views.contains_key(&snapshot.key)
+        && let Some(dropped) = drop_oldest_view(&mut pending.views)
+    {
+        let _ = event_tx.send(WorkerEvent::DocumentViewCancelled { key: dropped.snapshot.key });
+    }
+    pending.views.insert(snapshot.key.clone(), PendingViewJob { sequence: pending.sequence, snapshot, package });
+}
+
+/// Remove the freshest runnable job and apply any queued cache-retention update.
+fn take_next_job(pending: &Arc<Mutex<PendingQueues>>, package_cache: &mut PackageAnalysisCache) -> Option<WorkerJob> {
+    with_pending_queues(pending, |pending| {
+        if let Some(open_buckets) = pending.open_buckets.take() {
+            package_cache.retain_open_buckets(&open_buckets);
+        }
+
+        // Package jobs come first because they unblock definition waiters and
+        // any semantic-token document views that need fresh package analysis.
+        if let Some(snapshot) = take_latest_package(&mut pending.packages) {
+            Some(WorkerJob::Package(snapshot))
+        } else {
+            take_latest_view(&mut pending.views).map(|(snapshot, package)| WorkerJob::View(snapshot, package))
+        }
+    })
+}
+
+/// Remove the newest package job across all buckets.
+fn take_latest_package(pending: &mut PendingPackageJobs) -> Option<DocumentSnapshot> {
     let next_sequence = pending.values().max_by_key(|job| job.sequence)?.sequence;
     pending.extract_if(|_, job| job.sequence == next_sequence).next().map(|(_, job)| job.snapshot)
 }
 
-fn run_job(
+/// Remove the newest document-view job across all view keys.
+fn take_latest_view(pending: &mut PendingViewJobs) -> Option<(DocumentViewSnapshot, Arc<CachedPackageAnalysis>)> {
+    let next_sequence = pending.values().max_by_key(|job| job.sequence)?.sequence;
+    pending.extract_if(|_, job| job.sequence == next_sequence).next().map(|(_, job)| (job.snapshot, job.package))
+}
+
+/// Drop the oldest pending package job when the queue exceeds its cap.
+fn drop_oldest_package(pending: &mut PendingPackageJobs) -> Option<PendingPackageJob> {
+    if let Some(oldest) = pending.iter().min_by_key(|(_, job)| job.sequence).map(|(key, _)| key.clone()) {
+        return pending.remove(&oldest);
+    }
+    None
+}
+
+/// Drop the oldest pending view job when the queue exceeds its cap.
+fn drop_oldest_view(pending: &mut PendingViewJobs) -> Option<PendingViewJob> {
+    if let Some(oldest) = pending.iter().min_by_key(|(_, job)| job.sequence).map(|(key, _)| key.clone()) {
+        return pending.remove(&oldest);
+    }
+    None
+}
+
+/// Execute one package-analysis job inside the worker panic/cancellation boundary.
+fn run_package_job(
     snapshot: DocumentSnapshot,
     event_tx: &Sender<WorkerEvent>,
     panic_on_worker_job: bool,
@@ -189,10 +353,11 @@ fn run_job(
 ) {
     let uri = snapshot.uri.clone();
     let generation = snapshot.generation;
+    let key = snapshot.package_key.clone();
     let cancel_token = snapshot.cancel_token.clone();
 
     if is_cancelled(cancel_token.as_ref(), generation) {
-        let _ = event_tx.send(WorkerEvent::Cancelled { uri, generation });
+        let _ = event_tx.send(WorkerEvent::PackageCancelled { key, uri, generation });
         return;
     }
 
@@ -204,7 +369,12 @@ fn run_job(
             panic!("injected worker panic");
         }
 
-        DocumentAnalysis { uri: uri.clone(), generation, semantic_snapshot: analyze_snapshot(&snapshot, package_cache) }
+        PackageAnalysis {
+            uri: uri.clone(),
+            generation,
+            key: key.clone(),
+            result: analyze_package_snapshot(&snapshot, package_cache),
+        }
     });
 
     match result {
@@ -212,19 +382,56 @@ fn run_job(
             // Check cancellation again after analysis because a newer commit can
             // arrive while this job is already in flight.
             let event = if is_cancelled(cancel_token.as_ref(), generation) {
-                WorkerEvent::Cancelled { uri, generation }
+                WorkerEvent::PackageCancelled { key, uri, generation }
             } else {
-                WorkerEvent::Analyzed(analysis)
+                WorkerEvent::PackageAnalyzed(analysis)
             };
 
             let _ = event_tx.send(event);
         }
         Err(report) => {
-            let _ = event_tx.send(WorkerEvent::Panicked { uri, generation, report });
+            let _ = event_tx.send(WorkerEvent::PackagePanicked { key, uri, generation, report });
         }
     }
 }
 
+/// Execute one document-view rebuild inside the worker panic/cancellation boundary.
+fn run_view_job(
+    snapshot: DocumentViewSnapshot,
+    package: Arc<CachedPackageAnalysis>,
+    event_tx: &Sender<WorkerEvent>,
+    panic_on_worker_job: bool,
+) {
+    let key = snapshot.key.clone();
+    if is_cancelled(snapshot.cancel_token.as_ref(), key.document_generation) {
+        let _ = event_tx.send(WorkerEvent::DocumentViewCancelled { key });
+        return;
+    }
+
+    let result = catch_unwind("worker_document_view", Some(&snapshot.uri), Some(key.document_generation), || {
+        if panic_on_worker_job {
+            panic!("injected worker panic");
+        }
+
+        build_document_view(&snapshot, package)
+    });
+
+    match result {
+        Ok(view) => {
+            let event = if is_cancelled(snapshot.cancel_token.as_ref(), key.document_generation) {
+                WorkerEvent::DocumentViewCancelled { key }
+            } else {
+                WorkerEvent::DocumentViewBuilt(view)
+            };
+            let _ = event_tx.send(event);
+        }
+        Err(report) => {
+            let _ = event_tx.send(WorkerEvent::DocumentViewPanicked { key, report });
+        }
+    }
+}
+
+/// Return whether a snapshot generation has been superseded for its URI.
 fn is_cancelled(cancel_token: &AtomicU64, generation: u64) -> bool {
     // The token stores the latest committed generation for a URI, so any
     // mismatch means newer document state has superseded this snapshot.
@@ -233,8 +440,9 @@ fn is_cancelled(cancel_token: &AtomicU64, generation: u64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{PendingJobs, Scheduler, WorkerCommand, WorkerEvent, absorb_command, take_latest_pending};
-    use crate::document_store::DocumentSnapshot;
+    use super::{PendingQueues, Scheduler, WorkerEvent, queue_package, take_latest_package};
+    use crate::document_store::{AnalysisBucket, DocumentSnapshot, DocumentViewKey, PackageAnalysisKey};
+    use crossbeam_channel::unbounded;
     use line_index::LineIndex;
     use lsp_types::Uri;
     use std::{
@@ -243,67 +451,80 @@ mod tests {
         time::Duration,
     };
 
+    /// Build a test snapshot whose cancel token initially matches its generation.
     fn snapshot(uri: &str, generation: u64) -> DocumentSnapshot {
         snapshot_with_token(uri, generation, Arc::new(AtomicU64::new(generation)))
     }
 
+    /// Build a test snapshot with an explicit cancellation token.
     fn snapshot_with_token(uri: &str, generation: u64, cancel_token: Arc<AtomicU64>) -> DocumentSnapshot {
+        let uri = uri.parse::<Uri>().expect("valid uri");
+        let bucket = AnalysisBucket::UnmanagedDocument { uri: uri.clone() };
+        let package_key = PackageAnalysisKey { bucket, bucket_generation: generation };
+        let view_key =
+            DocumentViewKey { uri: uri.clone(), document_generation: generation, package: package_key.clone() };
         DocumentSnapshot {
-            uri: uri.parse::<Uri>().expect("valid uri"),
+            uri,
             text: Arc::from("program test.aleo {}"),
             line_index: Arc::new(LineIndex::new("program test.aleo {}")),
             version: generation as i32,
             generation,
             file_path: Some(Arc::new(PathBuf::from("/tmp/main.leo"))),
             project: None,
+            package_key,
+            view_key,
+            open_overlays: Arc::from([]),
             cancel_token,
         }
     }
 
+    /// Return a worker-event sender whose receiver is intentionally unused.
+    fn event_sink() -> crossbeam_channel::Sender<WorkerEvent> {
+        let (tx, _rx) = unbounded();
+        tx
+    }
+
+    /// Verifies per-bucket package job coalescing keeps only the latest snapshot.
     #[test]
     fn coalescing_keeps_latest_snapshot_per_uri() {
-        let mut pending = PendingJobs::new();
-        let mut sequence = 0;
+        let mut pending = PendingQueues::default();
+        let event_tx = event_sink();
         let uri = "file:///tmp/main.leo";
 
-        assert!(!absorb_command(WorkerCommand::Analyze(snapshot(uri, 1)), &mut pending, &mut sequence));
-        assert!(!absorb_command(WorkerCommand::Analyze(snapshot(uri, 2)), &mut pending, &mut sequence));
+        queue_package(&mut pending, snapshot(uri, 1), event_tx.clone());
+        queue_package(&mut pending, snapshot(uri, 2), event_tx);
 
-        let next = take_latest_pending(&mut pending).expect("pending snapshot");
+        let next = take_latest_package(&mut pending.packages).expect("pending snapshot");
         assert_eq!(next.generation, 2);
     }
 
+    /// Verifies global freshness ordering runs the most recently updated package first.
     #[test]
     fn latest_updated_document_runs_first() {
-        let mut pending = PendingJobs::new();
-        let mut sequence = 0;
+        let mut pending = PendingQueues::default();
+        let event_tx = event_sink();
 
-        assert!(
-            !absorb_command(WorkerCommand::Analyze(snapshot("file:///tmp/a.leo", 1)), &mut pending, &mut sequence,)
-        );
-        assert!(
-            !absorb_command(WorkerCommand::Analyze(snapshot("file:///tmp/b.leo", 1)), &mut pending, &mut sequence,)
-        );
-        assert!(
-            !absorb_command(WorkerCommand::Analyze(snapshot("file:///tmp/a.leo", 2)), &mut pending, &mut sequence,)
-        );
+        queue_package(&mut pending, snapshot("file:///tmp/a.leo", 1), event_tx.clone());
+        queue_package(&mut pending, snapshot("file:///tmp/b.leo", 1), event_tx.clone());
+        queue_package(&mut pending, snapshot("file:///tmp/a.leo", 2), event_tx);
 
-        let next = take_latest_pending(&mut pending).expect("pending snapshot");
+        let next = take_latest_package(&mut pending.packages).expect("pending snapshot");
         assert_eq!(next.uri.as_str(), "file:///tmp/a.leo");
         assert_eq!(next.generation, 2);
     }
 
+    /// Verifies a stale package snapshot is cancelled before expensive work begins.
     #[test]
     fn stale_snapshot_is_cancelled_before_work_starts() {
         let mut scheduler = Scheduler::new(false);
         let cancel_token = Arc::new(AtomicU64::new(2));
 
-        scheduler.enqueue(snapshot_with_token("file:///tmp/main.leo", 1, cancel_token));
+        scheduler.enqueue_package(snapshot_with_token("file:///tmp/main.leo", 1, cancel_token));
 
         let event = scheduler.events().recv_timeout(Duration::from_secs(1)).expect("worker event");
 
         match event {
-            WorkerEvent::Cancelled { uri, generation } => {
+            WorkerEvent::PackageCancelled { uri, generation, .. } => {
                 assert_eq!(uri.as_str(), "file:///tmp/main.leo");
                 assert_eq!(generation, 1);
             }

--- a/crates/lsp/src/semantics.rs
+++ b/crates/lsp/src/semantics.rs
@@ -16,7 +16,12 @@
 
 use leo_ast::Location;
 use leo_span::Symbol;
-use std::{path::PathBuf, sync::Arc};
+use line_index::LineIndex;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 /// Stable file-relative byte range for semantic indexing.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -84,6 +89,179 @@ pub enum SymbolIdentity {
     Unknown,
 }
 
+impl SymbolIdentity {
+    /// Return the transient semantic key used while lowering worker results.
+    ///
+    /// The key intentionally excludes embedded direct-declaration ranges for
+    /// global, member, and program identities. Those ranges are target hints,
+    /// not part of the identity: references and declarations for the same item
+    /// may learn their declaration range through different compiler paths.
+    pub fn key(&self) -> Option<SymbolKey> {
+        match self {
+            Self::Local { declaration } => Some(SymbolKey::Local { declaration: declaration.clone() }),
+            Self::GlobalItem { location, .. } => Some(SymbolKey::GlobalItem { location: location.clone() }),
+            Self::Member { owner: Some(owner), name, .. } => {
+                Some(SymbolKey::Member { owner: owner.clone(), name: *name })
+            }
+            Self::Member { owner: None, .. } | Self::Unknown => None,
+            Self::Program { name, .. } => Some(SymbolKey::Program { name: *name }),
+        }
+    }
+
+    /// Return the source range the compiler attached directly to this identity.
+    ///
+    /// Direct declarations let references jump even before the definition map
+    /// has seen the corresponding declaration occurrence. They are still
+    /// validated through the compact analyzed-file table before any LSP
+    /// response is emitted.
+    pub fn direct_declaration(&self) -> Option<&FileRange> {
+        match self {
+            Self::Local { declaration } => Some(declaration),
+            Self::GlobalItem { declaration, .. }
+            | Self::Member { declaration, .. }
+            | Self::Program { declaration, .. } => declaration.as_ref(),
+            Self::Unknown => None,
+        }
+    }
+}
+
+/// Build-time semantic key shared by related declarations and references.
+///
+/// `SymbolKey` is deliberately not stored in package caches. Local keys still
+/// contain `FileRange`, which duplicates paths and range objects. Worker
+/// lowering converts every key into [`CompactSymbolKey`] after file IDs are
+/// interned for the package analysis.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SymbolKey {
+    /// A lexical binding keyed by its declaration token.
+    Local { declaration: FileRange },
+    /// A globally addressable item keyed by compiler location.
+    GlobalItem { location: Location },
+    /// A member keyed by concrete owner and member name.
+    Member { owner: Location, name: Symbol },
+    /// A program or namespace key. This is navigation-only for PR 3.
+    Program { name: Symbol },
+}
+
+/// Compact file identifier used inside package-level semantic caches.
+pub type FileId = u32;
+
+/// Compact symbol-key identifier used inside package-level semantic caches.
+pub type SymbolKeyId = u32;
+
+/// Sentinel stored in [`CompactOccurrence::key`] for syntax-only tokens.
+pub const NO_SYMBOL_KEY: SymbolKeyId = u32::MAX;
+
+/// File-relative byte range stored without cloning paths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CompactRange {
+    /// Interned analyzed-file ID.
+    pub file: FileId,
+    /// Inclusive UTF-8 byte offset.
+    pub start: u32,
+    /// Exclusive UTF-8 byte offset.
+    pub end: u32,
+}
+
+/// Cached semantic key after local declarations have been lowered to file IDs.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CompactSymbolKey {
+    /// A lexical binding keyed by its compact declaration token.
+    Local { declaration: CompactRange },
+    /// A globally addressable item keyed by compiler location.
+    GlobalItem { location: Location },
+    /// A member keyed by concrete owner and member name.
+    Member { owner: Location, name: Symbol },
+    /// A program or namespace key. This is navigation-only for PR 3.
+    Program { name: Symbol },
+}
+
+/// Compact occurrence retained by package analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CompactOccurrence {
+    /// Source range for the occurrence.
+    pub range: CompactRange,
+    /// Interned semantic key, or [`NO_SYMBOL_KEY`] for syntax-only/unknown tokens.
+    pub key: SymbolKeyId,
+    /// Declaration/reference role for semantic-token modifiers and navigation.
+    pub role: OccurrenceRole,
+    /// Internal token kind reused by semantic-token document views.
+    pub token_kind: SemanticKind,
+    /// Whether this occurrence carries the readonly semantic-token modifier.
+    pub readonly: bool,
+}
+
+impl CompactOccurrence {
+    /// Return the optional semantic key for navigation-grade occurrences.
+    pub fn key_id(&self) -> Option<SymbolKeyId> {
+        (self.key != NO_SYMBOL_KEY).then_some(self.key)
+    }
+}
+
+/// Borrowed occurrence returned by fast cursor lookup.
+#[derive(Debug, Clone, Copy)]
+pub struct CompactOccurrenceRef<'a> {
+    /// The compact occurrence under the cursor.
+    pub occurrence: &'a CompactOccurrence,
+}
+
+/// Source fingerprint captured for exactly the bytes used during analysis.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceFingerprint {
+    /// The analyzed file came from an open editor buffer.
+    ///
+    /// Open buffers carry their own line index, so navigation can convert
+    /// compact byte ranges without touching disk.
+    OpenBuffer,
+    /// The analyzed file came from disk with stable metadata around the read.
+    ///
+    /// Disk targets must be re-read and hash-checked before returning an LSP
+    /// location, because the server intentionally does not retain file text.
+    Disk { modified_nanos: Option<u128>, len: u64, content_hash: u64 },
+    /// The file source could not prove that metadata matched the read bytes.
+    ///
+    /// Volatile files stay in the semantic index for highlighting and local
+    /// lookup, but cross-file definition responses are suppressed for them.
+    Volatile,
+}
+
+/// Compact metadata for one analyzed file.
+#[derive(Debug, Clone)]
+pub struct AnalyzedFile {
+    /// Interned file ID used by compact ranges.
+    pub id: FileId,
+    /// Canonical or compiler-normalized path for this file.
+    pub path: Arc<PathBuf>,
+    /// Source fingerprint for the exact bytes that fed semantic analysis.
+    pub fingerprint: SourceFingerprint,
+    /// Open-buffer line index retained only for unsaved editor content.
+    pub open_line_index: Option<Arc<LineIndex>>,
+}
+
+/// Memory-light analyzed-file table owned by one package analysis.
+#[derive(Debug, Clone, Default)]
+pub struct AnalyzedFileSet {
+    files: Arc<[AnalyzedFile]>,
+}
+
+impl AnalyzedFileSet {
+    /// Build a new analyzed-file table from file metadata already assigned IDs.
+    pub fn new(files: Vec<AnalyzedFile>) -> Self {
+        Self { files: Arc::from(files) }
+    }
+
+    /// Return the analyzed file for a compact ID.
+    pub fn get(&self, id: FileId) -> Option<&AnalyzedFile> {
+        self.files.get(id as usize).filter(|file| file.id == id)
+    }
+
+    /// Return all analyzed files in ID order.
+    #[allow(dead_code)]
+    pub fn as_slice(&self) -> &[AnalyzedFile] {
+        self.files.as_ref()
+    }
+}
+
 /// One symbol occurrence in a source file.
 ///
 /// These occurrences feed both semantic highlighting and the reusable semantic
@@ -130,15 +308,222 @@ impl SemanticTokenOccurrence {
     }
 }
 
-/// Plain-Rust semantic index cached on the main thread for later features.
+/// Compact semantic index cached once per package-analysis generation.
+///
+/// The index stores all paths and semantic keys once, then represents
+/// occurrences and definition targets as dense integer IDs plus byte ranges.
+/// This is the core memory guardrail for PR 3: opening ten files in one package
+/// must not clone ten package-sized occurrence graphs.
 #[derive(Debug, Clone, Default)]
 pub struct SemanticIndex {
-    /// All semantic occurrences known for the document generation.
+    /// Interned analyzed file paths.
+    pub files: Arc<[Arc<PathBuf>]>,
+    /// Path-to-file lookup table sorted for binary search.
+    pub file_lookup: Arc<[(Arc<PathBuf>, FileId)]>,
+    /// All compact occurrences in file/source order.
+    pub occurrences: Arc<[CompactOccurrence]>,
+    /// Per-file occurrence slices into `occurrences`.
+    pub file_occurrence_ranges: Arc<[(FileId, std::ops::Range<u32>)]>,
+    /// Per-key definition slices into `definition_ranges`.
+    pub definitions: Arc<[(SymbolKeyId, std::ops::Range<u32>)]>,
+    /// Deduplicated compact definition targets.
+    pub definition_ranges: Arc<[CompactRange]>,
+}
+
+impl SemanticIndex {
+    /// Lower rich worker occurrences into a compact package index.
+    ///
+    /// The returned `AnalyzedFileSet` mirrors `files`, assigning the same
+    /// `FileId`s so later LSP range conversion can recover paths and
+    /// line-index/fingerprint metadata without retaining source text.
+    pub fn build(
+        occurrences: &[SymbolOccurrence],
+        mut fingerprint_for_path: impl FnMut(&Path) -> SourceFingerprint,
+        mut open_line_index_for_path: impl FnMut(&Path) -> Option<Arc<LineIndex>>,
+    ) -> (Self, AnalyzedFileSet) {
+        let mut path_ids = HashMap::<Arc<PathBuf>, FileId>::new();
+        let mut files = Vec::<Arc<PathBuf>>::new();
+
+        for occurrence in occurrences {
+            intern_file(&occurrence.range.path, &mut path_ids, &mut files);
+            if let Some(declaration) = occurrence.identity.direct_declaration() {
+                intern_file(&declaration.path, &mut path_ids, &mut files);
+            }
+        }
+
+        let mut key_ids = HashMap::<CompactSymbolKey, SymbolKeyId>::new();
+        let mut compact_occurrences = Vec::<CompactOccurrence>::with_capacity(occurrences.len());
+        let mut definition_pairs = Vec::<(SymbolKeyId, CompactRange)>::new();
+
+        for occurrence in occurrences {
+            let range = compact_range(&occurrence.range, &path_ids).expect("occurrence file interned");
+            let key = occurrence.identity.key().and_then(|key| {
+                let compact = compact_symbol_key(key, &path_ids)?;
+                Some(intern_symbol_key(compact, &mut key_ids))
+            });
+
+            compact_occurrences.push(CompactOccurrence {
+                range,
+                key: key.unwrap_or(NO_SYMBOL_KEY),
+                role: occurrence.role,
+                token_kind: occurrence.token_kind,
+                readonly: occurrence.readonly,
+            });
+
+            if let Some(key) = key {
+                if occurrence.role == OccurrenceRole::Declaration {
+                    definition_pairs.push((key, range));
+                }
+                // Some compiler paths attach the declaration range directly to
+                // references before the declaration occurrence is visited. Keep
+                // both sources and deduplicate after sorting so go-to-definition
+                // is robust to AST traversal order.
+                if let Some(declaration) = occurrence.identity.direct_declaration()
+                    && let Some(declaration_range) = compact_range(declaration, &path_ids)
+                {
+                    definition_pairs.push((key, declaration_range));
+                }
+            }
+        }
+
+        compact_occurrences.sort_by(|left, right| {
+            left.range
+                .file
+                .cmp(&right.range.file)
+                .then_with(|| left.range.start.cmp(&right.range.start))
+                .then_with(|| left.range.end.cmp(&right.range.end))
+        });
+
+        let file_occurrence_ranges = file_occurrence_ranges(&compact_occurrences);
+        let (definitions, definition_ranges) = definition_slices(definition_pairs);
+        let mut file_lookup =
+            files.iter().enumerate().map(|(id, path)| (Arc::clone(path), id as FileId)).collect::<Vec<_>>();
+        file_lookup.sort_by(|(left, _), (right, _)| left.cmp(right));
+
+        let analyzed_files = files
+            .iter()
+            .enumerate()
+            .map(|(id, path)| AnalyzedFile {
+                id: id as FileId,
+                path: Arc::clone(path),
+                fingerprint: fingerprint_for_path(path.as_ref()),
+                open_line_index: open_line_index_for_path(path.as_ref()),
+            })
+            .collect();
+
+        (
+            Self {
+                files: Arc::from(files),
+                file_lookup: Arc::from(file_lookup),
+                occurrences: Arc::from(compact_occurrences),
+                file_occurrence_ranges: Arc::from(file_occurrence_ranges),
+                definitions: Arc::from(definitions),
+                definition_ranges: Arc::from(definition_ranges),
+            },
+            AnalyzedFileSet::new(analyzed_files),
+        )
+    }
+
+    /// Return the navigation-grade occurrence under a cursor byte offset.
+    ///
+    /// The lookup searches only the selected file slice. It accepts a cursor
+    /// immediately after an identifier because editors often report that
+    /// position when the caret visually sits at the end of a token.
+    pub fn occurrence_at(&self, path: &Path, offset: u32) -> Option<CompactOccurrenceRef<'_>> {
+        let file = self.file_id(path)?;
+        let range = self.file_occurrence_range(file)?;
+
+        let mut best = None::<&CompactOccurrence>;
+        for occurrence in &self.occurrences[range.start as usize..range.end as usize] {
+            if occurrence.key_id().is_none() {
+                continue;
+            }
+            let contains = occurrence.range.start <= offset && offset < occurrence.range.end;
+            let at_end = occurrence.range.start < offset && offset == occurrence.range.end;
+            if !(contains || at_end) {
+                continue;
+            }
+
+            best = match best {
+                Some(current) if range_len(current.range) <= range_len(occurrence.range) => Some(current),
+                _ => Some(occurrence),
+            };
+        }
+
+        best.map(|occurrence| CompactOccurrenceRef { occurrence })
+    }
+
+    /// Return all deduplicated definition targets for a compact key.
+    pub fn definitions_for(&self, key: SymbolKeyId) -> &[CompactRange] {
+        let Ok(index) = self.definitions.binary_search_by_key(&key, |(candidate, _)| *candidate) else {
+            return &[];
+        };
+        let (_, range) = &self.definitions[index];
+        &self.definition_ranges[range.start as usize..range.end as usize]
+    }
+
+    /// Return semantic-token occurrences for one file.
+    pub fn token_occurrences_for_file(&self, path: &Path) -> Vec<SemanticTokenOccurrence> {
+        let Some(file) = self.file_id(path) else {
+            return Vec::new();
+        };
+        let Some(range) = self.file_occurrence_range(file) else {
+            return Vec::new();
+        };
+
+        self.occurrences[range.start as usize..range.end as usize]
+            .iter()
+            .map(|occurrence| SemanticTokenOccurrence {
+                range: FileRange {
+                    path: Arc::clone(&self.files[occurrence.range.file as usize]),
+                    start: occurrence.range.start,
+                    end: occurrence.range.end,
+                },
+                token_kind: occurrence.token_kind,
+                role: occurrence.role,
+                readonly: occurrence.readonly,
+            })
+            .collect()
+    }
+
+    /// Return the compact ID for a path interned in this index.
+    pub fn file_id(&self, path: &Path) -> Option<FileId> {
+        let index = self.file_lookup.binary_search_by(|(candidate, _)| candidate.as_ref().as_path().cmp(path)).ok()?;
+        Some(self.file_lookup[index].1)
+    }
+
+    /// Return the contiguous occurrence slice for one interned file.
+    fn file_occurrence_range(&self, file: FileId) -> Option<std::ops::Range<u32>> {
+        let index = self.file_occurrence_ranges.binary_search_by_key(&file, |(candidate, _)| *candidate).ok()?;
+        Some(self.file_occurrence_ranges[index].1.clone())
+    }
+}
+
+/// Package-level semantic analysis shared by navigation and semantic tokens.
+#[derive(Debug, Clone)]
+pub struct CachedPackageAnalysis {
+    /// Freshness key for this package analysis.
+    pub key: crate::document_store::PackageAnalysisKey,
+    /// Compact semantic index for the package generation.
+    pub index: Arc<SemanticIndex>,
+    /// Metadata for every file referenced by compact ranges.
+    pub analyzed_files: Arc<AnalyzedFileSet>,
+    /// Whether compiler analysis refined the syntax fallback.
     #[allow(dead_code)]
-    pub occurrences: Vec<SymbolOccurrence>,
+    pub source: SemanticSource,
+}
+
+/// Small per-document semantic-token view built from a package analysis.
+#[derive(Debug, Clone)]
+pub struct CachedDocumentView {
+    /// Freshness key for this encoded token payload.
+    pub key: crate::document_store::DocumentViewKey,
+    /// LSP wire-format token data ready to return to the client.
+    pub encoded_tokens: Arc<[u32]>,
 }
 
 /// Cached semantic-token payload and reusable semantic index for one document generation.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct SemanticSnapshot {
     /// LSP wire-format token data ready to return to the client.
@@ -149,6 +534,99 @@ pub struct SemanticSnapshot {
     /// Whether the snapshot is syntax-only or compiler-enhanced.
     #[allow(dead_code)]
     pub source: SemanticSource,
+}
+
+/// Intern a path and return the compact file ID used by ranges.
+fn intern_file(
+    path: &Arc<PathBuf>,
+    path_ids: &mut HashMap<Arc<PathBuf>, FileId>,
+    files: &mut Vec<Arc<PathBuf>>,
+) -> FileId {
+    if let Some(id) = path_ids.get(path) {
+        return *id;
+    }
+    let id = files.len() as FileId;
+    files.push(Arc::clone(path));
+    path_ids.insert(Arc::clone(path), id);
+    id
+}
+
+/// Convert a path-bearing range into an ID-bearing compact range.
+fn compact_range(range: &FileRange, path_ids: &HashMap<Arc<PathBuf>, FileId>) -> Option<CompactRange> {
+    Some(CompactRange { file: *path_ids.get(&range.path)?, start: range.start, end: range.end })
+}
+
+/// Lower a build-time symbol key into the compact cached representation.
+fn compact_symbol_key(key: SymbolKey, path_ids: &HashMap<Arc<PathBuf>, FileId>) -> Option<CompactSymbolKey> {
+    match key {
+        SymbolKey::Local { declaration } => {
+            Some(CompactSymbolKey::Local { declaration: compact_range(&declaration, path_ids)? })
+        }
+        SymbolKey::GlobalItem { location } => Some(CompactSymbolKey::GlobalItem { location }),
+        SymbolKey::Member { owner, name } => Some(CompactSymbolKey::Member { owner, name }),
+        SymbolKey::Program { name } => Some(CompactSymbolKey::Program { name }),
+    }
+}
+
+/// Intern a compact symbol key and return its stable package-local ID.
+fn intern_symbol_key(key: CompactSymbolKey, key_ids: &mut HashMap<CompactSymbolKey, SymbolKeyId>) -> SymbolKeyId {
+    if let Some(id) = key_ids.get(&key) {
+        return *id;
+    }
+    let id = key_ids.len() as SymbolKeyId;
+    key_ids.insert(key, id);
+    id
+}
+
+/// Build per-file slices after occurrences have been sorted by file and range.
+fn file_occurrence_ranges(occurrences: &[CompactOccurrence]) -> Vec<(FileId, std::ops::Range<u32>)> {
+    let mut ranges = Vec::new();
+    let mut start = 0_usize;
+    while start < occurrences.len() {
+        let file = occurrences[start].range.file;
+        let mut end = start + 1;
+        while end < occurrences.len() && occurrences[end].range.file == file {
+            end += 1;
+        }
+        ranges.push((file, start as u32..end as u32));
+        start = end;
+    }
+    ranges
+}
+
+/// Build compact definition lookup tables from `(key, target)` pairs.
+fn definition_slices(
+    mut pairs: Vec<(SymbolKeyId, CompactRange)>,
+) -> (Vec<(SymbolKeyId, std::ops::Range<u32>)>, Vec<CompactRange>) {
+    pairs.sort_by(|(left_key, left_range), (right_key, right_range)| {
+        left_key.cmp(right_key).then_with(|| left_range.cmp(right_range))
+    });
+    pairs.dedup();
+
+    // Store targets in one flat range arena and keep a sorted `(key, slice)`
+    // table. That keeps package caches compact while preserving binary-search
+    // lookup for definition requests.
+    let mut definitions = Vec::new();
+    let mut ranges = Vec::new();
+    let mut start = 0_usize;
+    while start < pairs.len() {
+        let key = pairs[start].0;
+        let range_start = ranges.len() as u32;
+        let mut end = start;
+        while end < pairs.len() && pairs[end].0 == key {
+            ranges.push(pairs[end].1);
+            end += 1;
+        }
+        definitions.push((key, range_start..ranges.len() as u32));
+        start = end;
+    }
+
+    (definitions, ranges)
+}
+
+/// Return a compact range length, saturating defensively for malformed inputs.
+fn range_len(range: CompactRange) -> u32 {
+    range.end.saturating_sub(range.start)
 }
 
 /// Sort occurrences into stable file-relative source order.
@@ -211,6 +689,7 @@ mod tests {
     use super::{FileRange, OccurrenceRole, SemanticKind, SymbolIdentity, SymbolOccurrence, merge_occurrences};
     use std::{path::PathBuf, sync::Arc};
 
+    /// Build a minimal occurrence for merge-order unit tests.
     fn occurrence(path: &Arc<PathBuf>, start: u32, end: u32, token_kind: SemanticKind) -> SymbolOccurrence {
         SymbolOccurrence {
             range: FileRange::new(Arc::clone(path), start, end).expect("non-empty range"),
@@ -221,6 +700,7 @@ mod tests {
         }
     }
 
+    /// Verifies compiler occurrences win exact range conflicts with syntax fallback.
     #[test]
     fn merge_occurrences_prefers_compiler_occurrences_on_exact_range_conflicts() {
         let path = Arc::new(PathBuf::from("main.leo"));
@@ -237,6 +717,7 @@ mod tests {
         assert!(merged[0].readonly);
     }
 
+    /// Verifies merged occurrences are returned in stable source order.
     #[test]
     fn merge_occurrences_returns_source_ordered_output() {
         let a_path = Arc::new(PathBuf::from("a.leo"));

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -14,13 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::mutable_key_type)]
+
 use crate::{
-    document_store::DocumentStore,
-    features::semantic_tokens::{capability as semantic_tokens_capability, empty_response_value, response_value},
+    document_store::{AnalysisBucket, DocumentStore, DocumentViewKey, PackageAnalysisKey},
+    features::{
+        goto_definition::{
+            DefinitionQuery,
+            position_to_offset,
+            resolve as resolve_definition,
+            response_value as definition_response_value,
+        },
+        semantic_tokens::{capability as semantic_tokens_capability, empty_response_value, response_value},
+    },
     panic_boundary::catch_unwind,
     project_model::{ProjectModel, uri_to_file_path},
-    scheduler::{DocumentAnalysis, Scheduler, WorkerEvent},
-    semantics::SemanticSnapshot,
+    scheduler::{PackageAnalysis, Scheduler, WorkerEvent},
+    semantics::{CachedDocumentView, CachedPackageAnalysis},
 };
 use anyhow::{Context, Result};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response, ResponseError};
@@ -29,9 +39,11 @@ use lsp_types::{
     DidChangeTextDocumentParams,
     DidCloseTextDocumentParams,
     DidOpenTextDocumentParams,
+    GotoDefinitionParams,
     InitializeParams,
     InitializeResult,
     NumberOrString,
+    OneOf,
     SemanticTokensParams,
     ServerCapabilities,
     ServerInfo,
@@ -42,19 +54,42 @@ use lsp_types::{
     Uri,
 };
 use serde_json::Value;
-use std::{collections::HashMap, path::PathBuf, process::ExitCode};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    path::PathBuf,
+    process::ExitCode,
+    sync::Arc,
+};
 
+/// JSON-RPC code for internal server errors.
 const INTERNAL_ERROR: i32 = -32603;
+/// JSON-RPC code for unsupported LSP methods.
 const METHOD_NOT_FOUND: i32 = -32601;
 
+/// LSP initialized notification method.
 const INITIALIZED: &str = "initialized";
+/// LSP process-exit notification method.
 const EXIT: &str = "exit";
+/// LSP shutdown request method.
 const SHUTDOWN: &str = "shutdown";
+/// LSP open-document notification method.
 const DID_OPEN: &str = "textDocument/didOpen";
+/// LSP full-document change notification method.
 const DID_CHANGE: &str = "textDocument/didChange";
+/// LSP close-document notification method.
 const DID_CLOSE: &str = "textDocument/didClose";
+/// LSP request-cancellation notification method.
 const CANCEL_REQUEST: &str = "$/cancelRequest";
+/// LSP semantic-token request method.
 const SEMANTIC_TOKENS_FULL: &str = "textDocument/semanticTokens/full";
+/// LSP go-to-definition request method.
+const TEXT_DOCUMENT_DEFINITION: &str = "textDocument/definition";
+/// Maximum package analyses retained on the routing thread.
+const MAX_PACKAGE_CACHE_ENTRIES: usize = 8;
+/// Maximum pending go-to-definition requests across all packages.
+const MAX_PENDING_DEFINITIONS: usize = 128;
+/// Maximum pending go-to-definition requests waiting on one package key.
+const MAX_PENDING_DEFINITIONS_PER_KEY: usize = 16;
 
 /// In-memory state for one running `leo-lsp` server instance.
 ///
@@ -70,63 +105,71 @@ struct ServerState {
     documents: DocumentStore,
     project_model: ProjectModel,
     scheduler: Scheduler,
-    /// Async request state for generation-scoped semantic-token results.
-    ///
-    /// Additional async document features can reuse the same bookkeeping
-    /// pattern instead of growing bespoke pending/cached/failure maps.
-    semantic_tokens: DocumentRequestState<SemanticSnapshot>,
+    analysis: AnalysisCaches,
+    semantic_token_requests: SemanticTokenRequestState,
+    definition_requests: DefinitionRequestState,
+    client_definition_link_support: bool,
     hooks: TestHooks,
 }
 
-/// Shared state for one async LSP capability that resolves per-document generations.
-#[derive(Debug)]
-struct DocumentRequestState<T> {
-    cached: HashMap<Uri, CachedDocumentResult<T>>,
-    failed: HashMap<Uri, FailedDocumentResult>,
-    pending_by_uri: HashMap<Uri, Vec<RequestId>>,
-    pending_owner: HashMap<RequestId, Uri>,
+/// Shared semantic analysis and encoded document views.
+#[derive(Debug, Default)]
+struct AnalysisCaches {
+    /// Package analyses keyed by exact package/bucket generation.
+    packages: HashMap<PackageAnalysisKey, Arc<CachedPackageAnalysis>>,
+    /// FIFO package cache order, capped so stale packages cannot accumulate.
+    package_order: VecDeque<PackageAnalysisKey>,
+    /// Latest encoded view per URI. The embedded key proves freshness.
+    document_views: HashMap<Uri, CachedDocumentView>,
+    /// Package keys whose latest analysis panicked; repeated requests fail fast.
+    failed_packages: HashSet<PackageAnalysisKey>,
+    /// Document-view keys whose latest token-view build panicked.
+    failed_views: HashSet<DocumentViewKey>,
+    /// Package analyses scheduled or running on the worker.
+    in_flight_packages: HashSet<PackageAnalysisKey>,
+    /// Document views scheduled or running on the worker.
+    in_flight_views: HashSet<DocumentViewKey>,
 }
 
-/// Successful async result paired with the document generation it belongs to.
+/// Pending semantic-token requests keyed by exact document-view freshness.
+#[derive(Debug, Default)]
+struct SemanticTokenRequestState {
+    /// Waiters grouped by the document-view key that will answer them.
+    pending_by_key: HashMap<DocumentViewKey, Vec<RequestId>>,
+    /// Reverse lookup used to handle LSP `$/cancelRequest` in O(1) by ID.
+    pending_owner: HashMap<RequestId, DocumentViewKey>,
+}
+
+/// Pending go-to-definition requests keyed by package analysis.
+#[derive(Debug, Default)]
+struct DefinitionRequestState {
+    /// Waiters grouped by package analysis, each preserving its own cursor query.
+    pending_by_package: HashMap<PackageAnalysisKey, Vec<PendingDefinitionRequest>>,
+    /// Reverse lookup used to remove a cancelled request from its package queue.
+    pending_owner: HashMap<RequestId, PackageAnalysisKey>,
+}
+
+/// One pending definition request with its own cursor query preserved.
 #[derive(Debug, Clone)]
-struct CachedDocumentResult<T> {
-    generation: u64,
-    value: T,
+struct PendingDefinitionRequest {
+    /// Original LSP request ID to answer once package analysis is available.
+    id: RequestId,
+    /// Cursor and freshness state captured when the request arrived.
+    query: DefinitionQuery,
 }
 
-/// Failed async result paired with the document generation it belongs to.
-#[derive(Debug, Clone, Copy)]
-struct FailedDocumentResult {
-    generation: u64,
-}
-
-/// Immediate state of an async document request for the current generation.
-enum DocumentRequestStatus<'a, T> {
-    Cached(&'a T),
-    Failed,
-    Pending,
-}
-
-impl<T> Default for DocumentRequestState<T> {
-    fn default() -> Self {
-        Self {
-            cached: HashMap::new(),
-            failed: HashMap::new(),
-            pending_by_uri: HashMap::new(),
-            pending_owner: HashMap::new(),
-        }
-    }
-}
-
+/// Run the production LSP server with hooks loaded from the process environment.
 pub(crate) fn run(connection: Connection) -> Result<ExitCode> {
     run_with_hooks(connection, TestHooks::from_env())
 }
 
+/// Run the initialized server loop with optional test fault-injection hooks.
 fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> {
     let (request_id, params) = connection.initialize_start()?;
     let initialize_params: InitializeParams =
         serde_json::from_value(params).context("failed to deserialize initialize params")?;
     let workspace_roots = collect_workspace_roots(&initialize_params);
+    let client_definition_link_support = client_supports_definition_links(&initialize_params);
 
     // Finish the initialize handshake before any main-loop state exists so the
     // steady-state server only has to reason about post-initialize traffic.
@@ -147,7 +190,10 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
         documents: DocumentStore::default(),
         project_model: ProjectModel::default(),
         scheduler: Scheduler::new(hooks.panic_on_worker_job),
-        semantic_tokens: DocumentRequestState::default(),
+        analysis: AnalysisCaches::default(),
+        semantic_token_requests: SemanticTokenRequestState::default(),
+        definition_requests: DefinitionRequestState::default(),
+        client_definition_link_support,
         hooks,
     };
 
@@ -179,6 +225,7 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
 }
 
 impl ServerState {
+    /// Route one inbound LSP message to request, notification, or response handling.
     fn handle_message(&mut self, connection: &Connection, message: Message) -> Result<bool> {
         match message {
             Message::Request(request) => {
@@ -193,6 +240,7 @@ impl ServerState {
         }
     }
 
+    /// Handle an LSP request inside a panic boundary that can still answer the client.
     fn handle_request(&mut self, connection: &Connection, request: Request) -> Result<()> {
         let Request { id: request_id, method, params } = request;
 
@@ -210,6 +258,7 @@ impl ServerState {
         }
     }
 
+    /// Dispatch a deserialized request by method name.
     fn dispatch_request(
         &mut self,
         connection: &Connection,
@@ -229,6 +278,11 @@ impl ServerState {
                     serde_json::from_value(params).context("failed to deserialize semanticTokens/full")?;
                 self.handle_semantic_tokens_full(connection, request_id, params)
             }
+            TEXT_DOCUMENT_DEFINITION => {
+                let params: GotoDefinitionParams =
+                    serde_json::from_value(params).context("failed to deserialize textDocument/definition")?;
+                self.handle_goto_definition(connection, request_id, params)
+            }
             _ => {
                 tracing::debug!(method, "request is not implemented");
                 send_error_response(connection, request_id, METHOD_NOT_FOUND, "method not found")
@@ -236,6 +290,7 @@ impl ServerState {
         }
     }
 
+    /// Handle an LSP notification inside a logging-only panic boundary.
     fn handle_notification(&mut self, connection: &Connection, notification: Notification) -> Result<bool> {
         let method = notification.method.clone();
 
@@ -258,6 +313,7 @@ impl ServerState {
         }
     }
 
+    /// Dispatch a deserialized notification by method name.
     fn dispatch_notification(&mut self, connection: &Connection, notification: Notification) -> Result<bool> {
         match notification.method.as_str() {
             INITIALIZED => Ok(false),
@@ -268,13 +324,13 @@ impl ServerState {
             DID_OPEN => {
                 let params: DidOpenTextDocumentParams =
                     serde_json::from_value(notification.params).context("failed to deserialize didOpen")?;
-                self.handle_did_open(params);
+                self.handle_did_open(connection, params);
                 Ok(false)
             }
             DID_CHANGE => {
                 let params: DidChangeTextDocumentParams =
                     serde_json::from_value(notification.params).context("failed to deserialize didChange")?;
-                self.handle_did_change(params);
+                self.handle_did_change(connection, params);
                 Ok(false)
             }
             DID_CLOSE => {
@@ -296,8 +352,10 @@ impl ServerState {
         }
     }
 
-    fn handle_did_open(&mut self, params: DidOpenTextDocumentParams) {
+    /// Commit an opened document, invalidate its package bucket, and enqueue analysis.
+    fn handle_did_open(&mut self, connection: &Connection, params: DidOpenTextDocumentParams) {
         let document = params.text_document;
+        let previous_bucket = self.documents.package_key(&document.uri).map(|key| key.bucket);
         // Resolve the package root before commit so the worker snapshot and the
         // main-thread document state observe the same project context.
         let (file_path, project) = self.project_model.resolve_document_context(&document.uri);
@@ -313,12 +371,21 @@ impl ServerState {
         self.hooks.maybe_panic_notification(DID_OPEN);
 
         let snapshot = self.documents.commit_open(prepared);
-        self.semantic_tokens.invalidate(&snapshot.uri);
-        self.scheduler.enqueue(snapshot);
+        self.invalidate_bucket_for_new_snapshot(
+            connection,
+            previous_bucket.as_ref(),
+            &snapshot.package_key.bucket,
+            "package analysis was superseded",
+        );
+        self.scheduler.set_open_buckets(self.documents.open_buckets());
+        self.analysis.in_flight_packages.insert(snapshot.package_key.clone());
+        self.scheduler.enqueue_package(snapshot);
     }
 
-    fn handle_did_change(&mut self, params: DidChangeTextDocumentParams) {
+    /// Commit a full-document change and refresh package ownership before analysis.
+    fn handle_did_change(&mut self, connection: &Connection, params: DidChangeTextDocumentParams) {
         let DidChangeTextDocumentParams { text_document, content_changes } = params;
+        let previous_bucket = self.documents.package_key(&text_document.uri).map(|key| key.bucket);
 
         let Some(text) = extract_full_sync_text(content_changes) else {
             return;
@@ -338,46 +405,74 @@ impl ServerState {
         self.hooks.maybe_panic_notification(DID_CHANGE);
 
         let snapshot = self.documents.commit_change(prepared);
-        self.semantic_tokens.invalidate(&snapshot.uri);
-        self.scheduler.enqueue(snapshot);
+        self.invalidate_bucket_for_new_snapshot(
+            connection,
+            previous_bucket.as_ref(),
+            &snapshot.package_key.bucket,
+            "package analysis was superseded",
+        );
+        self.scheduler.set_open_buckets(self.documents.open_buckets());
+        self.analysis.in_flight_packages.insert(snapshot.package_key.clone());
+        self.scheduler.enqueue_package(snapshot);
     }
 
+    /// Close a document and flush or cancel any waiters tied to its bucket.
     fn handle_did_close(&mut self, connection: &Connection, params: DidCloseTextDocumentParams) {
         self.hooks.maybe_panic_notification(DID_CLOSE);
         let uri = params.text_document.uri;
+        let previous_bucket = self.documents.package_key(&uri).map(|key| key.bucket);
         self.documents.close(&uri);
-        if let Err(error) = send_ok_responses(connection, self.semantic_tokens.clear(&uri), empty_response_value()) {
+        self.scheduler.set_open_buckets(self.documents.open_buckets());
+        if let Err(error) =
+            send_ok_responses(connection, self.semantic_token_requests.clear_uri(&uri), empty_response_value())
+        {
             tracing::error!(uri = uri.as_str(), error = %error, "failed to flush semantic token close responses");
+        }
+        if let Err(error) = send_definition_nulls(connection, self.definition_requests.clear_uri(&uri)) {
+            tracing::error!(uri = uri.as_str(), error = %error, "failed to flush definition close responses");
+        }
+        if let Some(bucket) = previous_bucket {
+            self.analysis.invalidate_bucket(&bucket);
+            self.cancel_pending_bucket_requests(connection, &bucket, "package analysis was superseded");
+        } else {
+            self.analysis.invalidate_uri(&uri);
         }
     }
 
+    /// Remove a pending semantic-token or definition request by LSP request ID.
     fn handle_cancel_request(&mut self, connection: &Connection, params: CancelParams) -> Result<()> {
         let request_id = request_id_from_cancel(params.id);
-        if self.semantic_tokens.remove_pending_request(&request_id) {
+        if self.semantic_token_requests.remove_pending_request(&request_id) {
             send_error_response(
                 connection,
                 request_id,
                 ErrorCode::RequestCanceled as i32,
                 "semantic token request cancelled",
             )
+        } else if self.definition_requests.remove_pending_request(&request_id).is_some() {
+            send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "definition request cancelled",
+            )
         } else {
             Ok(())
         }
     }
 
+    /// Apply one worker event to caches and answer any pending client requests.
     fn handle_worker_event(&mut self, connection: &Connection, event: WorkerEvent) {
         match event {
-            WorkerEvent::Analyzed(DocumentAnalysis { uri, generation, semantic_snapshot }) => {
-                // Worker jobs finish asynchronously, so only the latest
-                // committed generation is allowed to surface as current.
-                if self.documents.generation(&uri) == Some(generation) {
-                    let pending = self.semantic_tokens.store_success(uri.clone(), generation, semantic_snapshot);
-                    if let Some(snapshot) = self.semantic_tokens.cached(&uri, generation)
-                        && let Err(error) =
-                            send_ok_responses(connection, pending, response_value(snapshot.encoded_tokens.as_ref()))
-                    {
-                        tracing::error!(uri = uri.as_str(), error = %error, "failed to send semantic token response");
-                    }
+            WorkerEvent::PackageAnalyzed(PackageAnalysis { uri, generation, key, result }) => {
+                self.analysis.in_flight_packages.remove(&key);
+                if self.documents.generation(&uri) == Some(generation)
+                    && self.documents.package_key(&uri) == Some(key.clone())
+                {
+                    self.analysis.store_package(Arc::clone(&result.package));
+                    self.store_document_view(connection, result.document_view);
+                    self.answer_pending_definitions(connection, &key);
+                    self.enqueue_pending_document_views_for_package(&key);
                     tracing::debug!(
                         uri = uri.as_str(),
                         generation,
@@ -385,29 +480,93 @@ impl ServerState {
                         "worker completed latest document"
                     );
                 } else {
-                    tracing::debug!(uri = uri.as_str(), generation, "dropping stale worker completion");
+                    self.cancel_pending_package_requests(connection, &key, "package analysis was superseded");
+                    tracing::debug!(uri = uri.as_str(), generation, "dropping stale package worker completion");
                 }
             }
-            WorkerEvent::Cancelled { uri, generation } => {
-                tracing::debug!(uri = uri.as_str(), generation, "worker cancelled stale document");
+            WorkerEvent::DocumentViewBuilt(view) => {
+                self.analysis.in_flight_views.remove(&view.key);
+                if self.documents.document_view_key(&view.key.uri) == Some(view.key.clone()) {
+                    self.store_document_view(connection, view);
+                } else {
+                    self.cancel_pending_document_view_requests(
+                        connection,
+                        &view.key,
+                        "semantic token document view was superseded",
+                    );
+                }
             }
-            WorkerEvent::Panicked { uri, generation, report } => {
+            WorkerEvent::PackageCancelled { key, uri, generation } => {
+                self.analysis.in_flight_packages.remove(&key);
+                self.cancel_pending_package_requests(connection, &key, "package analysis was cancelled");
+                tracing::debug!(uri = uri.as_str(), generation, "worker cancelled stale package analysis");
+            }
+            WorkerEvent::DocumentViewCancelled { key } => {
+                self.analysis.in_flight_views.remove(&key);
+                self.cancel_pending_document_view_requests(
+                    connection,
+                    &key,
+                    "semantic token document view was cancelled",
+                );
+                tracing::debug!(
+                    uri = key.uri.as_str(),
+                    generation = key.document_generation,
+                    "worker cancelled stale document view"
+                );
+            }
+            WorkerEvent::PackagePanicked { key, uri, generation, report } => {
                 report.log();
-                if self.documents.generation(&uri) == Some(generation) {
-                    let pending = self.semantic_tokens.store_failure(uri.clone(), generation);
+                self.analysis.in_flight_packages.remove(&key);
+                if self.documents.generation(&uri) == Some(generation)
+                    && self.documents.package_key(&uri) == Some(key.clone())
+                {
+                    self.analysis.store_failed_package(key.clone());
+                    let pending_semantic = self.semantic_token_requests.take_package(&key);
                     if let Err(error) = send_error_responses(
                         connection,
-                        pending,
+                        pending_semantic,
                         INTERNAL_ERROR,
                         "semantic token analysis panicked; see server logs for details",
                     ) {
                         tracing::error!(uri = uri.as_str(), error = %error, "failed to send semantic analysis panic");
                     }
+                    if let Err(error) = send_error_responses(
+                        connection,
+                        self.definition_requests.take_package(&key).into_iter().map(|pending| pending.id).collect(),
+                        INTERNAL_ERROR,
+                        "definition analysis panicked; see server logs for details",
+                    ) {
+                        tracing::error!(uri = uri.as_str(), error = %error, "failed to send definition analysis panic");
+                    }
+                } else {
+                    self.cancel_pending_package_requests(connection, &key, "package analysis was superseded");
+                }
+            }
+            WorkerEvent::DocumentViewPanicked { key, report } => {
+                report.log();
+                self.analysis.in_flight_views.remove(&key);
+                if self.documents.document_view_key(&key.uri) == Some(key.clone()) {
+                    self.analysis.failed_views.insert(key.clone());
+                    if let Err(error) = send_error_responses(
+                        connection,
+                        self.semantic_token_requests.take_key(&key),
+                        INTERNAL_ERROR,
+                        "semantic token document view panicked; see server logs for details",
+                    ) {
+                        tracing::error!(uri = key.uri.as_str(), error = %error, "failed to send document-view panic");
+                    }
+                } else {
+                    self.cancel_pending_document_view_requests(
+                        connection,
+                        &key,
+                        "semantic token document view was superseded",
+                    );
                 }
             }
         }
     }
 
+    /// Answer or queue one full semantic-token request.
     fn handle_semantic_tokens_full(
         &mut self,
         connection: &Connection,
@@ -415,108 +574,441 @@ impl ServerState {
         params: SemanticTokensParams,
     ) -> Result<()> {
         let uri = params.text_document.uri;
-        let Some(generation) = self.documents.generation(&uri) else {
+        let Some(view_key) = self.documents.document_view_key(&uri) else {
             return send_ok_response(connection, request_id, empty_response_value());
         };
 
-        match self.semantic_tokens.status_or_queue(uri, generation, request_id.clone()) {
-            DocumentRequestStatus::Cached(snapshot) => {
-                send_ok_response(connection, request_id, response_value(snapshot.encoded_tokens.as_ref()))
-            }
-            DocumentRequestStatus::Failed => send_error_response(
+        if let Some(view) = self.analysis.document_view(&view_key) {
+            return send_ok_response(connection, request_id, response_value(view.encoded_tokens.as_ref()));
+        }
+
+        if self.analysis.failed_views.contains(&view_key) || self.analysis.failed_packages.contains(&view_key.package) {
+            return send_error_response(
                 connection,
                 request_id,
                 INTERNAL_ERROR,
                 "semantic token analysis panicked; see server logs for details",
-            ),
-            DocumentRequestStatus::Pending => Ok(()),
+            );
+        }
+
+        self.semantic_token_requests.queue(view_key.clone(), request_id);
+        self.ensure_analysis_for_view(&view_key);
+        Ok(())
+    }
+
+    /// Answer or queue one go-to-definition request.
+    fn handle_goto_definition(
+        &mut self,
+        connection: &Connection,
+        request_id: RequestId,
+        params: GotoDefinitionParams,
+    ) -> Result<()> {
+        let uri = params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        let Some(document) = self.documents.open_document(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(file_path) = document.file_path.clone() else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(offset) = position_to_offset(document.line_index.as_ref(), position) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(view_key) = self.documents.document_view_key(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+
+        let query = DefinitionQuery {
+            uri: uri.clone(),
+            file_path,
+            position,
+            offset,
+            line_index: Arc::clone(&document.line_index),
+            view_key: view_key.clone(),
+            link_support: self.client_definition_link_support,
+        };
+
+        if let Some(package) = self.analysis.packages.get(&view_key.package) {
+            return send_ok_response(
+                connection,
+                request_id,
+                definition_response_value(resolve_definition(&query, package)),
+            );
+        }
+
+        if self.analysis.failed_packages.contains(&view_key.package) {
+            return send_error_response(
+                connection,
+                request_id,
+                INTERNAL_ERROR,
+                "definition analysis panicked; see server logs for details",
+            );
+        }
+
+        if self.definition_requests.queue(query, request_id.clone()) {
+            // Definition resolution needs the package index but not the encoded
+            // token view, so pending requests wait at package granularity.
+            self.ensure_package_analysis(&view_key.package, &uri);
+            Ok(())
+        } else {
+            send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "too many pending definition requests",
+            )
+        }
+    }
+
+    /// Ensure the package and document-view analysis needed for a token request is queued.
+    fn ensure_analysis_for_view(&mut self, view_key: &DocumentViewKey) {
+        if let Some(package) = self.analysis.packages.get(&view_key.package).cloned() {
+            self.ensure_document_view(view_key, package);
+        } else {
+            self.ensure_package_analysis(&view_key.package, &view_key.uri);
+        }
+    }
+
+    /// Queue package analysis unless the exact package key is cached or in flight.
+    fn ensure_package_analysis(&mut self, package_key: &PackageAnalysisKey, uri: &Uri) {
+        if self.analysis.in_flight_packages.contains(package_key) || self.analysis.packages.contains_key(package_key) {
+            return;
+        }
+        let Some(snapshot) = self.documents.snapshot_for_package_analysis(uri) else {
+            return;
+        };
+        self.analysis.in_flight_packages.insert(snapshot.package_key.clone());
+        self.scheduler.enqueue_package(snapshot);
+    }
+
+    /// Queue a document-view rebuild against a cached package analysis.
+    fn ensure_document_view(&mut self, view_key: &DocumentViewKey, package: Arc<CachedPackageAnalysis>) {
+        if self.analysis.in_flight_views.contains(view_key) || self.analysis.document_view(view_key).is_some() {
+            return;
+        }
+        let Some(snapshot) = self.documents.snapshot_for_document_view(&view_key.uri) else {
+            return;
+        };
+        self.analysis.in_flight_views.insert(snapshot.key.clone());
+        self.scheduler.enqueue_document_view(snapshot, package);
+    }
+
+    /// Cache an encoded document view and answer matching semantic-token waiters.
+    fn store_document_view(&mut self, connection: &Connection, view: CachedDocumentView) {
+        let key = view.key.clone();
+        let uri = key.uri.clone();
+        // Cache by URI for cheap steady-state lookup; `document_view` checks the
+        // embedded key so a stale view never answers a newer generation.
+        self.analysis.document_views.insert(uri.clone(), view.clone());
+        let pending = self.semantic_token_requests.take_key(&key);
+        if let Err(error) = send_ok_responses(connection, pending, response_value(view.encoded_tokens.as_ref())) {
+            tracing::error!(uri = uri.as_str(), error = %error, "failed to send semantic token response");
+        }
+    }
+
+    /// Resolve all queued definition requests waiting on one package analysis.
+    fn answer_pending_definitions(&mut self, connection: &Connection, key: &PackageAnalysisKey) {
+        let Some(package) = self.analysis.packages.get(key).cloned() else {
+            return;
+        };
+        for pending in self.definition_requests.take_package(key) {
+            // Each definition request keeps its original cursor offset and line
+            // index, so many requests can share one package analysis without
+            // collapsing to the same target.
+            let value = definition_response_value(resolve_definition(&pending.query, package.as_ref()));
+            if let Err(error) = send_ok_response(connection, pending.id, value) {
+                tracing::error!(error = %error, "failed to send definition response");
+            }
+        }
+    }
+
+    /// Start document-view jobs unblocked by a newly cached package analysis.
+    fn enqueue_pending_document_views_for_package(&mut self, key: &PackageAnalysisKey) {
+        let Some(package) = self.analysis.packages.get(key).cloned() else {
+            return;
+        };
+        let keys = self.semantic_token_requests.keys_for_package(key);
+        for view_key in keys {
+            self.ensure_document_view(&view_key, Arc::clone(&package));
+        }
+    }
+
+    /// Invalidate stale analysis state when a document enters a new package snapshot.
+    fn invalidate_bucket_for_new_snapshot(
+        &mut self,
+        connection: &Connection,
+        previous_bucket: Option<&AnalysisBucket>,
+        current_bucket: &AnalysisBucket,
+        message: &'static str,
+    ) {
+        // Package analysis spans all open buffers in the bucket. Any committed
+        // edit or bucket move invalidates package-level state, document views,
+        // in-flight markers, and pending waiters that depended on old inputs.
+        if let Some(previous_bucket) = previous_bucket
+            && previous_bucket != current_bucket
+        {
+            self.analysis.invalidate_bucket(previous_bucket);
+            self.cancel_pending_bucket_requests(connection, previous_bucket, message);
+        }
+        self.analysis.invalidate_bucket(current_bucket);
+        self.cancel_pending_bucket_requests(connection, current_bucket, message);
+    }
+
+    /// Cancel semantic-token and definition waiters tied to one analysis bucket.
+    fn cancel_pending_bucket_requests(
+        &mut self,
+        connection: &Connection,
+        bucket: &AnalysisBucket,
+        message: &'static str,
+    ) {
+        if let Err(error) = send_error_responses(
+            connection,
+            self.semantic_token_requests.take_bucket(bucket),
+            ErrorCode::RequestCanceled as i32,
+            format!("semantic token {message}"),
+        ) {
+            tracing::error!(error = %error, "failed to cancel semantic token bucket waiters");
+        }
+
+        let definition_requests =
+            self.definition_requests.take_bucket(bucket).into_iter().map(|pending| pending.id).collect();
+        if let Err(error) = send_error_responses(
+            connection,
+            definition_requests,
+            ErrorCode::RequestCanceled as i32,
+            format!("definition {message}"),
+        ) {
+            tracing::error!(error = %error, "failed to cancel definition bucket waiters");
+        }
+    }
+
+    /// Cancel semantic-token and definition waiters tied to one package key.
+    fn cancel_pending_package_requests(
+        &mut self,
+        connection: &Connection,
+        key: &PackageAnalysisKey,
+        message: &'static str,
+    ) {
+        if let Err(error) = send_error_responses(
+            connection,
+            self.semantic_token_requests.take_package(key),
+            ErrorCode::RequestCanceled as i32,
+            format!("semantic token {message}"),
+        ) {
+            tracing::error!(error = %error, "failed to cancel semantic token package waiters");
+        }
+
+        let definition_requests =
+            self.definition_requests.take_package(key).into_iter().map(|pending| pending.id).collect();
+        if let Err(error) = send_error_responses(
+            connection,
+            definition_requests,
+            ErrorCode::RequestCanceled as i32,
+            format!("definition {message}"),
+        ) {
+            tracing::error!(error = %error, "failed to cancel definition package waiters");
+        }
+    }
+
+    /// Cancel semantic-token waiters tied to one document-view key.
+    fn cancel_pending_document_view_requests(
+        &mut self,
+        connection: &Connection,
+        key: &DocumentViewKey,
+        message: &'static str,
+    ) {
+        if let Err(error) = send_error_responses(
+            connection,
+            self.semantic_token_requests.take_key(key),
+            ErrorCode::RequestCanceled as i32,
+            message,
+        ) {
+            tracing::error!(uri = key.uri.as_str(), error = %error, "failed to cancel semantic token view waiters");
         }
     }
 }
 
-impl<T> DocumentRequestState<T> {
-    /// Drop cached success/failure state for one URI after the document changes.
-    fn invalidate(&mut self, uri: &Uri) {
-        self.cached.remove(uri);
-        self.failed.remove(uri);
+impl AnalysisCaches {
+    /// Remove URI-local document-view state after close or reclassification.
+    fn invalidate_uri(&mut self, uri: &Uri) {
+        self.document_views.remove(uri);
+        self.failed_views.retain(|key| &key.uri != uri);
+        self.in_flight_views.retain(|key| &key.uri != uri);
     }
 
-    /// Drop all state for one URI and return any waiters that still need a response.
-    fn clear(&mut self, uri: &Uri) -> Vec<RequestId> {
-        self.invalidate(uri);
-        self.take_pending(uri)
+    /// Remove all package and document-view state for one analysis bucket.
+    fn invalidate_bucket(&mut self, bucket: &AnalysisBucket) {
+        self.packages.retain(|key, _| &key.bucket != bucket);
+        self.package_order.retain(|key| &key.bucket != bucket);
+        self.failed_packages.retain(|key| &key.bucket != bucket);
+        self.in_flight_packages.retain(|key| &key.bucket != bucket);
+        self.document_views.retain(|_, view| &view.key.package.bucket != bucket);
+        self.failed_views.retain(|key| &key.package.bucket != bucket);
+        self.in_flight_views.retain(|key| &key.package.bucket != bucket);
     }
 
-    /// Return the current-generation state for a request, or queue it as a waiter.
-    fn status_or_queue(&mut self, uri: Uri, generation: u64, request_id: RequestId) -> DocumentRequestStatus<'_, T> {
-        if let Some(cached) = self.cached.get(&uri)
-            && cached.generation == generation
-        {
-            return DocumentRequestStatus::Cached(&cached.value);
+    /// Return a cached document view only when the embedded key still matches.
+    fn document_view(&self, key: &DocumentViewKey) -> Option<&CachedDocumentView> {
+        self.document_views.get(&key.uri).filter(|view| &view.key == key)
+    }
+
+    /// Store a package analysis and enforce the routing-thread LRU cap.
+    fn store_package(&mut self, package: Arc<CachedPackageAnalysis>) {
+        self.failed_packages.remove(&package.key);
+        if !self.packages.contains_key(&package.key) {
+            self.package_order.push_back(package.key.clone());
         }
-
-        if let Some(failed) = self.failed.get(&uri)
-            && failed.generation == generation
-        {
-            return DocumentRequestStatus::Failed;
-        }
-
-        // Hold the request open until analysis for this generation finishes,
-        // then fan the single result out to every waiter on the same URI.
-        self.pending_by_uri.entry(uri.clone()).or_default().push(request_id.clone());
-        self.pending_owner.insert(request_id, uri);
-        DocumentRequestStatus::Pending
-    }
-
-    /// Cache a successful result and return every pending waiter for that URI.
-    fn store_success(&mut self, uri: Uri, generation: u64, value: T) -> Vec<RequestId> {
-        self.failed.remove(&uri);
-        self.cached.insert(uri.clone(), CachedDocumentResult { generation, value });
-        self.take_pending(&uri)
-    }
-
-    /// Cache a generation-scoped failure and return every pending waiter for that URI.
-    fn store_failure(&mut self, uri: Uri, generation: u64) -> Vec<RequestId> {
-        self.cached.remove(&uri);
-        self.failed.insert(uri.clone(), FailedDocumentResult { generation });
-        self.take_pending(&uri)
-    }
-
-    /// Return the cached success payload for one URI/generation pair.
-    fn cached(&self, uri: &Uri, generation: u64) -> Option<&T> {
-        self.cached.get(uri).filter(|entry| entry.generation == generation).map(|entry| &entry.value)
-    }
-
-    /// Remove one queued waiter by request ID.
-    fn remove_pending_request(&mut self, request_id: &RequestId) -> bool {
-        let Some(owner) = self.pending_owner.remove(request_id) else {
-            return false;
-        };
-
-        if let Some(queue) = self.pending_by_uri.get_mut(&owner) {
-            queue.retain(|pending| pending != request_id);
-            if queue.is_empty() {
-                self.pending_by_uri.remove(&owner);
+        self.packages.insert(package.key.clone(), package);
+        // Bound package analyses separately from worker stub caches. This keeps
+        // the routing thread from retaining package-sized indexes for closed or
+        // long-idle generations.
+        while self.package_order.len() > MAX_PACKAGE_CACHE_ENTRIES {
+            if let Some(oldest) = self.package_order.pop_front() {
+                self.packages.remove(&oldest);
+                self.failed_packages.remove(&oldest);
             }
         }
+    }
 
+    /// Remember that current package analysis failed so repeated requests fail fast.
+    fn store_failed_package(&mut self, key: PackageAnalysisKey) {
+        self.failed_packages.retain(|failed| failed.bucket != key.bucket);
+        self.failed_packages.insert(key);
+    }
+}
+
+impl SemanticTokenRequestState {
+    /// Queue a semantic-token waiter for an exact document-view key.
+    fn queue(&mut self, key: DocumentViewKey, request_id: RequestId) {
+        self.pending_by_key.entry(key.clone()).or_default().push(request_id.clone());
+        self.pending_owner.insert(request_id, key);
+    }
+
+    /// Remove one pending semantic-token request by request ID.
+    fn remove_pending_request(&mut self, request_id: &RequestId) -> bool {
+        let Some(key) = self.pending_owner.remove(request_id) else {
+            return false;
+        };
+        if let Some(queue) = self.pending_by_key.get_mut(&key) {
+            queue.retain(|pending| pending != request_id);
+            if queue.is_empty() {
+                self.pending_by_key.remove(&key);
+            }
+        }
         true
     }
 
-    /// Drain every queued waiter for one URI.
-    fn take_pending(&mut self, uri: &Uri) -> Vec<RequestId> {
-        let Some(requests) = self.pending_by_uri.remove(uri) else {
+    /// Drain every semantic-token waiter for a closed URI.
+    fn clear_uri(&mut self, uri: &Uri) -> Vec<RequestId> {
+        let keys = self.pending_by_key.keys().filter(|key| &key.uri == uri).cloned().collect::<Vec<_>>();
+        keys.into_iter().flat_map(|key| self.take_key(&key)).collect()
+    }
+
+    /// Drain every semantic-token waiter for an exact document-view key.
+    fn take_key(&mut self, key: &DocumentViewKey) -> Vec<RequestId> {
+        let Some(requests) = self.pending_by_key.remove(key) else {
             return Vec::new();
         };
-
         for request_id in &requests {
             self.pending_owner.remove(request_id);
         }
-
         requests
+    }
+
+    /// Drain every semantic-token waiter blocked on one package key.
+    fn take_package(&mut self, package: &PackageAnalysisKey) -> Vec<RequestId> {
+        let keys = self.keys_for_package(package);
+        keys.into_iter().flat_map(|key| self.take_key(&key)).collect()
+    }
+
+    /// Drain every semantic-token waiter blocked on one analysis bucket.
+    fn take_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<RequestId> {
+        let keys = self.pending_by_key.keys().filter(|key| &key.package.bucket == bucket).cloned().collect::<Vec<_>>();
+        keys.into_iter().flat_map(|key| self.take_key(&key)).collect()
+    }
+
+    /// Return document-view keys waiting on one package key.
+    fn keys_for_package(&self, package: &PackageAnalysisKey) -> Vec<DocumentViewKey> {
+        self.pending_by_key.keys().filter(|key| &key.package == package).cloned().collect()
     }
 }
 
+impl DefinitionRequestState {
+    /// Queue a definition request, enforcing global and per-package caps.
+    fn queue(&mut self, query: DefinitionQuery, request_id: RequestId) -> bool {
+        // Definition requests are cheap individually but can otherwise pile up
+        // behind one slow package analysis. Cap both global and per-package
+        // waiters so a client burst cannot turn into unbounded retained queries.
+        if self.pending_owner.len() >= MAX_PENDING_DEFINITIONS {
+            return false;
+        }
+        let package = query.view_key.package.clone();
+        let queue = self.pending_by_package.entry(package.clone()).or_default();
+        if queue.len() >= MAX_PENDING_DEFINITIONS_PER_KEY {
+            return false;
+        }
+        queue.push(PendingDefinitionRequest { id: request_id.clone(), query });
+        self.pending_owner.insert(request_id, package);
+        true
+    }
+
+    /// Remove one pending definition request by request ID.
+    fn remove_pending_request(&mut self, request_id: &RequestId) -> Option<PendingDefinitionRequest> {
+        let package = self.pending_owner.remove(request_id)?;
+        let queue = self.pending_by_package.get_mut(&package)?;
+        let index = queue.iter().position(|pending| &pending.id == request_id)?;
+        let pending = queue.remove(index);
+        if queue.is_empty() {
+            self.pending_by_package.remove(&package);
+        }
+        Some(pending)
+    }
+
+    /// Drain definition requests whose source document has closed.
+    fn clear_uri(&mut self, uri: &Uri) -> Vec<PendingDefinitionRequest> {
+        let packages = self.pending_by_package.keys().cloned().collect::<Vec<_>>();
+        let mut cleared = Vec::new();
+        for package in packages {
+            let Some(queue) = self.pending_by_package.get_mut(&package) else {
+                continue;
+            };
+            let mut index = 0;
+            while index < queue.len() {
+                if &queue[index].query.uri == uri {
+                    let pending = queue.remove(index);
+                    self.pending_owner.remove(&pending.id);
+                    cleared.push(pending);
+                } else {
+                    index += 1;
+                }
+            }
+            if queue.is_empty() {
+                self.pending_by_package.remove(&package);
+            }
+        }
+        cleared
+    }
+
+    /// Drain definition requests waiting on one package key.
+    fn take_package(&mut self, package: &PackageAnalysisKey) -> Vec<PendingDefinitionRequest> {
+        let Some(requests) = self.pending_by_package.remove(package) else {
+            return Vec::new();
+        };
+        for request in &requests {
+            self.pending_owner.remove(&request.id);
+        }
+        requests
+    }
+
+    /// Drain definition requests waiting on any package key in a bucket.
+    fn take_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingDefinitionRequest> {
+        let packages =
+            self.pending_by_package.keys().filter(|package| &package.bucket == bucket).cloned().collect::<Vec<_>>();
+        packages.into_iter().flat_map(|package| self.take_package(&package)).collect()
+    }
+}
+
+/// Collect initialize-time workspace roots using LSP's preferred fallback order.
 #[allow(deprecated)]
 fn collect_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
     let mut roots = Vec::new();
@@ -536,6 +1028,7 @@ fn collect_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
     roots
 }
 
+/// Advertise the LSP capabilities implemented by this server.
 fn server_capabilities() -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
@@ -546,10 +1039,23 @@ fn server_capabilities() -> ServerCapabilities {
             save: None,
         })),
         semantic_tokens_provider: Some(semantic_tokens_capability()),
+        definition_provider: Some(OneOf::Left(true)),
         ..Default::default()
     }
 }
 
+/// Return whether the client can consume rich `LocationLink` definition results.
+fn client_supports_definition_links(params: &InitializeParams) -> bool {
+    params
+        .capabilities
+        .text_document
+        .as_ref()
+        .and_then(|text_document| text_document.definition.as_ref())
+        .and_then(|definition| definition.link_support)
+        .unwrap_or(false)
+}
+
+/// Extract the committed text from a full-sync `didChange` payload.
 fn extract_full_sync_text(changes: Vec<TextDocumentContentChangeEvent>) -> Option<String> {
     if changes.is_empty() {
         tracing::warn!("didChange arrived without content changes");
@@ -566,6 +1072,7 @@ fn extract_full_sync_text(changes: Vec<TextDocumentContentChangeEvent>) -> Optio
     changes.into_iter().next_back().map(|change| change.text)
 }
 
+/// Convert LSP's string-or-number cancellation ID into `lsp_server::RequestId`.
 fn request_id_from_cancel(id: NumberOrString) -> RequestId {
     match id {
         NumberOrString::Number(number) => number.into(),
@@ -573,12 +1080,14 @@ fn request_id_from_cancel(id: NumberOrString) -> RequestId {
     }
 }
 
+/// Send one successful JSON-RPC response.
 fn send_ok_response(connection: &Connection, id: RequestId, result: Value) -> Result<()> {
     let response = Response { id, result: Some(result), error: None };
     connection.sender.send(Message::Response(response))?;
     Ok(())
 }
 
+/// Send one JSON-RPC error response.
 fn send_error_response(connection: &Connection, id: RequestId, code: i32, message: impl Into<String>) -> Result<()> {
     let response =
         Response { id, result: None, error: Some(ResponseError { code, message: message.into(), data: None }) };
@@ -592,6 +1101,18 @@ fn send_ok_responses(connection: &Connection, request_ids: Vec<RequestId>, resul
         send_ok_response(connection, request_id, result.clone())?;
     }
 
+    Ok(())
+}
+
+/// Send successful `null` definition responses for requests orphaned by close.
+fn send_definition_nulls(connection: &Connection, requests: Vec<PendingDefinitionRequest>) -> Result<()> {
+    for request in requests {
+        // A close means the source document no longer exists from the client's
+        // point of view, so a successful "no definition" result is less noisy
+        // than `RequestCanceled`. Superseded open documents still use explicit
+        // cancellation so clients can distinguish stale work from no target.
+        send_ok_response(connection, request.id, Value::Null)?;
+    }
     Ok(())
 }
 
@@ -616,12 +1137,16 @@ fn send_error_responses(
 /// dispatch code the binary uses, rather than a parallel test-only harness.
 #[derive(Debug, Clone, Default)]
 struct TestHooks {
+    /// Request method that should panic when dispatched.
     panic_on_request_method: Option<String>,
+    /// Notification method that should panic when dispatched.
     panic_on_notification_method: Option<String>,
+    /// Whether every worker job should panic under test.
     panic_on_worker_job: bool,
 }
 
 impl TestHooks {
+    /// Build test hooks from environment variables used by subprocess tests.
     fn from_env() -> Self {
         Self {
             panic_on_request_method: std::env::var("LEO_LSP_TEST_PANIC_REQUEST").ok(),
@@ -633,12 +1158,14 @@ impl TestHooks {
         }
     }
 
+    /// Panic when the configured request method is dispatched.
     fn maybe_panic_request(&self, method: &str) {
         if self.panic_on_request_method.as_deref() == Some(method) {
             panic!("injected request panic for {method}");
         }
     }
 
+    /// Panic when the configured notification method is dispatched.
     fn maybe_panic_notification(&self, method: &str) {
         if self.panic_on_notification_method.as_deref() == Some(method) {
             panic!("injected notification panic for {method}");
@@ -665,6 +1192,7 @@ mod tests {
     use std::{fs, path::Path, process::ExitCode, sync::Arc, thread, time::Duration};
     use tempfile::tempdir;
 
+    /// Spawn the real server loop over an in-memory transport.
     fn spawn_server(hooks: TestHooks) -> (Connection, thread::JoinHandle<anyhow::Result<ExitCode>>) {
         // Use an in-memory transport so these tests exercise the real server
         // event loop without paying the cost of subprocess management.
@@ -673,6 +1201,7 @@ mod tests {
         (client, handle)
     }
 
+    /// Build a test `file:` URI from a native path.
     fn file_uri(path: &Path) -> Uri {
         #[cfg(target_os = "windows")]
         let path = format!("/{}", path.display()).replace('\\', "/");
@@ -683,6 +1212,7 @@ mod tests {
         format!("file://{path}").parse().expect("file uri")
     }
 
+    /// Send a JSON-RPC request frame to the in-memory server.
     fn send_request(client: &Connection, id: i32, method: &str, params: Value) {
         client
             .sender
@@ -690,6 +1220,7 @@ mod tests {
             .expect("send request");
     }
 
+    /// Send a JSON-RPC notification frame to the in-memory server.
     fn send_notification(client: &Connection, method: &str, params: Value) {
         client
             .sender
@@ -697,6 +1228,7 @@ mod tests {
             .expect("send notification");
     }
 
+    /// Receive the next server response in tests with a short timeout.
     fn recv_response(client: &Connection) -> Response {
         // Requests in this module are strictly request/response, so the next
         // frame observed from the server must be the matching response.
@@ -706,14 +1238,7 @@ mod tests {
         }
     }
 
-    fn empty_semantic_snapshot() -> crate::semantics::SemanticSnapshot {
-        crate::semantics::SemanticSnapshot {
-            encoded_tokens: Arc::<[u32]>::from([]),
-            index: Arc::new(crate::semantics::SemanticIndex::default()),
-            source: crate::semantics::SemanticSource::SyntaxOnly,
-        }
-    }
-
+    /// Build semantic-token request params for a document URI.
     fn semantic_tokens_params(uri: Uri) -> SemanticTokensParams {
         SemanticTokensParams {
             work_done_progress_params: Default::default(),
@@ -722,6 +1247,7 @@ mod tests {
         }
     }
 
+    /// Build isolated server state for direct state-machine tests.
     fn test_state() -> super::ServerState {
         super::ServerState {
             shutdown_requested: false,
@@ -730,11 +1256,15 @@ mod tests {
             documents: crate::document_store::DocumentStore::default(),
             project_model: crate::project_model::ProjectModel::default(),
             scheduler: crate::scheduler::Scheduler::new(false),
-            semantic_tokens: super::DocumentRequestState::default(),
+            analysis: super::AnalysisCaches::default(),
+            semantic_token_requests: super::SemanticTokenRequestState::default(),
+            definition_requests: super::DefinitionRequestState::default(),
+            client_definition_link_support: false,
             hooks: TestHooks::default(),
         }
     }
 
+    /// Insert an unmanaged open document into direct state-machine tests.
     fn open_unmanaged_document(state: &mut super::ServerState, uri: &Uri, version: i32, text: &str) {
         state.documents.commit_open(state.documents.prepare_open(
             uri.clone(),
@@ -744,9 +1274,37 @@ mod tests {
             None,
             None,
         ));
-        state.semantic_tokens.invalidate(uri);
+        state.analysis.invalidate_uri(uri);
     }
 
+    /// Verifies bucket invalidation clears every package and view cache surface.
+    #[test]
+    fn bucket_invalidation_evicts_package_views_and_state() {
+        let mut state = test_state();
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+        open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+        let key = state.documents.document_view_key(&uri).expect("document view key");
+
+        state.analysis.document_views.insert(uri.clone(), crate::semantics::CachedDocumentView {
+            key: key.clone(),
+            encoded_tokens: Arc::from([]),
+        });
+        state.analysis.failed_packages.insert(key.package.clone());
+        state.analysis.in_flight_packages.insert(key.package.clone());
+        state.analysis.failed_views.insert(key.clone());
+        state.analysis.in_flight_views.insert(key.clone());
+
+        state.analysis.invalidate_bucket(&key.package.bucket);
+
+        assert!(state.analysis.document_views.is_empty());
+        assert!(state.analysis.failed_packages.is_empty());
+        assert!(state.analysis.in_flight_packages.is_empty());
+        assert!(state.analysis.failed_views.is_empty());
+        assert!(state.analysis.in_flight_views.is_empty());
+        state.scheduler.shutdown();
+    }
+
+    /// Complete the initialize/initialized handshake for server-loop tests.
     fn initialize(client: &Connection) {
         send_request(
             client,
@@ -764,6 +1322,7 @@ mod tests {
         send_notification(client, "initialized", json!({}));
     }
 
+    /// Verifies exiting before shutdown reports an unsuccessful server exit.
     #[test]
     fn exit_without_shutdown_returns_failure() {
         let (client, handle) = spawn_server(TestHooks::default());
@@ -775,6 +1334,7 @@ mod tests {
         assert_eq!(exit_code, ExitCode::from(1));
     }
 
+    /// Verifies notification panics are contained in the real server loop.
     #[test]
     fn notification_panic_can_be_tested_without_shelling_out() {
         let hooks = TestHooks { panic_on_notification_method: Some(DID_CHANGE.to_owned()), ..Default::default() };
@@ -821,6 +1381,7 @@ mod tests {
         assert_eq!(exit_code, ExitCode::SUCCESS);
     }
 
+    /// Verifies cancelling a queued semantic-token request returns request-cancelled.
     #[test]
     fn cancelled_semantic_request_returns_request_cancelled() {
         let (server, client) = Connection::memory();
@@ -839,10 +1400,37 @@ mod tests {
         let error = response.error.expect("cancelled response error");
         assert_eq!(error.code, ErrorCode::RequestCanceled as i32);
         assert!(error.message.contains("cancelled"));
-        assert!(state.semantic_tokens.pending_by_uri.is_empty());
+        assert!(state.semantic_token_requests.pending_by_key.is_empty());
         state.scheduler.shutdown();
     }
 
+    /// Verifies worker cancellation fails semantic-token waiters for that package.
+    #[test]
+    fn cancelled_package_analysis_fails_pending_waiters() {
+        let (server, client) = Connection::memory();
+        let mut state = test_state();
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+
+        open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+        let key = state.documents.document_view_key(&uri).expect("document view key");
+        state.semantic_token_requests.queue(key.clone(), 2.into());
+
+        state.handle_worker_event(&server, crate::scheduler::WorkerEvent::PackageCancelled {
+            key: key.package,
+            uri: uri.clone(),
+            generation: 1,
+        });
+
+        let response = recv_response(&client);
+        assert_eq!(response.id, 2.into());
+        let error = response.error.expect("cancelled response error");
+        assert_eq!(error.code, ErrorCode::RequestCanceled as i32);
+        assert!(error.message.contains("cancelled"));
+        assert!(state.semantic_token_requests.pending_by_key.is_empty());
+        state.scheduler.shutdown();
+    }
+
+    /// Verifies a current worker panic fails pending and repeated requests.
     #[test]
     fn current_generation_worker_panic_fails_pending_and_future_requests() {
         let (server, client) = Connection::memory();
@@ -859,7 +1447,9 @@ mod tests {
             panic!("boom");
         })
         .expect_err("panic report");
-        state.handle_worker_event(&server, crate::scheduler::WorkerEvent::Panicked {
+        let key = state.documents.package_key(&uri).expect("package key");
+        state.handle_worker_event(&server, crate::scheduler::WorkerEvent::PackagePanicked {
+            key,
             uri: uri.clone(),
             generation: 1,
             report: panic_report,
@@ -876,10 +1466,11 @@ mod tests {
         let second = recv_response(&client);
         assert_eq!(second.id, 3.into());
         assert_eq!(second.error.expect("repeat panic error").code, super::INTERNAL_ERROR);
-        assert!(state.semantic_tokens.pending_by_uri.is_empty());
+        assert!(state.semantic_token_requests.pending_by_key.is_empty());
         state.scheduler.shutdown();
     }
 
+    /// Verifies stale worker panics do not poison newer pending requests.
     #[test]
     fn stale_worker_panic_does_not_fail_newer_pending_request() {
         let (server, client) = Connection::memory();
@@ -887,13 +1478,14 @@ mod tests {
         let uri: Uri = "untitled:main.leo".parse().expect("uri");
 
         open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+        let stale_key = state.documents.package_key(&uri).expect("initial package key");
 
         let changed = state
             .documents
             .prepare_full_change(&uri, 2, "program test.aleo { fn main() {} }\n".to_owned(), None, None)
             .expect("prepared change");
         state.documents.commit_change(changed);
-        state.semantic_tokens.invalidate(&uri);
+        state.analysis.invalidate_uri(&uri);
 
         state
             .handle_semantic_tokens_full(&server, 2.into(), semantic_tokens_params(uri.clone()))
@@ -903,29 +1495,18 @@ mod tests {
             panic!("stale boom");
         })
         .expect_err("panic report");
-        state.handle_worker_event(&server, crate::scheduler::WorkerEvent::Panicked {
+        state.handle_worker_event(&server, crate::scheduler::WorkerEvent::PackagePanicked {
+            key: stale_key,
             uri: uri.clone(),
             generation: 1,
             report: panic_report,
         });
 
         assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err(), "stale panic should not respond");
-
-        state.handle_worker_event(
-            &server,
-            crate::scheduler::WorkerEvent::Analyzed(crate::scheduler::DocumentAnalysis {
-                uri: uri.clone(),
-                generation: 2,
-                semantic_snapshot: empty_semantic_snapshot(),
-            }),
-        );
-
-        let response = recv_response(&client);
-        assert_eq!(response.id, 2.into());
-        assert_eq!(response.result, Some(crate::features::semantic_tokens::empty_response_value()));
         state.scheduler.shutdown();
     }
 
+    /// Verifies didChange re-runs project discovery before queueing analysis.
     #[test]
     fn did_change_re_resolves_project_context() {
         let tempdir = tempdir().expect("tempdir");
@@ -943,11 +1524,15 @@ mod tests {
             documents: crate::document_store::DocumentStore::default(),
             project_model: crate::project_model::ProjectModel::default(),
             scheduler: crate::scheduler::Scheduler::new(false),
-            semantic_tokens: super::DocumentRequestState::default(),
+            analysis: super::AnalysisCaches::default(),
+            semantic_token_requests: super::SemanticTokenRequestState::default(),
+            definition_requests: super::DefinitionRequestState::default(),
+            client_definition_link_support: false,
             hooks: TestHooks::default(),
         };
+        let (server, _client) = Connection::memory();
 
-        state.handle_did_open(DidOpenTextDocumentParams {
+        state.handle_did_open(&server, DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: uri.clone(),
                 language_id: "leo".to_owned(),
@@ -970,7 +1555,7 @@ mod tests {
         )
         .expect("write manifest");
 
-        state.handle_did_change(DidChangeTextDocumentParams {
+        state.handle_did_change(&server, DidChangeTextDocumentParams {
             text_document: VersionedTextDocumentIdentifier { uri: uri.clone(), version: 2 },
             content_changes: vec![TextDocumentContentChangeEvent {
                 range: None,

--- a/crates/lsp/src/syntax_semantics.rs
+++ b/crates/lsp/src/syntax_semantics.rs
@@ -21,20 +21,30 @@
 //! lexical tokens for full editor highlighting coverage.
 
 use crate::{
-    document_store::DocumentSnapshot,
-    project_model::ProjectKind,
+    document_store::{DocumentSnapshot, DocumentViewSnapshot, OpenFileOverlay},
+    project_model::{ProjectContext, ProjectKind},
     semantics::{
         FileRange,
         OccurrenceRole,
         SemanticKind,
         SemanticTokenOccurrence,
+        SourceFingerprint,
         SymbolIdentity,
         SymbolOccurrence,
         sort_occurrences,
     },
 };
+use leo_package::{CompilationUnit, Dependency, Location, Manifest, ProgramData};
 use leo_parser_rowan::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken, parse_main, parse_module};
-use std::{collections::HashMap, path::PathBuf, sync::Arc};
+use leo_span::{Symbol, create_session_if_not_set_then};
+use std::{
+    collections::HashMap,
+    fs::{self, Metadata},
+    hash::{DefaultHasher, Hash, Hasher},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::UNIX_EPOCH,
+};
 
 /// Compiler-free semantic data extracted from one Rowan parse.
 #[derive(Debug, Default)]
@@ -43,18 +53,81 @@ pub(crate) struct SyntaxSemantics {
     pub(crate) occurrences: Vec<SymbolOccurrence>,
     /// Highlighting-only lexical tokens that should not affect navigation data.
     pub(crate) tokens: Vec<SemanticTokenOccurrence>,
+    /// Verified disk fingerprints for syntax-discovered cross-file targets.
+    pub(crate) fingerprints: HashMap<PathBuf, SourceFingerprint>,
 }
 
 /// Collect syntax-only symbols and lexical tokens for the snapshot's current text.
 pub(crate) fn collect(snapshot: &DocumentSnapshot) -> SyntaxSemantics {
-    let parse = match choose_syntax_parser(snapshot) {
-        SyntaxParser::Main => parse_main(snapshot.text.as_ref()),
-        SyntaxParser::Module => parse_module(snapshot.text.as_ref()),
+    collect_parts(
+        snapshot.text.as_ref(),
+        snapshot.file_path.as_ref(),
+        snapshot.project.as_ref(),
+        snapshot.open_overlays.as_ref(),
+        ProgramTargetMode::LocalDependencies,
+    )
+}
+
+/// Collect syntax fallback symbols for every open file in the package bucket.
+pub(crate) fn collect_package_fallback(snapshot: &DocumentSnapshot) -> SyntaxSemantics {
+    let mut semantics = collect_parts(
+        snapshot.text.as_ref(),
+        snapshot.file_path.as_ref(),
+        snapshot.project.as_ref(),
+        snapshot.open_overlays.as_ref(),
+        ProgramTargetMode::LocalDependencies,
+    );
+    let Some(trigger_path) = snapshot.file_path.as_ref() else {
+        return semantics;
     };
 
+    for overlay in snapshot.open_overlays.iter().filter(|overlay| overlay.path.as_ref() != trigger_path.as_ref()) {
+        let mut overlay_semantics = collect_parts(
+            overlay.text.as_ref(),
+            Some(&overlay.path),
+            snapshot.project.as_ref(),
+            snapshot.open_overlays.as_ref(),
+            ProgramTargetMode::LocalDependencies,
+        );
+        semantics.occurrences.append(&mut overlay_semantics.occurrences);
+        semantics.fingerprints.extend(overlay_semantics.fingerprints);
+    }
+
+    sort_occurrences(&mut semantics.occurrences);
+    semantics
+}
+
+/// Collect syntax-only symbols and lexical tokens for a document-view job.
+pub(crate) fn collect_view(snapshot: &DocumentViewSnapshot) -> SyntaxSemantics {
+    collect_parts(
+        snapshot.text.as_ref(),
+        snapshot.file_path.as_ref(),
+        snapshot.project.as_ref(),
+        &[],
+        ProgramTargetMode::None,
+    )
+}
+
+/// Shared collection path for package-analysis and document-view snapshots.
+fn collect_parts(
+    text: &str,
+    file_path: Option<&Arc<PathBuf>>,
+    project: Option<&Arc<ProjectContext>>,
+    open_overlays: &[OpenFileOverlay],
+    target_mode: ProgramTargetMode,
+) -> SyntaxSemantics {
+    let parse = match choose_syntax_parser(file_path, project) {
+        SyntaxParser::Main => parse_main(text),
+        SyntaxParser::Module => parse_module(text),
+    };
+
+    let document_path = current_document_path(file_path);
+    let (program_targets, fingerprints) =
+        syntax_program_targets(text, Arc::clone(&document_path), project, open_overlays, target_mode);
     let mut semantics = parse
-        .map(|tree| SyntaxSemanticCollector::new(current_document_path(snapshot)).collect(&tree))
+        .map(|tree| SyntaxSemanticCollector::new(document_path, program_targets).collect(&tree))
         .unwrap_or_default();
+    semantics.fingerprints = fingerprints;
     // Symbol occurrences are sorted here because compiler-backed occurrences
     // merge with this vector before final semantic-token encoding.
     sort_occurrences(&mut semantics.occurrences);
@@ -62,13 +135,13 @@ pub(crate) fn collect(snapshot: &DocumentSnapshot) -> SyntaxSemantics {
 }
 
 /// Choose the Rowan parser entry point that best matches this snapshot.
-fn choose_syntax_parser(snapshot: &DocumentSnapshot) -> SyntaxParser {
-    if let Some(project) = snapshot.project.as_ref() {
+fn choose_syntax_parser(file_path: Option<&Arc<PathBuf>>, project: Option<&Arc<ProjectContext>>) -> SyntaxParser {
+    if let Some(project) = project {
         // The Rowan parser uses a distinct entry-point grammar for `main.leo`.
         // Reuse the project model's entry-file resolution so syntax fallback
         // mirrors the same program-vs-module distinction as the compiler path.
         return match project.kind {
-            ProjectKind::Program if snapshot.file_path.as_ref() == Some(&project.entry_file) => SyntaxParser::Main,
+            ProjectKind::Program if file_path == Some(&project.entry_file) => SyntaxParser::Main,
             ProjectKind::Program | ProjectKind::Library => SyntaxParser::Module,
         };
     }
@@ -80,15 +153,129 @@ fn choose_syntax_parser(snapshot: &DocumentSnapshot) -> SyntaxParser {
 }
 
 /// Return the current document path, or an empty placeholder for unmanaged buffers.
-fn current_document_path(snapshot: &DocumentSnapshot) -> Arc<PathBuf> {
-    snapshot.file_path.clone().unwrap_or_else(|| Arc::new(PathBuf::new()))
+fn current_document_path(file_path: Option<&Arc<PathBuf>>) -> Arc<PathBuf> {
+    file_path.cloned().unwrap_or_else(|| Arc::new(PathBuf::new()))
 }
 
 /// Syntax parser mode used by the fallback highlighter.
 #[derive(Debug, Clone, Copy)]
 enum SyntaxParser {
+    /// Parse a file that may contain a full `program` declaration.
     Main,
+    /// Parse a package module or library source file.
     Module,
+}
+
+/// Import target discovery depth for a syntax collection pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProgramTargetMode {
+    /// Skip navigation target discovery for document-view highlighting.
+    None,
+    /// Collect open-buffer targets and local dependency sources.
+    LocalDependencies,
+}
+
+/// Collect program declaration targets visible to syntax-only import handling.
+fn syntax_program_targets(
+    text: &str,
+    document_path: Arc<PathBuf>,
+    project: Option<&Arc<ProjectContext>>,
+    open_overlays: &[OpenFileOverlay],
+    target_mode: ProgramTargetMode,
+) -> (HashMap<String, FileRange>, HashMap<PathBuf, SourceFingerprint>) {
+    let mut targets = HashMap::new();
+    let mut fingerprints = HashMap::new();
+    if target_mode == ProgramTargetMode::None {
+        return (targets, fingerprints);
+    }
+
+    add_program_targets_from_text(text, &document_path, &mut targets);
+    for overlay in open_overlays {
+        if overlay.path.as_ref() != document_path.as_ref() {
+            add_program_targets_from_text(overlay.text.as_ref(), &overlay.path, &mut targets);
+        }
+    }
+    if target_mode == ProgramTargetMode::LocalDependencies
+        && let Some(project) = project
+    {
+        add_local_dependency_program_targets(project.as_ref(), &mut targets, &mut fingerprints);
+    }
+    (targets, fingerprints)
+}
+
+/// Add `program name.aleo` declarations from one parsed source to the target map.
+fn add_program_targets_from_text(text: &str, path: &Arc<PathBuf>, targets: &mut HashMap<String, FileRange>) {
+    let Ok(tree) = parse_main(text) else {
+        return;
+    };
+    collect_program_target_tokens(&tree, path, targets);
+}
+
+/// Recursively collect program declaration name tokens from a Rowan tree.
+fn collect_program_target_tokens(node: &SyntaxNode, path: &Arc<PathBuf>, targets: &mut HashMap<String, FileRange>) {
+    for element in node.children_with_tokens() {
+        match element {
+            SyntaxElement::Node(child) => collect_program_target_tokens(&child, path, targets),
+            SyntaxElement::Token(token) if is_program_declaration_token(&token) => {
+                if let Some(range) =
+                    FileRange::new(Arc::clone(path), token.text_range().start().into(), token.text_range().end().into())
+                {
+                    targets.entry(token.text().to_owned()).or_insert(range);
+                }
+            }
+            SyntaxElement::Token(_) => {}
+        }
+    }
+}
+
+/// Add local manifest dependency program declarations to syntax-only import targets.
+fn add_local_dependency_program_targets(
+    project: &ProjectContext,
+    targets: &mut HashMap<String, FileRange>,
+    fingerprints: &mut HashMap<PathBuf, SourceFingerprint>,
+) {
+    let Ok(manifest) = Manifest::read_from_file(project.manifest_path.as_ref()) else {
+        return;
+    };
+
+    for dependency in manifest.dependencies.iter().flatten() {
+        let Some(source_path) = dependency_source_path(project.package_root.as_ref(), dependency) else {
+            continue;
+        };
+        let Some((source, fingerprint)) = read_stable_source(source_path.as_path()) else {
+            continue;
+        };
+        let source_path = source_path.canonicalize().unwrap_or(source_path);
+        let source_path = Arc::new(source_path);
+        add_program_targets_from_text(source.as_str(), &source_path, targets);
+        fingerprints.insert(source_path.as_ref().clone(), fingerprint);
+    }
+}
+
+/// Return the package-resolved source path for a local dependency.
+fn dependency_source_path(package_root: &Path, dependency: &Dependency) -> Option<PathBuf> {
+    if dependency.location != Location::Local {
+        return None;
+    }
+    let path = dependency.path.as_deref()?;
+    let root = if path.is_absolute() { path.to_path_buf() } else { package_root.join(path) };
+    let unit =
+        create_session_if_not_set_then(|_| CompilationUnit::from_package_path(Symbol::intern(&dependency.name), root));
+    let ProgramData::SourcePath { source, .. } = unit.ok()?.data else {
+        return None;
+    };
+    Some(source)
+}
+
+/// Read a source file and return a fingerprint for the exact bytes consumed.
+fn read_stable_source(path: &Path) -> Option<(String, SourceFingerprint)> {
+    let before = fs::metadata(path).ok().and_then(|metadata| disk_stamp(&metadata))?;
+    let source = fs::read_to_string(path).ok()?;
+    let after = fs::metadata(path).ok().and_then(|metadata| disk_stamp(&metadata))?;
+    (before == after).then(|| {
+        let content_hash = content_hash(source.as_str());
+        (source, SourceFingerprint::Disk { modified_nanos: Some(after.modified_nanos), len: after.len, content_hash })
+    })
 }
 
 /// Rowan-only fallback collector used when compiler analysis is unavailable.
@@ -100,12 +287,13 @@ struct SyntaxSemanticCollector {
     path: Arc<PathBuf>,
     semantics: SyntaxSemantics,
     local_scopes: Vec<HashMap<String, SyntaxLocalBinding>>,
+    program_targets: HashMap<String, FileRange>,
 }
 
 impl SyntaxSemanticCollector {
     /// Create a new syntax collector for one document path.
-    fn new(path: Arc<PathBuf>) -> Self {
-        Self { path, semantics: SyntaxSemantics::default(), local_scopes: vec![HashMap::new()] }
+    fn new(path: Arc<PathBuf>, program_targets: HashMap<String, FileRange>) -> Self {
+        Self { path, semantics: SyntaxSemantics::default(), local_scopes: vec![HashMap::new()], program_targets }
     }
 
     /// Walk a Rowan syntax tree and emit best-effort semantic data.
@@ -135,6 +323,11 @@ impl SyntaxSemanticCollector {
 
     /// Classify and record one token, binding local declarations as they appear.
     fn collect_token(&mut self, token: &SyntaxToken) {
+        if let Some(occurrence) = self.import_occurrence(token) {
+            self.semantics.occurrences.push(occurrence);
+            return;
+        }
+
         let classification = classify_syntax_token(token).or_else(|| self.classify_local_reference(token));
         if let Some((token_kind, role, readonly)) = classification {
             self.push_symbol_token(token, token_kind, role, readonly);
@@ -146,6 +339,22 @@ impl SyntaxSemanticCollector {
         } else if let Some(token_kind) = classify_lexical_token(token.kind()) {
             self.push_lexical_token(token, token_kind);
         }
+    }
+
+    /// Record an import program segment as a namespace reference.
+    fn import_occurrence(&self, token: &SyntaxToken) -> Option<SymbolOccurrence> {
+        if !is_import_program_token(token) {
+            return None;
+        }
+        let range = self.token_range(token)?;
+        let name = create_session_if_not_set_then(|_| Symbol::intern(token.text()));
+        Some(SymbolOccurrence {
+            range,
+            identity: SymbolIdentity::Program { name, declaration: self.program_targets.get(token.text()).cloned() },
+            role: OccurrenceRole::Reference,
+            token_kind: SemanticKind::Namespace,
+            readonly: false,
+        })
     }
 
     /// Record a syntax-derived symbol occurrence.
@@ -206,7 +415,9 @@ impl SyntaxSemanticCollector {
 /// Minimal binding metadata for syntax-only local reference highlighting.
 #[derive(Debug, Clone, Copy)]
 struct SyntaxLocalBinding {
+    /// Token kind originally assigned to the local declaration.
     token_kind: SemanticKind,
+    /// Whether references should inherit the readonly modifier.
     readonly: bool,
 }
 
@@ -398,24 +609,69 @@ fn next_non_trivia_token(token: &SyntaxToken) -> Option<SyntaxToken> {
     None
 }
 
+/// Return whether this token is the program name in `program name.aleo`.
+fn is_program_declaration_token(token: &SyntaxToken) -> bool {
+    token.kind() == SyntaxKind::IDENT
+        && prev_non_trivia_token(token).is_some_and(|previous| previous.kind() == SyntaxKind::KW_PROGRAM)
+        && token_is_followed_by_aleo_suffix(token)
+}
+
+/// Return whether this token is the imported program name in `import name.aleo`.
+fn is_import_program_token(token: &SyntaxToken) -> bool {
+    token.kind() == SyntaxKind::IDENT
+        && prev_non_trivia_token(token).is_some_and(|previous| previous.kind() == SyntaxKind::KW_IMPORT)
+        && token_is_followed_by_aleo_suffix(token)
+}
+
+/// Return whether an identifier token is followed by `.aleo`.
+fn token_is_followed_by_aleo_suffix(token: &SyntaxToken) -> bool {
+    let Some(dot) = next_non_trivia_token(token) else {
+        return false;
+    };
+    dot.kind() == SyntaxKind::DOT
+        && next_non_trivia_token(&dot).is_some_and(|network| network.kind() == SyntaxKind::KW_ALEO)
+}
+
+/// Cheap filesystem stamp used to prove a syntax-side disk read was stable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DiskStamp {
+    /// File length observed in metadata.
+    len: u64,
+    /// Last-modified timestamp converted to nanoseconds since the Unix epoch.
+    modified_nanos: u128,
+}
+
+/// Build a comparable stamp from filesystem metadata.
+fn disk_stamp(metadata: &Metadata) -> Option<DiskStamp> {
+    Some(DiskStamp { len: metadata.len(), modified_nanos: metadata_modified_nanos(metadata)? })
+}
+
+/// Hash source text for stale-target detection without retaining full text.
+fn content_hash(contents: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    contents.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Convert file metadata modification time into a nanosecond stamp.
+fn metadata_modified_nanos(metadata: &Metadata) -> Option<u128> {
+    metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok().map(|duration| duration.as_nanos())
+}
+
 #[cfg(test)]
 mod tests {
     use super::collect;
     use crate::{
         compiler_bridge::PackageAnalysisCache,
-        document_store::DocumentSnapshot,
+        document_store::{DocumentSnapshot, DocumentStore},
         project_model::ProjectModel,
         semantics::{OccurrenceRole, SemanticKind, SemanticSource},
     };
-    use line_index::LineIndex;
     use lsp_types::Uri;
-    use std::{
-        fs,
-        path::Path,
-        sync::{Arc, atomic::AtomicU64},
-    };
+    use std::{fs, path::Path};
     use tempfile::tempdir;
 
+    /// Build a test `file:` URI from a native path.
     fn file_uri(path: &Path) -> Uri {
         #[cfg(target_os = "windows")]
         let path = {
@@ -430,23 +686,16 @@ mod tests {
         format!("file://{path}").parse().expect("file uri")
     }
 
+    /// Build a committed document snapshot for syntax fallback tests.
     fn snapshot_for(path: &Path, text: &str) -> DocumentSnapshot {
         let uri = file_uri(path);
         let mut projects = ProjectModel::default();
         let (file_path, project) = projects.resolve_document_context(&uri);
-
-        DocumentSnapshot {
-            uri,
-            text: Arc::from(text),
-            line_index: Arc::new(LineIndex::new(text)),
-            version: 1,
-            generation: 1,
-            file_path,
-            project,
-            cancel_token: Arc::new(AtomicU64::new(1)),
-        }
+        let mut documents = DocumentStore::default();
+        documents.commit_open(documents.prepare_open(uri, "leo".to_owned(), 1, text.to_owned(), file_path, project))
     }
 
+    /// Verifies unmanaged buffers get syntax symbols and lexical token coverage.
     #[test]
     fn unmanaged_program_buffers_emit_symbols_and_full_lexical_coverage() {
         let tempdir = tempdir().expect("tempdir");

--- a/crates/lsp/tests/protocol.rs
+++ b/crates/lsp/tests/protocol.rs
@@ -22,6 +22,7 @@ use serde_json::{Value, json};
 use std::{fs, path::Path, time::Duration};
 use tempfile::tempdir;
 
+/// Send the initialize request and return the raw response for protocol assertions.
 fn initialize(server: &mut TestServer) -> Value {
     // Tests assert on the raw initialize response, so this helper stops before
     // sending the follow-up `initialized` notification.
@@ -36,9 +37,14 @@ fn initialize(server: &mut TestServer) -> Value {
     )
 }
 
+/// Build a test `file:` URI from a native path.
 fn file_uri(path: &Path) -> Uri {
     #[cfg(target_os = "windows")]
-    let path = format!("/{}", path.display()).replace('\\', "/");
+    let path = {
+        let display = path.display().to_string();
+        let display = display.strip_prefix(r"\\?\").unwrap_or(display.as_str());
+        format!("/{}", display).replace('\\', "/")
+    };
 
     #[cfg(not(target_os = "windows"))]
     let path = path.display().to_string();
@@ -46,6 +52,35 @@ fn file_uri(path: &Path) -> Uri {
     format!("file://{path}").parse().expect("file uri")
 }
 
+/// Return the LSP position for the selected occurrence of a source substring.
+fn position_json(source: &str, needle: &str, occurrence: usize) -> Value {
+    let offset = source
+        .match_indices(needle)
+        .nth(occurrence)
+        .map(|(offset, _)| offset)
+        .unwrap_or_else(|| panic!("missing occurrence {occurrence} of {needle:?}"));
+    let line = source[..offset].bytes().filter(|byte| *byte == b'\n').count() as u32;
+    let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
+    json!({ "line": line, "character": (offset - line_start) as u32 })
+}
+
+/// Return the LSP range for the selected occurrence of a source substring.
+fn range_json(source: &str, needle: &str, occurrence: usize) -> Value {
+    let start = source
+        .match_indices(needle)
+        .nth(occurrence)
+        .map(|(offset, _)| offset)
+        .unwrap_or_else(|| panic!("missing occurrence {occurrence} of {needle:?}"));
+    let end = start + needle.len();
+    let position = |offset| {
+        let line = source[..offset].bytes().filter(|byte| *byte == b'\n').count() as u32;
+        let line_start = source[..offset].rfind('\n').map_or(0, |index| index + 1);
+        json!({ "line": line, "character": (offset - line_start) as u32 })
+    };
+    json!({ "start": position(start), "end": position(end) })
+}
+
+/// Verifies initialize, shutdown, and exit follow the LSP lifecycle.
 #[test]
 fn initialize_shutdown_exit_round_trip() {
     let mut server = TestServer::spawn(&[]);
@@ -61,6 +96,7 @@ fn initialize_shutdown_exit_round_trip() {
         })
     );
     assert_eq!(initialize["result"]["capabilities"]["semanticTokensProvider"]["full"], json!(true));
+    assert_eq!(initialize["result"]["capabilities"]["definitionProvider"], json!(true));
     assert_eq!(
         initialize["result"]["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"],
         json!([
@@ -91,6 +127,437 @@ fn initialize_shutdown_exit_round_trip() {
     assert!(status.success(), "stderr:\n{stderr}");
 }
 
+/// Verifies go-to-definition returns a local variable declaration target.
+#[test]
+fn definition_returns_local_variable_declaration() {
+    let tempdir = tempdir().expect("tempdir");
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        package_root.join("program.json"),
+        r#"{ "program": "demo.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write manifest");
+
+    let source = concat!(
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let total: u32 = 1u32;\n",
+        "        return total;\n",
+        "    }\n",
+        "}\n",
+    );
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+    let document_uri = file_uri(&main_path);
+    let canonical_file_uri = file_uri(&main_path.canonicalize().expect("canonical main path"));
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+
+    let response = server.request(
+        2,
+        "textDocument/definition",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": {
+                "line": 3,
+                "character": 16,
+            }
+        }),
+    );
+
+    assert_eq!(response["id"], 2);
+    assert_eq!(response["result"][0]["uri"], json!(canonical_file_uri.to_string()));
+    assert_eq!(
+        response["result"][0]["range"],
+        json!({
+            "start": { "line": 2, "character": 12 },
+            "end": { "line": 2, "character": 17 },
+        })
+    );
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies go-to-definition resolves function, type, and member targets.
+#[test]
+fn definition_resolves_function_type_and_member_targets() {
+    let tempdir = tempdir().expect("tempdir");
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        package_root.join("program.json"),
+        r#"{ "program": "demo.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write manifest");
+
+    let source = concat!(
+        "struct Point { x: u32, }\n\n",
+        "fn helper(point: Point) -> u32 {\n",
+        "    return point.x;\n",
+        "}\n\n",
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let local: Point = Point { x: 1u32 };\n",
+        "        return helper(local);\n",
+        "    }\n",
+        "}\n",
+    );
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+    let document_uri = file_uri(&main_path);
+    let canonical_uri = file_uri(&main_path.canonicalize().expect("canonical main path"));
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+
+    let cases = [
+        (2, "helper", 1, range_json(source, "helper", 0)),
+        (3, "Point", 2, range_json(source, "Point", 0)),
+        (4, "x", 1, range_json(source, "x", 0)),
+    ];
+
+    for (id, needle, occurrence, expected_range) in cases {
+        let response = server.request(
+            id,
+            "textDocument/definition",
+            json!({
+                "textDocument": {
+                    "uri": document_uri,
+                },
+                "position": position_json(source, needle, occurrence),
+            }),
+        );
+        assert_eq!(
+            response["result"][0]["uri"],
+            json!(canonical_uri.to_string()),
+            "bad uri for {needle}: {response}; stderr:\n{}",
+            server.stderr_contents()
+        );
+        assert_eq!(response["result"][0]["range"], expected_range, "bad target for {needle}");
+    }
+
+    let shutdown = server.request(5, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies loose program files still resolve struct field member targets.
+#[test]
+fn definition_resolves_unmanaged_struct_field_targets() {
+    let tempdir = tempdir().expect("tempdir");
+    let source = concat!(
+        "program test.aleo {\n",
+        "    struct Point {\n",
+        "        x: u64,\n",
+        "        y: u64,\n",
+        "    }\n\n",
+        "    struct TransferInfo {\n",
+        "        sender_amount: u64,\n",
+        "        receiver_amount: u64,\n",
+        "        transfer_fee: u64,\n",
+        "    }\n\n",
+        "    fn main(public a: u64, public b: u64) -> u64 {\n",
+        "        let p: Point = Point { x: 1u64, y: 2u64 };\n",
+        "        let info: TransferInfo = TransferInfo {\n",
+        "            sender_amount: a,\n",
+        "            receiver_amount: b,\n",
+        "            transfer_fee: 10u64,\n",
+        "        };\n",
+        "        return p.x + info.sender_amount;\n",
+        "    }\n",
+        "}\n",
+    );
+    let file_path = tempdir.path().join("wrap_struct_expr.leo");
+    fs::write(&file_path, source).expect("write source");
+    let document_uri = file_uri(&file_path);
+    let canonical_uri = file_uri(&file_path.canonicalize().expect("canonical source"));
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+
+    let response = server.request(
+        2,
+        "textDocument/definition",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": position_json(source, "sender_amount", 2),
+        }),
+    );
+
+    assert_eq!(
+        response["result"][0]["uri"],
+        json!(canonical_uri.to_string()),
+        "bad uri for sender_amount: {response}; stderr:\n{}",
+        server.stderr_contents()
+    );
+    assert_eq!(response["result"][0]["range"], range_json(source, "sender_amount", 0));
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies go-to-definition can target saved local dependency sources.
+#[test]
+fn definition_resolves_saved_local_source_dependency_target() {
+    let tempdir = tempdir().expect("tempdir");
+
+    let helper_root = tempdir.path().join("helper");
+    let helper_src = helper_root.join("src");
+    fs::create_dir_all(&helper_src).expect("create helper source dir");
+    fs::write(
+        helper_root.join("program.json"),
+        r#"{ "program": "helper.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write helper manifest");
+    let helper_source = concat!(
+        "program helper.aleo {\n",
+        "    fn double(x: u32) -> u32 {\n",
+        "        return x + x;\n",
+        "    }\n",
+        "}\n",
+    );
+    let helper_path = helper_src.join("main.leo");
+    fs::write(&helper_path, helper_source).expect("write helper source");
+    let helper_root = helper_root.canonicalize().expect("canonical helper root");
+    let helper_uri = file_uri(&helper_path.canonicalize().expect("canonical helper source"));
+
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        package_root.join("program.json"),
+        json!({
+            "program": "demo.aleo",
+            "version": "0.1.0",
+            "description": "",
+            "license": "MIT",
+            "leo": "4.0.0",
+            "dependencies": [
+                {
+                    "name": "helper.aleo",
+                    "location": "local",
+                    "path": helper_root,
+                }
+            ],
+        })
+        .to_string(),
+    )
+    .expect("write manifest");
+
+    let source = concat!(
+        "import helper.aleo;\n\n",
+        "program demo.aleo {\n",
+        "    fn main(x: u32) -> u32 {\n",
+        "        return helper.aleo::double(x);\n",
+        "    }\n",
+        "}\n",
+    );
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+    let document_uri = file_uri(&main_path);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+
+    let response = server.request(
+        2,
+        "textDocument/definition",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": position_json(source, "double", 0),
+        }),
+    );
+
+    assert_eq!(
+        response["result"][0]["uri"],
+        json!(helper_uri.to_string()),
+        "bad uri for dependency target: {response}; stderr:\n{}",
+        server.stderr_contents()
+    );
+    assert_eq!(response["result"][0]["range"], range_json(helper_source, "double", 0));
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies an import name resolves to the imported local program source.
+#[test]
+fn definition_resolves_imported_program_target() {
+    let tempdir = tempdir().expect("tempdir");
+
+    let helper_root = tempdir.path().join("helper");
+    let helper_src = helper_root.join("src");
+    fs::create_dir_all(&helper_src).expect("create helper source dir");
+    fs::write(
+        helper_root.join("program.json"),
+        r#"{ "program": "helper.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write helper manifest");
+    let helper_source = concat!(
+        "program helper.aleo {\n",
+        "    fn double(x: u32) -> u32 {\n",
+        "        return x + x;\n",
+        "    }\n",
+        "}\n",
+    );
+    let helper_path = helper_src.join("main.leo");
+    fs::write(&helper_path, helper_source).expect("write helper source");
+    let helper_root = helper_root.canonicalize().expect("canonical helper root");
+    let helper_uri = file_uri(&helper_path.canonicalize().expect("canonical helper source"));
+
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        package_root.join("program.json"),
+        json!({
+            "program": "demo.aleo",
+            "version": "0.1.0",
+            "description": "",
+            "license": "MIT",
+            "leo": "4.0.0",
+            "dependencies": [
+                {
+                    "name": "helper.aleo",
+                    "location": "local",
+                    "path": helper_root,
+                }
+            ],
+        })
+        .to_string(),
+    )
+    .expect("write manifest");
+
+    let source = concat!(
+        "import helper.aleo;\n\n",
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        return 1u32;\n",
+        "    }\n",
+        "}\n",
+    );
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+    let document_uri = file_uri(&main_path);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+
+    let response = server.request(
+        2,
+        "textDocument/definition",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": position_json(source, "helper", 0),
+        }),
+    );
+
+    assert_eq!(
+        response["result"][0]["uri"],
+        json!(helper_uri.to_string()),
+        "bad uri for import target: {response}; stderr:\n{}",
+        server.stderr_contents()
+    );
+    assert_eq!(response["result"][0]["range"], range_json(helper_source, "helper", 0));
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies exit before shutdown returns a nonzero process status.
 #[test]
 fn exit_without_shutdown_returns_nonzero() {
     let mut server = TestServer::spawn(&[]);
@@ -103,6 +570,7 @@ fn exit_without_shutdown_returns_nonzero() {
     assert!(!status.success(), "stderr:\n{stderr}");
 }
 
+/// Verifies malformed open/change/close payloads do not kill the server.
 #[test]
 fn malformed_open_change_close_lifecycle_stays_alive() {
     let tempdir = tempdir().expect("tempdir");
@@ -166,6 +634,7 @@ fn malformed_open_change_close_lifecycle_stays_alive() {
     assert!(status.success(), "stderr:\n{stderr}");
 }
 
+/// Verifies malformed notifications are contained and logged.
 #[test]
 fn malformed_notification_payload_stays_alive() {
     let mut server = TestServer::spawn(&[]);
@@ -183,6 +652,7 @@ fn malformed_notification_payload_stays_alive() {
     assert!(stderr.contains("failed to handle client notification"), "stderr:\n{stderr}");
 }
 
+/// Verifies semantic tokens return data and reuse the cached snapshot.
 #[test]
 fn semantic_tokens_full_returns_tokens_and_reuses_cached_snapshot() {
     let tempdir = tempdir().expect("tempdir");
@@ -235,6 +705,11 @@ fn semantic_tokens_full_returns_tokens_and_reuses_cached_snapshot() {
     );
     let first_data = first["result"]["data"].as_array().expect("semantic token data");
     assert!(!first_data.is_empty(), "expected semantic tokens, got {first}");
+    assert!(
+        server.wait_for_stderr_contains("worker completed latest document", Duration::from_secs(1)),
+        "stderr:\n{}",
+        server.finish().1
+    );
     assert_eq!(server.stderr_contents().matches("worker completed latest document").count(), 1);
 
     let second = server.request(
@@ -277,6 +752,7 @@ fn semantic_tokens_full_returns_tokens_and_reuses_cached_snapshot() {
     assert!(status.success(), "stderr:\n{stderr}");
 }
 
+/// Verifies worker panics surface as internal semantic-token errors.
 #[test]
 fn semantic_tokens_full_returns_internal_error_after_worker_panic() {
     let mut server = TestServer::spawn(&[("LEO_LSP_TEST_PANIC_WORKER", "1")]);


### PR DESCRIPTION
## Summary
- add `textDocument/definition` support to `leo-lsp`
- build a compiler-backed semantic index for source declarations, references, members, and cross-file targets
- reuse package and document semantic state so definition requests stay responsive under active editing
- resolve definitions for local symbols, top-level declarations, composite fields, imported local dependencies, and source-backed qualified paths

Tracking issue: https://github.com/ProvableHQ/leo/issues/29264

Related VScode plugin PR: https://github.com/ProvableHQ/leo-lsp-clients/pull/9