### PR TITLE
fix(typeck): handle un-typed tuple-let surplus var inside final {} without panic

### DIFF
--- a/crates/passes/src/common/block_to_function_rewriter.rs
+++ b/crates/passes/src/common/block_to_function_rewriter.rs
@@ -273,7 +273,13 @@ impl BlockToFunctionRewriter<'_> {
 
                 // All other variables become parameters to the function being built.
                 let var = self.state.symbol_table.lookup_local(local_var_name)?;
-                Some(make_inputs_and_arguments(self, local_var_name, &var.type_.expect("must be known by now"), *index))
+                // The variable's type is `None` only when an earlier type-checking diagnostic
+                // already prevented it from being typed (e.g. a tuple-pattern arity mismatch
+                // like `let (a, b, c): (u32, u32) = ...` leaves the surplus identifier
+                // un-typed). Skip such variables so the rewriter does not panic before the
+                // user-facing diagnostic surfaces.
+                let ty = var.type_.clone()?;
+                Some(make_inputs_and_arguments(self, local_var_name, &ty, *index))
             })
             .flatten()
             .unzip();

--- a/tests/expectations/compiler/async_blocks/tuple_let_arity_mismatch_in_final_fail.out
+++ b/tests/expectations/compiler/async_blocks/tuple_let_arity_mismatch_in_final_fail.out
@@ -1,0 +1,5 @@
+[ETYC0372072] Error: Expected a tuple with 2 elements, found one with 3 elements
+    ╭─[ compiler-test:14:9 ]
+    │
+ 14 │         let (a, b, c): (u32, u32) = (1u32, 2u32);
+────╯

--- a/tests/tests/compiler/async_blocks/tuple_let_arity_mismatch_in_final_fail.leo
+++ b/tests/tests/compiler/async_blocks/tuple_let_arity_mismatch_in_final_fail.leo
@@ -1,0 +1,17 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29391
+// The compiler should emit a diagnostic error, not panic, when a tuple-pattern
+// `let` binding has an arity mismatch with its annotated tuple type and any of
+// the resulting identifiers (including the surplus one whose type was never
+// resolved) is referenced inside a `final {}` block. Before the fix,
+// `BlockToFunctionRewriter::rewrite_block` looked up the surplus identifier's
+// type and `expect()`ed it, panicking with `must be known by now` after the
+// type-checker had already emitted ETYC0372072.
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn touch() -> Final {
+        let (a, b, c): (u32, u32) = (1u32, 2u32);
+        return final { let _ = a + b + c; };
+    }
+}


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #29391 

`leo build` panics with `must be known by now` at `block_to_function_rewriter.rs:276` when a tuple-pattern `let` binding has an arity mismatch with its annotated tuple type **and** any of the resulting identifiers is referenced inside a `final {}` block. The type checker correctly emits `ETYC0372072: Expected a tuple with N elements, found one with M elements`, but the same pass keeps running, the rewriter walks the `final {}` block to identify free variables, and `expect()`s the surplus identifier's type — which is `None` because typeck couldn't unify the arity. The user sees an ICE banner instead of the diagnostic.


## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->
cargo test -p leo-compiler test_compiler          # full compiler/* fixture corpus — all pass
cargo clippy --workspace --all-targets -- -D warnings  # clean