### PR TITLE
fix(typeck): close stack-overflow on struct that recurses through Opt…

### DIFF
--- a/tests/expectations/compiler/structs/cyclic_optional_struct_array_of_optional_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_optional_struct_array_of_optional_fail.out
@@ -1,0 +1,6 @@
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/Node` --> `test.aleo/Node`
+   ╭─[ compiler-test:4:14 ]
+   │
+   │ 
+───╯
+[ETYC0372083] Error: A program must have at least one entry point fn.

--- a/tests/expectations/compiler/structs/cyclic_optional_struct_mutual_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_optional_struct_mutual_fail.out
@@ -1,0 +1,10 @@
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/A` --> `test.aleo/B` --> `test.aleo/A`
+   ╭─[ compiler-test:2:8 ]
+   │
+ 2 │ struct A {
+───╯
+[ETYC0372083] Error: A program must have at least one entry point fn.
+    ╭─[ compiler-test:10:9 ]
+    │
+ 10 │ program test.aleo {}
+────╯

--- a/tests/expectations/compiler/structs/cyclic_optional_struct_optional_array_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_optional_struct_optional_array_fail.out
@@ -1,0 +1,6 @@
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/Node` --> `test.aleo/Node`
+   ╭─[ compiler-test:4:14 ]
+   │
+   │ 
+───╯
+[ETYC0372083] Error: A program must have at least one entry point fn.

--- a/tests/expectations/compiler/structs/cyclic_optional_struct_three_cycle_fail.out
+++ b/tests/expectations/compiler/structs/cyclic_optional_struct_three_cycle_fail.out
@@ -1,0 +1,10 @@
+[ETYC0372058] Error: Cyclic dependency between composites: `test.aleo/A` --> `test.aleo/B` --> `test.aleo/C` --> `test.aleo/A`
+   ╭─[ compiler-test:2:8 ]
+   │
+ 2 │ struct A {
+───╯
+[ETYC0372083] Error: A program must have at least one entry point fn.
+    ╭─[ compiler-test:14:9 ]
+    │
+ 14 │ program test.aleo {}
+────╯

--- a/tests/tests/compiler/structs/cyclic_optional_struct_array_of_optional_fail.leo
+++ b/tests/tests/compiler/structs/cyclic_optional_struct_array_of_optional_fail.leo
@@ -1,0 +1,8 @@
+// Regression for #29405: recursion via `[Self?; N]` (Array of Optional of Composite).
+// Exercises Type::Array(Type::Optional(Type::Composite(_))) — the composite-graph edge
+// insertion must traverse Array → Optional → Composite to record the self-edge.
+struct Node {
+    kids: [Node?; 2],
+}
+
+program test.aleo {}

--- a/tests/tests/compiler/structs/cyclic_optional_struct_mutual_fail.leo
+++ b/tests/tests/compiler/structs/cyclic_optional_struct_mutual_fail.leo
@@ -1,0 +1,10 @@
+// Regression for #29405: mutual recursion through `Option` fields.
+struct A {
+    b: B?,
+}
+
+struct B {
+    a: A?,
+}
+
+program test.aleo {}

--- a/tests/tests/compiler/structs/cyclic_optional_struct_optional_array_fail.leo
+++ b/tests/tests/compiler/structs/cyclic_optional_struct_optional_array_fail.leo
@@ -1,0 +1,8 @@
+// Regression for #29405: recursion via `[Self; N]?` (Optional of Array of Composite).
+// Exercises Type::Optional(Type::Array(Type::Composite(_))) — the composite-graph edge
+// insertion must traverse Optional → Array → Composite to record the self-edge.
+struct Node {
+    kids: [Node; 1]?,
+}
+
+program test.aleo {}

--- a/tests/tests/compiler/structs/cyclic_optional_struct_three_cycle_fail.leo
+++ b/tests/tests/compiler/structs/cyclic_optional_struct_three_cycle_fail.leo
@@ -1,0 +1,14 @@
+// Regression for #29405: 3-cycle A -> B? -> C? -> A?.
+struct A {
+    b: B?,
+}
+
+struct B {
+    c: C?,
+}
+
+struct C {
+    a: A?,
+}
+
+program test.aleo {}


### PR DESCRIPTION
…ion (#29405)


<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Closes #29405 

A struct that recurses through `Option` — directly (`struct Node { next: Node? }`), mutually (`A -> B? -> A?`), or via an array of optionals (`[Self?; N]`, `[Self; N]?`) — drives the type-checker into an uncatchable stack overflow: the compiler aborts mid-typeck with `fatal runtime error: stack overflow, aborting`, no diagnostic, no exit code. The equivalent non-`Option` form (`struct Node { next: Node }`) already produces a clean `ETYC0372058 Cyclic dependency between composites`, which is exactly the diagnostic this case should emit.

Two cooperating gaps in `crates/passes/src/type_checking/`:

1. **`program.rs`** — composite-dependency-graph edge insertion handled `Type::Composite` and `Type::Array` members but had no arm for `Type::Optional(Composite(_))`. A field typed `Foo?` added no edge, so the cycle check at the top of `visit_program_scope` never fired.
2. **`visitor.rs`** — `disallowed_inside_optional` recursed through composite member types, unwrapping any field-level `Option`, with no visited-set tracking. For `Node { next: Node? }` the recursion descended `Node → unwrap(Node?) → Node → …` without termination.

**Fix:**
- Replaced the explicit `Composite`/`Array` match in `program.rs` with a small recursive helper `unwrap_to_composite_path` that peels arbitrarily layered `Array` and `Optional` wrappers down to the base `Composite`. Strictly more general than the original two-arm version — handles `Foo`, `[Foo; N]`, `Foo?`, `[Foo?; N]`, `[Foo; N]?`, and any nested combination.
- Mirrored the visited-set pattern from the sibling helper `contains_optional_type_inner` into `disallowed_inside_optional` via a thin `_inner` helper that carries an `IndexSet<Vec<Symbol>>` of already-visited composite paths.

After the fix all the recursive-`Option` shapes report `ETYC0372058` cleanly and exit non-zero.


## Test Plan

<!--
    If you changed any code,
    please provide us with clear instructions on how you verified your changes work.
    Bonus points for screenshots and videos!
-->
Added 5 regression tests under `tests/tests/compiler/structs/`:

| Test | Shape | Cycle in expectation |
|---|---|---|
| `cyclic_optional_struct_direct_fail.leo` | `Node { next: Node? }` | `Node → Node` |
| `cyclic_optional_struct_mutual_fail.leo` | `A { b: B? } / B { a: A? }` | `A → B → A` |
| `cyclic_optional_struct_three_cycle_fail.leo` | `A → B? → C? → A?` | `A → B → C → A` |
| `cyclic_optional_struct_array_of_optional_fail.leo` | `Node { kids: [Node?; 2] }` | `Node → Node` |
| `cyclic_optional_struct_optional_array_fail.leo` | `Node { kids: [Node; 1]? }` | `Node → Node` |

Pre-fix each test panics with the stack overflow; post-fix each emits `ETYC0372058 Cyclic dependency between composites`.

```sh
# Just the new ones
TEST_FILTER=cyclic_optional_struct cargo test -p leo-compiler test_compiler

# Full `structs` category (46 tests, includes pre-existing cyclic_structs_* coverage)
TEST_FILTER=structs cargo test -p leo-compiler test_compiler

# Full compiler suite
cargo test -p leo-compiler test_compiler
```

Verified locally on macOS Darwin 25.4.0, rustc 1.95.0:
- 5 new tests pass
- 41 pre-existing `structs` tests untouched (no regressions)
- Full `compiler` test suite passes
