### PR TITLE
feat(LSP) Implement find all references.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,6 +2447,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "tracing-subscriber",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -6261,6 +6262,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ tracing-subscriber = { version = "0.3", features = [ "env-filter", "fmt" ] }
 ureq               = { version = "3.0", features = [ "json" ] }
 walkdir            = "2.5"
 which              = "8.0"
+xxhash-rust       = { version = "0.8", features = [ "xxh3" ] }
 
 [profile.release]
 opt-level = 3

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -40,6 +40,7 @@ lsp-types          = { workspace = true }
 serde_json         = { workspace = true }
 tracing            = { workspace = true }
 tracing-subscriber = { workspace = true }
+xxhash-rust        = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/lsp/src/compiler_bridge.rs
+++ b/crates/lsp/src/compiler_bridge.rs
@@ -27,7 +27,7 @@
 
 use crate::{
     document_store::{AnalysisBucket, DocumentSnapshot, DocumentViewSnapshot, OpenFileOverlay},
-    features::semantic_tokens::encode_tokens,
+    features::{lsp_range::hash_text, semantic_tokens::encode_tokens},
     project_model::ProjectContext,
     semantics::{
         CachedDocumentView,
@@ -119,10 +119,24 @@ pub struct PackageWorkerAnalysis {
 }
 
 /// Worker-local cache of package dependency stubs.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct PackageAnalysisCache {
     entries: HashMap<PathBuf, PackageAnalysisCacheEntry>,
     order: VecDeque<PathBuf>,
+    network_sentinel: Arc<PathBuf>,
+    library_sentinel: Arc<PathBuf>,
+}
+
+impl Default for PackageAnalysisCache {
+    /// Create an empty worker-local cache with stable virtual roots for stubs.
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            order: VecDeque::new(),
+            network_sentinel: Arc::new(PathBuf::from("leo-vfs:network")),
+            library_sentinel: Arc::new(PathBuf::from("leo-vfs:library")),
+        }
+    }
 }
 
 /// One cached package entry, including both the imported stubs and the
@@ -138,6 +152,8 @@ struct PackageAnalysisCacheEntry {
     /// lowering one worker result, so `fingerprints_with` builds that transient
     /// map at the boundary where it is actually useful.
     fingerprints: Arc<[(PathBuf, SourceFingerprint)]>,
+    /// Program roots keyed by both manifest import names and leaf identifiers.
+    dependency_roots: Arc<HashMap<Symbol, Arc<PathBuf>>>,
     /// Filesystem inputs whose metadata changes invalidate `import_stubs`.
     watch_paths: Arc<[PathBuf]>,
     /// Per-path revision memo reused to avoid rehashing unchanged watched inputs.
@@ -157,6 +173,8 @@ struct CachedImportStubs {
     import_stubs: Arc<IndexMap<Symbol, leo_ast::Stub>>,
     /// Sorted slice instead of a cached hash table to keep package caches lean.
     fingerprints: Arc<[(PathBuf, SourceFingerprint)]>,
+    /// Resolved roots used to make program namespace identities collision-free.
+    dependency_roots: Arc<HashMap<Symbol, Arc<PathBuf>>>,
 }
 
 /// Memoized revision for one watched path.
@@ -187,6 +205,63 @@ enum WatchedPathStamp {
 struct CompilerOutput {
     occurrences: Vec<SymbolOccurrence>,
     fingerprints: HashMap<PathBuf, SourceFingerprint>,
+}
+
+/// Program roots available to one compiler semantic collection pass.
+#[derive(Debug, Clone)]
+struct ProgramRoots {
+    /// Package root for the snapshot's owning package, absent for loose files.
+    current: Option<Arc<PathBuf>>,
+    /// Source dependency roots keyed by both full import and leaf symbols.
+    source_dependencies: Arc<HashMap<Symbol, Arc<PathBuf>>>,
+    /// Shared virtual root for bytecode/network-only programs.
+    network_sentinel: Arc<PathBuf>,
+    /// Shared virtual root for standard-library identities.
+    library_sentinel: Arc<PathBuf>,
+}
+
+impl ProgramRoots {
+    /// Build roots for the current package plus every imported stub identity.
+    fn for_package(
+        current: Arc<PathBuf>,
+        dependency_roots: Arc<HashMap<Symbol, Arc<PathBuf>>>,
+        import_stubs: &IndexMap<Symbol, leo_ast::Stub>,
+        network_sentinel: Arc<PathBuf>,
+        library_sentinel: Arc<PathBuf>,
+    ) -> Self {
+        let mut source_dependencies = dependency_roots.as_ref().clone();
+        for (import_name, stub) in import_stubs {
+            let root = match stub {
+                Stub::FromLeo { .. } => source_dependencies.get(import_name).cloned(),
+                Stub::FromAleo { .. } => Some(Arc::clone(&network_sentinel)),
+                Stub::FromLibrary { .. } => Some(Arc::clone(&library_sentinel)),
+            };
+            if let Some(root) = root {
+                insert_stub_root_aliases(&mut source_dependencies, *import_name, stub, root);
+            }
+        }
+
+        Self {
+            current: Some(current),
+            source_dependencies: Arc::new(source_dependencies),
+            network_sentinel,
+            library_sentinel,
+        }
+    }
+
+    /// Return the root that makes a program identity stable.
+    fn root_for_symbol(&self, symbol: Symbol) -> Option<Arc<PathBuf>> {
+        self.source_dependencies.get(&symbol).cloned()
+    }
+
+    /// Return a virtual root for a compiler stub with no source package.
+    fn root_for_stub(&self, stub: &Stub) -> Option<Arc<PathBuf>> {
+        match stub {
+            Stub::FromLeo { .. } => None,
+            Stub::FromAleo { .. } => Some(Arc::clone(&self.network_sentinel)),
+            Stub::FromLibrary { .. } => Some(Arc::clone(&self.library_sentinel)),
+        }
+    }
 }
 
 /// Build the latest package analysis plus the trigger document's token view.
@@ -269,11 +344,14 @@ pub fn build_document_view(snapshot: &DocumentViewSnapshot, package: Arc<CachedP
 /// Lower merged occurrences into a shared package index and trigger-document view.
 fn package_analysis(
     snapshot: &DocumentSnapshot,
-    occurrences: Vec<SymbolOccurrence>,
+    mut occurrences: Vec<SymbolOccurrence>,
     lexical_tokens: Vec<SemanticTokenOccurrence>,
     source: SemanticSource,
     recorded_fingerprints: HashMap<PathBuf, SourceFingerprint>,
 ) -> PackageWorkerAnalysis {
+    let package_source_files = PackageSourceFiles::from_snapshot(snapshot);
+    retain_in_scope_occurrences(&mut occurrences, &package_source_files);
+
     let (index, analyzed_files) = SemanticIndex::build(
         &occurrences,
         |path| {
@@ -300,6 +378,50 @@ fn package_analysis(
     let document_view = CachedDocumentView { key: snapshot.view_key.clone(), encoded_tokens };
 
     PackageWorkerAnalysis { package, document_view }
+}
+
+/// Canonical package source membership used to trim dependency-stub noise.
+#[derive(Debug, Clone)]
+pub(crate) struct PackageSourceFiles {
+    source_directory: Option<Arc<PathBuf>>,
+    paths: Box<[Arc<PathBuf>]>,
+}
+
+impl PackageSourceFiles {
+    /// Capture the source paths that belong to the current package snapshot.
+    fn from_snapshot(snapshot: &DocumentSnapshot) -> Self {
+        let source_directory = snapshot.project.as_ref().map(|project| Arc::clone(&project.source_directory));
+        let mut paths = Vec::<Arc<PathBuf>>::new();
+        if let Some(file_path) = snapshot.file_path.as_ref() {
+            paths.push(Arc::clone(file_path));
+        }
+        for overlay in snapshot.open_overlays.iter() {
+            paths.push(Arc::clone(&overlay.path));
+        }
+        paths.sort_by(|left, right| left.as_path().cmp(right.as_path()));
+        paths.dedup_by(|left, right| left.as_path() == right.as_path());
+        Self { source_directory, paths: paths.into_boxed_slice() }
+    }
+
+    /// Return whether a path belongs to the package being actively edited.
+    pub(crate) fn contains(&self, path: &StdPath) -> bool {
+        if self.source_directory.as_ref().is_some_and(|source_directory| path.starts_with(source_directory.as_ref())) {
+            return true;
+        }
+        self.paths.binary_search_by(|candidate| candidate.as_path().cmp(path)).is_ok()
+    }
+}
+
+/// Drop dependency-stub noise while retaining declarations and keyed references.
+pub(crate) fn retain_in_scope_occurrences(
+    occurrences: &mut Vec<SymbolOccurrence>,
+    package_source_files: &PackageSourceFiles,
+) {
+    occurrences.retain(|occurrence| {
+        package_source_files.contains(occurrence.range.path.as_ref())
+            || occurrence.role == OccurrenceRole::Declaration
+            || occurrence.identity.key().is_some()
+    });
 }
 
 /// Merge symbol occurrences with highlighting-only lexical tokens for encoding.
@@ -348,6 +470,13 @@ fn compiler_occurrences(
                     );
                     error
                 })?;
+                let program_roots = ProgramRoots::for_package(
+                    Arc::clone(&project.package_root),
+                    Arc::clone(&import_stubs.dependency_roots),
+                    import_stubs.import_stubs.as_ref(),
+                    Arc::clone(&package_cache.network_sentinel),
+                    Arc::clone(&package_cache.library_sentinel),
+                );
 
                 // Run the compiler against every open same-package editor
                 // buffer while recording fingerprints for disk files at the
@@ -358,6 +487,7 @@ fn compiler_occurrences(
                     project.source_directory.as_ref(),
                     &file_source,
                     import_stubs.import_stubs.as_ref().clone(),
+                    program_roots,
                     || check_snapshot_current(snapshot),
                 )
                 .map_err(|error| error.to_string())?;
@@ -370,6 +500,12 @@ fn compiler_occurrences(
             }
             CompilerInput::StandaloneProgram { file_path, source_directory } => {
                 let single_file_source = SingleFileSource::new(&file_source);
+                let program_roots = ProgramRoots {
+                    current: None,
+                    source_dependencies: Arc::new(HashMap::new()),
+                    network_sentinel: Arc::clone(&package_cache.network_sentinel),
+                    library_sentinel: Arc::clone(&package_cache.library_sentinel),
+                };
                 // Loose editor buffers should be analyzed as exactly one file.
                 // Scanning the parent directory would accidentally treat
                 // formatter fixtures or unrelated scratch files as Leo modules.
@@ -379,6 +515,7 @@ fn compiler_occurrences(
                     source_directory.as_ref(),
                     &single_file_source,
                     IndexMap::new(),
+                    program_roots,
                     || check_snapshot_current(snapshot),
                 )
                 .map_err(|error| error.to_string())?;
@@ -431,6 +568,7 @@ fn run_compiler_analysis(
     source_directory: &StdPath,
     file_source: &impl FileSource,
     import_stubs: IndexMap<Symbol, leo_ast::Stub>,
+    program_roots: ProgramRoots,
     mut should_continue: impl FnMut() -> leo_errors::Result<()>,
 ) -> leo_errors::Result<Vec<SymbolOccurrence>> {
     let mut compiler = Compiler::new(
@@ -452,7 +590,7 @@ fn run_compiler_analysis(
     )?;
 
     let FrontendAnalysis { ast, symbol_table, type_table } = frontend;
-    Ok(CompilerSemanticCollector::new(symbol_table, type_table).collect(ast))
+    Ok(CompilerSemanticCollector::new(symbol_table, type_table, program_roots).collect(ast))
 }
 
 /// File source that serves all open same-package buffers and records read fingerprints.
@@ -601,9 +739,7 @@ fn open_line_index(overlays: &[OpenFileOverlay], path: &StdPath) -> Option<Arc<l
 
 /// Hash source text for stale-target detection without retaining full text.
 fn content_hash(contents: &str) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    contents.hash(&mut hasher);
-    hasher.finish()
+    hash_text(contents)
 }
 
 impl PackageAnalysisCache {
@@ -629,8 +765,9 @@ impl PackageAnalysisCache {
         {
             let import_stubs = Arc::clone(&entry.import_stubs);
             let fingerprints = Arc::clone(&entry.fingerprints);
+            let dependency_roots = Arc::clone(&entry.dependency_roots);
             self.touch_entry(project.package_root.as_ref());
-            return Ok(CachedImportStubs { import_stubs, fingerprints });
+            return Ok(CachedImportStubs { import_stubs, fingerprints, dependency_roots });
         }
 
         // Import stubs are package-wide, but they depend on manifest/source
@@ -645,22 +782,24 @@ impl PackageAnalysisCache {
         let mut watch_state = HashMap::new();
         let revision = watched_paths_revision_cached(watch_paths.as_ref(), &mut watch_state);
         let import_stubs = Arc::new(loaded.stubs);
+        let dependency_roots = dependency_roots_from_stubs(import_stubs.as_ref());
         // Capturing dependency fingerprints here is what lets source-dependency
-        // go-to-definition return real disk locations on cache hits. Without
-        // carrying these fingerprints alongside the stubs, dependency targets
-        // would later look volatile and be filtered out as unsafe.
+        // navigation return real disk locations on cache hits. Without carrying
+        // these fingerprints alongside the stubs, dependency definition and
+        // reference targets would later look volatile and be filtered out.
         let fingerprints = file_source.dependency_fingerprints();
         let package_root = project.package_root.as_ref().clone();
         self.entries.insert(package_root.clone(), PackageAnalysisCacheEntry {
             import_stubs: Arc::clone(&import_stubs),
             fingerprints: Arc::clone(&fingerprints),
+            dependency_roots: Arc::clone(&dependency_roots),
             watch_paths,
             watch_state,
             revision,
         });
         self.touch_entry(&package_root);
         self.evict_old_entries(&package_root);
-        Ok(CachedImportStubs { import_stubs, fingerprints })
+        Ok(CachedImportStubs { import_stubs, fingerprints, dependency_roots })
     }
 
     /// Mark a package-root cache entry as most recently used.
@@ -687,6 +826,71 @@ impl PackageAnalysisCache {
     }
 }
 
+/// Recover source dependency roots from stub declaration spans without widening compiler APIs.
+fn dependency_roots_from_stubs(stubs: &IndexMap<Symbol, Stub>) -> Arc<HashMap<Symbol, Arc<PathBuf>>> {
+    let mut roots = HashMap::new();
+    for (import_name, stub) in stubs {
+        match stub {
+            Stub::FromLeo { program, .. } => {
+                let Some(root) = stub_program_declaration_range(stub)
+                    .and_then(|range| package_root_for_source(range.path.as_ref()))
+                    .map(Arc::new)
+                else {
+                    continue;
+                };
+                insert_program_root_aliases(&mut roots, *import_name, Arc::clone(&root));
+                for scope in program.program_scopes.values() {
+                    insert_program_root_aliases(&mut roots, scope.program_id.as_symbol(), Arc::clone(&root));
+                    insert_program_root_aliases(&mut roots, scope.program_id.name.name, Arc::clone(&root));
+                }
+            }
+            Stub::FromAleo { .. } | Stub::FromLibrary { .. } => {}
+        }
+    }
+    Arc::new(roots)
+}
+
+/// Insert both full and leaf symbols when they differ.
+fn insert_program_root_aliases(roots: &mut HashMap<Symbol, Arc<PathBuf>>, symbol: Symbol, root: Arc<PathBuf>) {
+    roots.entry(symbol).or_insert(root);
+}
+
+/// Insert every symbol spelling that can name an imported stub.
+fn insert_stub_root_aliases(
+    roots: &mut HashMap<Symbol, Arc<PathBuf>>,
+    import_name: Symbol,
+    stub: &Stub,
+    root: Arc<PathBuf>,
+) {
+    insert_program_root_aliases(roots, import_name, Arc::clone(&root));
+    match stub {
+        Stub::FromLeo { program, .. } => {
+            for scope in program.program_scopes.values() {
+                insert_program_root_aliases(roots, scope.program_id.as_symbol(), Arc::clone(&root));
+                insert_program_root_aliases(roots, scope.program_id.name.name, Arc::clone(&root));
+            }
+        }
+        Stub::FromAleo { program, .. } => {
+            insert_program_root_aliases(roots, program.stub_id.as_symbol(), Arc::clone(&root));
+            insert_program_root_aliases(roots, program.stub_id.name.name, root);
+        }
+        Stub::FromLibrary { library, .. } => {
+            insert_program_root_aliases(roots, library.name, root);
+        }
+    }
+}
+
+/// Find the nearest manifest root owning a source file.
+fn package_root_for_source(path: &StdPath) -> Option<PathBuf> {
+    for ancestor in path.parent()?.ancestors() {
+        let manifest = ancestor.join(leo_package::MANIFEST_FILENAME);
+        if manifest.is_file() {
+            return Some(ancestor.canonicalize().unwrap_or_else(|_| ancestor.to_path_buf()));
+        }
+    }
+    None
+}
+
 /// Lexically scoped binding metadata reused when later paths resolve locally.
 #[derive(Debug, Clone)]
 struct LocalBinding {
@@ -709,7 +913,10 @@ struct CompilerSemanticCollector<'a> {
     #[allow(dead_code)]
     type_table: &'a TypeTable,
     occurrences: Vec<SymbolOccurrence>,
+    program_roots: ProgramRoots,
     current_program: Symbol,
+    current_program_root: Option<Arc<PathBuf>>,
+    stub_depth: usize,
     current_module: Vec<Symbol>,
     local_scopes: Vec<HashMap<Symbol, LocalBinding>>,
     owner_stack: Vec<Option<Location>>,
@@ -717,12 +924,15 @@ struct CompilerSemanticCollector<'a> {
 
 impl<'a> CompilerSemanticCollector<'a> {
     /// Create a fresh collector bound to one compiler frontend snapshot.
-    fn new(symbol_table: &'a SymbolTable, type_table: &'a TypeTable) -> Self {
+    fn new(symbol_table: &'a SymbolTable, type_table: &'a TypeTable, program_roots: ProgramRoots) -> Self {
         Self {
             symbol_table,
             type_table,
             occurrences: Vec::new(),
+            current_program_root: program_roots.current.clone(),
+            program_roots,
             current_program: Symbol::intern(""),
+            stub_depth: 0,
             current_module: Vec::new(),
             local_scopes: Vec::new(),
             owner_stack: Vec::new(),
@@ -793,6 +1003,7 @@ impl<'a> CompilerSemanticCollector<'a> {
             identifier,
             role,
             matches!(role, OccurrenceRole::Declaration).then(|| span_to_file_range(identifier.span)).flatten(),
+            self.namespace_root(identifier.name, role),
         );
     }
 
@@ -802,16 +1013,27 @@ impl<'a> CompilerSemanticCollector<'a> {
         identifier: &Identifier,
         role: OccurrenceRole,
         declaration: Option<FileRange>,
+        package_root: Option<Arc<PathBuf>>,
     ) {
         if let Some(range) = span_to_file_range(identifier.span) {
             self.occurrences.push(SymbolOccurrence {
                 range,
-                identity: SymbolIdentity::Program { name: identifier.name, declaration },
+                identity: SymbolIdentity::Program { program: identifier.name, package_root, declaration },
                 role,
                 token_kind: SemanticKind::Namespace,
                 readonly: false,
             });
         }
+    }
+
+    /// Resolve a namespace identifier to a package root when the compiler made it stable.
+    fn namespace_root(&self, symbol: Symbol, role: OccurrenceRole) -> Option<Arc<PathBuf>> {
+        if role == OccurrenceRole::Declaration {
+            return self.current_program_root.clone();
+        }
+        self.program_roots
+            .root_for_symbol(symbol)
+            .or_else(|| (symbol == self.current_program).then(|| self.current_program_root.clone()).flatten())
     }
 
     /// Record a globally addressable declaration or reference.
@@ -913,18 +1135,52 @@ impl<'a> CompilerSemanticCollector<'a> {
             .get(&import.as_symbol())
             .or_else(|| program.stubs.get(&import.name.name))
             .and_then(stub_program_declaration_range);
-        self.add_namespace_occurrence_with_declaration(&import.name, OccurrenceRole::Reference, declaration);
+        let package_root = self
+            .program_roots
+            .root_for_symbol(import.as_symbol())
+            .or_else(|| self.program_roots.root_for_symbol(import.name.name))
+            .or_else(|| {
+                program
+                    .stubs
+                    .get(&import.as_symbol())
+                    .or_else(|| program.stubs.get(&import.name.name))
+                    .and_then(|stub| self.program_roots.root_for_stub(stub))
+            });
+        let import_name = import.name.name.to_string();
+        let range = identifier_range_from_span(import.span(), import_name.as_str())
+            .or_else(|| span_to_file_range(import.name.span));
+        if let Some(range) = range {
+            self.occurrences.push(SymbolOccurrence {
+                range,
+                identity: SymbolIdentity::Program { program: import.name.name, package_root, declaration },
+                role: OccurrenceRole::Reference,
+                token_kind: SemanticKind::Namespace,
+                readonly: false,
+            });
+        }
     }
 
     /// Resolve a global path through the compiler symbol tables and emit the
     /// most accurate semantic kind available for its target declaration.
     fn visit_global_path(&mut self, path: &Path) {
         if let Some(user_program) = path.user_program() {
-            self.add_namespace_occurrence(&user_program.name, OccurrenceRole::Reference);
+            let package_root = self
+                .program_roots
+                .root_for_symbol(user_program.as_symbol())
+                .or_else(|| self.program_roots.root_for_symbol(user_program.name.name));
+            self.add_namespace_occurrence_with_declaration(
+                &user_program.name,
+                OccurrenceRole::Reference,
+                None,
+                package_root,
+            );
         } else if let Some(first) = path.qualifier().first()
             && (self.symbol_table.is_library(first.name) || first.name == self.current_program)
         {
-            self.add_namespace_occurrence(first, OccurrenceRole::Reference);
+            let package_root = self.namespace_root(first.name, OccurrenceRole::Reference).or_else(|| {
+                self.symbol_table.is_library(first.name).then(|| Arc::clone(&self.program_roots.library_sentinel))
+            });
+            self.add_namespace_occurrence_with_declaration(first, OccurrenceRole::Reference, None, package_root);
         }
 
         let location =
@@ -1171,6 +1427,25 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
     }
 
+    /// Visit dependency stubs with the active program root set to the stub's identity.
+    fn visit_stub(&mut self, input: &Stub) {
+        let previous_root = self.current_program_root.clone();
+        self.stub_depth += 1;
+        match input {
+            Stub::FromLeo { program, .. } => self.visit_program(program),
+            Stub::FromAleo { program, .. } => {
+                self.current_program_root = Some(Arc::clone(&self.program_roots.network_sentinel));
+                self.visit_aleo_program(program);
+            }
+            Stub::FromLibrary { library, .. } => {
+                self.current_program_root = Some(Arc::clone(&self.program_roots.library_sentinel));
+                self.visit_library(library);
+            }
+        }
+        self.stub_depth -= 1;
+        self.current_program_root = previous_root;
+    }
+
     /// Visit a library root while preserving the surrounding module context.
     fn visit_library(&mut self, input: &leo_ast::Library) {
         // Libraries reuse the same collector machinery as programs, but their
@@ -1179,6 +1454,9 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         let previous_module = std::mem::take(&mut self.current_module);
 
         self.current_program = input.name;
+        if self.stub_depth > 0 {
+            self.current_program_root = Some(Arc::clone(&self.program_roots.library_sentinel));
+        }
         input.consts.iter().for_each(|(_, declaration)| self.visit_const(declaration));
         input.structs.iter().for_each(|(_, composite)| self.visit_composite(composite));
         input.functions.iter().for_each(|(_, function)| self.visit_function(function));
@@ -1193,9 +1471,18 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         // Reset the module path at each program scope so top-level locations do
         // not accidentally inherit a nested module qualifier.
         let previous_program = self.current_program;
+        let previous_root = self.current_program_root.clone();
         let previous_module = std::mem::take(&mut self.current_module);
 
         self.current_program = input.program_id.as_symbol();
+        self.current_program_root = if self.stub_depth == 0 {
+            self.program_roots.current.clone()
+        } else {
+            self.program_roots
+                .root_for_symbol(input.program_id.as_symbol())
+                .or_else(|| self.program_roots.root_for_symbol(input.program_id.name.name))
+                .or(previous_root.clone())
+        };
         self.add_namespace_occurrence(&input.program_id.name, OccurrenceRole::Declaration);
         input.parents.iter().for_each(|(_, parent)| self.visit_type(parent));
         input.consts.iter().for_each(|(_, declaration)| self.visit_const(declaration));
@@ -1209,6 +1496,7 @@ impl<'a> UnitVisitor for CompilerSemanticCollector<'a> {
         }
 
         self.current_program = previous_program;
+        self.current_program_root = previous_root;
         self.current_module = previous_module;
     }
 
@@ -1501,12 +1789,39 @@ fn program_name_range_from_span(span: leo_span::Span, name: &str) -> Option<File
     })
 }
 
+/// Recover an identifier token from a larger source span.
+fn identifier_range_from_span(span: leo_span::Span, name: &str) -> Option<FileRange> {
+    if span.is_dummy() {
+        return None;
+    }
+
+    with_session_globals(|session| {
+        let source_file = session.source_map.find_source_file(span.lo)?;
+        if span.hi > source_file.absolute_end {
+            return None;
+        }
+        let FileName::Real(path) = &source_file.name else {
+            return None;
+        };
+
+        let span_text = source_file.contents_of_span(span);
+        let name_offset = find_identifier_in_text(span_text, name)?;
+        let start = source_file.relative_offset(span.lo).checked_add(u32::try_from(name_offset).ok()?)?;
+        let end = start.checked_add(u32::try_from(name.len()).ok()?)?;
+        FileRange::new(Arc::new(path.clone()), start, end)
+    })
+}
+
 /// Find the identifier token in a `program name.aleo` source slice.
 fn find_program_name_in_text(text: &str, name: &str) -> Option<usize> {
     let program_end = text.find("program")?.checked_add("program".len())?;
+    find_identifier_in_text(&text[program_end..], name).map(|relative| program_end + relative)
+}
+
+/// Find an identifier token by spelling while respecting identifier boundaries.
+fn find_identifier_in_text(text: &str, name: &str) -> Option<usize> {
     let bytes = text.as_bytes();
-    text[program_end..].match_indices(name).find_map(|(relative, _)| {
-        let start = program_end + relative;
+    text.match_indices(name).find_map(|(start, _)| {
         let end = start + name.len();
         let left_boundary = start == 0 || !is_identifier_byte(bytes[start - 1]);
         let right_boundary = end == bytes.len() || !is_identifier_byte(bytes[end]);
@@ -1677,7 +1992,15 @@ mod tests {
     use crate::{
         document_store::{DocumentSnapshot, DocumentStore},
         project_model::ProjectModel,
-        semantics::{OccurrenceRole, SemanticSource, SourceFingerprint},
+        semantics::{
+            FileRange,
+            OccurrenceRole,
+            SemanticKind,
+            SemanticSource,
+            SourceFingerprint,
+            SymbolIdentity,
+            SymbolOccurrence,
+        },
     };
     use leo_ast::NetworkName;
     use leo_compiler::load_import_stubs_for_package;
@@ -1797,6 +2120,7 @@ mod tests {
             cache.entries.insert(package_root.clone(), PackageAnalysisCacheEntry {
                 import_stubs: Arc::new(Default::default()),
                 fingerprints: Arc::from(Vec::<(PathBuf, SourceFingerprint)>::new()),
+                dependency_roots: Arc::new(std::collections::HashMap::new()),
                 watch_paths: Arc::from([]),
                 watch_state: Default::default(),
                 revision: index as u64,
@@ -1902,6 +2226,51 @@ mod tests {
         assert_ne!(first, second);
     }
 
+    /// Verifies dependency stubs retain declarations and keyed occurrences but drop unkeyed references.
+    #[test]
+    fn retain_in_scope_occurrences_drops_unkeyed_stub_references() {
+        let local = Arc::new(PathBuf::from("/tmp/root/src/main.leo"));
+        let stub = Arc::new(PathBuf::from("/tmp/helper/src/main.leo"));
+        let declaration = FileRange::new(Arc::clone(&local), 1, 5).expect("declaration");
+        let mut occurrences = vec![
+            test_occurrence(&local, 1, 5, SymbolIdentity::Unknown),
+            test_occurrence(&stub, 1, 5, SymbolIdentity::Unknown),
+            test_occurrence(&stub, 8, 12, SymbolIdentity::Member {
+                owner: None,
+                name: leo_span::Symbol::new(1),
+                declaration: None,
+            }),
+            test_occurrence(&stub, 15, 19, SymbolIdentity::Local { declaration }),
+        ];
+        occurrences[1].role = OccurrenceRole::Declaration;
+        let source_files =
+            super::PackageSourceFiles { source_directory: None, paths: vec![Arc::clone(&local)].into_boxed_slice() };
+
+        super::retain_in_scope_occurrences(&mut occurrences, &source_files);
+
+        assert_eq!(occurrences.len(), 3);
+        assert_eq!(occurrences[0].range.path.as_ref(), local.as_ref());
+        assert_eq!(occurrences[1].range.path.as_ref(), stub.as_ref());
+        assert_eq!(occurrences[1].role, OccurrenceRole::Declaration);
+        assert!(occurrences[2].identity.key().is_some());
+        assert!(
+            !occurrences
+                .iter()
+                .any(|occurrence| matches!(occurrence.identity, SymbolIdentity::Member { owner: None, .. }))
+        );
+    }
+
+    /// Build a symbol occurrence for filter tests.
+    fn test_occurrence(path: &Arc<PathBuf>, start: u32, end: u32, identity: SymbolIdentity) -> SymbolOccurrence {
+        SymbolOccurrence {
+            range: FileRange::new(Arc::clone(path), start, end).expect("range"),
+            identity,
+            role: OccurrenceRole::Reference,
+            token_kind: SemanticKind::Variable,
+            readonly: false,
+        }
+    }
+
     /// Verifies top-level const references share the declaration identity.
     #[test]
     fn top_level_consts_share_global_identity_with_references() {
@@ -1928,9 +2297,10 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(occurrences.len(), 2);
         assert!(occurrences.iter().all(|occurrence| occurrence.key_id().is_some()));
-        assert!(occurrences.iter().any(|occurrence| occurrence.role == OccurrenceRole::Declaration));
-        assert!(occurrences.iter().any(|occurrence| occurrence.role == OccurrenceRole::Reference));
-        assert!(occurrences.iter().all(|occurrence| occurrence.key == occurrences[0].key));
+        assert!(occurrences.iter().any(|occurrence| occurrence.role() == OccurrenceRole::Declaration));
+        assert!(occurrences.iter().any(|occurrence| occurrence.role() == OccurrenceRole::Reference));
+        let key = occurrences[0].key_id();
+        assert!(occurrences.iter().all(|occurrence| occurrence.key_id() == key));
     }
 
     /// Verifies import names carry a dependency-source definition target.
@@ -1941,11 +2311,13 @@ mod tests {
         write_manifest(&helper_root, "helper.aleo", "null");
         let helper_source = "program helper.aleo {\n    fn double(x: u32) -> u32 { return x + x; }\n}\n";
         fs::write(helper_root.join("src").join("main.leo"), helper_source).expect("write helper source");
+        let helper_main_path = helper_root.join("src").join("main.leo").canonicalize().expect("canonical helper path");
+        let helper_root = helper_root.canonicalize().expect("canonical helper root");
 
         let root = tempdir.path().join("root");
         let dependencies = json!([{ "name": "helper.aleo", "location": "local", "path": helper_root }]).to_string();
         write_manifest(&root, "root.aleo", dependencies.as_str());
-        let source = "import helper.aleo;\n\nprogram root.aleo {\n    fn main() -> u32 { return 1u32; }\n}\n";
+        let source = "import helper.aleo;\n\nprogram root.aleo {\n    fn main() -> u32 { return helper.aleo::double(1u32); }\n}\n";
         fs::write(root.join("src").join("main.leo"), source).expect("write root source");
         let main_path = root.join("src").join("main.leo").canonicalize().expect("canonical main path");
 
@@ -1963,7 +2335,13 @@ mod tests {
             })
             .expect("helper import occurrence");
         let key = occurrence.key_id().expect("navigation-grade import key");
-        assert!(!semantic_snapshot.index.definitions_for(key).is_empty());
+        assert!(
+            semantic_snapshot
+                .index
+                .definitions_for(key)
+                .iter()
+                .any(|range| { semantic_snapshot.index.files[range.file as usize].as_ref() == &helper_main_path })
+        );
     }
 
     /// Verifies member references resolve through the composite owner.
@@ -2001,9 +2379,10 @@ mod tests {
         assert_eq!(x_occurrences.len(), 3);
 
         assert!(x_occurrences.iter().all(|occurrence| occurrence.key_id().is_some()));
-        assert!(x_occurrences.iter().all(|occurrence| occurrence.key == x_occurrences[0].key));
-        assert!(x_occurrences.iter().any(|occurrence| occurrence.role == OccurrenceRole::Declaration));
-        assert_eq!(x_occurrences.iter().filter(|occurrence| occurrence.role == OccurrenceRole::Reference).count(), 2);
+        let key = x_occurrences[0].key_id();
+        assert!(x_occurrences.iter().all(|occurrence| occurrence.key_id() == key));
+        assert!(x_occurrences.iter().any(|occurrence| occurrence.role() == OccurrenceRole::Declaration));
+        assert_eq!(x_occurrences.iter().filter(|occurrence| occurrence.role() == OccurrenceRole::Reference).count(), 2);
     }
 
     /// Verifies same-named interface prototypes stay owner-qualified.
@@ -2041,8 +2420,8 @@ mod tests {
             })
             .collect::<Vec<_>>();
         assert_eq!(shared_occurrences.len(), 2);
-        assert!(shared_occurrences.iter().all(|occurrence| occurrence.role == OccurrenceRole::Declaration));
+        assert!(shared_occurrences.iter().all(|occurrence| occurrence.role() == OccurrenceRole::Declaration));
         assert!(shared_occurrences.iter().all(|occurrence| occurrence.key_id().is_some()));
-        assert_ne!(shared_occurrences[0].key, shared_occurrences[1].key);
+        assert_ne!(shared_occurrences[0].key_id(), shared_occurrences[1].key_id());
     }
 }

--- a/crates/lsp/src/document_store.rs
+++ b/crates/lsp/src/document_store.rs
@@ -16,6 +16,13 @@
 
 #![allow(clippy::mutable_key_type)]
 
+//! Open-document state, freshness keys, and worker snapshots for `leo-lsp`.
+//!
+//! The server owns mutable editor state on the routing thread. This module is
+//! the boundary that turns LSP open/change/close events into immutable worker
+//! snapshots with generation and bucket keys strong enough to reject stale
+//! package analysis, semantic-token views, and navigation responses.
+
 use crate::project_model::ProjectContext;
 use line_index::LineIndex;
 use lsp_types::Uri;
@@ -81,15 +88,23 @@ pub struct OpenFileOverlay {
 /// recent committed generation for that URI.
 #[derive(Debug)]
 pub struct OpenDocument {
+    /// LSP language identifier supplied by the client.
     pub language_id: Arc<str>,
+    /// Latest committed editor text.
     pub text: Arc<str>,
+    /// Line index for the latest committed editor text.
     pub line_index: Arc<LineIndex>,
+    /// Latest LSP document version supplied by the client.
     pub version: i32,
+    /// Monotonic per-URI document generation.
     pub generation: u64,
+    /// Native file path, when the URI resolves to a local file.
     pub file_path: Option<Arc<PathBuf>>,
+    /// Resolved Leo project context, when the file belongs to a package.
     pub project: Option<Arc<ProjectContext>>,
     /// Package-sized invalidation bucket this open document contributes to.
     pub analysis_bucket: AnalysisBucket,
+    /// Shared generation token used by worker jobs to detect stale snapshots.
     pub cancel_token: Arc<AtomicU64>,
 }
 
@@ -99,15 +114,22 @@ pub struct OpenDocument {
 /// matching `generation`, even if the URI still refers to an open document.
 #[derive(Debug, Clone)]
 pub struct DocumentSnapshot {
+    /// Open document URI that triggered package analysis.
     pub uri: Uri,
+    /// Committed text for the trigger document.
     pub text: Arc<str>,
+    /// Line index for the trigger document text.
     #[allow(dead_code)]
     pub line_index: Arc<LineIndex>,
+    /// LSP document version for the trigger document.
     #[allow(dead_code)]
     pub version: i32,
+    /// Document generation captured when this snapshot was prepared.
     pub generation: u64,
+    /// Native file path for the trigger document, if any.
     #[allow(dead_code)]
     pub file_path: Option<Arc<PathBuf>>,
+    /// Project context captured with the trigger document.
     #[allow(dead_code)]
     pub project: Option<Arc<ProjectContext>>,
     /// Package-analysis key for this snapshot's package-sized inputs.
@@ -116,18 +138,26 @@ pub struct DocumentSnapshot {
     pub view_key: DocumentViewKey,
     /// Same-package open buffers visible to compiler analysis.
     pub open_overlays: Arc<[OpenFileOverlay]>,
+    /// Shared generation token checked before and during worker analysis.
     pub cancel_token: Arc<AtomicU64>,
 }
 
 /// Document-sized worker input for rebuilding one semantic-token view.
 #[derive(Debug, Clone)]
 pub struct DocumentViewSnapshot {
+    /// Freshness key for the document view being rebuilt.
     pub key: DocumentViewKey,
+    /// Open document URI for the encoded semantic-token view.
     pub uri: Uri,
+    /// Committed document text to encode.
     pub text: Arc<str>,
+    /// Line index for the committed document text.
     pub line_index: Arc<LineIndex>,
+    /// Native file path for the document, if any.
     pub file_path: Option<Arc<PathBuf>>,
+    /// Project context captured with the document.
     pub project: Option<Arc<ProjectContext>>,
+    /// Shared generation token checked before worker results are accepted.
     pub cancel_token: Arc<AtomicU64>,
 }
 
@@ -302,6 +332,11 @@ impl DocumentStore {
     /// Return the committed document for main-thread request handling.
     pub fn open_document(&self, uri: &Uri) -> Option<&OpenDocument> {
         self.documents.get(uri)
+    }
+
+    /// Iterate currently open documents with their owning URIs.
+    pub fn iter_open(&self) -> impl Iterator<Item = (&Uri, &OpenDocument)> {
+        self.documents.iter()
     }
 
     /// Build the latest package-analysis snapshot for an open document.

--- a/crates/lsp/src/features/goto_definition.rs
+++ b/crates/lsp/src/features/goto_definition.rs
@@ -24,18 +24,13 @@
 
 use crate::{
     document_store::DocumentViewKey,
-    project_model::path_to_file_uri,
-    semantics::{CachedPackageAnalysis, CompactRange, SourceFingerprint},
+    features::lsp_range::{compact_range_to_location_parts, compact_range_to_origin_lsp_range},
+    semantics::CachedPackageAnalysis,
 };
-use line_index::{LineIndex, TextSize, WideEncoding, WideLineCol};
+use line_index::LineIndex;
 use lsp_types::{GotoDefinitionResponse, Location, LocationLink, Position, Range, Uri};
 use serde_json::Value;
-use std::{
-    hash::{DefaultHasher, Hash, Hasher},
-    path::{Path, PathBuf},
-    sync::Arc,
-    time::UNIX_EPOCH,
-};
+use std::{path::PathBuf, sync::Arc};
 
 /// Cursor query captured before any async package-analysis wait.
 ///
@@ -72,13 +67,6 @@ pub enum DefinitionResult {
     Links(Vec<LocationLink>),
 }
 
-/// Convert an LSP UTF-16 position into a byte offset for the current document.
-pub fn position_to_offset(line_index: &LineIndex, position: Position) -> Option<u32> {
-    let wide = WideLineCol { line: position.line, col: position.character };
-    let utf8 = line_index.to_utf8(WideEncoding::Utf16, wide)?;
-    Some(u32::from(line_index.offset(utf8)?))
-}
-
 /// Resolve a go-to-definition query against a fresh package analysis.
 pub fn resolve(query: &DefinitionQuery, package: &CachedPackageAnalysis) -> DefinitionResult {
     let Some(occurrence) = package.index.occurrence_at(query.file_path.as_ref(), query.offset) else {
@@ -88,13 +76,19 @@ pub fn resolve(query: &DefinitionQuery, package: &CachedPackageAnalysis) -> Defi
         return DefinitionResult::None;
     };
 
-    let origin_range = compact_range_to_open_lsp_range(occurrence.occurrence.range, package, &query.line_index)
-        .unwrap_or_else(|| Range::new(query.position, query.position));
+    let origin_range = compact_range_to_origin_lsp_range(
+        occurrence.occurrence.range,
+        package.analyzed_files.as_ref(),
+        &query.line_index,
+    )
+    .unwrap_or_else(|| Range::new(query.position, query.position));
     let mut locations = Vec::new();
     let mut links = Vec::new();
 
     for target in package.index.definitions_for(key_id) {
-        let Some((target_uri, target_range)) = compact_range_to_location_parts(*target, package) else {
+        let Some((target_uri, target_range)) =
+            compact_range_to_location_parts(*target, package.analyzed_files.as_ref())
+        else {
             continue;
         };
 
@@ -128,73 +122,4 @@ pub fn response_value(result: DefinitionResult) -> Value {
         DefinitionResult::Links(links) => serde_json::to_value(GotoDefinitionResponse::Link(links))
             .expect("GotoDefinitionResponse::Link should serialize"),
     }
-}
-
-/// Convert a source occurrence range in the requesting open buffer to LSP coordinates.
-fn compact_range_to_open_lsp_range(
-    range: CompactRange,
-    package: &CachedPackageAnalysis,
-    line_index: &LineIndex,
-) -> Option<Range> {
-    let file = package.analyzed_files.get(range.file)?;
-    if !matches!(file.fingerprint, SourceFingerprint::OpenBuffer) {
-        return None;
-    }
-    byte_range_to_lsp_range(line_index, range.start, range.end)
-}
-
-/// Convert a compact definition target into a safe external URI/range pair.
-fn compact_range_to_location_parts(range: CompactRange, package: &CachedPackageAnalysis) -> Option<(Uri, Range)> {
-    let file = package.analyzed_files.get(range.file)?;
-    let uri = path_to_file_uri(file.path.as_ref())?;
-    let lsp_range = match &file.fingerprint {
-        SourceFingerprint::OpenBuffer => {
-            byte_range_to_lsp_range(file.open_line_index.as_ref()?, range.start, range.end)?
-        }
-        SourceFingerprint::Disk { .. } => {
-            // Disk-backed targets are only emitted if the file still matches the
-            // exact bytes analyzed by the worker. This avoids returning ranges
-            // into a dependency file that changed after indexing.
-            let text = read_verified_disk_text(file.path.as_ref(), &file.fingerprint)?;
-            let line_index = LineIndex::new(text.as_str());
-            byte_range_to_lsp_range(&line_index, range.start, range.end)?
-        }
-        SourceFingerprint::Volatile => return None,
-    };
-    Some((uri, lsp_range))
-}
-
-/// Convert UTF-8 byte offsets into the UTF-16 positions required by LSP.
-fn byte_range_to_lsp_range(line_index: &LineIndex, start: u32, end: u32) -> Option<Range> {
-    let start = line_index.try_line_col(TextSize::from(start))?;
-    let end = line_index.try_line_col(TextSize::from(end))?;
-    let start = line_index.to_wide(WideEncoding::Utf16, start)?;
-    let end = line_index.to_wide(WideEncoding::Utf16, end)?;
-    Some(Range::new(Position::new(start.line, start.col), Position::new(end.line, end.col)))
-}
-
-/// Re-read disk text only when it still matches the analysis fingerprint.
-fn read_verified_disk_text(path: &Path, expected: &SourceFingerprint) -> Option<String> {
-    let SourceFingerprint::Disk { modified_nanos, len, content_hash } = expected else {
-        return None;
-    };
-    let metadata = std::fs::metadata(path).ok()?;
-    let current_modified = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?.as_nanos();
-    // Size and mtime are cheap rejection tests; the content hash is the final
-    // guard for same-size rewrites or coarse filesystem timestamp behavior.
-    if *len != metadata.len() || *modified_nanos != Some(current_modified) {
-        return None;
-    }
-    let text = std::fs::read_to_string(path).ok()?;
-    if *content_hash != hash_text(text.as_str()) {
-        return None;
-    }
-    Some(text)
-}
-
-/// Hash text using the same lightweight process-local hasher as analysis.
-fn hash_text(text: &str) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    text.hash(&mut hasher);
-    hasher.finish()
 }

--- a/crates/lsp/src/features/lsp_range.rs
+++ b/crates/lsp/src/features/lsp_range.rs
@@ -1,0 +1,117 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! UTF-8/UTF-16 and file-range conversion shared by navigation features.
+//!
+//! The worker cache stores compact UTF-8 byte ranges and source fingerprints.
+//! This module is the only LSP feature layer that turns those ranges back into
+//! client-facing UTF-16 coordinates, after verifying disk-backed files still
+//! match the bytes that were analyzed.
+
+use crate::{
+    project_model::path_to_file_uri,
+    semantics::{AnalyzedFileSet, CompactRange, SourceFingerprint},
+};
+use line_index::{LineIndex, TextSize, WideEncoding, WideLineCol};
+use lsp_types::{Position, Range, Uri};
+use std::{path::Path, time::UNIX_EPOCH};
+use xxhash_rust::xxh3::xxh3_64;
+
+/// Convert an LSP UTF-16 position into a UTF-8 byte offset.
+pub fn position_to_offset(line_index: &LineIndex, position: Position) -> Option<u32> {
+    let wide = WideLineCol { line: position.line, col: position.character };
+    let utf8 = line_index.to_utf8(WideEncoding::Utf16, wide)?;
+    Some(u32::from(line_index.offset(utf8)?))
+}
+
+/// Convert a source occurrence range in the requesting open buffer to LSP coordinates.
+pub fn compact_range_to_origin_lsp_range(
+    range: CompactRange,
+    analyzed_files: &AnalyzedFileSet,
+    line_index: &LineIndex,
+) -> Option<Range> {
+    let file = analyzed_files.get(range.file)?;
+    if file.is_sentinel || !matches!(file.fingerprint, SourceFingerprint::OpenBuffer) {
+        return None;
+    }
+    byte_range_to_lsp_range(line_index, range.start, range.end)
+}
+
+/// Convert a compact target into a safe external URI/range pair.
+pub fn compact_range_to_location_parts(range: CompactRange, analyzed_files: &AnalyzedFileSet) -> Option<(Uri, Range)> {
+    let file = analyzed_files.get(range.file)?;
+    if file.is_sentinel {
+        return None;
+    }
+    let uri = path_to_file_uri(file.path.as_ref())?;
+    let lsp_range = match &file.fingerprint {
+        SourceFingerprint::OpenBuffer => {
+            byte_range_to_lsp_range(file.open_line_index.as_ref()?, range.start, range.end)?
+        }
+        SourceFingerprint::Disk { .. } => {
+            let text = read_verified_disk_text(file.path.as_ref(), &file.fingerprint)?;
+            let line_index = LineIndex::new(text.as_str());
+            byte_range_to_lsp_range(&line_index, range.start, range.end)?
+        }
+        SourceFingerprint::Volatile => return None,
+    };
+    Some((uri, lsp_range))
+}
+
+/// Convert a compact range with a caller-provided line index into a location.
+pub fn compact_range_to_location_with_line_index(
+    range: CompactRange,
+    analyzed_files: &AnalyzedFileSet,
+    line_index: &LineIndex,
+) -> Option<(Uri, Range)> {
+    let file = analyzed_files.get(range.file)?;
+    if file.is_sentinel {
+        return None;
+    }
+    let uri = path_to_file_uri(file.path.as_ref())?;
+    Some((uri, byte_range_to_lsp_range(line_index, range.start, range.end)?))
+}
+
+/// Convert UTF-8 byte offsets into the UTF-16 positions required by LSP.
+pub fn byte_range_to_lsp_range(line_index: &LineIndex, start: u32, end: u32) -> Option<Range> {
+    let start = line_index.try_line_col(TextSize::from(start))?;
+    let end = line_index.try_line_col(TextSize::from(end))?;
+    let start = line_index.to_wide(WideEncoding::Utf16, start)?;
+    let end = line_index.to_wide(WideEncoding::Utf16, end)?;
+    Some(Range::new(Position::new(start.line, start.col), Position::new(end.line, end.col)))
+}
+
+/// Re-read disk text only when it still matches the analysis fingerprint.
+pub fn read_verified_disk_text(path: &Path, expected: &SourceFingerprint) -> Option<String> {
+    let SourceFingerprint::Disk { modified_nanos, len, content_hash } = expected else {
+        return None;
+    };
+    let metadata = std::fs::metadata(path).ok()?;
+    let current_modified = metadata.modified().ok()?.duration_since(UNIX_EPOCH).ok()?.as_nanos();
+    if *len != metadata.len() || *modified_nanos != Some(current_modified) {
+        return None;
+    }
+    let text = std::fs::read_to_string(path).ok()?;
+    if *content_hash != hash_text(text.as_str()) {
+        return None;
+    }
+    Some(text)
+}
+
+/// Hash source text for stale-target detection without retaining full text.
+pub fn hash_text(text: &str) -> u64 {
+    xxh3_64(text.as_bytes())
+}

--- a/crates/lsp/src/features/mod.rs
+++ b/crates/lsp/src/features/mod.rs
@@ -14,6 +14,18 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+//! LSP feature modules owned by `leo-lsp`.
+//!
+//! Each child module owns one protocol-facing capability or one shared helper
+//! layer used by those capabilities. Server routing stays outside this module;
+//! feature modules consume snapshot-safe semantic data and return LSP-ready
+//! values.
+
+/// Go-to-definition query resolution.
 pub mod goto_definition;
+/// Shared LSP range and URI conversion helpers.
+pub mod lsp_range;
+/// Find-all-references query resolution.
+pub mod references;
 /// Semantic token capability wiring and wire-format encoding helpers.
 pub mod semantic_tokens;

--- a/crates/lsp/src/features/references.rs
+++ b/crates/lsp/src/features/references.rs
@@ -1,0 +1,197 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Find-all-references resolution for Leo LSP.
+//!
+//! This module deliberately stops at compact byte ranges. It does not know
+//! about JSON-RPC request IDs, worker scheduling, disk reads, or connection
+//! writes; the server and response pool own those runtime concerns.
+
+use crate::{
+    document_store::DocumentViewKey,
+    semantics::{CachedPackageAnalysis, CompactRange, OccurrenceRole},
+};
+use lsp_types::{Location, Position};
+use serde_json::Value;
+use std::path::Path;
+
+/// Cursor query captured before any async package-analysis wait.
+#[derive(Debug, Clone)]
+pub struct ReferenceQuery {
+    /// UTF-8 byte offset resolved from the original LSP position.
+    pub offset: u32,
+    /// Original LSP position retained for diagnostics and future link-style responses.
+    #[allow(dead_code)]
+    pub position: Position,
+    /// Freshness key for the document view active when the request arrived.
+    pub view_key: DocumentViewKey,
+    /// Whether declaration occurrences should be included in the result.
+    pub include_declaration: bool,
+}
+
+/// Feature-level compact result before LSP range conversion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReferenceTargets {
+    /// Whether the cursor was on a navigation-grade semantic occurrence.
+    pub navigable: bool,
+    /// Compact ranges for retained references, already in deterministic order.
+    pub ranges: Vec<CompactRange>,
+}
+
+/// Resolve reference ranges for a cursor query against a fresh package analysis.
+pub fn resolve_targets(
+    query: &ReferenceQuery,
+    package: &CachedPackageAnalysis,
+    source_path: &Path,
+) -> ReferenceTargets {
+    let Some(occurrence) = package.index.occurrence_at(source_path, query.offset) else {
+        return ReferenceTargets { navigable: false, ranges: Vec::new() };
+    };
+    let Some(key_id) = occurrence.occurrence.key_id() else {
+        return ReferenceTargets { navigable: false, ranges: Vec::new() };
+    };
+
+    let mut ranges = package
+        .index
+        .occurrences_for(key_id)
+        .filter(|occurrence| query.include_declaration || occurrence.role() != OccurrenceRole::Declaration)
+        .map(|occurrence| occurrence.range)
+        .collect::<Vec<_>>();
+    if query.include_declaration {
+        ranges.extend_from_slice(package.index.definitions_for(key_id));
+        ranges.sort_unstable();
+        ranges.dedup();
+    }
+    ReferenceTargets { navigable: true, ranges }
+}
+
+/// Serialize references into the standard LSP response payload.
+pub fn response_value(navigable: bool, locations: Vec<Location>) -> Value {
+    if navigable { serde_json::to_value(locations).expect("references should serialize") } else { Value::Null }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReferenceQuery, resolve_targets, response_value};
+    use crate::{
+        document_store::{AnalysisBucket, DocumentViewKey, PackageAnalysisKey},
+        semantics::{
+            CachedPackageAnalysis,
+            FileRange,
+            OccurrenceRole,
+            SemanticIndex,
+            SemanticKind,
+            SemanticSource,
+            SourceFingerprint,
+            SymbolIdentity,
+            SymbolOccurrence,
+        },
+    };
+    use lsp_types::{Position, Uri};
+    use serde_json::json;
+    use std::{path::PathBuf, sync::Arc};
+
+    /// Build a package analysis around the supplied synthetic occurrences.
+    fn package(occurrences: Vec<SymbolOccurrence>) -> (CachedPackageAnalysis, DocumentViewKey, Arc<PathBuf>) {
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+        let path = Arc::new(PathBuf::from("main.leo"));
+        let key =
+            PackageAnalysisKey { bucket: AnalysisBucket::UnmanagedDocument { uri: uri.clone() }, bucket_generation: 1 };
+        let view_key = DocumentViewKey { uri, document_generation: 1, package: key.clone() };
+        let (index, analyzed_files) = SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None);
+        (
+            CachedPackageAnalysis {
+                key,
+                index: Arc::new(index),
+                analyzed_files: Arc::new(analyzed_files),
+                source: SemanticSource::CompilerEnhanced,
+            },
+            view_key,
+            path,
+        )
+    }
+
+    /// Build a keyed local occurrence for reference-resolution unit tests.
+    fn local_occurrence(
+        path: &Arc<PathBuf>,
+        start: u32,
+        end: u32,
+        declaration: &FileRange,
+        role: OccurrenceRole,
+    ) -> SymbolOccurrence {
+        SymbolOccurrence {
+            range: FileRange::new(Arc::clone(path), start, end).expect("range"),
+            identity: SymbolIdentity::Local { declaration: declaration.clone() },
+            role,
+            token_kind: SemanticKind::Variable,
+            readonly: false,
+        }
+    }
+
+    /// Build a references query with the requested cursor and declaration mode.
+    fn query(view_key: DocumentViewKey, offset: u32, include_declaration: bool) -> ReferenceQuery {
+        ReferenceQuery { offset, position: Position::new(0, 0), view_key, include_declaration }
+    }
+
+    /// Verifies reference resolution preserves source order and declaration filtering.
+    #[test]
+    fn resolve_targets_preserves_order_and_include_declaration() {
+        let path = Arc::new(PathBuf::from("main.leo"));
+        let declaration = FileRange::new(Arc::clone(&path), 1, 6).expect("declaration");
+        let occurrences = vec![
+            local_occurrence(&path, 20, 25, &declaration, OccurrenceRole::Reference),
+            local_occurrence(&path, 1, 6, &declaration, OccurrenceRole::Declaration),
+            local_occurrence(&path, 10, 15, &declaration, OccurrenceRole::Reference),
+        ];
+        let (package, view_key, source_path) = package(occurrences);
+
+        let with_declaration = resolve_targets(&query(view_key.clone(), 12, true), &package, source_path.as_ref());
+        assert!(with_declaration.navigable);
+        assert_eq!(with_declaration.ranges.iter().map(|range| range.start).collect::<Vec<_>>(), vec![1, 10, 20]);
+
+        let references_only = resolve_targets(&query(view_key, 12, false), &package, source_path.as_ref());
+        assert!(references_only.navigable);
+        assert_eq!(references_only.ranges.iter().map(|range| range.start).collect::<Vec<_>>(), vec![10, 20]);
+    }
+
+    /// Verifies navigable declaration-only symbols return an empty array, not `null`.
+    #[test]
+    fn resolve_targets_distinguishes_null_from_empty_array() {
+        let path = Arc::new(PathBuf::from("main.leo"));
+        let declaration = FileRange::new(Arc::clone(&path), 1, 6).expect("declaration");
+        let (package, view_key, source_path) =
+            package(vec![local_occurrence(&path, 1, 6, &declaration, OccurrenceRole::Declaration)]);
+
+        let empty = resolve_targets(&query(view_key, 2, false), &package, source_path.as_ref());
+        assert!(empty.navigable);
+        assert!(empty.ranges.is_empty());
+        assert_eq!(response_value(empty.navigable, Vec::new()), json!([]));
+
+        let unknown = resolve_targets(&query(empty_query_key(), 50, true), &package, source_path.as_ref());
+        assert!(!unknown.navigable);
+        assert_eq!(response_value(unknown.navigable, Vec::new()), serde_json::Value::Null);
+    }
+
+    /// Build a package key for a query that intentionally misses the test package.
+    fn empty_query_key() -> DocumentViewKey {
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+        DocumentViewKey {
+            uri: uri.clone(),
+            document_generation: 1,
+            package: PackageAnalysisKey { bucket: AnalysisBucket::UnmanagedDocument { uri }, bucket_generation: 1 },
+        }
+    }
+}

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -24,6 +24,7 @@ mod document_store;
 mod features;
 mod panic_boundary;
 mod project_model;
+mod response_pool;
 mod scheduler;
 mod semantics;
 mod server;
@@ -76,6 +77,7 @@ pub fn run_standalone() -> ExitCode {
     }
 }
 
+/// Initialize stderr logging once for the process.
 fn init_logging() {
     // LSP servers must keep stdout reserved for protocol traffic, so route all
     // diagnostics through a best-effort stderr subscriber.

--- a/crates/lsp/src/response_pool.rs
+++ b/crates/lsp/src/response_pool.rs
@@ -1,0 +1,310 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Small response-conversion pool for navigation requests with disk targets.
+//!
+//! Package analysis stores compact byte ranges, not retained file text. This
+//! pool keeps disk re-read, fingerprint verification, and UTF-16 range
+//! conversion off the routing thread while sending completions back through the
+//! single JSON-RPC writer.
+
+use crate::{
+    document_store::{DocumentStore, PackageAnalysisKey},
+    features::{
+        lsp_range::{compact_range_to_location_with_line_index, read_verified_disk_text},
+        references::{ReferenceQuery, resolve_targets, response_value as references_response_value},
+    },
+    semantics::{CachedPackageAnalysis, FileId, SourceFingerprint},
+};
+use crossbeam_channel::{Receiver, Sender, unbounded};
+use line_index::LineIndex;
+use lsp_server::RequestId;
+use lsp_types::{Location, Uri};
+use serde_json::Value;
+use std::{
+    collections::HashMap,
+    panic::{AssertUnwindSafe, catch_unwind},
+    path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread::{self, JoinHandle},
+};
+
+const RESPONSE_WORKERS: usize = 2;
+
+/// Bounded worker pool for response materialization.
+#[derive(Debug)]
+pub struct ResponsePool {
+    job_tx: Sender<ResponseJob>,
+    completion_rx: Receiver<ResponseCompletion>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+/// Work item executed off the routing thread.
+#[derive(Debug)]
+pub enum ResponseJob {
+    /// Convert one find-all-references query into its final LSP response value.
+    References {
+        /// Original JSON-RPC request ID.
+        id: RequestId,
+        /// Cursor query captured by the routing thread.
+        query: Box<ReferenceQuery>,
+        /// Package analysis containing compact reference ranges.
+        package: Arc<CachedPackageAnalysis>,
+        /// Open-buffer line indexes captured when the job was dispatched.
+        open_line_indexes: Arc<OpenLineIndexes>,
+        /// Cancellation flag shared with the routing thread.
+        cancel: Arc<AtomicBool>,
+    },
+    /// Ask a worker to stop after completing any current job.
+    Shutdown,
+}
+
+/// Snapshot of open-document line indexes captured at job dispatch time.
+#[derive(Debug, Default)]
+pub struct OpenLineIndexes {
+    indexes: HashMap<Arc<PathBuf>, Arc<LineIndex>>,
+    uri_paths: Vec<(Uri, Arc<PathBuf>)>,
+}
+
+/// Pool-to-routing notification sent after a job completes.
+#[derive(Debug)]
+pub enum ResponseCompletion {
+    /// Completed find-all-references response materialization.
+    References {
+        /// Original JSON-RPC request ID.
+        id: RequestId,
+        /// Package key the response was computed against.
+        key: PackageAnalysisKey,
+        /// Cancellation token captured at dispatch, used to reject reused IDs.
+        cancel: Arc<AtomicBool>,
+        /// Final response payload or error.
+        result: ResponseResult,
+    },
+}
+
+/// Prepared response payload returned to the routing thread.
+#[derive(Debug)]
+pub enum ResponseResult {
+    /// Successful JSON-RPC result payload.
+    Ok(Value),
+    /// Internal error message to return for a failed conversion.
+    InternalError(String),
+}
+
+impl ResponsePool {
+    /// Start the fixed-size response conversion pool.
+    pub fn new() -> Self {
+        let (job_tx, job_rx) = unbounded();
+        let (completion_tx, completion_rx) = unbounded();
+        let workers =
+            (0..RESPONSE_WORKERS).map(|index| spawn_worker(index, job_rx.clone(), completion_tx.clone())).collect();
+        Self { job_tx, completion_rx, workers }
+    }
+
+    /// Return the completion channel observed by the routing loop.
+    pub fn completions(&self) -> &Receiver<ResponseCompletion> {
+        &self.completion_rx
+    }
+
+    /// Submit one response conversion job.
+    pub fn submit(&self, job: ResponseJob) {
+        if let Err(error) = self.job_tx.send(job) {
+            tracing::debug!(error = %error, "response pool is shut down");
+        }
+    }
+
+    /// Stop worker threads and wait for them to exit.
+    pub fn shutdown(&mut self) {
+        for _ in 0..self.workers.len() {
+            let _ = self.job_tx.send(ResponseJob::Shutdown);
+        }
+        while let Some(worker) = self.workers.pop() {
+            if let Err(error) = worker.join() {
+                tracing::error!(?error, "response worker panicked during shutdown");
+            }
+        }
+    }
+}
+
+impl Drop for ResponsePool {
+    /// Shut down response workers when the pool owner is dropped.
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+impl Default for ResponsePool {
+    /// Start a default fixed-size response conversion pool.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl OpenLineIndexes {
+    /// Snapshot open file paths and line indexes with Arc clones only.
+    pub fn snapshot(documents: &DocumentStore) -> Arc<Self> {
+        let mut indexes = HashMap::new();
+        let mut uri_paths = Vec::new();
+        for (uri, document) in documents.iter_open() {
+            let Some(path) = document.file_path.as_ref() else {
+                continue;
+            };
+            indexes.entry(Arc::clone(path)).or_insert_with(|| Arc::clone(&document.line_index));
+            uri_paths.push((uri.clone(), Arc::clone(path)));
+        }
+        Arc::new(Self { indexes, uri_paths })
+    }
+
+    /// Return the open line index for a path, if that file is currently open.
+    fn get(&self, path: &Path) -> Option<&Arc<LineIndex>> {
+        self.indexes.iter().find_map(|(candidate, line_index)| (candidate.as_path() == path).then_some(line_index))
+    }
+
+    /// Return the native path for an open document URI in this snapshot.
+    fn path_for_uri(&self, uri: &Uri) -> Option<&Arc<PathBuf>> {
+        self.uri_paths.iter().find_map(|(candidate, path)| (candidate == uri).then_some(path))
+    }
+}
+
+/// Spawn one response worker thread.
+fn spawn_worker(
+    index: usize,
+    job_rx: Receiver<ResponseJob>,
+    completion_tx: Sender<ResponseCompletion>,
+) -> JoinHandle<()> {
+    thread::Builder::new()
+        .name(format!("leo-lsp-response-{index}"))
+        .spawn(move || {
+            while let Ok(job) = job_rx.recv() {
+                match job {
+                    ResponseJob::References { id, query, package, open_line_indexes, cancel } => {
+                        let key = package.key.clone();
+                        let completion_cancel = Arc::clone(&cancel);
+                        let result = catch_unwind(AssertUnwindSafe(|| {
+                            references_response(*query, package, open_line_indexes, cancel)
+                        }));
+                        let result = match result {
+                            Ok(Some(value)) => ResponseResult::Ok(value),
+                            Ok(None) => continue,
+                            Err(_) => ResponseResult::InternalError(
+                                "references response conversion panicked; see server logs for details".to_owned(),
+                            ),
+                        };
+                        let _ = completion_tx.send(ResponseCompletion::References {
+                            id,
+                            key,
+                            cancel: completion_cancel,
+                            result,
+                        });
+                    }
+                    ResponseJob::Shutdown => break,
+                }
+            }
+        })
+        .expect("spawn leo-lsp response worker")
+}
+
+/// Resolve and materialize one references response off the routing thread.
+fn references_response(
+    query: ReferenceQuery,
+    package: Arc<CachedPackageAnalysis>,
+    open_line_indexes: Arc<OpenLineIndexes>,
+    cancel: Arc<AtomicBool>,
+) -> Option<Value> {
+    let Some(source_path) = open_line_indexes.path_for_uri(&query.view_key.uri) else {
+        return Some(references_response_value(false, Vec::new()));
+    };
+    let targets = resolve_targets(&query, package.as_ref(), source_path.as_ref());
+    if !targets.navigable {
+        return Some(references_response_value(false, Vec::new()));
+    }
+
+    let mut locations = Vec::new();
+    let mut start = 0_usize;
+    while start < targets.ranges.len() {
+        if cancel.load(Ordering::SeqCst) {
+            return None;
+        }
+        let file = targets.ranges[start].file;
+        let mut end = start + 1;
+        while end < targets.ranges.len() && targets.ranges[end].file == file {
+            end += 1;
+        }
+        append_file_locations(
+            file,
+            &targets.ranges[start..end],
+            package.as_ref(),
+            open_line_indexes.as_ref(),
+            &mut locations,
+        );
+        start = end;
+    }
+
+    Some(references_response_value(true, locations))
+}
+
+/// Append all verified locations for one analyzed file.
+fn append_file_locations(
+    file_id: FileId,
+    ranges: &[crate::semantics::CompactRange],
+    package: &CachedPackageAnalysis,
+    open_line_indexes: &OpenLineIndexes,
+    locations: &mut Vec<Location>,
+) {
+    let Some(file) = package.analyzed_files.get(file_id) else {
+        return;
+    };
+    if file.is_sentinel {
+        return;
+    }
+
+    match &file.fingerprint {
+        SourceFingerprint::OpenBuffer => {
+            let line_index = file.open_line_index.as_ref().or_else(|| open_line_indexes.get(file.path.as_ref()));
+            let Some(line_index) = line_index else {
+                return;
+            };
+            append_locations_with_line_index(ranges, package, line_index.as_ref(), locations);
+        }
+        SourceFingerprint::Disk { .. } => {
+            let Some(text) = read_verified_disk_text(file.path.as_ref(), &file.fingerprint) else {
+                return;
+            };
+            let line_index = LineIndex::new(text.as_str());
+            append_locations_with_line_index(ranges, package, &line_index, locations);
+        }
+        SourceFingerprint::Volatile => {}
+    }
+}
+
+/// Convert compact ranges through a known line index and append LSP locations.
+fn append_locations_with_line_index(
+    ranges: &[crate::semantics::CompactRange],
+    package: &CachedPackageAnalysis,
+    line_index: &LineIndex,
+    locations: &mut Vec<Location>,
+) {
+    for range in ranges {
+        if let Some((uri, range)) =
+            compact_range_to_location_with_line_index(*range, package.analyzed_files.as_ref(), line_index)
+        {
+            locations.push(Location { uri, range });
+        }
+    }
+}

--- a/crates/lsp/src/semantics.rs
+++ b/crates/lsp/src/semantics.rs
@@ -14,11 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+//! Shared semantic data model for LSP highlighting and navigation.
+//!
+//! Compiler and syntax collectors emit rich source occurrences into this
+//! module's types. Package analysis then lowers them into compact file IDs,
+//! symbol-key IDs, and byte ranges so semantic tokens, go-to-definition,
+//! references, and future rename support can reuse one bounded index.
+
 use leo_ast::Location;
 use leo_span::Symbol;
 use line_index::LineIndex;
 use std::{
     collections::HashMap,
+    hash::{Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -67,6 +75,45 @@ pub enum SemanticKind {
     Operator,
 }
 
+impl SemanticKind {
+    /// Pack the fixed semantic-kind legend into the occurrence flag word.
+    pub fn to_packed_bits(self) -> u32 {
+        match self {
+            Self::Namespace => 0,
+            Self::Type => 1,
+            Self::Interface => 2,
+            Self::Function => 3,
+            Self::Parameter => 4,
+            Self::Variable => 5,
+            Self::Property => 6,
+            Self::Keyword => 7,
+            Self::Comment => 8,
+            Self::String => 9,
+            Self::Number => 10,
+            Self::Operator => 11,
+        }
+    }
+
+    /// Unpack a semantic kind previously written by [`Self::to_packed_bits`].
+    pub fn from_packed_bits(bits: u32) -> Self {
+        match bits {
+            0 => Self::Namespace,
+            1 => Self::Type,
+            2 => Self::Interface,
+            3 => Self::Function,
+            4 => Self::Parameter,
+            5 => Self::Variable,
+            6 => Self::Property,
+            7 => Self::Keyword,
+            8 => Self::Comment,
+            9 => Self::String,
+            10 => Self::Number,
+            11 => Self::Operator,
+            _ => panic!("invalid packed semantic kind {bits}"),
+        }
+    }
+}
+
 /// Declaration-vs-reference role tracked for later navigation features.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum OccurrenceRole {
@@ -83,8 +130,8 @@ pub enum SymbolIdentity {
     GlobalItem { location: Location, declaration: Option<FileRange> },
     /// A member declaration or access owned by the current surrounding item.
     Member { owner: Option<Location>, name: Symbol, declaration: Option<FileRange> },
-    /// A program or imported namespace reference.
-    Program { name: Symbol, declaration: Option<FileRange> },
+    /// A program declaration or namespace occurrence scoped by package root.
+    Program { program: Symbol, package_root: Option<Arc<PathBuf>>, declaration: Option<FileRange> },
     /// Syntax-only occurrence without enough semantic data to identify the symbol.
     Unknown,
 }
@@ -104,7 +151,10 @@ impl SymbolIdentity {
                 Some(SymbolKey::Member { owner: owner.clone(), name: *name })
             }
             Self::Member { owner: None, .. } | Self::Unknown => None,
-            Self::Program { name, .. } => Some(SymbolKey::Program { name: *name }),
+            Self::Program { program, package_root: Some(package_root), .. } => {
+                Some(SymbolKey::Program { program: *program, package_root: Arc::clone(package_root) })
+            }
+            Self::Program { package_root: None, .. } => None,
         }
     }
 
@@ -131,7 +181,7 @@ impl SymbolIdentity {
 /// contain `FileRange`, which duplicates paths and range objects. Worker
 /// lowering converts every key into [`CompactSymbolKey`] after file IDs are
 /// interned for the package analysis.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Eq)]
 pub enum SymbolKey {
     /// A lexical binding keyed by its declaration token.
     Local { declaration: FileRange },
@@ -139,8 +189,56 @@ pub enum SymbolKey {
     GlobalItem { location: Location },
     /// A member keyed by concrete owner and member name.
     Member { owner: Location, name: Symbol },
-    /// A program or namespace key. This is navigation-only for PR 3.
-    Program { name: Symbol },
+    /// A program or namespace key scoped by resolved package root.
+    Program { program: Symbol, package_root: Arc<PathBuf> },
+}
+
+impl PartialEq for SymbolKey {
+    /// Compare symbol keys while treating equal package-root paths as equal Arcs.
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Local { declaration: left }, Self::Local { declaration: right }) => left == right,
+            (Self::GlobalItem { location: left }, Self::GlobalItem { location: right }) => left == right,
+            (
+                Self::Member { owner: left_owner, name: left_name },
+                Self::Member { owner: right_owner, name: right_name },
+            ) => left_owner == right_owner && left_name == right_name,
+            (
+                Self::Program { program: left_program, package_root: left_root },
+                Self::Program { program: right_program, package_root: right_root },
+            ) => {
+                left_program == right_program
+                    && (Arc::ptr_eq(left_root, right_root) || left_root.as_ref() == right_root.as_ref())
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Hash for SymbolKey {
+    /// Hash symbol keys by semantic identity rather than Arc pointer identity.
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Local { declaration } => {
+                0_u8.hash(state);
+                declaration.hash(state);
+            }
+            Self::GlobalItem { location } => {
+                1_u8.hash(state);
+                location.hash(state);
+            }
+            Self::Member { owner, name } => {
+                2_u8.hash(state);
+                owner.hash(state);
+                name.hash(state);
+            }
+            Self::Program { program, package_root } => {
+                3_u8.hash(state);
+                program.hash(state);
+                package_root.as_ref().hash(state);
+            }
+        }
+    }
 }
 
 /// Compact file identifier used inside package-level semantic caches.
@@ -149,7 +247,7 @@ pub type FileId = u32;
 /// Compact symbol-key identifier used inside package-level semantic caches.
 pub type SymbolKeyId = u32;
 
-/// Sentinel stored in [`CompactOccurrence::key`] for syntax-only tokens.
+/// Sentinel packed into [`CompactOccurrence`] for syntax-only tokens without a key.
 pub const NO_SYMBOL_KEY: SymbolKeyId = u32::MAX;
 
 /// File-relative byte range stored without cloning paths.
@@ -164,7 +262,7 @@ pub struct CompactRange {
 }
 
 /// Cached semantic key after local declarations have been lowered to file IDs.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Eq)]
 pub enum CompactSymbolKey {
     /// A lexical binding keyed by its compact declaration token.
     Local { declaration: CompactRange },
@@ -172,30 +270,134 @@ pub enum CompactSymbolKey {
     GlobalItem { location: Location },
     /// A member keyed by concrete owner and member name.
     Member { owner: Location, name: Symbol },
-    /// A program or namespace key. This is navigation-only for PR 3.
-    Program { name: Symbol },
+    /// A program or namespace key scoped by resolved package root.
+    Program { program: Symbol, package_root: Arc<PathBuf> },
+}
+
+impl PartialEq for CompactSymbolKey {
+    /// Compare compact keys while preserving path-value equality for program roots.
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Local { declaration: left }, Self::Local { declaration: right }) => left == right,
+            (Self::GlobalItem { location: left }, Self::GlobalItem { location: right }) => left == right,
+            (
+                Self::Member { owner: left_owner, name: left_name },
+                Self::Member { owner: right_owner, name: right_name },
+            ) => left_owner == right_owner && left_name == right_name,
+            (
+                Self::Program { program: left_program, package_root: left_root },
+                Self::Program { program: right_program, package_root: right_root },
+            ) => {
+                left_program == right_program
+                    && (Arc::ptr_eq(left_root, right_root) || left_root.as_ref() == right_root.as_ref())
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Hash for CompactSymbolKey {
+    /// Hash compact keys by semantic identity rather than Arc pointer identity.
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Local { declaration } => {
+                0_u8.hash(state);
+                declaration.hash(state);
+            }
+            Self::GlobalItem { location } => {
+                1_u8.hash(state);
+                location.hash(state);
+            }
+            Self::Member { owner, name } => {
+                2_u8.hash(state);
+                owner.hash(state);
+                name.hash(state);
+            }
+            Self::Program { program, package_root } => {
+                3_u8.hash(state);
+                program.hash(state);
+                package_root.as_ref().hash(state);
+            }
+        }
+    }
 }
 
 /// Compact occurrence retained by package analysis.
+///
+/// The semantic key and token metadata intentionally share one trailing word:
+/// low 26 bits store the package-local key ID, while the high 6 bits store
+/// declaration/reference, readonly, and semantic-kind flags. That keeps the
+/// occurrence table at 16 bytes, which is the memory budget that pays for the
+/// secondary references index.
+#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CompactOccurrence {
     /// Source range for the occurrence.
     pub range: CompactRange,
-    /// Interned semantic key, or [`NO_SYMBOL_KEY`] for syntax-only/unknown tokens.
-    pub key: SymbolKeyId,
-    /// Declaration/reference role for semantic-token modifiers and navigation.
-    pub role: OccurrenceRole,
-    /// Internal token kind reused by semantic-token document views.
-    pub token_kind: SemanticKind,
-    /// Whether this occurrence carries the readonly semantic-token modifier.
-    pub readonly: bool,
+    /// Packed semantic key plus role/readonly/kind flags.
+    key_and_flags: u32,
 }
 
+const PACKED_KEY_BITS: u32 = 26;
+const PACKED_KEY_MASK: u32 = (1 << PACKED_KEY_BITS) - 1;
+const PACKED_NO_SYMBOL_KEY: u32 = PACKED_KEY_MASK;
+const FLAG_ROLE_DECLARATION: u32 = 1 << PACKED_KEY_BITS;
+const FLAG_READONLY: u32 = 1 << (PACKED_KEY_BITS + 1);
+const FLAG_KIND_SHIFT: u32 = PACKED_KEY_BITS + 2;
+const FLAG_KIND_MASK: u32 = 0b1111 << FLAG_KIND_SHIFT;
+
 impl CompactOccurrence {
+    /// Construct a compact occurrence with packed metadata flags.
+    pub fn new(
+        range: CompactRange,
+        key: SymbolKeyId,
+        role: OccurrenceRole,
+        token_kind: SemanticKind,
+        readonly: bool,
+    ) -> Self {
+        let mut key_and_flags = pack_symbol_key(key) | (token_kind.to_packed_bits() << FLAG_KIND_SHIFT);
+        if role == OccurrenceRole::Declaration {
+            key_and_flags |= FLAG_ROLE_DECLARATION;
+        }
+        if readonly {
+            key_and_flags |= FLAG_READONLY;
+        }
+        Self { range, key_and_flags }
+    }
+
     /// Return the optional semantic key for navigation-grade occurrences.
     pub fn key_id(&self) -> Option<SymbolKeyId> {
-        (self.key != NO_SYMBOL_KEY).then_some(self.key)
+        let key = self.key_and_flags & PACKED_KEY_MASK;
+        (key != PACKED_NO_SYMBOL_KEY).then_some(key)
     }
+
+    /// Return whether this occurrence is a declaration or reference.
+    pub fn role(&self) -> OccurrenceRole {
+        if self.key_and_flags & FLAG_ROLE_DECLARATION != 0 {
+            OccurrenceRole::Declaration
+        } else {
+            OccurrenceRole::Reference
+        }
+    }
+
+    /// Return the token kind carried by this occurrence.
+    pub fn token_kind(&self) -> SemanticKind {
+        SemanticKind::from_packed_bits((self.key_and_flags & FLAG_KIND_MASK) >> FLAG_KIND_SHIFT)
+    }
+
+    /// Return whether this occurrence carries the readonly modifier.
+    pub fn readonly(&self) -> bool {
+        self.key_and_flags & FLAG_READONLY != 0
+    }
+}
+
+/// Pack an optional symbol key into the reserved low bits of an occurrence.
+fn pack_symbol_key(key: SymbolKeyId) -> u32 {
+    if key == NO_SYMBOL_KEY {
+        return PACKED_NO_SYMBOL_KEY;
+    }
+    assert!(key < PACKED_NO_SYMBOL_KEY, "too many distinct symbol keys for one LSP package index");
+    key
 }
 
 /// Borrowed occurrence returned by fast cursor lookup.
@@ -236,6 +438,8 @@ pub struct AnalyzedFile {
     pub fingerprint: SourceFingerprint,
     /// Open-buffer line index retained only for unsaved editor content.
     pub open_line_index: Option<Arc<LineIndex>>,
+    /// Virtual sentinel paths are semantic identities only, never LSP locations.
+    pub is_sentinel: bool,
 }
 
 /// Memory-light analyzed-file table owned by one package analysis.
@@ -324,10 +528,18 @@ pub struct SemanticIndex {
     pub occurrences: Arc<[CompactOccurrence]>,
     /// Per-file occurrence slices into `occurrences`.
     pub file_occurrence_ranges: Arc<[(FileId, std::ops::Range<u32>)]>,
-    /// Per-key definition slices into `definition_ranges`.
-    pub definitions: Arc<[(SymbolKeyId, std::ops::Range<u32>)]>,
+    /// Sorted distinct keys with at least one definition target.
+    pub definition_keys: Arc<[SymbolKeyId]>,
+    /// Cumulative end offsets into `definition_ranges`.
+    pub definition_ends: Arc<[u32]>,
     /// Deduplicated compact definition targets.
     pub definition_ranges: Arc<[CompactRange]>,
+    /// Sorted distinct keys with at least one occurrence.
+    pub key_occurrence_keys: Arc<[SymbolKeyId]>,
+    /// Cumulative end offsets into `key_occurrence_indices`.
+    pub key_occurrence_ends: Arc<[u32]>,
+    /// Occurrence indices grouped by key and ordered by file/range.
+    pub key_occurrence_indices: Arc<[u32]>,
 }
 
 impl SemanticIndex {
@@ -362,13 +574,13 @@ impl SemanticIndex {
                 Some(intern_symbol_key(compact, &mut key_ids))
             });
 
-            compact_occurrences.push(CompactOccurrence {
+            compact_occurrences.push(CompactOccurrence::new(
                 range,
-                key: key.unwrap_or(NO_SYMBOL_KEY),
-                role: occurrence.role,
-                token_kind: occurrence.token_kind,
-                readonly: occurrence.readonly,
-            });
+                key.unwrap_or(NO_SYMBOL_KEY),
+                occurrence.role,
+                occurrence.token_kind,
+                occurrence.readonly,
+            ));
 
             if let Some(key) = key {
                 if occurrence.role == OccurrenceRole::Declaration {
@@ -395,7 +607,9 @@ impl SemanticIndex {
         });
 
         let file_occurrence_ranges = file_occurrence_ranges(&compact_occurrences);
-        let (definitions, definition_ranges) = definition_slices(definition_pairs);
+        let (definition_keys, definition_ends, definition_ranges) = definition_slices(definition_pairs);
+        let (key_occurrence_keys, key_occurrence_ends, key_occurrence_indices) =
+            key_occurrence_slices(&compact_occurrences);
         let mut file_lookup =
             files.iter().enumerate().map(|(id, path)| (Arc::clone(path), id as FileId)).collect::<Vec<_>>();
         file_lookup.sort_by(|(left, _), (right, _)| left.cmp(right));
@@ -408,6 +622,7 @@ impl SemanticIndex {
                 path: Arc::clone(path),
                 fingerprint: fingerprint_for_path(path.as_ref()),
                 open_line_index: open_line_index_for_path(path.as_ref()),
+                is_sentinel: is_sentinel_path(path.as_ref()),
             })
             .collect();
 
@@ -417,8 +632,12 @@ impl SemanticIndex {
                 file_lookup: Arc::from(file_lookup),
                 occurrences: Arc::from(compact_occurrences),
                 file_occurrence_ranges: Arc::from(file_occurrence_ranges),
-                definitions: Arc::from(definitions),
+                definition_keys: Arc::from(definition_keys),
+                definition_ends: Arc::from(definition_ends),
                 definition_ranges: Arc::from(definition_ranges),
+                key_occurrence_keys: Arc::from(key_occurrence_keys),
+                key_occurrence_ends: Arc::from(key_occurrence_ends),
+                key_occurrence_indices: Arc::from(key_occurrence_indices),
             },
             AnalyzedFileSet::new(analyzed_files),
         )
@@ -455,11 +674,20 @@ impl SemanticIndex {
 
     /// Return all deduplicated definition targets for a compact key.
     pub fn definitions_for(&self, key: SymbolKeyId) -> &[CompactRange] {
-        let Ok(index) = self.definitions.binary_search_by_key(&key, |(candidate, _)| *candidate) else {
+        let Ok(index) = self.definition_keys.binary_search(&key) else {
             return &[];
         };
-        let (_, range) = &self.definitions[index];
-        &self.definition_ranges[range.start as usize..range.end as usize]
+        let start = if index == 0 { 0 } else { self.definition_ends[index - 1] };
+        let end = self.definition_ends[index];
+        &self.definition_ranges[start as usize..end as usize]
+    }
+
+    /// Return all occurrences for a compact key in deterministic file/range order.
+    pub fn occurrences_for(&self, key: SymbolKeyId) -> impl Iterator<Item = &CompactOccurrence> + '_ {
+        let range = self.key_occurrence_index_range(key).unwrap_or(0..0);
+        self.key_occurrence_indices[range.start as usize..range.end as usize]
+            .iter()
+            .map(|index| &self.occurrences[*index as usize])
     }
 
     /// Return semantic-token occurrences for one file.
@@ -479,9 +707,9 @@ impl SemanticIndex {
                     start: occurrence.range.start,
                     end: occurrence.range.end,
                 },
-                token_kind: occurrence.token_kind,
-                role: occurrence.role,
-                readonly: occurrence.readonly,
+                token_kind: occurrence.token_kind(),
+                role: occurrence.role(),
+                readonly: occurrence.readonly(),
             })
             .collect()
     }
@@ -496,6 +724,13 @@ impl SemanticIndex {
     fn file_occurrence_range(&self, file: FileId) -> Option<std::ops::Range<u32>> {
         let index = self.file_occurrence_ranges.binary_search_by_key(&file, |(candidate, _)| *candidate).ok()?;
         Some(self.file_occurrence_ranges[index].1.clone())
+    }
+
+    /// Return the compact index slice for one symbol key.
+    fn key_occurrence_index_range(&self, key: SymbolKeyId) -> Option<std::ops::Range<u32>> {
+        let index = self.key_occurrence_keys.binary_search(&key).ok()?;
+        let start = if index == 0 { 0 } else { self.key_occurrence_ends[index - 1] };
+        Some(start..self.key_occurrence_ends[index])
     }
 }
 
@@ -564,7 +799,7 @@ fn compact_symbol_key(key: SymbolKey, path_ids: &HashMap<Arc<PathBuf>, FileId>) 
         }
         SymbolKey::GlobalItem { location } => Some(CompactSymbolKey::GlobalItem { location }),
         SymbolKey::Member { owner, name } => Some(CompactSymbolKey::Member { owner, name }),
-        SymbolKey::Program { name } => Some(CompactSymbolKey::Program { name }),
+        SymbolKey::Program { program, package_root } => Some(CompactSymbolKey::Program { program, package_root }),
     }
 }
 
@@ -595,38 +830,77 @@ fn file_occurrence_ranges(occurrences: &[CompactOccurrence]) -> Vec<(FileId, std
 }
 
 /// Build compact definition lookup tables from `(key, target)` pairs.
-fn definition_slices(
-    mut pairs: Vec<(SymbolKeyId, CompactRange)>,
-) -> (Vec<(SymbolKeyId, std::ops::Range<u32>)>, Vec<CompactRange>) {
+fn definition_slices(mut pairs: Vec<(SymbolKeyId, CompactRange)>) -> (Vec<SymbolKeyId>, Vec<u32>, Vec<CompactRange>) {
     pairs.sort_by(|(left_key, left_range), (right_key, right_range)| {
         left_key.cmp(right_key).then_with(|| left_range.cmp(right_range))
     });
     pairs.dedup();
 
-    // Store targets in one flat range arena and keep a sorted `(key, slice)`
-    // table. That keeps package caches compact while preserving binary-search
-    // lookup for definition requests.
-    let mut definitions = Vec::new();
+    // CSR keeps the key lookup table compact while preserving binary-search
+    // lookup for definition and references requests.
+    let mut keys = Vec::new();
+    let mut ends = Vec::new();
     let mut ranges = Vec::new();
     let mut start = 0_usize;
     while start < pairs.len() {
         let key = pairs[start].0;
-        let range_start = ranges.len() as u32;
         let mut end = start;
         while end < pairs.len() && pairs[end].0 == key {
             ranges.push(pairs[end].1);
             end += 1;
         }
-        definitions.push((key, range_start..ranges.len() as u32));
+        keys.push(key);
+        ends.push(ranges.len() as u32);
         start = end;
     }
 
-    (definitions, ranges)
+    (keys, ends, ranges)
+}
+
+/// Build the secondary occurrence index in key/file/range order.
+fn key_occurrence_slices(occurrences: &[CompactOccurrence]) -> (Vec<SymbolKeyId>, Vec<u32>, Vec<u32>) {
+    let mut pairs = Vec::<(SymbolKeyId, u32)>::new();
+    for (index, occurrence) in occurrences.iter().enumerate() {
+        if let Some(key) = occurrence.key_id() {
+            pairs.push((key, index as u32));
+        }
+    }
+
+    pairs.sort_unstable_by(|left, right| {
+        left.0.cmp(&right.0).then_with(|| {
+            let left_range = occurrences[left.1 as usize].range;
+            let right_range = occurrences[right.1 as usize].range;
+            left_range.cmp(&right_range)
+        })
+    });
+
+    let mut keys = Vec::<SymbolKeyId>::new();
+    let mut ends = Vec::<u32>::new();
+    let mut indices = Vec::<u32>::with_capacity(pairs.len());
+    let mut start = 0_usize;
+    while start < pairs.len() {
+        let key = pairs[start].0;
+        let mut end = start;
+        while end < pairs.len() && pairs[end].0 == key {
+            indices.push(pairs[end].1);
+            end += 1;
+        }
+        keys.push(key);
+        ends.push(indices.len() as u32);
+        start = end;
+    }
+
+    (keys, ends, indices)
 }
 
 /// Return a compact range length, saturating defensively for malformed inputs.
 fn range_len(range: CompactRange) -> u32 {
     range.end.saturating_sub(range.start)
+}
+
+/// Return whether an interned path is a compiler-bridge virtual sentinel.
+pub(crate) fn is_sentinel_path(path: &Path) -> bool {
+    path.as_os_str().to_string_lossy().starts_with("leo-vfs:")
 }
 
 /// Sort occurrences into stable file-relative source order.
@@ -686,7 +960,19 @@ pub fn merge_occurrences(
 
 #[cfg(test)]
 mod tests {
-    use super::{FileRange, OccurrenceRole, SemanticKind, SymbolIdentity, SymbolOccurrence, merge_occurrences};
+    use super::{
+        CompactOccurrence,
+        CompactRange,
+        FileRange,
+        OccurrenceRole,
+        SemanticIndex,
+        SemanticKind,
+        SourceFingerprint,
+        SymbolIdentity,
+        SymbolKeyId,
+        SymbolOccurrence,
+        merge_occurrences,
+    };
     use std::{path::PathBuf, sync::Arc};
 
     /// Build a minimal occurrence for merge-order unit tests.
@@ -698,6 +984,65 @@ mod tests {
             token_kind,
             readonly: false,
         }
+    }
+
+    /// Verifies every semantic kind survives compact occurrence packing.
+    #[test]
+    fn compact_occurrence_flags_round_trip() {
+        let range = CompactRange { file: 0, start: 1, end: 4 };
+        let kinds = [
+            SemanticKind::Namespace,
+            SemanticKind::Type,
+            SemanticKind::Interface,
+            SemanticKind::Function,
+            SemanticKind::Parameter,
+            SemanticKind::Variable,
+            SemanticKind::Property,
+            SemanticKind::Keyword,
+            SemanticKind::Comment,
+            SemanticKind::String,
+            SemanticKind::Number,
+            SemanticKind::Operator,
+        ];
+
+        for kind in kinds {
+            let occurrence = CompactOccurrence::new(range, 7, OccurrenceRole::Declaration, kind, true);
+            assert_eq!(occurrence.key_id(), Some(7));
+            assert_eq!(occurrence.role(), OccurrenceRole::Declaration);
+            assert_eq!(occurrence.token_kind(), kind);
+            assert!(occurrence.readonly());
+        }
+        assert_eq!(std::mem::size_of::<CompactOccurrence>(), 16);
+    }
+
+    /// Verifies the secondary occurrence index returns source-ordered matches.
+    #[test]
+    fn occurrences_for_returns_keyed_source_order() {
+        let path = Arc::new(PathBuf::from("main.leo"));
+        let declaration = FileRange::new(Arc::clone(&path), 4, 9).expect("declaration range");
+        let occurrences = vec![
+            SymbolOccurrence {
+                range: FileRange::new(Arc::clone(&path), 20, 25).expect("reference range"),
+                identity: SymbolIdentity::Local { declaration: declaration.clone() },
+                role: OccurrenceRole::Reference,
+                token_kind: SemanticKind::Variable,
+                readonly: false,
+            },
+            SymbolOccurrence {
+                range: declaration.clone(),
+                identity: SymbolIdentity::Local { declaration },
+                role: OccurrenceRole::Declaration,
+                token_kind: SemanticKind::Variable,
+                readonly: false,
+            },
+        ];
+
+        let (index, _) = SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None);
+        let key = index.occurrences[0].key_id().expect("keyed declaration");
+        let starts = index.occurrences_for(key).map(|occurrence| occurrence.range.start).collect::<Vec<_>>();
+
+        assert_eq!(starts, vec![4, 20]);
+        assert!(index.occurrences_for(SymbolKeyId::MAX - 1).next().is_none());
     }
 
     /// Verifies compiler occurrences win exact range conflicts with syntax fallback.

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -16,19 +16,28 @@
 
 #![allow(clippy::mutable_key_type)]
 
+//! Main `leo-lsp` protocol loop and routing-thread state.
+//!
+//! This module owns the initialized LSP lifecycle, open-document routing,
+//! request cancellation, worker completion handling, and response-pool
+//! handoffs. Feature modules answer semantic questions; this layer preserves
+//! freshness, ordering, and single-writer JSON-RPC response semantics.
+
 use crate::{
     document_store::{AnalysisBucket, DocumentStore, DocumentViewKey, PackageAnalysisKey},
     features::{
         goto_definition::{
             DefinitionQuery,
-            position_to_offset,
             resolve as resolve_definition,
             response_value as definition_response_value,
         },
+        lsp_range::position_to_offset,
+        references::ReferenceQuery,
         semantic_tokens::{capability as semantic_tokens_capability, empty_response_value, response_value},
     },
     panic_boundary::catch_unwind,
     project_model::{ProjectModel, uri_to_file_path},
+    response_pool::{OpenLineIndexes, ResponseCompletion, ResponseJob, ResponsePool, ResponseResult},
     scheduler::{PackageAnalysis, Scheduler, WorkerEvent},
     semantics::{CachedDocumentView, CachedPackageAnalysis},
 };
@@ -44,6 +53,7 @@ use lsp_types::{
     InitializeResult,
     NumberOrString,
     OneOf,
+    ReferenceParams,
     SemanticTokensParams,
     ServerCapabilities,
     ServerInfo,
@@ -58,7 +68,10 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     path::PathBuf,
     process::ExitCode,
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 /// JSON-RPC code for internal server errors.
@@ -84,12 +97,18 @@ const CANCEL_REQUEST: &str = "$/cancelRequest";
 const SEMANTIC_TOKENS_FULL: &str = "textDocument/semanticTokens/full";
 /// LSP go-to-definition request method.
 const TEXT_DOCUMENT_DEFINITION: &str = "textDocument/definition";
+/// LSP find-all-references request method.
+const TEXT_DOCUMENT_REFERENCES: &str = "textDocument/references";
 /// Maximum package analyses retained on the routing thread.
 const MAX_PACKAGE_CACHE_ENTRIES: usize = 8;
 /// Maximum pending go-to-definition requests across all packages.
 const MAX_PENDING_DEFINITIONS: usize = 128;
 /// Maximum pending go-to-definition requests waiting on one package key.
 const MAX_PENDING_DEFINITIONS_PER_KEY: usize = 16;
+/// Maximum pending references requests across all packages.
+const MAX_PENDING_REFERENCES: usize = 128;
+/// Maximum pending references requests waiting on one package key.
+const MAX_PENDING_REFERENCES_PER_KEY: usize = 16;
 
 /// In-memory state for one running `leo-lsp` server instance.
 ///
@@ -105,9 +124,11 @@ struct ServerState {
     documents: DocumentStore,
     project_model: ProjectModel,
     scheduler: Scheduler,
+    response_pool: ResponsePool,
     analysis: AnalysisCaches,
     semantic_token_requests: SemanticTokenRequestState,
     definition_requests: DefinitionRequestState,
+    reference_requests: ReferencesRequestState,
     client_definition_link_support: bool,
     hooks: TestHooks,
 }
@@ -158,6 +179,28 @@ struct PendingDefinitionRequest {
     query: DefinitionQuery,
 }
 
+/// Pending references requests keyed by package analysis.
+#[derive(Debug, Default)]
+struct ReferencesRequestState {
+    /// Waiters and in-flight conversions grouped by package analysis.
+    pending_by_package: HashMap<PackageAnalysisKey, Vec<PendingReferencesRequest>>,
+    /// Reverse lookup used to cancel or complete a request by ID.
+    pending_owner: HashMap<RequestId, PackageAnalysisKey>,
+}
+
+/// One pending references request with cancellation state owned by routing.
+#[derive(Debug, Clone)]
+struct PendingReferencesRequest {
+    /// Original LSP request ID to answer when conversion completes.
+    id: RequestId,
+    /// Cursor and freshness state captured when the request arrived.
+    query: ReferenceQuery,
+    /// Cancellation flag observed by the response pool.
+    cancel: Arc<AtomicBool>,
+    /// Whether this request has already been handed to the response pool.
+    dispatched: bool,
+}
+
 /// Run the production LSP server with hooks loaded from the process environment.
 pub(crate) fn run(connection: Connection) -> Result<ExitCode> {
     run_with_hooks(connection, TestHooks::from_env())
@@ -190,9 +233,11 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
         documents: DocumentStore::default(),
         project_model: ProjectModel::default(),
         scheduler: Scheduler::new(hooks.panic_on_worker_job),
+        response_pool: ResponsePool::new(),
         analysis: AnalysisCaches::default(),
         semantic_token_requests: SemanticTokenRequestState::default(),
         definition_requests: DefinitionRequestState::default(),
+        reference_requests: ReferencesRequestState::default(),
         client_definition_link_support,
         hooks,
     };
@@ -217,10 +262,16 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
                     state.handle_worker_event(&connection, event);
                 }
             }
+            recv(state.response_pool.completions()) -> completion => {
+                if let Ok(completion) = completion {
+                    state.handle_response_completion(&connection, completion);
+                }
+            }
         }
     }
 
     state.scheduler.shutdown();
+    state.response_pool.shutdown();
     Ok(state.exit_code.unwrap_or(ExitCode::from(1)))
 }
 
@@ -282,6 +333,11 @@ impl ServerState {
                 let params: GotoDefinitionParams =
                     serde_json::from_value(params).context("failed to deserialize textDocument/definition")?;
                 self.handle_goto_definition(connection, request_id, params)
+            }
+            TEXT_DOCUMENT_REFERENCES => {
+                let params: ReferenceParams =
+                    serde_json::from_value(params).context("failed to deserialize textDocument/references")?;
+                self.handle_references(connection, request_id, params)
             }
             _ => {
                 tracing::debug!(method, "request is not implemented");
@@ -431,6 +487,9 @@ impl ServerState {
         if let Err(error) = send_definition_nulls(connection, self.definition_requests.clear_uri(&uri)) {
             tracing::error!(uri = uri.as_str(), error = %error, "failed to flush definition close responses");
         }
+        if let Err(error) = send_reference_nulls(connection, self.reference_requests.clear_uri(&uri)) {
+            tracing::error!(uri = uri.as_str(), error = %error, "failed to flush references close responses");
+        }
         if let Some(bucket) = previous_bucket {
             self.analysis.invalidate_bucket(&bucket);
             self.cancel_pending_bucket_requests(connection, &bucket, "package analysis was superseded");
@@ -439,7 +498,7 @@ impl ServerState {
         }
     }
 
-    /// Remove a pending semantic-token or definition request by LSP request ID.
+    /// Remove a pending semantic-token, definition, or references request by LSP request ID.
     fn handle_cancel_request(&mut self, connection: &Connection, params: CancelParams) -> Result<()> {
         let request_id = request_id_from_cancel(params.id);
         if self.semantic_token_requests.remove_pending_request(&request_id) {
@@ -456,6 +515,14 @@ impl ServerState {
                 ErrorCode::RequestCanceled as i32,
                 "definition request cancelled",
             )
+        } else if let Some(pending) = self.reference_requests.remove_pending_request(&request_id) {
+            pending.cancel.store(true, Ordering::SeqCst);
+            send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "references request cancelled",
+            )
         } else {
             Ok(())
         }
@@ -469,9 +536,16 @@ impl ServerState {
                 if self.documents.generation(&uri) == Some(generation)
                     && self.documents.package_key(&uri) == Some(key.clone())
                 {
-                    self.analysis.store_package(Arc::clone(&result.package));
+                    for evicted in self.analysis.store_package(Arc::clone(&result.package)) {
+                        self.cancel_pending_package_requests(
+                            connection,
+                            &evicted,
+                            "package analysis was evicted from cache",
+                        );
+                    }
                     self.store_document_view(connection, result.document_view);
                     self.answer_pending_definitions(connection, &key);
+                    self.answer_pending_references(&key);
                     self.enqueue_pending_document_views_for_package(&key);
                     tracing::debug!(
                         uri = uri.as_str(),
@@ -538,6 +612,18 @@ impl ServerState {
                     ) {
                         tracing::error!(uri = uri.as_str(), error = %error, "failed to send definition analysis panic");
                     }
+                    let references = self.reference_requests.take_package(&key);
+                    for pending in &references {
+                        pending.cancel.store(true, Ordering::SeqCst);
+                    }
+                    if let Err(error) = send_error_responses(
+                        connection,
+                        references.into_iter().map(|pending| pending.id).collect(),
+                        INTERNAL_ERROR,
+                        "references analysis panicked; see server logs for details",
+                    ) {
+                        tracing::error!(uri = uri.as_str(), error = %error, "failed to send references analysis panic");
+                    }
                 } else {
                     self.cancel_pending_package_requests(connection, &key, "package analysis was superseded");
                 }
@@ -561,6 +647,36 @@ impl ServerState {
                         &key,
                         "semantic token document view was superseded",
                     );
+                }
+            }
+        }
+    }
+
+    /// Forward a response-pool completion if the request is still live.
+    fn handle_response_completion(&mut self, connection: &Connection, completion: ResponseCompletion) {
+        match completion {
+            ResponseCompletion::References { id, key, cancel, result } => {
+                let Some(pending) = self.reference_requests.get(&id) else {
+                    return;
+                };
+                // JSON-RPC IDs can be reused after cancellation. The package
+                // key proves freshness for the analysis; the Arc identity
+                // proves this completion belongs to the same dispatched waiter,
+                // not an older request that happened to use the same ID.
+                if pending.query.view_key.package != key || !Arc::ptr_eq(&pending.cancel, &cancel) {
+                    return;
+                }
+                let Some(_pending) = self.reference_requests.remove_pending_request(&id) else {
+                    return;
+                };
+                let send_result = match result {
+                    ResponseResult::Ok(value) => send_ok_response(connection, id, value),
+                    ResponseResult::InternalError(message) => {
+                        send_error_response(connection, id, INTERNAL_ERROR, message)
+                    }
+                };
+                if let Err(error) = send_result {
+                    tracing::error!(error = %error, "failed to send references response");
                 }
             }
         }
@@ -660,6 +776,63 @@ impl ServerState {
         }
     }
 
+    /// Answer or queue one find-all-references request.
+    fn handle_references(
+        &mut self,
+        connection: &Connection,
+        request_id: RequestId,
+        params: ReferenceParams,
+    ) -> Result<()> {
+        let uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let Some(document) = self.documents.open_document(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        if document.file_path.is_none() {
+            return send_ok_response(connection, request_id, Value::Null);
+        }
+        let Some(offset) = position_to_offset(document.line_index.as_ref(), position) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(view_key) = self.documents.document_view_key(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+
+        if self.analysis.failed_packages.contains(&view_key.package) {
+            return send_error_response(
+                connection,
+                request_id,
+                INTERNAL_ERROR,
+                "references analysis panicked; see server logs for details",
+            );
+        }
+
+        let package = self.analysis.packages.get(&view_key.package).cloned();
+        let query = ReferenceQuery {
+            offset,
+            position,
+            view_key: view_key.clone(),
+            include_declaration: params.context.include_declaration,
+        };
+        let cancel = Arc::new(AtomicBool::new(false));
+        let dispatched = package.is_some();
+        if !self.reference_requests.queue(query, request_id.clone(), Arc::clone(&cancel), dispatched) {
+            return send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "too many pending references requests",
+            );
+        }
+
+        if let Some(package) = package {
+            self.dispatch_reference_job(request_id, view_key.package, package, cancel);
+        } else {
+            self.ensure_package_analysis(&view_key.package, &uri);
+        }
+        Ok(())
+    }
+
     /// Ensure the package and document-view analysis needed for a token request is queued.
     fn ensure_analysis_for_view(&mut self, view_key: &DocumentViewKey) {
         if let Some(package) = self.analysis.packages.get(&view_key.package).cloned() {
@@ -722,6 +895,36 @@ impl ServerState {
         }
     }
 
+    /// Dispatch queued references requests unblocked by a cached package.
+    fn answer_pending_references(&mut self, key: &PackageAnalysisKey) {
+        let Some(package) = self.analysis.packages.get(key).cloned() else {
+            return;
+        };
+        for pending in self.reference_requests.mark_undispatched(key) {
+            self.dispatch_reference_job(pending.id, key.clone(), Arc::clone(&package), Arc::clone(&pending.cancel));
+        }
+    }
+
+    /// Hand one references request to the response pool.
+    fn dispatch_reference_job(
+        &self,
+        request_id: RequestId,
+        _key: PackageAnalysisKey,
+        package: Arc<CachedPackageAnalysis>,
+        cancel: Arc<AtomicBool>,
+    ) {
+        let Some(pending) = self.reference_requests.get(&request_id) else {
+            return;
+        };
+        self.response_pool.submit(ResponseJob::References {
+            id: request_id,
+            query: Box::new(pending.query.clone()),
+            package,
+            open_line_indexes: OpenLineIndexes::snapshot(&self.documents),
+            cancel,
+        });
+    }
+
     /// Start document-view jobs unblocked by a newly cached package analysis.
     fn enqueue_pending_document_views_for_package(&mut self, key: &PackageAnalysisKey) {
         let Some(package) = self.analysis.packages.get(key).cloned() else {
@@ -754,7 +957,7 @@ impl ServerState {
         self.cancel_pending_bucket_requests(connection, current_bucket, message);
     }
 
-    /// Cancel semantic-token and definition waiters tied to one analysis bucket.
+    /// Cancel semantic-token, definition, and references waiters tied to one analysis bucket.
     fn cancel_pending_bucket_requests(
         &mut self,
         connection: &Connection,
@@ -780,9 +983,22 @@ impl ServerState {
         ) {
             tracing::error!(error = %error, "failed to cancel definition bucket waiters");
         }
+
+        let reference_requests = self.reference_requests.take_bucket(bucket);
+        for pending in &reference_requests {
+            pending.cancel.store(true, Ordering::SeqCst);
+        }
+        if let Err(error) = send_error_responses(
+            connection,
+            reference_requests.into_iter().map(|pending| pending.id).collect(),
+            ErrorCode::RequestCanceled as i32,
+            format!("references {message}"),
+        ) {
+            tracing::error!(error = %error, "failed to cancel references bucket waiters");
+        }
     }
 
-    /// Cancel semantic-token and definition waiters tied to one package key.
+    /// Cancel semantic-token, definition, and references waiters tied to one package key.
     fn cancel_pending_package_requests(
         &mut self,
         connection: &Connection,
@@ -807,6 +1023,19 @@ impl ServerState {
             format!("definition {message}"),
         ) {
             tracing::error!(error = %error, "failed to cancel definition package waiters");
+        }
+
+        let reference_requests = self.reference_requests.take_package(key);
+        for pending in &reference_requests {
+            pending.cancel.store(true, Ordering::SeqCst);
+        }
+        if let Err(error) = send_error_responses(
+            connection,
+            reference_requests.into_iter().map(|pending| pending.id).collect(),
+            ErrorCode::RequestCanceled as i32,
+            format!("references {message}"),
+        ) {
+            tracing::error!(error = %error, "failed to cancel references package waiters");
         }
     }
 
@@ -853,12 +1082,13 @@ impl AnalysisCaches {
     }
 
     /// Store a package analysis and enforce the routing-thread LRU cap.
-    fn store_package(&mut self, package: Arc<CachedPackageAnalysis>) {
+    fn store_package(&mut self, package: Arc<CachedPackageAnalysis>) -> Vec<PackageAnalysisKey> {
         self.failed_packages.remove(&package.key);
         if !self.packages.contains_key(&package.key) {
             self.package_order.push_back(package.key.clone());
         }
         self.packages.insert(package.key.clone(), package);
+        let mut evicted = Vec::new();
         // Bound package analyses separately from worker stub caches. This keeps
         // the routing thread from retaining package-sized indexes for closed or
         // long-idle generations.
@@ -866,8 +1096,10 @@ impl AnalysisCaches {
             if let Some(oldest) = self.package_order.pop_front() {
                 self.packages.remove(&oldest);
                 self.failed_packages.remove(&oldest);
+                evicted.push(oldest);
             }
         }
+        evicted
     }
 
     /// Remember that current package analysis failed so repeated requests fail fast.
@@ -1008,6 +1240,105 @@ impl DefinitionRequestState {
     }
 }
 
+impl ReferencesRequestState {
+    /// Queue a references request, enforcing global and per-package caps.
+    fn queue(
+        &mut self,
+        query: ReferenceQuery,
+        request_id: RequestId,
+        cancel: Arc<AtomicBool>,
+        dispatched: bool,
+    ) -> bool {
+        if self.pending_owner.len() >= MAX_PENDING_REFERENCES {
+            return false;
+        }
+        let package = query.view_key.package.clone();
+        let queue = self.pending_by_package.entry(package.clone()).or_default();
+        if queue.len() >= MAX_PENDING_REFERENCES_PER_KEY {
+            return false;
+        }
+        queue.push(PendingReferencesRequest { id: request_id.clone(), query, cancel, dispatched });
+        self.pending_owner.insert(request_id, package);
+        true
+    }
+
+    /// Return one pending references request without mutating ownership.
+    fn get(&self, request_id: &RequestId) -> Option<&PendingReferencesRequest> {
+        let package = self.pending_owner.get(request_id)?;
+        self.pending_by_package.get(package)?.iter().find(|pending| &pending.id == request_id)
+    }
+
+    /// Remove one pending references request by request ID.
+    fn remove_pending_request(&mut self, request_id: &RequestId) -> Option<PendingReferencesRequest> {
+        let package = self.pending_owner.remove(request_id)?;
+        let queue = self.pending_by_package.get_mut(&package)?;
+        let index = queue.iter().position(|pending| &pending.id == request_id)?;
+        let pending = queue.remove(index);
+        if queue.is_empty() {
+            self.pending_by_package.remove(&package);
+        }
+        Some(pending)
+    }
+
+    /// Mark undispatched requests for one package as handed to the response pool.
+    fn mark_undispatched(&mut self, package: &PackageAnalysisKey) -> Vec<PendingReferencesRequest> {
+        let Some(queue) = self.pending_by_package.get_mut(package) else {
+            return Vec::new();
+        };
+        let mut pending = Vec::new();
+        for request in queue.iter_mut() {
+            if !request.dispatched {
+                request.dispatched = true;
+                pending.push(request.clone());
+            }
+        }
+        pending
+    }
+
+    /// Drain references requests whose source document has closed.
+    fn clear_uri(&mut self, uri: &Uri) -> Vec<PendingReferencesRequest> {
+        let packages = self.pending_by_package.keys().cloned().collect::<Vec<_>>();
+        let mut cleared = Vec::new();
+        for package in packages {
+            let Some(queue) = self.pending_by_package.get_mut(&package) else {
+                continue;
+            };
+            let mut index = 0;
+            while index < queue.len() {
+                if &queue[index].query.view_key.uri == uri {
+                    let pending = queue.remove(index);
+                    self.pending_owner.remove(&pending.id);
+                    cleared.push(pending);
+                } else {
+                    index += 1;
+                }
+            }
+            if queue.is_empty() {
+                self.pending_by_package.remove(&package);
+            }
+        }
+        cleared
+    }
+
+    /// Drain references requests waiting on one package key.
+    fn take_package(&mut self, package: &PackageAnalysisKey) -> Vec<PendingReferencesRequest> {
+        let Some(requests) = self.pending_by_package.remove(package) else {
+            return Vec::new();
+        };
+        for request in &requests {
+            self.pending_owner.remove(&request.id);
+        }
+        requests
+    }
+
+    /// Drain references requests waiting on any package key in a bucket.
+    fn take_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingReferencesRequest> {
+        let packages =
+            self.pending_by_package.keys().filter(|package| &package.bucket == bucket).cloned().collect::<Vec<_>>();
+        packages.into_iter().flat_map(|package| self.take_package(&package)).collect()
+    }
+}
+
 /// Collect initialize-time workspace roots using LSP's preferred fallback order.
 #[allow(deprecated)]
 fn collect_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
@@ -1040,6 +1371,7 @@ fn server_capabilities() -> ServerCapabilities {
         })),
         semantic_tokens_provider: Some(semantic_tokens_capability()),
         definition_provider: Some(OneOf::Left(true)),
+        references_provider: Some(OneOf::Left(true)),
         ..Default::default()
     }
 }
@@ -1116,6 +1448,15 @@ fn send_definition_nulls(connection: &Connection, requests: Vec<PendingDefinitio
     Ok(())
 }
 
+/// Send successful `null` references responses for requests orphaned by close.
+fn send_reference_nulls(connection: &Connection, requests: Vec<PendingReferencesRequest>) -> Result<()> {
+    for request in requests {
+        request.cancel.store(true, Ordering::SeqCst);
+        send_ok_response(connection, request.id, Value::Null)?;
+    }
+    Ok(())
+}
+
 /// Send the same error payload to every queued waiter on a URI.
 fn send_error_responses(
     connection: &Connection,
@@ -1176,12 +1517,13 @@ impl TestHooks {
 #[cfg(test)]
 mod tests {
     use super::{DID_CHANGE, TestHooks, run_with_hooks};
-    use lsp_server::{Connection, ErrorCode, Message, Notification, Request, Response};
+    use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response};
     use lsp_types::{
         CancelParams,
         DidChangeTextDocumentParams,
         DidOpenTextDocumentParams,
         NumberOrString,
+        Position,
         SemanticTokensParams,
         TextDocumentContentChangeEvent,
         TextDocumentItem,
@@ -1189,7 +1531,17 @@ mod tests {
         VersionedTextDocumentIdentifier,
     };
     use serde_json::{Value, json};
-    use std::{fs, path::Path, process::ExitCode, sync::Arc, thread, time::Duration};
+    use std::{
+        fs,
+        path::Path,
+        process::ExitCode,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::Duration,
+    };
     use tempfile::tempdir;
 
     /// Spawn the real server loop over an in-memory transport.
@@ -1247,6 +1599,11 @@ mod tests {
         }
     }
 
+    /// Build a references query for direct pending-state tests.
+    fn reference_query(key: crate::document_store::DocumentViewKey) -> super::ReferenceQuery {
+        super::ReferenceQuery { offset: 0, position: Position::new(0, 0), view_key: key, include_declaration: true }
+    }
+
     /// Build isolated server state for direct state-machine tests.
     fn test_state() -> super::ServerState {
         super::ServerState {
@@ -1256,9 +1613,11 @@ mod tests {
             documents: crate::document_store::DocumentStore::default(),
             project_model: crate::project_model::ProjectModel::default(),
             scheduler: crate::scheduler::Scheduler::new(false),
+            response_pool: super::ResponsePool::new(),
             analysis: super::AnalysisCaches::default(),
             semantic_token_requests: super::SemanticTokenRequestState::default(),
             definition_requests: super::DefinitionRequestState::default(),
+            reference_requests: super::ReferencesRequestState::default(),
             client_definition_link_support: false,
             hooks: TestHooks::default(),
         }
@@ -1404,6 +1763,63 @@ mod tests {
         state.scheduler.shutdown();
     }
 
+    /// Verifies package cancellation drains pending references and flips pool cancel flags.
+    #[test]
+    fn package_cancellation_cancels_pending_references() {
+        let (server, client) = Connection::memory();
+        let mut state = test_state();
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+
+        open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+        let key = state.documents.document_view_key(&uri).expect("document view key");
+        let cancel = Arc::new(AtomicBool::new(false));
+        assert!(state.reference_requests.queue(reference_query(key.clone()), 2.into(), Arc::clone(&cancel), true));
+
+        state.cancel_pending_package_requests(&server, &key.package, "package analysis was evicted from cache");
+
+        let response = recv_response(&client);
+        assert_eq!(response.id, 2.into());
+        let error = response.error.expect("cancelled references response");
+        assert_eq!(error.code, ErrorCode::RequestCanceled as i32);
+        assert!(error.message.contains("evicted"));
+        assert!(cancel.load(Ordering::SeqCst));
+        assert!(state.reference_requests.pending_by_package.is_empty());
+        assert!(state.reference_requests.pending_owner.is_empty());
+        state.scheduler.shutdown();
+    }
+
+    /// Verifies a late response-pool completion cannot steal a reused request ID.
+    #[test]
+    fn stale_reference_completion_with_reused_id_is_dropped() {
+        let (server, client) = Connection::memory();
+        let mut state = test_state();
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+
+        open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+        let key = state.documents.document_view_key(&uri).expect("document view key");
+        let request_id: RequestId = 2.into();
+        let old_cancel = Arc::new(AtomicBool::new(true));
+        let new_cancel = Arc::new(AtomicBool::new(false));
+        assert!(state.reference_requests.queue(
+            reference_query(key.clone()),
+            request_id.clone(),
+            Arc::clone(&new_cancel),
+            true,
+        ));
+
+        state.handle_response_completion(&server, super::ResponseCompletion::References {
+            id: request_id.clone(),
+            key: key.package,
+            cancel: old_cancel,
+            result: super::ResponseResult::Ok(Value::Null),
+        });
+
+        assert!(client.receiver.recv_timeout(Duration::from_millis(50)).is_err());
+        assert!(state.reference_requests.get(&request_id).is_some());
+        assert!(!new_cancel.load(Ordering::SeqCst));
+        state.scheduler.shutdown();
+    }
+
     /// Verifies worker cancellation fails semantic-token waiters for that package.
     #[test]
     fn cancelled_package_analysis_fails_pending_waiters() {
@@ -1524,9 +1940,11 @@ mod tests {
             documents: crate::document_store::DocumentStore::default(),
             project_model: crate::project_model::ProjectModel::default(),
             scheduler: crate::scheduler::Scheduler::new(false),
+            response_pool: super::ResponsePool::new(),
             analysis: super::AnalysisCaches::default(),
             semantic_token_requests: super::SemanticTokenRequestState::default(),
             definition_requests: super::DefinitionRequestState::default(),
+            reference_requests: super::ReferencesRequestState::default(),
             client_definition_link_support: false,
             hooks: TestHooks::default(),
         };

--- a/crates/lsp/src/syntax_semantics.rs
+++ b/crates/lsp/src/syntax_semantics.rs
@@ -22,6 +22,7 @@
 
 use crate::{
     document_store::{DocumentSnapshot, DocumentViewSnapshot, OpenFileOverlay},
+    features::lsp_range::hash_text,
     project_model::{ProjectContext, ProjectKind},
     semantics::{
         FileRange,
@@ -40,7 +41,6 @@ use leo_span::{Symbol, create_session_if_not_set_then};
 use std::{
     collections::HashMap,
     fs::{self, Metadata},
-    hash::{DefaultHasher, Hash, Hasher},
     path::{Path, PathBuf},
     sync::Arc,
     time::UNIX_EPOCH,
@@ -182,17 +182,18 @@ fn syntax_program_targets(
     project: Option<&Arc<ProjectContext>>,
     open_overlays: &[OpenFileOverlay],
     target_mode: ProgramTargetMode,
-) -> (HashMap<String, FileRange>, HashMap<PathBuf, SourceFingerprint>) {
+) -> (HashMap<String, ProgramSyntaxTarget>, HashMap<PathBuf, SourceFingerprint>) {
     let mut targets = HashMap::new();
     let mut fingerprints = HashMap::new();
     if target_mode == ProgramTargetMode::None {
         return (targets, fingerprints);
     }
 
-    add_program_targets_from_text(text, &document_path, &mut targets);
+    let current_root = project.map(|project| Arc::clone(&project.package_root));
+    add_program_targets_from_text(text, &document_path, current_root.as_ref(), &mut targets);
     for overlay in open_overlays {
         if overlay.path.as_ref() != document_path.as_ref() {
-            add_program_targets_from_text(overlay.text.as_ref(), &overlay.path, &mut targets);
+            add_program_targets_from_text(overlay.text.as_ref(), &overlay.path, current_root.as_ref(), &mut targets);
         }
     }
     if target_mode == ProgramTargetMode::LocalDependencies
@@ -203,24 +204,43 @@ fn syntax_program_targets(
     (targets, fingerprints)
 }
 
+/// Syntax-only import target with the declaration and stable program root.
+#[derive(Debug, Clone)]
+struct ProgramSyntaxTarget {
+    declaration: FileRange,
+    package_root: Option<Arc<PathBuf>>,
+}
+
 /// Add `program name.aleo` declarations from one parsed source to the target map.
-fn add_program_targets_from_text(text: &str, path: &Arc<PathBuf>, targets: &mut HashMap<String, FileRange>) {
+fn add_program_targets_from_text(
+    text: &str,
+    path: &Arc<PathBuf>,
+    package_root: Option<&Arc<PathBuf>>,
+    targets: &mut HashMap<String, ProgramSyntaxTarget>,
+) {
     let Ok(tree) = parse_main(text) else {
         return;
     };
-    collect_program_target_tokens(&tree, path, targets);
+    collect_program_target_tokens(&tree, path, package_root, targets);
 }
 
 /// Recursively collect program declaration name tokens from a Rowan tree.
-fn collect_program_target_tokens(node: &SyntaxNode, path: &Arc<PathBuf>, targets: &mut HashMap<String, FileRange>) {
+fn collect_program_target_tokens(
+    node: &SyntaxNode,
+    path: &Arc<PathBuf>,
+    package_root: Option<&Arc<PathBuf>>,
+    targets: &mut HashMap<String, ProgramSyntaxTarget>,
+) {
     for element in node.children_with_tokens() {
         match element {
-            SyntaxElement::Node(child) => collect_program_target_tokens(&child, path, targets),
+            SyntaxElement::Node(child) => collect_program_target_tokens(&child, path, package_root, targets),
             SyntaxElement::Token(token) if is_program_declaration_token(&token) => {
                 if let Some(range) =
                     FileRange::new(Arc::clone(path), token.text_range().start().into(), token.text_range().end().into())
                 {
-                    targets.entry(token.text().to_owned()).or_insert(range);
+                    targets
+                        .entry(token.text().to_owned())
+                        .or_insert(ProgramSyntaxTarget { declaration: range, package_root: package_root.cloned() });
                 }
             }
             SyntaxElement::Token(_) => {}
@@ -231,7 +251,7 @@ fn collect_program_target_tokens(node: &SyntaxNode, path: &Arc<PathBuf>, targets
 /// Add local manifest dependency program declarations to syntax-only import targets.
 fn add_local_dependency_program_targets(
     project: &ProjectContext,
-    targets: &mut HashMap<String, FileRange>,
+    targets: &mut HashMap<String, ProgramSyntaxTarget>,
     fingerprints: &mut HashMap<PathBuf, SourceFingerprint>,
 ) {
     let Ok(manifest) = Manifest::read_from_file(project.manifest_path.as_ref()) else {
@@ -239,7 +259,8 @@ fn add_local_dependency_program_targets(
     };
 
     for dependency in manifest.dependencies.iter().flatten() {
-        let Some(source_path) = dependency_source_path(project.package_root.as_ref(), dependency) else {
+        let Some((source_path, package_root)) = dependency_source_path(project.package_root.as_ref(), dependency)
+        else {
             continue;
         };
         let Some((source, fingerprint)) = read_stable_source(source_path.as_path()) else {
@@ -247,24 +268,26 @@ fn add_local_dependency_program_targets(
         };
         let source_path = source_path.canonicalize().unwrap_or(source_path);
         let source_path = Arc::new(source_path);
-        add_program_targets_from_text(source.as_str(), &source_path, targets);
+        let package_root = Arc::new(package_root);
+        add_program_targets_from_text(source.as_str(), &source_path, Some(&package_root), targets);
         fingerprints.insert(source_path.as_ref().clone(), fingerprint);
     }
 }
 
 /// Return the package-resolved source path for a local dependency.
-fn dependency_source_path(package_root: &Path, dependency: &Dependency) -> Option<PathBuf> {
+fn dependency_source_path(package_root: &Path, dependency: &Dependency) -> Option<(PathBuf, PathBuf)> {
     if dependency.location != Location::Local {
         return None;
     }
     let path = dependency.path.as_deref()?;
     let root = if path.is_absolute() { path.to_path_buf() } else { package_root.join(path) };
+    let dependency_root = root.canonicalize().unwrap_or_else(|_| root.clone());
     let unit =
         create_session_if_not_set_then(|_| CompilationUnit::from_package_path(Symbol::intern(&dependency.name), root));
     let ProgramData::SourcePath { source, .. } = unit.ok()?.data else {
         return None;
     };
-    Some(source)
+    Some((source, dependency_root))
 }
 
 /// Read a source file and return a fingerprint for the exact bytes consumed.
@@ -287,19 +310,51 @@ struct SyntaxSemanticCollector {
     path: Arc<PathBuf>,
     semantics: SyntaxSemantics,
     local_scopes: Vec<HashMap<String, SyntaxLocalBinding>>,
-    program_targets: HashMap<String, FileRange>,
+    function_bindings: HashMap<String, FileRange>,
+    type_bindings: HashMap<String, FileRange>,
+    program_targets: HashMap<String, ProgramSyntaxTarget>,
 }
 
 impl SyntaxSemanticCollector {
     /// Create a new syntax collector for one document path.
-    fn new(path: Arc<PathBuf>, program_targets: HashMap<String, FileRange>) -> Self {
-        Self { path, semantics: SyntaxSemantics::default(), local_scopes: vec![HashMap::new()], program_targets }
+    fn new(path: Arc<PathBuf>, program_targets: HashMap<String, ProgramSyntaxTarget>) -> Self {
+        Self {
+            path,
+            semantics: SyntaxSemantics::default(),
+            local_scopes: vec![HashMap::new()],
+            function_bindings: HashMap::new(),
+            type_bindings: HashMap::new(),
+            program_targets,
+        }
     }
 
     /// Walk a Rowan syntax tree and emit best-effort semantic data.
     fn collect(mut self, tree: &SyntaxNode) -> SyntaxSemantics {
+        self.collect_file_bindings(tree);
         self.collect_node(tree);
         self.semantics
+    }
+
+    /// Pre-bind same-file items so fallback references are not order-sensitive.
+    fn collect_file_bindings(&mut self, node: &SyntaxNode) {
+        for element in node.children_with_tokens() {
+            match element {
+                SyntaxElement::Node(child) => self.collect_file_bindings(&child),
+                SyntaxElement::Token(token) => {
+                    let Some((
+                        token_kind @ (SemanticKind::Function | SemanticKind::Type | SemanticKind::Interface),
+                        OccurrenceRole::Declaration,
+                        _,
+                    )) = classify_syntax_token(&token)
+                    else {
+                        continue;
+                    };
+                    if let Some(range) = self.token_range(&token) {
+                        self.bind_file_item(&token, token_kind, range);
+                    }
+                }
+            }
+        }
     }
 
     /// Recursively walk syntax in source order while maintaining lightweight local scopes.
@@ -330,11 +385,16 @@ impl SyntaxSemanticCollector {
 
         let classification = classify_syntax_token(token).or_else(|| self.classify_local_reference(token));
         if let Some((token_kind, role, readonly)) = classification {
-            self.push_symbol_token(token, token_kind, role, readonly);
-            if role == OccurrenceRole::Declaration
-                && matches!(token_kind, SemanticKind::Parameter | SemanticKind::Variable)
+            if let Some(range) = self.push_symbol_token(token, token_kind, role, readonly)
+                && role == OccurrenceRole::Declaration
             {
-                self.bind_local(token, token_kind, readonly);
+                match token_kind {
+                    SemanticKind::Parameter | SemanticKind::Variable => self.bind_local(token, token_kind, readonly),
+                    SemanticKind::Function | SemanticKind::Type | SemanticKind::Interface => {
+                        self.bind_file_item(token, token_kind, range);
+                    }
+                    _ => {}
+                }
             }
         } else if let Some(token_kind) = classify_lexical_token(token.kind()) {
             self.push_lexical_token(token, token_kind);
@@ -350,7 +410,15 @@ impl SyntaxSemanticCollector {
         let name = create_session_if_not_set_then(|_| Symbol::intern(token.text()));
         Some(SymbolOccurrence {
             range,
-            identity: SymbolIdentity::Program { name, declaration: self.program_targets.get(token.text()).cloned() },
+            identity: self
+                .program_targets
+                .get(token.text())
+                .map(|target| SymbolIdentity::Program {
+                    program: name,
+                    package_root: target.package_root.clone(),
+                    declaration: Some(target.declaration.clone()),
+                })
+                .unwrap_or(SymbolIdentity::Unknown),
             role: OccurrenceRole::Reference,
             token_kind: SemanticKind::Namespace,
             readonly: false,
@@ -364,17 +432,45 @@ impl SyntaxSemanticCollector {
         token_kind: SemanticKind,
         role: OccurrenceRole,
         readonly: bool,
-    ) {
-        let Some(range) = self.token_range(token) else {
-            return;
-        };
+    ) -> Option<FileRange> {
+        let range = self.token_range(token)?;
+        let identity = self.symbol_identity(token, token_kind, role, &range);
         self.semantics.occurrences.push(SymbolOccurrence {
-            range,
-            identity: SymbolIdentity::Unknown,
+            range: range.clone(),
+            identity,
             role,
             token_kind,
             readonly,
         });
+        Some(range)
+    }
+
+    /// Return the strongest syntax-only identity available for this token.
+    fn symbol_identity(
+        &self,
+        token: &SyntaxToken,
+        token_kind: SemanticKind,
+        role: OccurrenceRole,
+        range: &FileRange,
+    ) -> SymbolIdentity {
+        match (token_kind, role) {
+            (SemanticKind::Function | SemanticKind::Type | SemanticKind::Interface, OccurrenceRole::Declaration) => {
+                SymbolIdentity::Local { declaration: range.clone() }
+            }
+            (SemanticKind::Function, OccurrenceRole::Reference) => self
+                .function_bindings
+                .get(token.text())
+                .cloned()
+                .map(|declaration| SymbolIdentity::Local { declaration })
+                .unwrap_or(SymbolIdentity::Unknown),
+            (SemanticKind::Type | SemanticKind::Interface, OccurrenceRole::Reference) => self
+                .type_bindings
+                .get(token.text())
+                .cloned()
+                .map(|declaration| SymbolIdentity::Local { declaration })
+                .unwrap_or(SymbolIdentity::Unknown),
+            _ => SymbolIdentity::Unknown,
+        }
     }
 
     /// Record a lexical token that is useful for highlighting but not navigation.
@@ -399,6 +495,19 @@ impl SyntaxSemanticCollector {
     fn bind_local(&mut self, token: &SyntaxToken, token_kind: SemanticKind, readonly: bool) {
         if let Some(scope) = self.local_scopes.last_mut() {
             scope.insert(token.text().to_owned(), SyntaxLocalBinding { token_kind, readonly });
+        }
+    }
+
+    /// Bind a syntax-visible file item for later same-file references.
+    fn bind_file_item(&mut self, token: &SyntaxToken, token_kind: SemanticKind, declaration: FileRange) {
+        match token_kind {
+            SemanticKind::Function => {
+                self.function_bindings.insert(token.text().to_owned(), declaration);
+            }
+            SemanticKind::Type | SemanticKind::Interface => {
+                self.type_bindings.insert(token.text().to_owned(), declaration);
+            }
+            _ => {}
         }
     }
 
@@ -648,9 +757,7 @@ fn disk_stamp(metadata: &Metadata) -> Option<DiskStamp> {
 
 /// Hash source text for stale-target detection without retaining full text.
 fn content_hash(contents: &str) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    contents.hash(&mut hasher);
-    hasher.finish()
+    hash_text(contents)
 }
 
 /// Convert file metadata modification time into a nanosecond stamp.
@@ -732,8 +839,8 @@ mod tests {
         let has_symbol = |spelling: &str, token_kind: SemanticKind, role: Option<OccurrenceRole>| {
             semantic_snapshot.index.occurrences.iter().any(|occurrence| {
                 &source[occurrence.range.start as usize..occurrence.range.end as usize] == spelling
-                    && occurrence.token_kind == token_kind
-                    && role.is_none_or(|role| occurrence.role == role)
+                    && occurrence.token_kind() == token_kind
+                    && role.is_none_or(|role| occurrence.role() == role)
             })
         };
         let has_lexical_token = |spelling: &str, token_kind: SemanticKind| {
@@ -762,7 +869,7 @@ mod tests {
                 .index
                 .occurrences
                 .iter()
-                .any(|occurrence| lexical_kinds.contains(&occurrence.token_kind)),
+                .any(|occurrence| lexical_kinds.contains(&occurrence.token_kind())),
             "lexical tokens should not pollute the symbol index"
         );
 

--- a/crates/lsp/tests/protocol.rs
+++ b/crates/lsp/tests/protocol.rs
@@ -14,13 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+//! End-to-end protocol coverage for the `leo-lsp` binary.
+//!
+//! These tests drive the server through JSON-RPC requests and notifications so
+//! lifecycle, malformed-message handling, semantic tokens, definitions, and
+//! references are validated through the same transport surface used by editors.
+
 mod common;
 
 use self::common::TestServer;
 use lsp_types::Uri;
 use serde_json::{Value, json};
 use std::{fs, path::Path, time::Duration};
-use tempfile::tempdir;
+use tempfile::{TempDir, tempdir};
 
 /// Send the initialize request and return the raw response for protocol assertions.
 fn initialize(server: &mut TestServer) -> Value {
@@ -80,6 +86,68 @@ fn range_json(source: &str, needle: &str, occurrence: usize) -> Value {
     json!({ "start": position(start), "end": position(end) })
 }
 
+/// Write a minimal package around `source` and return its open/canonical URIs.
+fn write_test_package(source: &str) -> (TempDir, Uri, Uri) {
+    write_test_package_with_manifest(
+        source,
+        r#"{ "program": "demo.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+}
+
+/// Write a test package with a custom manifest and return its open/canonical URIs.
+fn write_test_package_with_manifest(source: &str, manifest: &str) -> (TempDir, Uri, Uri) {
+    let tempdir = tempdir().expect("tempdir");
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(package_root.join("program.json"), manifest).expect("write manifest");
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+    let document_uri = file_uri(&main_path);
+    let canonical_uri = file_uri(&main_path.canonicalize().expect("canonical main path"));
+    (tempdir, document_uri, canonical_uri)
+}
+
+/// Open a Leo document in the test server.
+fn open_document(server: &mut TestServer, document_uri: &Uri, source: &str) {
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+}
+
+/// Request references for a substring occurrence.
+fn request_references(
+    server: &mut TestServer,
+    id: i64,
+    document_uri: &Uri,
+    source: &str,
+    needle: &str,
+    occurrence: usize,
+    include_declaration: bool,
+) -> Value {
+    server.request(
+        id,
+        "textDocument/references",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": position_json(source, needle, occurrence),
+            "context": {
+                "includeDeclaration": include_declaration,
+            }
+        }),
+    )
+}
+
 /// Verifies initialize, shutdown, and exit follow the LSP lifecycle.
 #[test]
 fn initialize_shutdown_exit_round_trip() {
@@ -97,6 +165,7 @@ fn initialize_shutdown_exit_round_trip() {
     );
     assert_eq!(initialize["result"]["capabilities"]["semanticTokensProvider"]["full"], json!(true));
     assert_eq!(initialize["result"]["capabilities"]["definitionProvider"], json!(true));
+    assert_eq!(initialize["result"]["capabilities"]["referencesProvider"], json!(true));
     assert_eq!(
         initialize["result"]["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"],
         json!([
@@ -124,6 +193,318 @@ fn initialize_shutdown_exit_round_trip() {
     server.notify("exit", json!({}));
     let (status, stderr) = server.finish();
 
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies find-all-references returns local variable uses with LSP null/array semantics.
+#[test]
+fn references_returns_local_variable_occurrences() {
+    let tempdir = tempdir().expect("tempdir");
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        package_root.join("program.json"),
+        r#"{ "program": "demo.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write manifest");
+
+    let source = concat!(
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let total: u32 = 1u32;\n",
+        "        let next: u32 = total + 1u32;\n",
+        "        return total + next;\n",
+        "    }\n",
+        "}\n",
+    );
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+    let document_uri = file_uri(&main_path);
+    let canonical_file_uri = file_uri(&main_path.canonicalize().expect("canonical main path"));
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+
+    let include_declaration = server.request(
+        2,
+        "textDocument/references",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": position_json(source, "total", 1),
+            "context": {
+                "includeDeclaration": true,
+            }
+        }),
+    );
+    assert_eq!(include_declaration["id"], 2);
+    let results = include_declaration["result"].as_array().expect("references array");
+    assert_eq!(results.len(), 3, "bad references response: {include_declaration}");
+    assert!(results.iter().all(|location| location["uri"] == json!(canonical_file_uri.to_string())));
+    assert_eq!(results[0]["range"], range_json(source, "total", 0));
+    assert_eq!(results[1]["range"], range_json(source, "total", 1));
+    assert_eq!(results[2]["range"], range_json(source, "total", 2));
+
+    let references_only = server.request(
+        3,
+        "textDocument/references",
+        json!({
+            "textDocument": {
+                "uri": document_uri,
+            },
+            "position": position_json(source, "total", 1),
+            "context": {
+                "includeDeclaration": false,
+            }
+        }),
+    );
+    let results = references_only["result"].as_array().expect("references-only array");
+    assert_eq!(results.len(), 2, "bad references-only response: {references_only}");
+    assert_eq!(results[0]["range"], range_json(source, "total", 1));
+    assert_eq!(results[1]["range"], range_json(source, "total", 2));
+
+    let shutdown = server.request(4, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies references cover compiler-backed parameters, functions, types, and members.
+#[test]
+fn references_cover_core_compiler_symbol_families() {
+    let source = concat!(
+        "const LIMIT: u32 = 3u32;\n\n",
+        "struct Point {\n",
+        "    x_coordinate: u32,\n",
+        "}\n\n",
+        "fn combine(left_value: u32, right_value: u32) -> u32 {\n",
+        "    let sum_value: u32 = left_value + LIMIT;\n",
+        "    return sum_value + right_value;\n",
+        "}\n\n",
+        "fn unused(unused_value: u32) -> u32 {\n",
+        "    return 0u32;\n",
+        "}\n\n",
+        "fn consume(point_value: Point) -> u32 {\n",
+        "    let first_value: u32 = point_value.x_coordinate;\n",
+        "    return first_value + point_value.x_coordinate;\n",
+        "}\n\n",
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let first_value: u32 = combine(1u32, LIMIT);\n",
+        "        return first_value + combine(2u32, LIMIT);\n",
+        "    }\n",
+        "}\n",
+    );
+    let (_tempdir, document_uri, canonical_uri) = write_test_package(source);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    let function = request_references(&mut server, 2, &document_uri, source, "combine", 1, true);
+    assert!(function["result"].is_array(), "bad function response: {function}");
+    let function_results = function["result"].as_array().expect("function references");
+    assert_eq!(function_results.len(), 3, "bad function references: {function}");
+    assert_eq!(function_results[0]["range"], range_json(source, "combine", 0));
+    assert_eq!(function_results[1]["range"], range_json(source, "combine", 1));
+    assert_eq!(function_results[2]["range"], range_json(source, "combine", 2));
+
+    let parameter = request_references(&mut server, 3, &document_uri, source, "left_value", 1, true);
+    let parameter_results = parameter["result"].as_array().expect("parameter references");
+    assert_eq!(parameter_results.len(), 2, "bad parameter references: {parameter}");
+    assert_eq!(parameter_results[0]["range"], range_json(source, "left_value", 0));
+    assert_eq!(parameter_results[1]["range"], range_json(source, "left_value", 1));
+
+    let declaration_only = request_references(&mut server, 4, &document_uri, source, "unused_value", 0, false);
+    assert_eq!(declaration_only["result"], json!([]), "declaration-only token should be navigable-empty");
+
+    let type_refs = request_references(&mut server, 5, &document_uri, source, "Point", 1, true);
+    let type_results = type_refs["result"].as_array().expect("type references");
+    assert_eq!(type_results.len(), 2, "bad type references: {type_refs}");
+    assert_eq!(type_results[0]["range"], range_json(source, "Point", 0));
+    assert_eq!(type_results[1]["range"], range_json(source, "Point", 1));
+
+    let member = request_references(&mut server, 6, &document_uri, source, "x_coordinate", 1, true);
+    let member_results = member["result"].as_array().expect("member references");
+    assert_eq!(member_results.len(), 3, "bad member references: {member}");
+    assert_eq!(member_results[0]["range"], range_json(source, "x_coordinate", 0));
+    assert_eq!(member_results[1]["range"], range_json(source, "x_coordinate", 1));
+    assert_eq!(member_results[2]["range"], range_json(source, "x_coordinate", 2));
+    assert!(member_results.iter().all(|location| location["uri"] == json!(canonical_uri.to_string())));
+
+    let unknown = request_references(&mut server, 7, &document_uri, source, "u32", 0, true);
+    assert_eq!(unknown["result"], Value::Null, "keyword/type primitive should not be a guessed reference target");
+
+    let shutdown = server.request(8, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies syntax fallback keys same-file program types and functions when dependency analysis cannot run.
+#[test]
+fn references_cover_syntax_fallback_program_type_and_function_occurrences() {
+    let source = concat!(
+        "import credits.aleo;\n\n",
+        "program demo.aleo {\n",
+        "    struct TransferAuth {\n",
+        "        amount: u64,\n",
+        "    }\n",
+        "\n",
+        "    fn main(first: u64, second: u64) -> u64 {\n",
+        "        let one: u64 = auth_digest(first);\n",
+        "        return one + auth_digest(second);\n",
+        "    }\n",
+        "}\n\n",
+        "// TransferAuth in comments is not a semantic reference.\n",
+        "fn auth_digest(amount: u64) -> u64 {\n",
+        "    let auth: TransferAuth = TransferAuth { amount: amount };\n",
+        "    return auth.amount;\n",
+        "}\n",
+    );
+    let (_tempdir, document_uri, canonical_uri) = write_test_package_with_manifest(
+        source,
+        r#"{
+  "program": "demo.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "leo": "4.0.0",
+  "dependencies": [{ "name": "credits.aleo", "location": "network", "path": null, "edition": null }]
+}"#,
+    );
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    let response = request_references(&mut server, 2, &document_uri, source, "TransferAuth", 0, true);
+    let results = response["result"].as_array().expect("syntax fallback type references");
+    assert_eq!(results.len(), 3, "bad syntax fallback references: {response}");
+    assert!(results.iter().all(|location| location["uri"] == json!(canonical_uri.to_string())));
+    assert_eq!(results[0]["range"], range_json(source, "TransferAuth", 0));
+    assert_eq!(results[1]["range"], range_json(source, "TransferAuth", 2));
+    assert_eq!(results[2]["range"], range_json(source, "TransferAuth", 3));
+
+    let response = request_references(&mut server, 3, &document_uri, source, "auth_digest", 2, true);
+    let results = response["result"].as_array().expect("syntax fallback function references");
+    assert_eq!(results.len(), 3, "bad syntax fallback function references: {response}");
+    assert_eq!(results[0]["range"], range_json(source, "auth_digest", 0));
+    assert_eq!(results[1]["range"], range_json(source, "auth_digest", 1));
+    assert_eq!(results[2]["range"], range_json(source, "auth_digest", 2));
+
+    let shutdown = server.request(4, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies references on an unopened document return `null`.
+#[test]
+fn references_on_unopened_document_returns_null() {
+    let source = "program demo.aleo {}\n";
+    let (_tempdir, document_uri, _) = write_test_package(source);
+    let mut server = TestServer::spawn(&[]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+
+    let response = request_references(&mut server, 2, &document_uri, source, "demo", 0, true);
+    assert_eq!(response["result"], Value::Null);
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies imported program namespaces return both import-site and dependency-source references.
+#[test]
+fn references_return_source_dependency_program_namespace_occurrences() {
+    let tempdir = tempdir().expect("tempdir");
+    let helper_root = tempdir.path().join("helper");
+    fs::create_dir_all(helper_root.join("src")).expect("create helper source dir");
+    fs::write(
+        helper_root.join("program.json"),
+        r#"{ "program": "helper.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write helper manifest");
+    let helper_source = "program helper.aleo {\n    fn double(x: u32) -> u32 { return x + x; }\n}\n";
+    let helper_main = helper_root.join("src").join("main.leo");
+    fs::write(&helper_main, helper_source).expect("write helper source");
+    let helper_root = helper_root.canonicalize().expect("canonical helper root");
+    let helper_uri = file_uri(&helper_main.canonicalize().expect("canonical helper source"));
+
+    let root = tempdir.path().join("root");
+    fs::create_dir_all(root.join("src")).expect("create root source dir");
+    fs::write(
+        root.join("program.json"),
+        format!(
+            r#"{{
+  "program": "demo.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "leo": "4.0.0",
+  "dependencies": [{{ "name": "helper.aleo", "location": "local", "path": {} }}]
+}}"#,
+            serde_json::to_string(&helper_root).expect("helper root json")
+        ),
+    )
+    .expect("write root manifest");
+    let source = concat!(
+        "import helper.aleo;\n\n",
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        return helper.aleo::double(1u32);\n",
+        "    }\n",
+        "}\n",
+    );
+    let main_path = root.join("src").join("main.leo");
+    fs::write(&main_path, source).expect("write root source");
+    let document_uri = file_uri(&main_path);
+    let canonical_uri = file_uri(&main_path.canonicalize().expect("canonical root source"));
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    let response = request_references(&mut server, 2, &document_uri, source, "helper", 1, true);
+    let results = response["result"].as_array().expect("program namespace references");
+    assert_eq!(results.len(), 3, "bad namespace references: {response}");
+    assert_eq!(results[0]["uri"], json!(canonical_uri.to_string()));
+    assert_eq!(results[0]["range"], range_json(source, "helper", 0));
+    assert_eq!(results[1]["uri"], json!(canonical_uri.to_string()));
+    assert_eq!(results[1]["range"], range_json(source, "helper", 1));
+    assert_eq!(results[2]["uri"], json!(helper_uri.to_string()));
+    assert_eq!(results[2]["range"], range_json(helper_source, "helper", 0));
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
     assert!(status.success(), "stderr:\n{stderr}");
 }
 


### PR DESCRIPTION
## Summary
- add `textDocument/references` support to `leo-lsp`
- build a compact key-keyed occurrence index on top of the existing package semantic cache
- route references requests through snapshot-safe package analysis, cancellation, close, panic, and reused-request-ID handling
- resolve references for local symbols, compiler-backed declarations, members, imported program namespaces, and syntax-fallback same-file functions/types
- move shared UTF-8/UTF-16 range and verified disk-target conversion into reusable navigation helpers

Tracking issue: https://github.com/ProvableHQ/leo/issues/29264


https://github.com/user-attachments/assets/4db17fe0-9823-4b9a-95a0-2908f22e4923

