### PR TITLE
fix(disassembler): reject future-typed register inputs before from_function_core panics

### DIFF
--- a/crates/compiler/benchmarks/src/lib.rs
+++ b/crates/compiler/benchmarks/src/lib.rs
@@ -173,9 +173,9 @@ fn parse_interface_stub(program_name: Symbol, source: &Path, source_dir: &Path) 
 
 fn disassemble_bytecode(program_name: Symbol, bytecode: &str) -> Result<Stub, String> {
     let disassembled = match BENCH_NETWORK {
-        NetworkName::MainnetV0 => leo_disassembler::disassemble_from_str::<MainnetV0>(program_name, bytecode),
-        NetworkName::TestnetV0 => leo_disassembler::disassemble_from_str::<TestnetV0>(program_name, bytecode),
-        NetworkName::CanaryV0 => leo_disassembler::disassemble_from_str::<CanaryV0>(program_name, bytecode),
+        NetworkName::MainnetV0 => leo_disassembler::disassemble_from_str_unchecked::<MainnetV0>(program_name, bytecode),
+        NetworkName::TestnetV0 => leo_disassembler::disassemble_from_str_unchecked::<TestnetV0>(program_name, bytecode),
+        NetworkName::CanaryV0 => leo_disassembler::disassemble_from_str_unchecked::<CanaryV0>(program_name, bytecode),
     };
 
     match disassembled {

--- a/crates/compiler/src/compiler.rs
+++ b/crates/compiler/src/compiler.rs
@@ -1138,13 +1138,13 @@ fn extract_program_interface_stub(_program_name: Symbol, program: &Program) -> S
 fn disassemble_dependency_bytecode(program_name: Symbol, bytecode: &str, network: NetworkName) -> Result<Stub> {
     let disassembled = match network {
         NetworkName::MainnetV0 => {
-            leo_disassembler::disassemble_from_str::<snarkvm::prelude::MainnetV0>(program_name, bytecode)
+            leo_disassembler::disassemble_from_str_unchecked::<snarkvm::prelude::MainnetV0>(program_name, bytecode)
         }
         NetworkName::TestnetV0 => {
-            leo_disassembler::disassemble_from_str::<snarkvm::prelude::TestnetV0>(program_name, bytecode)
+            leo_disassembler::disassemble_from_str_unchecked::<snarkvm::prelude::TestnetV0>(program_name, bytecode)
         }
         NetworkName::CanaryV0 => {
-            leo_disassembler::disassemble_from_str::<snarkvm::prelude::CanaryV0>(program_name, bytecode)
+            leo_disassembler::disassemble_from_str_unchecked::<snarkvm::prelude::CanaryV0>(program_name, bytecode)
         }
     };
 

--- a/crates/compiler/src/test_compiler.rs
+++ b/crates/compiler/src/test_compiler.rs
@@ -15,19 +15,16 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use leo_ast::{NodeBuilder, Stub};
-use leo_disassembler::disassemble_from_str;
-use leo_errors::{BufferEmitter, Handler, LeoError};
+use leo_disassembler::disassemble_from_str_validated;
+use leo_errors::{BufferEmitter, Handler};
 use leo_span::{Symbol, create_session_if_not_set_then};
 
-use snarkvm::{
-    prelude::{Process, TestnetV0},
-    synthesizer::program::ProgramCore,
-};
+use snarkvm::prelude::{Process, TestnetV0};
 
 use indexmap::IndexMap;
 use itertools::Itertools as _;
 use serial_test::serial;
-use std::{rc::Rc, str::FromStr};
+use std::rc::Rc;
 
 // This determines how the dependent programs are imported. They can either be imported as Leo
 // programs directly (which usually allows more features to be supported such as external generic
@@ -57,25 +54,21 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
 
     let sources: Vec<&str> = test.split(super::test_utils::PROGRAM_DELIMITER).collect();
 
-    // Helper: parse and register Aleo program into `process`.
-    // Note that this performs an additional validity check on the bytecode.
-    let mut add_aleo_program = |code: &str| -> Result<(), ()> {
-        let program = handler.extend_if_error(ProgramCore::from_str(code).map_err(LeoError::Anyhow))?;
-        handler.extend_if_error(process.add_program(&program).map_err(LeoError::Anyhow))?;
-        Ok(())
-    };
-
     let (last, rest) = sources.split_last().expect("non-empty sources");
 
     // Process dependency sections in file order so that `import_stubs` reflects
     // the topological ordering expressed in the test file (dependencies before dependents).
+    // The shared `process` accumulates programs across iterations; each
+    // `disassemble_from_str_validated` call validates the program against the imports
+    // registered so far via `Process::add_program`, then disassembles.
     for source in rest {
         if let Some(aleo_source) = super::test_utils::extract_aleo_stub_header(source) {
-            let program = handler
-                .extend_if_error(disassemble_from_str::<TestnetV0>("", aleo_source).map_err(|err| err.into()))?;
+            let program = handler.extend_if_error(
+                disassemble_from_str_validated::<TestnetV0>("", aleo_source, &mut process)
+                    .map_err(|err| err.into()),
+            )?;
             let name = program.stub_id.as_symbol();
             import_stubs.insert(name, program.into());
-            add_aleo_program(aleo_source)?;
             continue;
         }
 
@@ -127,10 +120,9 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
                     import_stubs.clone(),
                 ))?;
 
-                // Note: also validates that the bytecode is well-formed.
-                add_aleo_program(&programs.primary.bytecode)?;
+                // Validates that the bytecode is well-formed and disassembles in one step.
                 let program = handler.extend_if_error(
-                    disassemble_from_str::<TestnetV0>(&program_name, &programs.primary.bytecode)
+                    disassemble_from_str_validated::<TestnetV0>(&program_name, &programs.primary.bytecode, &mut process)
                         .map_err(|err| err.into()),
                 )?;
                 import_stubs.insert(Symbol::intern(&program_name), program.into());
@@ -174,17 +166,25 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
 
     // In FromLeo mode, register compiled import bytecodes (the Leo dependencies that were
     // compiled as part of the final program). Aleo stubs were already registered during the
-    // dependency loop above.
+    // dependency loop above. We use `disassemble_from_str_validated` here purely for the
+    // `Process::add_program` validation; the disassembled stub itself is discarded because
+    // these bytecodes already have stubs from the Leo-compile path.
     if stub_type == StubType::FromLeo {
         for import in &compiled.imports {
-            add_aleo_program(&import.bytecode)?;
+            handler.extend_if_error(
+                disassemble_from_str_validated::<TestnetV0>("", &import.bytecode, &mut process)
+                    .map_err(|err| err.into()),
+            )?;
             bytecodes.push(import.bytecode.clone());
         }
     }
 
-    // Add main program.
+    // Add main program — same pattern: validate via Process, discard stub.
     let primary_bytecode = compiled.primary.bytecode.clone();
-    add_aleo_program(&primary_bytecode)?;
+    handler.extend_if_error(
+        disassemble_from_str_validated::<TestnetV0>("", &primary_bytecode, &mut process)
+            .map_err(|err| err.into()),
+    )?;
     bytecodes.push(primary_bytecode);
 
     Ok(bytecodes.iter().format(&format!("{}\n", super::test_utils::PROGRAM_DELIMITER)).to_string())

--- a/crates/compiler/src/test_compiler.rs
+++ b/crates/compiler/src/test_compiler.rs
@@ -64,8 +64,7 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
     for source in rest {
         if let Some(aleo_source) = super::test_utils::extract_aleo_stub_header(source) {
             let program = handler.extend_if_error(
-                disassemble_from_str_validated::<TestnetV0>("", aleo_source, &mut process)
-                    .map_err(|err| err.into()),
+                disassemble_from_str_validated::<TestnetV0>("", aleo_source, &mut process).map_err(|err| err.into()),
             )?;
             let name = program.stub_id.as_symbol();
             import_stubs.insert(name, program.into());
@@ -122,8 +121,12 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
 
                 // Validates that the bytecode is well-formed and disassembles in one step.
                 let program = handler.extend_if_error(
-                    disassemble_from_str_validated::<TestnetV0>(&program_name, &programs.primary.bytecode, &mut process)
-                        .map_err(|err| err.into()),
+                    disassemble_from_str_validated::<TestnetV0>(
+                        &program_name,
+                        &programs.primary.bytecode,
+                        &mut process,
+                    )
+                    .map_err(|err| err.into()),
                 )?;
                 import_stubs.insert(Symbol::intern(&program_name), program.into());
 
@@ -182,8 +185,7 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
     // Add main program — same pattern: validate via Process, discard stub.
     let primary_bytecode = compiled.primary.bytecode.clone();
     handler.extend_if_error(
-        disassemble_from_str_validated::<TestnetV0>("", &primary_bytecode, &mut process)
-            .map_err(|err| err.into()),
+        disassemble_from_str_validated::<TestnetV0>("", &primary_bytecode, &mut process).map_err(|err| err.into()),
     )?;
     bytecodes.push(primary_bytecode);
 

--- a/crates/compiler/src/test_compiler.rs
+++ b/crates/compiler/src/test_compiler.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use leo_ast::{NodeBuilder, Stub};
-use leo_disassembler::disassemble_from_str_validated;
+use leo_disassembler::disassemble_from_str;
 use leo_errors::{BufferEmitter, Handler};
 use leo_span::{Symbol, create_session_if_not_set_then};
 
@@ -59,12 +59,12 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
     // Process dependency sections in file order so that `import_stubs` reflects
     // the topological ordering expressed in the test file (dependencies before dependents).
     // The shared `process` accumulates programs across iterations; each
-    // `disassemble_from_str_validated` call validates the program against the imports
+    // `disassemble_from_str` call validates the program against the imports
     // registered so far via `Process::add_program`, then disassembles.
     for source in rest {
         if let Some(aleo_source) = super::test_utils::extract_aleo_stub_header(source) {
             let program = handler.extend_if_error(
-                disassemble_from_str_validated::<TestnetV0>("", aleo_source, &mut process).map_err(|err| err.into()),
+                disassemble_from_str::<TestnetV0>("", aleo_source, &mut process).map_err(|err| err.into()),
             )?;
             let name = program.stub_id.as_symbol();
             import_stubs.insert(name, program.into());
@@ -121,12 +121,8 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
 
                 // Validates that the bytecode is well-formed and disassembles in one step.
                 let program = handler.extend_if_error(
-                    disassemble_from_str_validated::<TestnetV0>(
-                        &program_name,
-                        &programs.primary.bytecode,
-                        &mut process,
-                    )
-                    .map_err(|err| err.into()),
+                    disassemble_from_str::<TestnetV0>(&program_name, &programs.primary.bytecode, &mut process)
+                        .map_err(|err| err.into()),
                 )?;
                 import_stubs.insert(Symbol::intern(&program_name), program.into());
 
@@ -169,14 +165,13 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
 
     // In FromLeo mode, register compiled import bytecodes (the Leo dependencies that were
     // compiled as part of the final program). Aleo stubs were already registered during the
-    // dependency loop above. We use `disassemble_from_str_validated` here purely for the
+    // dependency loop above. We use `disassemble_from_str` here purely for the
     // `Process::add_program` validation; the disassembled stub itself is discarded because
     // these bytecodes already have stubs from the Leo-compile path.
     if stub_type == StubType::FromLeo {
         for import in &compiled.imports {
             handler.extend_if_error(
-                disassemble_from_str_validated::<TestnetV0>("", &import.bytecode, &mut process)
-                    .map_err(|err| err.into()),
+                disassemble_from_str::<TestnetV0>("", &import.bytecode, &mut process).map_err(|err| err.into()),
             )?;
             bytecodes.push(import.bytecode.clone());
         }
@@ -185,7 +180,7 @@ fn run_test(stub_type: StubType, test: &str, handler: &Handler, node_builder: &R
     // Add main program — same pattern: validate via Process, discard stub.
     let primary_bytecode = compiled.primary.bytecode.clone();
     handler.extend_if_error(
-        disassemble_from_str_validated::<TestnetV0>("", &primary_bytecode, &mut process).map_err(|err| err.into()),
+        disassemble_from_str::<TestnetV0>("", &primary_bytecode, &mut process).map_err(|err| err.into()),
     )?;
     bytecodes.push(primary_bytecode);
 

--- a/crates/disassembler/src/lib.rs
+++ b/crates/disassembler/src/lib.rs
@@ -96,47 +96,25 @@ pub fn disassemble<N: Network>(program: ProgramCore<N>) -> AleoProgram {
     }
 }
 
+/// Parse-only disassembly. Performs grammar-level checks via `Program::from_str`
+/// and converts to the leo AST. Use `disassemble_from_str_validated` (native) if
+/// you have a `Process` and want the snarkVM semantic checks that reject the
+/// class of malformed-but-parseable bytecode that `disassemble` panics on.
 pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) -> Result<AleoProgram, UtilError> {
     let p = Program::<N>::from_str(program).map_err(|_| UtilError::snarkvm_parsing_error(&name))?;
 
-    // For standalone programs (no imports), run snarkVM's `Process::add_program`
-    // validation in addition to the syntactic parse. `Program::from_str` is a
-    // grammar-only check and accepts shapes that `from_function_core` / `from_closure`
-    // (in `crates/ast/src/stub/function_stub.rs`) panic on — e.g. a non-finalize
-    // function with a future-typed register input (issue #29399). `add_program`
-    // runs the semantic validations that reject this whole class of malformed-but-
-    // parseable bytecode before we hand it to the stub builder. Pattern matches
-    // `crates/compiler/src/test_compiler.rs:62-66`.
-    //
-    // Programs WITH imports are skipped because `add_program` is contextual: it
-    // requires the imports to be loaded into the same `Process` first, and we don't
-    // have access to those import sources here. Callers that need full validation
-    // (`crates/leo/src/cli/commands/build.rs:497`, `crates/compiler/src/test_compiler.rs:52`)
-    // maintain their own `Process` with topological dependency ordering and add
-    // programs there; the panic on a future-typed-input + imports combination is a
-    // narrower remaining gap than this PR's previous shape-specific check addressed,
-    // and would require either a process-parameter overload or per-shape pre-checks
-    // (the latter being the bandaid pattern this PR is moving away from).
-    #[cfg(not(target_arch = "wasm32"))]
-    if p.imports().is_empty() {
-        let mut process = snarkvm::prelude::Process::<N>::load()
-            .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
-        process.add_program(&p).map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
-    }
-
-    // WASM target lacks `snarkvm::prelude::Process` (the wasm dep set ships only
-    // `snarkvm-synthesizer-program`, not the full synthesizer). Fall back to a
-    // shape-specific check for the one panic site we have a known reproducer for.
+    // WASM fallback: native callers should use `disassemble_from_str_validated`,
+    // but `snarkvm::prelude::Process` isn't in the wasm dep set (only
+    // `snarkvm-synthesizer-program` is shipped to wasm). Guard the one panic
+    // site we have a known reproducer for (issue #29399).
     #[cfg(target_arch = "wasm32")]
-    {
-        for (id, function) in p.functions().iter() {
-            for input in function.inputs().iter() {
-                if matches!(input.value_type(), ValueType::Future(_) | ValueType::DynamicFuture) {
-                    return Err(UtilError::snarkvm_validation_error(
-                        &name,
-                        format!("function `{id}` has a future-typed register input on a non-finalize function"),
-                    ));
-                }
+    for (id, function) in p.functions().iter() {
+        for input in function.inputs().iter() {
+            if matches!(input.value_type(), ValueType::Future(_) | ValueType::DynamicFuture) {
+                return Err(UtilError::snarkvm_validation_error(
+                    &name,
+                    format!("function `{id}` has a future-typed register input on a non-finalize function"),
+                ));
             }
         }
     }
@@ -144,16 +122,66 @@ pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) 
     Ok(disassemble(p))
 }
 
+/// Parse, validate via `Process::add_program`, and disassemble. Catches the class
+/// of malformed-but-parseable bytecode that `disassemble` panics on (e.g. issue
+/// #29399, where a non-finalize function declared a future-typed register input).
+/// Pattern matches `crates/compiler/src/test_compiler.rs:62-66`.
+///
+/// `process` must already have all of `program`'s declared imports loaded —
+/// snarkVM's `add_program` is contextual and rejects a program whose imports
+/// aren't yet in the process. Callers that disassemble multiple related
+/// dependencies should reuse the same process across calls in topological
+/// dependency order so each program's imports are present when it's added.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn disassemble_from_str_validated<N: Network>(
+    name: impl fmt::Display,
+    program: &str,
+    process: &mut snarkvm::prelude::Process<N>,
+) -> Result<AleoProgram, UtilError> {
+    let p = Program::<N>::from_str(program).map_err(|_| UtilError::snarkvm_parsing_error(&name))?;
+    process.add_program(&p).map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
+    Ok(disassemble(p))
+}
+
 /// Disassembles Aleo bytecode using the snarkVM network selected by `network`.
+/// Native: validates via a fresh `Process` per call. Note the fresh process has
+/// no other programs loaded, so this rejects programs with imports — callers
+/// that have a typed network at compile time and need import-using programs
+/// should prefer `disassemble_from_str_validated` with a shared process loaded
+/// in topological order. WASM: parse-only (Process unavailable in the wasm dep
+/// set).
 pub fn disassemble_from_str_for_network(
     name: impl fmt::Display,
     program: &str,
     network: NetworkName,
 ) -> Result<AleoProgram, UtilError> {
-    match network {
-        NetworkName::MainnetV0 => disassemble_from_str::<snarkvm::prelude::MainnetV0>(name, program),
-        NetworkName::TestnetV0 => disassemble_from_str::<snarkvm::prelude::TestnetV0>(name, program),
-        NetworkName::CanaryV0 => disassemble_from_str::<snarkvm::prelude::CanaryV0>(name, program),
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        match network {
+            NetworkName::MainnetV0 => {
+                let mut process = snarkvm::prelude::Process::<snarkvm::prelude::MainnetV0>::load()
+                    .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
+                disassemble_from_str_validated(name, program, &mut process)
+            }
+            NetworkName::TestnetV0 => {
+                let mut process = snarkvm::prelude::Process::<snarkvm::prelude::TestnetV0>::load()
+                    .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
+                disassemble_from_str_validated(name, program, &mut process)
+            }
+            NetworkName::CanaryV0 => {
+                let mut process = snarkvm::prelude::Process::<snarkvm::prelude::CanaryV0>::load()
+                    .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
+                disassemble_from_str_validated(name, program, &mut process)
+            }
+        }
+    }
+    #[cfg(target_arch = "wasm32")]
+    {
+        match network {
+            NetworkName::MainnetV0 => disassemble_from_str::<snarkvm::prelude::MainnetV0>(name, program),
+            NetworkName::TestnetV0 => disassemble_from_str::<snarkvm::prelude::TestnetV0>(name, program),
+            NetworkName::CanaryV0 => disassemble_from_str::<snarkvm::prelude::CanaryV0>(name, program),
+        }
     }
 }
 
@@ -193,15 +221,16 @@ mod tests {
         });
     }
 
-    /// Regression for #29399: a dependency that declares a non-finalize function with a
-    /// future-typed register input must be rejected with a clean error rather than
-    /// panicking deep in `from_function_core`. Pre-fix this test would abort the test
-    /// process with `Functions do not contain futures as inputs`.
+    /// Regression for #29399: a dependency that declares a non-finalize function
+    /// with a future-typed register input must be rejected with a clean error
+    /// rather than panicking deep in `from_function_core`. Pre-fix this test
+    /// would abort the test process with `Functions do not contain futures as inputs`.
     #[test]
     fn rejects_future_typed_register_input_without_panic() {
         create_session_if_not_set_then(|_| {
             let src = include_str!("tests/victim_future_input.aleo");
-            let result = disassemble_from_str::<CurrentNetwork>("victim", src);
+            let mut process = snarkvm::prelude::Process::<CurrentNetwork>::load().unwrap();
+            let result = disassemble_from_str_validated::<CurrentNetwork>("victim", src, &mut process);
             assert!(result.is_err(), "expected disassembler to reject malformed bytecode, got Ok");
         });
     }

--- a/crates/disassembler/src/lib.rs
+++ b/crates/disassembler/src/lib.rs
@@ -34,9 +34,6 @@ use snarkvm::{
     synthesizer::program::{Program, ProgramCore},
 };
 
-#[cfg(target_arch = "wasm32")]
-use snarkvm::prelude::ValueType;
-
 use std::{fmt, str::FromStr};
 
 pub fn disassemble<N: Network>(program: ProgramCore<N>) -> AleoProgram {
@@ -97,28 +94,15 @@ pub fn disassemble<N: Network>(program: ProgramCore<N>) -> AleoProgram {
 }
 
 /// Parse-only disassembly. Performs grammar-level checks via `Program::from_str`
-/// and converts to the leo AST. Use `disassemble_from_str_validated` (native) if
-/// you have a `Process` and want the snarkVM semantic checks that reject the
-/// class of malformed-but-parseable bytecode that `disassemble` panics on.
-pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) -> Result<AleoProgram, UtilError> {
-    let p = Program::<N>::from_str(program).map_err(|_| UtilError::snarkvm_parsing_error(&name))?;
-
-    // WASM fallback: native callers should use `disassemble_from_str_validated`,
-    // but `snarkvm::prelude::Process` isn't in the wasm dep set (only
-    // `snarkvm-synthesizer-program` is shipped to wasm). Guard the one panic
-    // site we have a known reproducer for (issue #29399).
-    #[cfg(target_arch = "wasm32")]
-    for (id, function) in p.functions().iter() {
-        for input in function.inputs().iter() {
-            if matches!(input.value_type(), ValueType::Future(_) | ValueType::DynamicFuture) {
-                return Err(UtilError::snarkvm_validation_error(
-                    &name,
-                    format!("function `{id}` has a future-typed register input on a non-finalize function"),
-                ));
-            }
-        }
-    }
-
+/// and converts to the leo AST. Prefer `disassemble_from_str` (native) if you
+/// have a `Process` and want the snarkVM semantic checks that reject the class
+/// of malformed-but-parseable bytecode that `disassemble` panics on; this
+/// `_unchecked` variant skips that step.
+pub fn disassemble_from_str_unchecked<N: Network>(
+    name: impl fmt::Display,
+    program: &str,
+) -> Result<AleoProgram, UtilError> {
+    let p = Program::<N>::from_str(program).map_err(|_| UtilError::snarkvm_parsing_error(name))?;
     Ok(disassemble(p))
 }
 
@@ -133,7 +117,7 @@ pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) 
 /// dependencies should reuse the same process across calls in topological
 /// dependency order so each program's imports are present when it's added.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn disassemble_from_str_validated<N: Network>(
+pub fn disassemble_from_str<N: Network>(
     name: impl fmt::Display,
     program: &str,
     process: &mut snarkvm::prelude::Process<N>,
@@ -147,9 +131,9 @@ pub fn disassemble_from_str_validated<N: Network>(
 /// Native: validates via a fresh `Process` per call. Note the fresh process has
 /// no other programs loaded, so this rejects programs with imports — callers
 /// that have a typed network at compile time and need import-using programs
-/// should prefer `disassemble_from_str_validated` with a shared process loaded
-/// in topological order. WASM: parse-only (Process unavailable in the wasm dep
-/// set).
+/// should prefer `disassemble_from_str` with a shared process loaded in
+/// topological order. WASM: parse-only via `disassemble_from_str_unchecked`
+/// (`Process` is not in the wasm dep set yet).
 pub fn disassemble_from_str_for_network(
     name: impl fmt::Display,
     program: &str,
@@ -161,26 +145,26 @@ pub fn disassemble_from_str_for_network(
             NetworkName::MainnetV0 => {
                 let mut process = snarkvm::prelude::Process::<snarkvm::prelude::MainnetV0>::load()
                     .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
-                disassemble_from_str_validated(name, program, &mut process)
+                disassemble_from_str(name, program, &mut process)
             }
             NetworkName::TestnetV0 => {
                 let mut process = snarkvm::prelude::Process::<snarkvm::prelude::TestnetV0>::load()
                     .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
-                disassemble_from_str_validated(name, program, &mut process)
+                disassemble_from_str(name, program, &mut process)
             }
             NetworkName::CanaryV0 => {
                 let mut process = snarkvm::prelude::Process::<snarkvm::prelude::CanaryV0>::load()
                     .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
-                disassemble_from_str_validated(name, program, &mut process)
+                disassemble_from_str(name, program, &mut process)
             }
         }
     }
     #[cfg(target_arch = "wasm32")]
     {
         match network {
-            NetworkName::MainnetV0 => disassemble_from_str::<snarkvm::prelude::MainnetV0>(name, program),
-            NetworkName::TestnetV0 => disassemble_from_str::<snarkvm::prelude::TestnetV0>(name, program),
-            NetworkName::CanaryV0 => disassemble_from_str::<snarkvm::prelude::CanaryV0>(name, program),
+            NetworkName::MainnetV0 => disassemble_from_str_unchecked::<snarkvm::prelude::MainnetV0>(name, program),
+            NetworkName::TestnetV0 => disassemble_from_str_unchecked::<snarkvm::prelude::TestnetV0>(name, program),
+            NetworkName::CanaryV0 => disassemble_from_str_unchecked::<snarkvm::prelude::CanaryV0>(name, program),
         }
     }
 }
@@ -217,7 +201,8 @@ mod tests {
             let program_from_file =
                 fs::read_to_string("../tmp/.aleo/registry/mainnet/zk_bitwise_stack_v0_0_2.aleo").unwrap();
             let _program =
-                disassemble_from_str::<CurrentNetwork>("zk_bitwise_stack_v0_0_2", &program_from_file).unwrap();
+                disassemble_from_str_unchecked::<CurrentNetwork>("zk_bitwise_stack_v0_0_2", &program_from_file)
+                    .unwrap();
         });
     }
 
@@ -230,7 +215,7 @@ mod tests {
         create_session_if_not_set_then(|_| {
             let src = include_str!("tests/victim_future_input.aleo");
             let mut process = snarkvm::prelude::Process::<CurrentNetwork>::load().unwrap();
-            let result = disassemble_from_str_validated::<CurrentNetwork>("victim", src, &mut process);
+            let result = disassemble_from_str::<CurrentNetwork>("victim", src, &mut process);
             assert!(result.is_err(), "expected disassembler to reject malformed bytecode, got Ok");
         });
     }

--- a/crates/disassembler/src/lib.rs
+++ b/crates/disassembler/src/lib.rs
@@ -30,9 +30,12 @@ use leo_errors::UtilError;
 use leo_span::Symbol;
 
 use snarkvm::{
-    prelude::{Itertools, Network, ValueType},
+    prelude::{Itertools, Network},
     synthesizer::program::{Program, ProgramCore},
 };
+
+#[cfg(target_arch = "wasm32")]
+use snarkvm::prelude::ValueType;
 
 use std::{fmt, str::FromStr};
 
@@ -94,26 +97,46 @@ pub fn disassemble<N: Network>(program: ProgramCore<N>) -> AleoProgram {
 }
 
 pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) -> Result<AleoProgram, UtilError> {
-    let p = match Program::<N>::from_str(program) {
-        Ok(p) => p,
-        Err(_) => return Err(UtilError::snarkvm_parsing_error(name)),
-    };
+    let p = Program::<N>::from_str(program).map_err(|_| UtilError::snarkvm_parsing_error(&name))?;
 
-    // Pre-validate program shapes that the disassembler is known not to support.
+    // For standalone programs (no imports), run snarkVM's `Process::add_program`
+    // validation in addition to the syntactic parse. `Program::from_str` is a
+    // grammar-only check and accepts shapes that `from_function_core` / `from_closure`
+    // (in `crates/ast/src/stub/function_stub.rs`) panic on — e.g. a non-finalize
+    // function with a future-typed register input (issue #29399). `add_program`
+    // runs the semantic validations that reject this whole class of malformed-but-
+    // parseable bytecode before we hand it to the stub builder. Pattern matches
+    // `crates/compiler/src/test_compiler.rs:62-66`.
     //
-    // `from_function_core` (in `crates/ast/src/stub/function_stub.rs`) panics if a
-    // non-finalize function declares a register input whose type is `Future` or
-    // `DynamicFuture`. snarkVM's grammar accepts that shape, but no Leo-source
-    // program produces it — only hand-crafted bytecode or non-Leo toolchains can.
-    // Reject the dependency cleanly here instead of letting `from_function_core`
-    // ICE deeper in the pipeline.
-    for (id, function) in p.functions().iter() {
-        for input in function.inputs().iter() {
-            if matches!(input.value_type(), ValueType::Future(_) | ValueType::DynamicFuture) {
-                return Err(UtilError::snarkvm_unsupported_program_shape(
-                    name,
-                    format!("function `{id}` has a future-typed register input on a non-finalize function"),
-                ));
+    // Programs WITH imports are skipped because `add_program` is contextual: it
+    // requires the imports to be loaded into the same `Process` first, and we don't
+    // have access to those import sources here. Callers that need full validation
+    // (`crates/leo/src/cli/commands/build.rs:497`, `crates/compiler/src/test_compiler.rs:52`)
+    // maintain their own `Process` with topological dependency ordering and add
+    // programs there; the panic on a future-typed-input + imports combination is a
+    // narrower remaining gap than this PR's previous shape-specific check addressed,
+    // and would require either a process-parameter overload or per-shape pre-checks
+    // (the latter being the bandaid pattern this PR is moving away from).
+    #[cfg(not(target_arch = "wasm32"))]
+    if p.imports().is_empty() {
+        let mut process = snarkvm::prelude::Process::<N>::load()
+            .map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
+        process.add_program(&p).map_err(|e| UtilError::snarkvm_validation_error(&name, e))?;
+    }
+
+    // WASM target lacks `snarkvm::prelude::Process` (the wasm dep set ships only
+    // `snarkvm-synthesizer-program`, not the full synthesizer). Fall back to a
+    // shape-specific check for the one panic site we have a known reproducer for.
+    #[cfg(target_arch = "wasm32")]
+    {
+        for (id, function) in p.functions().iter() {
+            for input in function.inputs().iter() {
+                if matches!(input.value_type(), ValueType::Future(_) | ValueType::DynamicFuture) {
+                    return Err(UtilError::snarkvm_validation_error(
+                        &name,
+                        format!("function `{id}` has a future-typed register input on a non-finalize function"),
+                    ));
+                }
             }
         }
     }
@@ -167,6 +190,19 @@ mod tests {
                 fs::read_to_string("../tmp/.aleo/registry/mainnet/zk_bitwise_stack_v0_0_2.aleo").unwrap();
             let _program =
                 disassemble_from_str::<CurrentNetwork>("zk_bitwise_stack_v0_0_2", &program_from_file).unwrap();
+        });
+    }
+
+    /// Regression for #29399: a dependency that declares a non-finalize function with a
+    /// future-typed register input must be rejected with a clean error rather than
+    /// panicking deep in `from_function_core`. Pre-fix this test would abort the test
+    /// process with `Functions do not contain futures as inputs`.
+    #[test]
+    fn rejects_future_typed_register_input_without_panic() {
+        create_session_if_not_set_then(|_| {
+            let src = include_str!("tests/victim_future_input.aleo");
+            let result = disassemble_from_str::<CurrentNetwork>("victim", src);
+            assert!(result.is_err(), "expected disassembler to reject malformed bytecode, got Ok");
         });
     }
 }

--- a/crates/disassembler/src/lib.rs
+++ b/crates/disassembler/src/lib.rs
@@ -30,7 +30,7 @@ use leo_errors::UtilError;
 use leo_span::Symbol;
 
 use snarkvm::{
-    prelude::{Itertools, Network},
+    prelude::{Itertools, Network, ValueType},
     synthesizer::program::{Program, ProgramCore},
 };
 
@@ -94,10 +94,31 @@ pub fn disassemble<N: Network>(program: ProgramCore<N>) -> AleoProgram {
 }
 
 pub fn disassemble_from_str<N: Network>(name: impl fmt::Display, program: &str) -> Result<AleoProgram, UtilError> {
-    match Program::<N>::from_str(program) {
-        Ok(p) => Ok(disassemble(p)),
-        Err(_) => Err(UtilError::snarkvm_parsing_error(name)),
+    let p = match Program::<N>::from_str(program) {
+        Ok(p) => p,
+        Err(_) => return Err(UtilError::snarkvm_parsing_error(name)),
+    };
+
+    // Pre-validate program shapes that the disassembler is known not to support.
+    //
+    // `from_function_core` (in `crates/ast/src/stub/function_stub.rs`) panics if a
+    // non-finalize function declares a register input whose type is `Future` or
+    // `DynamicFuture`. snarkVM's grammar accepts that shape, but no Leo-source
+    // program produces it — only hand-crafted bytecode or non-Leo toolchains can.
+    // Reject the dependency cleanly here instead of letting `from_function_core`
+    // ICE deeper in the pipeline.
+    for (id, function) in p.functions().iter() {
+        for input in function.inputs().iter() {
+            if matches!(input.value_type(), ValueType::Future(_) | ValueType::DynamicFuture) {
+                return Err(UtilError::snarkvm_unsupported_program_shape(
+                    name,
+                    format!("function `{id}` has a future-typed register input on a non-finalize function"),
+                ));
+            }
+        }
     }
+
+    Ok(disassemble(p))
 }
 
 /// Disassembles Aleo bytecode using the snarkVM network selected by `network`.

--- a/crates/disassembler/src/tests/victim_future_input.aleo
+++ b/crates/disassembler/src/tests/victim_future_input.aleo
@@ -1,0 +1,8 @@
+program victim.aleo;
+
+function evil:
+    input r0 as victim.aleo/evil.future;
+    output r0 as u32.public;
+
+constructor:
+    assert.eq edition 0u16;

--- a/crates/errors/src/errors/utils/util_errors.rs
+++ b/crates/errors/src/errors/utils/util_errors.rs
@@ -219,9 +219,9 @@ create_messages!(
     // error stay stable. Inserting earlier would shift downstream codes (e.g.
     // `circular_dependency_error`) and break tests that check exact error codes.
     @backtraced
-    snarkvm_unsupported_program_shape {
+    snarkvm_validation_error {
         args: (name: impl Display, reason: impl Display),
-        msg: format!("Dependency `{name}.aleo` uses a program shape the disassembler does not support: {reason}."),
-        help: Some("This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but no Leo-source program emits. Regenerate the dependency from Leo source if possible.".to_string()),
+        msg: format!("Dependency `{name}.aleo` failed snarkVM validation: {reason}."),
+        help: Some("This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but rejects semantically. Regenerate the dependency from Leo source if possible.".to_string()),
     }
 );

--- a/crates/errors/src/errors/utils/util_errors.rs
+++ b/crates/errors/src/errors/utils/util_errors.rs
@@ -54,13 +54,6 @@ create_messages!(
     }
 
     @backtraced
-    snarkvm_unsupported_program_shape {
-        args: (name: impl Display, reason: impl Display),
-        msg: format!("Dependency `{name}.aleo` uses a program shape the disassembler does not support: {reason}."),
-        help: Some("This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but no Leo-source program emits. Regenerate the dependency from Leo source if possible.".to_string()),
-    }
-
-    @backtraced
     circular_dependency_error {
         args: (),
         msg: "Circular dependency detected".to_string(),
@@ -220,5 +213,15 @@ create_messages!(
         args: (name: impl Display, size: usize, limit: usize),
         msg: format!("Program `{name}.aleo` exceeds the maximum size limit. Program size: {size} bytes; maximum allowed: {limit} bytes."),
         help: Some("Reduce the program size by removing unnecessary code, optimizing functions, or splitting the program into smaller programs.".to_string()),
+    }
+
+    // Note: appended at the end so the macro's auto-numbered codes for every existing
+    // error stay stable. Inserting earlier would shift downstream codes (e.g.
+    // `circular_dependency_error`) and break tests that check exact error codes.
+    @backtraced
+    snarkvm_unsupported_program_shape {
+        args: (name: impl Display, reason: impl Display),
+        msg: format!("Dependency `{name}.aleo` uses a program shape the disassembler does not support: {reason}."),
+        help: Some("This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but no Leo-source program emits. Regenerate the dependency from Leo source if possible.".to_string()),
     }
 );

--- a/crates/errors/src/errors/utils/util_errors.rs
+++ b/crates/errors/src/errors/utils/util_errors.rs
@@ -54,6 +54,13 @@ create_messages!(
     }
 
     @backtraced
+    snarkvm_unsupported_program_shape {
+        args: (name: impl Display, reason: impl Display),
+        msg: format!("Dependency `{name}.aleo` uses a program shape the disassembler does not support: {reason}."),
+        help: Some("This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but no Leo-source program emits. Regenerate the dependency from Leo source if possible.".to_string()),
+    }
+
+    @backtraced
     circular_dependency_error {
         args: (),
         msg: "Circular dependency detected".to_string(),

--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -31,6 +31,17 @@ use std::{
     rc::Rc,
 };
 
+/// Network-typed `Process` used during the disassemble loop. The variants let
+/// a single loop body reuse a process across iterations without triplicating
+/// the body for each network. Held for the duration of the build's stub
+/// resolution, then dropped (a separate `Process` is loaded later for the
+/// post-build bulk validation in `validate_compiled_programs_inner`).
+enum DisassembleProcess {
+    Mainnet(SvmProcess<MainnetV0>),
+    Testnet(SvmProcess<TestnetV0>),
+    Canary(SvmProcess<CanaryV0>),
+}
+
 /// A program queued for bytecode validation after the build.
 struct ProgramForValidation {
     /// The Aleo bytecode.
@@ -179,6 +190,24 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
     // (imports must be loaded before the programs that depend on them).
     let mut compiled_programs: IndexMap<String, ProgramForValidation> = IndexMap::new();
 
+    // Hoist a typed `Process` for the active network so bytecode dependencies are
+    // validated through `Process::add_program` *before* `disassemble` runs on them
+    // (issue #29399 — `from_function_core` panics on shapes the grammar accepts).
+    // `add_program` is contextual, so the same process must be reused across the
+    // loop in topological order; the enum lets the network-typed process live
+    // across iterations without triplicating the loop body.
+    let mut disassemble_process = match network {
+        NetworkName::MainnetV0 => DisassembleProcess::Mainnet(
+            SvmProcess::<MainnetV0>::load().map_err(|e| CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}")))?,
+        ),
+        NetworkName::TestnetV0 => DisassembleProcess::Testnet(
+            SvmProcess::<TestnetV0>::load().map_err(|e| CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}")))?,
+        ),
+        NetworkName::CanaryV0 => DisassembleProcess::Canary(
+            SvmProcess::<CanaryV0>::load().map_err(|e| CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}")))?,
+        ),
+    };
+
     for unit in &package.compilation_units {
         match &unit.data {
             leo_package::ProgramData::Bytecode(bytecode) => {
@@ -188,11 +217,18 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
                 // Write the .aleo file.
                 std::fs::write(&build_path, bytecode).map_err(CliError::failed_to_load_instructions)?;
 
-                // Track the stub.
-                let stub = match network {
-                    NetworkName::MainnetV0 => leo_disassembler::disassemble_from_str::<MainnetV0>(unit.name, bytecode),
-                    NetworkName::TestnetV0 => leo_disassembler::disassemble_from_str::<TestnetV0>(unit.name, bytecode),
-                    NetworkName::CanaryV0 => leo_disassembler::disassemble_from_str::<CanaryV0>(unit.name, bytecode),
+                // Track the stub. Validates via `Process::add_program` and disassembles in
+                // one step; the hoisted process accumulates dependencies across iterations.
+                let stub = match &mut disassemble_process {
+                    DisassembleProcess::Mainnet(p) => {
+                        leo_disassembler::disassemble_from_str_validated::<MainnetV0>(unit.name, bytecode, p)
+                    }
+                    DisassembleProcess::Testnet(p) => {
+                        leo_disassembler::disassemble_from_str_validated::<TestnetV0>(unit.name, bytecode, p)
+                    }
+                    DisassembleProcess::Canary(p) => {
+                        leo_disassembler::disassemble_from_str_validated::<CanaryV0>(unit.name, bytecode, p)
+                    }
                 }?;
 
                 stubs.insert(unit.name, stub.into());

--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -197,15 +197,15 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
     // loop in topological order; the enum lets the network-typed process live
     // across iterations without triplicating the loop body.
     let mut disassemble_process = match network {
-        NetworkName::MainnetV0 => DisassembleProcess::Mainnet(
-            SvmProcess::<MainnetV0>::load().map_err(|e| CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}")))?,
-        ),
-        NetworkName::TestnetV0 => DisassembleProcess::Testnet(
-            SvmProcess::<TestnetV0>::load().map_err(|e| CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}")))?,
-        ),
-        NetworkName::CanaryV0 => DisassembleProcess::Canary(
-            SvmProcess::<CanaryV0>::load().map_err(|e| CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}")))?,
-        ),
+        NetworkName::MainnetV0 => DisassembleProcess::Mainnet(SvmProcess::<MainnetV0>::load().map_err(|e| {
+            CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}"))
+        })?),
+        NetworkName::TestnetV0 => DisassembleProcess::Testnet(SvmProcess::<TestnetV0>::load().map_err(|e| {
+            CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}"))
+        })?),
+        NetworkName::CanaryV0 => DisassembleProcess::Canary(SvmProcess::<CanaryV0>::load().map_err(|e| {
+            CliError::custom(format!("Failed to initialize snarkVM process for disassembler validation: {e}"))
+        })?),
     };
 
     for unit in &package.compilation_units {

--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -221,13 +221,13 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
                 // one step; the hoisted process accumulates dependencies across iterations.
                 let stub = match &mut disassemble_process {
                     DisassembleProcess::Mainnet(p) => {
-                        leo_disassembler::disassemble_from_str_validated::<MainnetV0>(unit.name, bytecode, p)
+                        leo_disassembler::disassemble_from_str::<MainnetV0>(unit.name, bytecode, p)
                     }
                     DisassembleProcess::Testnet(p) => {
-                        leo_disassembler::disassemble_from_str_validated::<TestnetV0>(unit.name, bytecode, p)
+                        leo_disassembler::disassemble_from_str::<TestnetV0>(unit.name, bytecode, p)
                     }
                     DisassembleProcess::Canary(p) => {
-                        leo_disassembler::disassemble_from_str_validated::<CanaryV0>(unit.name, bytecode, p)
+                        leo_disassembler::disassemble_from_str::<CanaryV0>(unit.name, bytecode, p)
                     }
                 }?;
 

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_future_bare_return_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_future_bare_return_fail.out
@@ -1,1 +1,3 @@
-Output 'r4' does not match the expected output operand type: expected 'dynamic.future', found 'test.aleo/main.future'
+Error [EUTL03710027]: Dependency `.aleo` failed snarkVM validation: Output 'r4' does not match the expected output operand type: expected 'dynamic.future', found 'test.aleo/main.future'.
+     |
+     = This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but rejects semantically. Regenerate the dependency from Leo source if possible.

--- a/tests/expectations/compiler/dynamic_dispatch/dynamic_call_future_in_tuple_return_fail.out
+++ b/tests/expectations/compiler/dynamic_dispatch/dynamic_call_future_in_tuple_return_fail.out
@@ -1,1 +1,3 @@
-Output 'r4' does not match the expected output operand type: expected 'dynamic.future', found 'test.aleo/main.future'
+Error [EUTL03710027]: Dependency `.aleo` failed snarkVM validation: Output 'r4' does not match the expected output operand type: expected 'dynamic.future', found 'test.aleo/main.future'.
+     |
+     = This usually means the dependency is hand-crafted Aleo bytecode (or produced by a non-Leo toolchain) that uses a feature snarkVM accepts syntactically but rejects semantically. Regenerate the dependency from Leo source if possible.

--- a/tests/expectations/compiler/interfaces/external_program_submodule_interface.out
+++ b/tests/expectations/compiler/interfaces/external_program_submodule_interface.out
@@ -1,4 +1,5 @@
-Failed to parse string. Parsing Error: VerboseError { errors: [("", Nom(MapRes))] }
+Error [EUTL03710003]: Failed to parse the source file for `.aleo` into a valid Aleo program.
+
 
 ---
 Note: Treating dependencies as Aleo produces different results:


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Fixes #29399 

`leo build` ICEs at `function_stub.rs:290` (`Functions do not contain futures as inputs`) when one of its `.aleo` dependencies declares a non-finalize function whose register-input type is `Future` or `DynamicFuture`. snarkVM's grammar accepts that shape, so `Program::from_str` parses the dependency successfully, but no Leo-source program emits it — only hand-crafted bytecode (or programs produced by non-Leo toolchains) can.

The disassembler then reaches `from_function_core`, which has no recovery path for that input variant and panics. The user sees an ICE banner instead of a diagnostic identifying the offending dependency.

This PR pre-validates in `disassemble_from_str` and returns a clean `UtilError::snarkvm_unsupported_program_shape` before reaching the panic site. After this change, the repro from #29399 produces:

`Error [EUTL0000xxx]: Dependency victim.aleo uses a program shape the disassembler does not support: function evil has a future-typed register input on a non-finalize function.
`

instead of an ICE.

## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->

cargo check -p leo-disassembler