### PR TITLE
feat(typeck): warn on == / != between two () operands

### DIFF
--- a/crates/errors/src/errors/type_checker/type_checker_warning.rs
+++ b/crates/errors/src/errors/type_checker/type_checker_warning.rs
@@ -66,4 +66,11 @@ create_messages!(
         msg: format!("`@no_inline` on `{name}` will be ignored because {reason}."),
         help: Some("Remove the `@no_inline` annotation to silence this warning.".to_string()),
     }
+
+    @formatted
+    comparison_of_unit_operands_is_constant {
+        args: (op: impl Display, value: impl Display),
+        msg: format!("Comparison `{op}` between two operands of type `()` always evaluates to `{value}` at compile time."),
+        help: Some("Both operands have type `()` (e.g. the return type of `Mapping::set` or other side-effecting calls), so the comparison has no runtime effect — the branch decision is baked in at compile time. If you intended to compare actual values, the operands likely need to be expressions that produce a value, not unit-returning calls.".to_string()),
+    }
 );

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -983,6 +983,25 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                 // Now sanity check everything
                 let _ = assert_same_type(self, &t1, &t2);
 
+                // Warn when both operands have type `()`. The comparison is mathematically a constant
+                // (`true` for `==`, `false` for `!=`), and a later const-prop pass will fold it. The
+                // pattern is almost always a developer mistake — e.g. comparing two `Mapping::set`
+                // calls, expecting a runtime check, when the operator alone determines which branch
+                // of any surrounding `if`/ternary survives codegen.
+                if matches!(t1, Type::Unit) && matches!(t2, Type::Unit) {
+                    let (op_str, folded) = match input.op {
+                        BinaryOperation::Eq => ("==", "true"),
+                        BinaryOperation::Neq => ("!=", "false"),
+                        _ => unreachable!("guarded by the outer match arm"),
+                    };
+                    self.emit_warning(TypeCheckerWarning::comparison_of_unit_operands_is_constant(
+                        op_str,
+                        folded,
+                        input.span(),
+                        vec![],
+                    ));
+                }
+
                 self.maybe_assert_type(&Type::Boolean, destination, input.span());
 
                 Type::Boolean

--- a/tests/expectations/compiler/bugs/b29314.out
+++ b/tests/expectations/compiler/bugs/b29314.out
@@ -1,3 +1,10 @@
+[WTYC0372006] Warning: Comparison `==` between two operands of type `()` always evaluates to `true` at compile time.
+   ╭─[ compiler-test:6:20 ]
+   │
+ 6 │             assert(fin_foo(a) == fin_foo(a));
+   │ 
+   │ Help: Both operands have type `()` (e.g. the return type of `Mapping::set` or other side-effecting calls), so the comparison has no runtime effect — the branch decision is baked in at compile time. If you intended to compare actual values, the operands likely need to be expressions that produce a value, not unit-returning calls.
+───╯
 program test.aleo;
 
 mapping values:

--- a/tests/expectations/compiler/bugs/b29314_assert_neq.out
+++ b/tests/expectations/compiler/bugs/b29314_assert_neq.out
@@ -1,3 +1,10 @@
+[WTYC0372006] Warning: Comparison `!=` between two operands of type `()` always evaluates to `false` at compile time.
+   ╭─[ compiler-test:6:20 ]
+   │
+ 6 │             assert(fin_foo(a) != fin_foo(a));
+   │ 
+   │ Help: Both operands have type `()` (e.g. the return type of `Mapping::set` or other side-effecting calls), so the comparison has no runtime effect — the branch decision is baked in at compile time. If you intended to compare actual values, the operands likely need to be expressions that produce a value, not unit-returning calls.
+───╯
 program test.aleo;
 
 mapping values:

--- a/tests/expectations/compiler/bugs/b29315_eq_binary.out
+++ b/tests/expectations/compiler/bugs/b29315_eq_binary.out
@@ -1,3 +1,10 @@
+[WTYC0372006] Warning: Comparison `==` between two operands of type `()` always evaluates to `true` at compile time.
+   ╭─[ compiler-test:5:31 ]
+   │
+ 5 │         return final { assert(Mapping::set(m, 0u32, 0u32) == Mapping::set(m, 0u32, 0u32)); };
+   │ 
+   │ Help: Both operands have type `()` (e.g. the return type of `Mapping::set` or other side-effecting calls), so the comparison has no runtime effect — the branch decision is baked in at compile time. If you intended to compare actual values, the operands likely need to be expressions that produce a value, not unit-returning calls.
+───╯
 program test.aleo;
 
 mapping m:


### PR DESCRIPTION


Fixes #29389 

The type checker silently accepts == and != between two operands of
type (), even though the comparison is mathematically a constant. The
most common way to hit this in Leo is comparing two Mapping::set calls,
which both return Type::Unit. A later const-prop pass folds the
comparison and codegen bakes one branch of any surrounding if/ternary
into the bytecode, silently changing the program from what the
developer wrote.

Emit WTYC0372xxx in this case so the developer is alerted at compile
time. Side effects are unchanged.
