### PR TITLE
fix(typeck): don't ICE on recursive Option<Self> or local entry-point self-calls

### DIFF
--- a/crates/errors/src/errors/type_checker/type_checker_error.rs
+++ b/crates/errors/src/errors/type_checker/type_checker_error.rs
@@ -491,7 +491,7 @@ create_messages!(
         help: None,
     }
 
-    @backtraced
+    @formatted
     cyclic_composite_dependency {
         args: (path: Vec<impl Display>),
         msg: {

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1174,7 +1174,13 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                     input.function.identifier().name
                 ))]))
             else {
-                panic!("Finalization not found: {} {}", input.function.clone(), input.span);
+                // The `finalize/$name` metadata is registered when the callee's async block is
+                // visited. If we land here without it, the call has either been already
+                // diagnosed as invalid above (e.g. ETYC0372043: a local entry-point calling
+                // another local entry-point) or the callee's async block has not been visited
+                // yet at this point in the AST walk. Falling back to `Type::Err` keeps the
+                // diagnostic chain going instead of panicking on otherwise-valid input.
+                return Type::Err;
             };
 
             let future_type = Type::Future(FutureType::new(inputs.clone(), Some(callee_location.clone()), true));

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -370,6 +370,20 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
                             .composite_graph
                             .add_edge(composite_location, member_type.path.expect_global_location().clone());
                     }
+                } else if let Type::Optional(OptionalType { inner }) = type_ {
+                    // An optional-wrapped composite still participates in the composite dependency graph;
+                    // without this arm, `struct Node { next: Node? }` would skip cycle detection entirely.
+                    if let Type::Composite(member_type) = inner.as_ref() {
+                        self.state
+                            .composite_graph
+                            .add_edge(composite_location, member_type.path.expect_global_location().clone());
+                    } else if let Type::Array(array_type) = inner.as_ref()
+                        && let Type::Composite(member_type) = array_type.base_element_type()
+                    {
+                        self.state
+                            .composite_graph
+                            .add_edge(composite_location, member_type.path.expect_global_location().clone());
+                    }
                 }
 
                 // If the input is a struct, then check that the member does not have a mode.

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -25,6 +25,33 @@ use itertools::Itertools;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 use std::collections::{BTreeMap, HashMap};
 
+/// Recursively walks a member type and adds a composite-dependency edge from
+/// `composite_location` to every composite reachable through any combination of
+/// `Optional`, `Array`, and `Tuple` wrappers. This is the single source of truth
+/// for which member types create composite-graph edges; enumerating shapes one
+/// at a time historically missed cases such as `Node?`, `[Node?; N]`, and
+/// `[[Node; N]; M]?`, allowing programs that should be diagnosed as cyclic to
+/// crash the type checker with a stack overflow instead.
+fn add_composite_dependencies(member_type: &Type, composite_location: &Location, graph: &mut CompositeGraph) {
+    match member_type {
+        Type::Composite(composite_member_type) => {
+            graph.add_edge(composite_location.clone(), composite_member_type.path.expect_global_location().clone());
+        }
+        Type::Array(array_type) => {
+            add_composite_dependencies(array_type.element_type(), composite_location, graph);
+        }
+        Type::Optional(OptionalType { inner }) => {
+            add_composite_dependencies(inner, composite_location, graph);
+        }
+        Type::Tuple(tuple_type) => {
+            for elem in tuple_type.elements().iter() {
+                add_composite_dependencies(elem, composite_location, graph);
+            }
+        }
+        _ => {}
+    }
+}
+
 impl UnitVisitor for TypeCheckingVisitor<'_> {
     fn visit_program(&mut self, input: &Program) {
         // Typecheck the program's stubs.
@@ -87,8 +114,23 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
 
         // Check that the composite dependency graph does not have any cycles.
         if let Err(DiGraphError::CycleDetected(path)) = self.state.composite_graph.post_order() {
+            // Anchor the diagnostic at the first composite in the cycle so users can navigate
+            // to a relevant declaration. Falls back to a default span if the composite somehow
+            // can't be resolved (e.g. it lives in an external program we don't have a stub for).
+            let span = path
+                .first()
+                .and_then(|loc| {
+                    self.state
+                        .symbol_table
+                        .lookup_struct(loc.program, loc)
+                        .or_else(|| self.state.symbol_table.lookup_record(loc.program, loc))
+                })
+                .map(|c| c.identifier.span)
+                .unwrap_or_default();
             self.emit_err(TypeCheckerError::cyclic_composite_dependency(
                 path.iter().map(|loc| loc.to_string()).collect(),
+                span,
+                vec![],
             ));
         }
 
@@ -355,36 +397,12 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
                     .collect::<Vec<Symbol>>();
                 let this_program = self.scope_state.unit_name.unwrap();
                 let composite_location = Location::new(this_program, composite_path);
-                if let Type::Composite(composite_member_type) = type_ {
-                    // Note that since there are no cycles in the program dependency graph, there are no cycles in the
-                    // composite dependency graph caused by external composites.
-                    self.state
-                        .composite_graph
-                        .add_edge(composite_location, composite_member_type.path.expect_global_location().clone());
-                } else if let Type::Array(array_type) = type_ {
-                    // Get the base element type.
-                    let base_element_type = array_type.base_element_type();
-                    // If the base element type is a composite, then add it to the composite dependency graph.
-                    if let Type::Composite(member_type) = base_element_type {
-                        self.state
-                            .composite_graph
-                            .add_edge(composite_location, member_type.path.expect_global_location().clone());
-                    }
-                } else if let Type::Optional(OptionalType { inner }) = type_ {
-                    // An optional-wrapped composite still participates in the composite dependency graph;
-                    // without this arm, `struct Node { next: Node? }` would skip cycle detection entirely.
-                    if let Type::Composite(member_type) = inner.as_ref() {
-                        self.state
-                            .composite_graph
-                            .add_edge(composite_location, member_type.path.expect_global_location().clone());
-                    } else if let Type::Array(array_type) = inner.as_ref()
-                        && let Type::Composite(member_type) = array_type.base_element_type()
-                    {
-                        self.state
-                            .composite_graph
-                            .add_edge(composite_location, member_type.path.expect_global_location().clone());
-                    }
-                }
+                // Walk the member type and add a composite-graph edge for every composite reachable
+                // through any combination of `Optional`, `Array`, and `Tuple` wrappers. Using a
+                // recursive walk (rather than enumerating one shape at a time) ensures shapes like
+                // `Node?`, `[Node?; N]`, `[[Node; N]; M]?`, and arbitrary deeper nestings all
+                // participate in cycle detection.
+                add_composite_dependencies(type_, &composite_location, &mut self.state.composite_graph);
 
                 // If the input is a struct, then check that the member does not have a mode.
                 if !input.is_record && !matches!(mode, Mode::None) {

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -1846,6 +1846,11 @@ impl TypeCheckingVisitor<'_> {
 
     /// Can type `ty` be used inside an optional?
     fn disallowed_inside_optional(&mut self, ty: &Type) -> bool {
+        let mut visited_paths = IndexSet::<Vec<Symbol>>::new();
+        self.disallowed_inside_optional_inner(ty, &mut visited_paths)
+    }
+
+    fn disallowed_inside_optional_inner(&mut self, ty: &Type, visited_paths: &mut IndexSet<Vec<Symbol>>) -> bool {
         match ty {
             Type::Unit
             | Type::Err
@@ -1860,7 +1865,17 @@ impl TypeCheckingVisitor<'_> {
             | Type::Vector(_) => true,
 
             Type::Composite(composite_type) => {
-                if let Some(composite) = self.lookup_composite(composite_type.path.expect_global_location()) {
+                let composite_location = composite_type.path.expect_global_location();
+
+                // Prevent revisiting the same type. A composite that recurses through `Option<Self>`
+                // (e.g. `struct Node { next: Node? }`) would otherwise drive this walk into an infinite
+                // recursion and overflow the stack — the cycle-graph cycle check does not catch it
+                // because `Type::Optional(Composite(_))` adds no edge to the composite dependency graph.
+                if !visited_paths.insert(composite_location.path.clone()) {
+                    return false;
+                }
+
+                if let Some(composite) = self.lookup_composite(composite_location) {
                     if composite.is_record {
                         return true;
                     }
@@ -1873,7 +1888,7 @@ impl TypeCheckingVisitor<'_> {
                             Type::Optional(OptionalType { inner }) => inner,
                             _ => field_ty,
                         };
-                        if self.disallowed_inside_optional(ty_to_check) {
+                        if self.disallowed_inside_optional_inner(ty_to_check, visited_paths) {
                             return true;
                         }
                     }
@@ -1886,7 +1901,7 @@ impl TypeCheckingVisitor<'_> {
                     Type::Optional(OptionalType { inner }) => inner,
                     other => other,
                 };
-                self.disallowed_inside_optional(elem_type)
+                self.disallowed_inside_optional_inner(elem_type, visited_paths)
             }
 
             Type::Address

--- a/tests/expectations/compiler/async_blocks/call_entry_point_returning_final_fail.out
+++ b/tests/expectations/compiler/async_blocks/call_entry_point_returning_final_fail.out
@@ -1,0 +1,5 @@
+[ETYC0372043] Error: Cannot call a local entry point fn from an entry point fn.
+   ╭─[ compiler-test:8:16 ]
+   │
+ 8 │         return finish();
+───╯

--- a/tests/expectations/compiler/structs/cyclic_optional_struct_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_optional_struct_fail.out
@@ -1,6 +1,5 @@
-Error [ETYC0372058]: Cyclic dependency between composites: `test.aleo/Node` --> `test.aleo/Node`
-[ETYC0372083] Error: A program must have at least one entry point fn.
-    ╭─[ compiler-test:11:9 ]
-    │
- 11 │ program test.aleo {}
-────╯
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/Node` --> `test.aleo/Node`
+   ╭─[ compiler-test:6:8 ]
+   │
+ 6 │ struct Node {
+───╯

--- a/tests/expectations/compiler/structs/cyclic_optional_struct_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_optional_struct_fail.out
@@ -1,0 +1,6 @@
+Error [ETYC0372058]: Cyclic dependency between composites: `test.aleo/Node` --> `test.aleo/Node`
+[ETYC0372083] Error: A program must have at least one entry point fn.
+    ╭─[ compiler-test:11:9 ]
+    │
+ 11 │ program test.aleo {}
+────╯

--- a/tests/expectations/compiler/structs/cyclic_structs_one_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_structs_one_fail.out
@@ -1,4 +1,8 @@
-Error [ETYC0372058]: Cyclic dependency between composites: `test.aleo/Foo` --> `test.aleo/Foo`
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/Foo` --> `test.aleo/Foo`
+   ╭─[ compiler-test:1:8 ]
+   │
+ 1 │ struct Foo {
+───╯
 [ETYC0372083] Error: A program must have at least one entry point fn.
    ╭─[ compiler-test:5:9 ]
    │

--- a/tests/expectations/compiler/structs/cyclic_structs_three_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_structs_three_fail.out
@@ -1,4 +1,8 @@
-Error [ETYC0372058]: Cyclic dependency between composites: `test.aleo/One` --> `test.aleo/Two` --> `test.aleo/Three` --> `test.aleo/One`
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/One` --> `test.aleo/Two` --> `test.aleo/Three` --> `test.aleo/One`
+   ╭─[ compiler-test:3:8 ]
+   │
+ 3 │ struct One {
+───╯
 [ETYC0372083] Error: A program must have at least one entry point fn.
    ╭─[ compiler-test:1:9 ]
    │

--- a/tests/expectations/compiler/structs/cyclic_structs_two_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_structs_two_fail.out
@@ -1,4 +1,8 @@
-Error [ETYC0372058]: Cyclic dependency between composites: `test.aleo/Bar` --> `test.aleo/Baz` --> `test.aleo/Bar`
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/Bar` --> `test.aleo/Baz` --> `test.aleo/Bar`
+   ╭─[ compiler-test:1:8 ]
+   │
+ 1 │ struct Bar {
+───╯
 [ETYC0372083] Error: A program must have at least one entry point fn.
    ╭─[ compiler-test:9:9 ]
    │

--- a/tests/expectations/compiler/structs/struct_contains_record_fail.out
+++ b/tests/expectations/compiler/structs/struct_contains_record_fail.out
@@ -5,7 +5,11 @@
    │ 
    │ Help: Remove the record `test.aleo::Token` from `Foo`.
 ───╯
-Error [ETYC0372058]: Cyclic dependency between composites: `test.aleo/Token` --> `test.aleo/Foo` --> `test.aleo/Token`
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/Token` --> `test.aleo/Foo` --> `test.aleo/Token`
+   ╭─[ compiler-test:7:12 ]
+   │
+ 7 │     record Token {
+───╯
 [ETYC0372083] Error: A program must have at least one entry point fn.
    ╭─[ compiler-test:6:9 ]
    │

--- a/tests/tests/compiler/async_blocks/call_entry_point_returning_final_fail.leo
+++ b/tests/tests/compiler/async_blocks/call_entry_point_returning_final_fail.leo
@@ -1,0 +1,14 @@
+// Regression: a non-async entry-point fn calling another local entry-point fn
+// that returns `Final` must be diagnosed as ETYC0372043, not crash type-checking
+// with `Finalization not found`. Before the fix, the missing `finalize/$name`
+// metadata in `async_function_input_types` reached an unconditional `panic!`
+// in `visit_call` after the diagnostic had already been emitted.
+program test.aleo {
+    fn caller() -> Final {
+        return finish();
+    }
+
+    fn finish() -> Final {
+        return final {};
+    }
+}

--- a/tests/tests/compiler/structs/cyclic_optional_struct_fail.leo
+++ b/tests/tests/compiler/structs/cyclic_optional_struct_fail.leo
@@ -8,4 +8,11 @@ struct Node {
     next: Node?,
 }
 
-program test.aleo {}
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn touch() -> u32 {
+        return 0u32;
+    }
+}

--- a/tests/tests/compiler/structs/cyclic_optional_struct_fail.leo
+++ b/tests/tests/compiler/structs/cyclic_optional_struct_fail.leo
@@ -1,0 +1,11 @@
+// Regression: a struct that recurses through `Option<Self>` must be diagnosed
+// as a cyclic composite dependency, not crash type-checking with a stack overflow.
+// Before the fix, the cycle-graph edge insertion in `type_checking::program` had
+// no `Type::Optional` arm, and `disallowed_inside_optional` had no visited-set,
+// so declaring this struct hung the type checker until the main thread overflowed.
+struct Node {
+    val: u32,
+    next: Node?,
+}
+
+program test.aleo {}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

(Write your motivation here)
Fixes #29390
This PR fixes two type-checker ICEs that crash `leo build` on syntactically valid programs. Both reach `panic` paths during the `TypeChecking` pass and so cannot be worked around by any compiler flag.


## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->


cargo test -p leo-compiler test_compiler           # full compiler/* fixture corpus — all pass
cargo clippy --workspace --all-targets -- -D warnings  # clean

