### PR TITLE
feat(LSP) Implement rename.

### DIFF
--- a/crates/lsp/src/compiler_bridge.rs
+++ b/crates/lsp/src/compiler_bridge.rs
@@ -362,6 +362,7 @@ fn package_analysis(
                 .unwrap_or(SourceFingerprint::Volatile)
         },
         |path| open_line_index(snapshot.open_overlays.as_ref(), path),
+        |path| package_source_files.contains(path),
     );
     let index = Arc::new(index);
     let package = Arc::new(CachedPackageAnalysis {

--- a/crates/lsp/src/features/mod.rs
+++ b/crates/lsp/src/features/mod.rs
@@ -27,5 +27,7 @@ pub mod goto_definition;
 pub mod lsp_range;
 /// Find-all-references query resolution.
 pub mod references;
+/// Rename and prepare-rename query resolution.
+pub mod rename;
 /// Semantic token capability wiring and wire-format encoding helpers.
 pub mod semantic_tokens;

--- a/crates/lsp/src/features/references.rs
+++ b/crates/lsp/src/features/references.rs
@@ -111,7 +111,8 @@ mod tests {
         let key =
             PackageAnalysisKey { bucket: AnalysisBucket::UnmanagedDocument { uri: uri.clone() }, bucket_generation: 1 };
         let view_key = DocumentViewKey { uri, document_generation: 1, package: key.clone() };
-        let (index, analyzed_files) = SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None);
+        let (index, analyzed_files) =
+            SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None, |_| true);
         (
             CachedPackageAnalysis {
                 key,

--- a/crates/lsp/src/features/rename.rs
+++ b/crates/lsp/src/features/rename.rs
@@ -1,0 +1,386 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Rename and prepare-rename resolution for Leo LSP.
+//!
+//! This module deliberately stops at compact byte ranges and per-file rename
+//! eligibility. It does not know about JSON-RPC request IDs, worker scheduling,
+//! disk reads, or `WorkspaceEdit` materialization — those concerns live in the
+//! response pool worker. The validator delegates to the canonical Leo lexer so
+//! adding a keyword in the parser automatically extends rename rejection.
+
+use crate::{
+    document_store::DocumentViewKey,
+    semantics::{CachedPackageAnalysis, CompactRange, FileId, SourceFingerprint},
+};
+use leo_parser_rowan::{SyntaxKind, lex};
+use lsp_types::Position;
+use std::path::Path;
+
+/// Cursor query captured before any async package-analysis wait.
+#[derive(Debug, Clone)]
+pub struct RenameQuery {
+    /// UTF-8 byte offset resolved from the original LSP position.
+    pub offset: u32,
+    /// Original LSP position retained for diagnostics.
+    #[allow(dead_code)]
+    pub position: Position,
+    /// Freshness key for the document view active when the request arrived.
+    pub view_key: DocumentViewKey,
+    /// Validated new identifier text the client requested.
+    pub new_name: String,
+}
+
+/// Cursor query captured for prepare-rename, mirroring `RenameQuery` minus the new name.
+#[derive(Debug, Clone)]
+pub struct PrepareRenameQuery {
+    /// UTF-8 byte offset resolved from the original LSP position.
+    pub offset: u32,
+    /// Original LSP position retained for diagnostics.
+    #[allow(dead_code)]
+    pub position: Position,
+    /// Freshness key for the document view active when the request arrived.
+    pub view_key: DocumentViewKey,
+}
+
+/// Compact rename edit before any LSP-range or URI conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RenameTarget {
+    /// Interned analyzed-file ID this edit lives in.
+    pub file: FileId,
+    /// Compact byte range to be replaced with the validated new name.
+    pub range: CompactRange,
+}
+
+/// Structured rename failure surfaced to the routing thread.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RenameError {
+    /// The new name is not a single Leo identifier token.
+    InvalidIdentifier(String),
+    /// The cursor occurrence is not eligible for rename (`null` reply).
+    NotRenameable,
+    /// A disk-backed source file changed between analysis and materialization.
+    /// Constructed by the response-pool worker after `read_verified_disk_text`.
+    #[allow(dead_code)]
+    SourceChanged { path: String },
+    /// At least one occurrence resolves to a file outside the current package.
+    LeavesPackage { path: String },
+    /// At least one occurrence resolves to a volatile-fingerprint file.
+    VolatileSource { path: String },
+}
+
+/// Validate that `name` lexes as exactly one Leo identifier token.
+///
+/// The validator delegates to the canonical Leo lexer so keyword and
+/// identifier shape rules track the parser without a parallel keyword table.
+pub fn validate_new_name(name: &str) -> Result<(), RenameError> {
+    let (tokens, errors) = lex(name);
+    if !errors.is_empty() {
+        return Err(RenameError::InvalidIdentifier(
+            "contains characters that are not part of any Leo token".to_owned(),
+        ));
+    }
+    let payload: Vec<&_> =
+        tokens.iter().filter(|token| !token.kind.is_trivia() && token.kind != SyntaxKind::EOF).collect();
+    match payload.as_slice() {
+        [token] if token.kind == SyntaxKind::IDENT => Ok(()),
+        [token] if token.kind.is_keyword() => Err(RenameError::InvalidIdentifier(format!("'{name}' is a Leo keyword"))),
+        [] => Err(RenameError::InvalidIdentifier("name is empty".to_owned())),
+        [_] => Err(RenameError::InvalidIdentifier("name is not a Leo identifier".to_owned())),
+        _ => Err(RenameError::InvalidIdentifier("name is more than one Leo token".to_owned())),
+    }
+}
+
+/// Resolve every package-internal occurrence sharing the cursor's symbol key.
+///
+/// Returns `Err(NotRenameable)` for cursors that should produce a `null` LSP
+/// reply (no occurrence, no key, or a `Program` identity). Returns the other
+/// error variants when a per-file invariant rejects the whole rename.
+pub fn resolve_targets(
+    query: &RenameQuery,
+    package: &CachedPackageAnalysis,
+    source_path: &Path,
+) -> Result<Vec<RenameTarget>, RenameError> {
+    let _ = query;
+    let occurrence = package.index.occurrence_at(source_path, query.offset).ok_or(RenameError::NotRenameable)?;
+    let key_id = occurrence.occurrence.key_id().ok_or(RenameError::NotRenameable)?;
+    if package.index.is_program_key(key_id) {
+        return Err(RenameError::NotRenameable);
+    }
+
+    let mut targets = Vec::new();
+    let mut current_file: Option<FileId> = None;
+    for occurrence in package.index.occurrences_for(key_id) {
+        let file_id = occurrence.range.file;
+        if Some(file_id) != current_file {
+            let analyzed = package
+                .analyzed_files
+                .get(file_id)
+                .ok_or_else(|| RenameError::LeavesPackage { path: format!("<unknown file id {file_id}>") })?;
+            if analyzed.is_sentinel || !analyzed.in_package_scope {
+                return Err(RenameError::LeavesPackage { path: analyzed.path.display().to_string() });
+            }
+            if matches!(analyzed.fingerprint, SourceFingerprint::Volatile) {
+                return Err(RenameError::VolatileSource { path: analyzed.path.display().to_string() });
+            }
+            current_file = Some(file_id);
+        }
+        targets.push(RenameTarget { file: file_id, range: occurrence.range });
+    }
+    Ok(targets)
+}
+
+/// Return the compact byte range of the renameable cursor occurrence.
+pub fn prepare_rename_target(
+    query: &PrepareRenameQuery,
+    package: &CachedPackageAnalysis,
+    source_path: &Path,
+) -> Option<CompactRange> {
+    let occurrence = package.index.occurrence_at(source_path, query.offset)?;
+    let key_id = occurrence.occurrence.key_id()?;
+    if package.index.is_program_key(key_id) {
+        return None;
+    }
+    Some(occurrence.occurrence.range)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        PrepareRenameQuery,
+        RenameError,
+        RenameQuery,
+        prepare_rename_target,
+        resolve_targets,
+        validate_new_name,
+    };
+    use crate::{
+        document_store::{AnalysisBucket, DocumentViewKey, PackageAnalysisKey},
+        semantics::{
+            CachedPackageAnalysis,
+            FileRange,
+            OccurrenceRole,
+            SemanticIndex,
+            SemanticKind,
+            SemanticSource,
+            SourceFingerprint,
+            SymbolIdentity,
+            SymbolOccurrence,
+        },
+    };
+    use leo_span::{Symbol, create_session_if_not_set_then};
+    use lsp_types::{Position, Uri};
+    use std::{path::PathBuf, sync::Arc};
+
+    /// Build an unmanaged-document view key for synthetic rename-resolution tests.
+    fn document_view_key(uri: &Uri) -> DocumentViewKey {
+        let bucket = AnalysisBucket::UnmanagedDocument { uri: uri.clone() };
+        DocumentViewKey {
+            uri: uri.clone(),
+            document_generation: 1,
+            package: PackageAnalysisKey { bucket, bucket_generation: 1 },
+        }
+    }
+
+    /// Build a rename query at the given cursor offset with the given new name.
+    fn rename_query(offset: u32, view_key: DocumentViewKey, new_name: &str) -> RenameQuery {
+        RenameQuery { offset, position: Position::new(0, 0), view_key, new_name: new_name.to_owned() }
+    }
+
+    /// Build a prepare-rename query at the given cursor offset.
+    fn prepare_query(offset: u32, view_key: DocumentViewKey) -> PrepareRenameQuery {
+        PrepareRenameQuery { offset, position: Position::new(0, 0), view_key }
+    }
+
+    /// Build a keyed local occurrence for rename-resolution unit tests.
+    fn local_occurrence(
+        path: &Arc<PathBuf>,
+        start: u32,
+        end: u32,
+        declaration: &FileRange,
+        role: OccurrenceRole,
+    ) -> SymbolOccurrence {
+        SymbolOccurrence {
+            range: FileRange::new(Arc::clone(path), start, end).expect("range"),
+            identity: SymbolIdentity::Local { declaration: declaration.clone() },
+            role,
+            token_kind: SemanticKind::Variable,
+            readonly: false,
+        }
+    }
+
+    /// Build a package analysis from synthetic occurrences with a custom in-scope predicate.
+    fn build_package(
+        occurrences: Vec<SymbolOccurrence>,
+        in_scope: impl Fn(&std::path::Path) -> bool + Copy,
+    ) -> CachedPackageAnalysis {
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+        let key = PackageAnalysisKey { bucket: AnalysisBucket::UnmanagedDocument { uri }, bucket_generation: 1 };
+        let (index, analyzed_files) = SemanticIndex::build(
+            &occurrences,
+            |_| SourceFingerprint::Disk { modified_nanos: Some(0), len: 0, content_hash: 0 },
+            |_| None,
+            |path| in_scope(path),
+        );
+        CachedPackageAnalysis {
+            key,
+            index: Arc::new(index),
+            analyzed_files: Arc::new(analyzed_files),
+            source: SemanticSource::CompilerEnhanced,
+        }
+    }
+
+    /// Verifies validate_new_name accepts simple identifiers.
+    #[test]
+    fn validate_new_name_accepts_simple_identifiers() {
+        for name in ["x", "total", "Foo123", "_inner"] {
+            let result = validate_new_name(name);
+            assert!(result.is_ok(), "{name} should be accepted: {result:?}");
+        }
+    }
+
+    /// Verifies validate_new_name rejects empty, digit-prefixed, and punctuation names.
+    #[test]
+    fn validate_new_name_rejects_invalid_shapes() {
+        assert!(matches!(validate_new_name(""), Err(RenameError::InvalidIdentifier(_))));
+        assert!(matches!(validate_new_name("1abc"), Err(RenameError::InvalidIdentifier(_))));
+        assert!(matches!(validate_new_name("foo bar"), Err(RenameError::InvalidIdentifier(_))));
+        assert!(matches!(validate_new_name("foo-bar"), Err(RenameError::InvalidIdentifier(_))));
+        assert!(matches!(validate_new_name("foo.bar"), Err(RenameError::InvalidIdentifier(_))));
+    }
+
+    /// Verifies validate_new_name rejects every Leo keyword by name.
+    #[test]
+    fn validate_new_name_rejects_keywords() {
+        for keyword in ["let", "fn", "program", "if", "else", "return", "for", "true", "false"] {
+            let result = validate_new_name(keyword);
+            assert!(matches!(result, Err(RenameError::InvalidIdentifier(_))), "{keyword} should be rejected");
+        }
+    }
+
+    /// Verifies resolve_targets returns NotRenameable when the cursor misses every occurrence.
+    #[test]
+    fn resolve_targets_rejects_unknown_cursor() {
+        create_session_if_not_set_then(|_| {
+            let path = Arc::new(PathBuf::from("/pkg/src/main.leo"));
+            let declaration = FileRange::new(Arc::clone(&path), 1, 6).expect("declaration");
+            let package =
+                build_package(vec![local_occurrence(&path, 1, 6, &declaration, OccurrenceRole::Declaration)], |_| true);
+            let view_key = document_view_key(&"untitled:main.leo".parse().unwrap());
+            let result = resolve_targets(&rename_query(50, view_key, "renamed"), &package, path.as_ref());
+            assert_eq!(result, Err(RenameError::NotRenameable));
+        });
+    }
+
+    /// Verifies resolve_targets returns every package-internal occurrence for a Local key.
+    #[test]
+    fn resolve_targets_returns_local_occurrences() {
+        create_session_if_not_set_then(|_| {
+            let path = Arc::new(PathBuf::from("/pkg/src/main.leo"));
+            let declaration = FileRange::new(Arc::clone(&path), 1, 6).expect("declaration");
+            let package = build_package(
+                vec![
+                    local_occurrence(&path, 1, 6, &declaration, OccurrenceRole::Declaration),
+                    local_occurrence(&path, 10, 15, &declaration, OccurrenceRole::Reference),
+                    local_occurrence(&path, 20, 25, &declaration, OccurrenceRole::Reference),
+                ],
+                |_| true,
+            );
+            let view_key = document_view_key(&"untitled:main.leo".parse().unwrap());
+            let targets = resolve_targets(&rename_query(12, view_key, "renamed"), &package, path.as_ref())
+                .expect("eligible local");
+            let starts = targets.iter().map(|target| target.range.start).collect::<Vec<_>>();
+            assert_eq!(starts, vec![1, 10, 20]);
+        });
+    }
+
+    /// Verifies resolve_targets rejects cursors whose key is the Program variant.
+    #[test]
+    fn resolve_targets_rejects_program_cursor() {
+        create_session_if_not_set_then(|_| {
+            let path = Arc::new(PathBuf::from("/pkg/src/main.leo"));
+            let package_root = Arc::new(PathBuf::from("/pkg"));
+            let occurrence = SymbolOccurrence {
+                range: FileRange::new(Arc::clone(&path), 1, 9).expect("range"),
+                identity: SymbolIdentity::Program {
+                    program: Symbol::intern("hello"),
+                    package_root: Some(Arc::clone(&package_root)),
+                    declaration: None,
+                },
+                role: OccurrenceRole::Declaration,
+                token_kind: SemanticKind::Namespace,
+                readonly: true,
+            };
+            let package = build_package(vec![occurrence], |_| true);
+            let view_key = document_view_key(&"untitled:main.leo".parse().unwrap());
+            let result = resolve_targets(&rename_query(3, view_key, "world"), &package, path.as_ref());
+            assert_eq!(result, Err(RenameError::NotRenameable));
+        });
+    }
+
+    /// Verifies resolve_targets rejects renames that touch out-of-package files.
+    #[test]
+    fn resolve_targets_rejects_out_of_package_target() {
+        create_session_if_not_set_then(|_| {
+            let in_path = Arc::new(PathBuf::from("/pkg/src/main.leo"));
+            let stub_path = Arc::new(PathBuf::from("/dep/src/lib.leo"));
+            let declaration = FileRange::new(Arc::clone(&in_path), 1, 6).expect("declaration");
+            let package = build_package(
+                vec![
+                    local_occurrence(&in_path, 1, 6, &declaration, OccurrenceRole::Declaration),
+                    local_occurrence(&stub_path, 30, 35, &declaration, OccurrenceRole::Reference),
+                ],
+                |path| path == std::path::Path::new("/pkg/src/main.leo"),
+            );
+            let view_key = document_view_key(&"untitled:main.leo".parse().unwrap());
+            let result = resolve_targets(&rename_query(3, view_key, "renamed"), &package, in_path.as_ref());
+            assert!(matches!(result, Err(RenameError::LeavesPackage { .. })), "{result:?}");
+        });
+    }
+
+    /// Verifies prepare_rename_target returns the cursor occurrence range for renameable keys.
+    #[test]
+    fn prepare_rename_target_returns_cursor_range() {
+        create_session_if_not_set_then(|_| {
+            let path = Arc::new(PathBuf::from("/pkg/src/main.leo"));
+            let declaration = FileRange::new(Arc::clone(&path), 1, 6).expect("declaration");
+            let package = build_package(
+                vec![
+                    local_occurrence(&path, 1, 6, &declaration, OccurrenceRole::Declaration),
+                    local_occurrence(&path, 10, 15, &declaration, OccurrenceRole::Reference),
+                ],
+                |_| true,
+            );
+            let view_key = document_view_key(&"untitled:main.leo".parse().unwrap());
+            let range = prepare_rename_target(&prepare_query(11, view_key), &package, path.as_ref())
+                .expect("renameable cursor");
+            assert_eq!((range.start, range.end), (10, 15));
+        });
+    }
+
+    /// Verifies prepare_rename_target returns None for cursor positions in whitespace.
+    #[test]
+    fn prepare_rename_target_returns_none_in_whitespace() {
+        create_session_if_not_set_then(|_| {
+            let path = Arc::new(PathBuf::from("/pkg/src/main.leo"));
+            let declaration = FileRange::new(Arc::clone(&path), 1, 6).expect("declaration");
+            let package =
+                build_package(vec![local_occurrence(&path, 1, 6, &declaration, OccurrenceRole::Declaration)], |_| true);
+            let view_key = document_view_key(&"untitled:main.leo".parse().unwrap());
+            assert!(prepare_rename_target(&prepare_query(50, view_key), &package, path.as_ref()).is_none());
+        });
+    }
+}

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -23,6 +23,7 @@ mod compiler_bridge;
 mod document_store;
 mod features;
 mod panic_boundary;
+mod pending;
 mod project_model;
 mod response_pool;
 mod scheduler;

--- a/crates/lsp/src/pending.rs
+++ b/crates/lsp/src/pending.rs
@@ -1,0 +1,120 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+#![allow(clippy::mutable_key_type)]
+
+//! Shared drain abstractions for routing-thread pending-request state.
+//!
+//! Five pending-request structs (`semantic_tokens`, `definitions`,
+//! `references`, `rename`, `prepare_rename`) all surface the same lifecycle
+//! events: `didClose`, package eviction, bucket invalidation, and worker
+//! panic. Each event drains pending entries on one of three dimensions —
+//! URI, `PackageAnalysisKey`, or `AnalysisBucket` — then replies to the
+//! drained requests. Without a shared abstraction, every fan-out helper in
+//! `server.rs` repeats five copies of the same `drain_* + send_*` sequence.
+//!
+//! `PendingFeature` and `PendingRequest` collapse that to one generic helper.
+//! The trait is generic over the per-feature request type so each implementor
+//! keeps its own struct shape (cancel flag for references/rename; bare
+//! `RequestId` for semantic tokens; query-only for definitions and
+//! prepare-rename) without least-common-denominator dispatch.
+//!
+//! Per-feature operations that are not a four-dimension drain (semantic
+//! tokens' `take_key`, references' and rename's `mark_undispatched`) stay on
+//! the concrete state types — collapsing those would force every implementor
+//! to grow methods it does not need.
+
+use crate::document_store::{AnalysisBucket, PackageAnalysisKey};
+use anyhow::Result;
+use lsp_server::{Connection, Message, RequestId, Response, ResponseError};
+use lsp_types::Uri;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+/// One drainable pending request, sufficient to reply on cancellation.
+pub trait PendingRequest {
+    /// Original JSON-RPC request ID to answer.
+    fn id(&self) -> &RequestId;
+
+    /// Cancellation flag observed by any response-pool job dispatched against
+    /// this request. References and rename carry one; semantic tokens,
+    /// definitions, and prepare-rename do not. Routing-thread cancel paths
+    /// flip the flag before replying so a still-running pool job drops its
+    /// completion on arrival.
+    fn cancel_flag(&self) -> Option<&Arc<AtomicBool>> {
+        None
+    }
+}
+
+impl PendingRequest for RequestId {
+    /// A bare request ID is its own identity; carries no cancel flag.
+    fn id(&self) -> &RequestId {
+        self
+    }
+}
+
+/// Routing-thread pending-state container shared by all LSP features.
+///
+/// Each implementor exposes the same three drain dimensions so the fan-out
+/// helpers in `server.rs` can iterate them generically. The per-feature
+/// `Request` associated type stays concrete so cancel flags and other
+/// per-feature payload survive the drain.
+pub trait PendingFeature {
+    /// Per-feature pending request payload (e.g. `PendingRenameRequest`).
+    type Request: PendingRequest;
+
+    /// Remove and return all pending requests targeting this URI.
+    /// Called from `didClose`.
+    fn drain_uri(&mut self, uri: &Uri) -> Vec<Self::Request>;
+
+    /// Remove and return all pending requests for one package key.
+    /// Called from package-eviction, package-cancellation, and worker-panic
+    /// fan-outs.
+    fn drain_package(&mut self, key: &PackageAnalysisKey) -> Vec<Self::Request>;
+
+    /// Remove and return all pending requests for one analysis bucket.
+    /// Called from bucket-bump invalidation.
+    fn drain_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<Self::Request>;
+}
+
+/// Flip every cancel flag and send the same error reply to every drained request.
+///
+/// Cancel flags are flipped before any response is sent so an in-flight pool
+/// completion that races the cancel reply observes the cancellation and drops
+/// its payload on arrival rather than emitting a stale value the client
+/// already received an error for.
+pub fn cancel_drained<R: PendingRequest>(
+    connection: &Connection,
+    requests: Vec<R>,
+    code: i32,
+    message: impl Into<String>,
+) -> Result<()> {
+    let message = message.into();
+    for request in requests {
+        if let Some(flag) = request.cancel_flag() {
+            flag.store(true, Ordering::SeqCst);
+        }
+        let response = Response {
+            id: request.id().clone(),
+            result: None,
+            error: Some(ResponseError { code, message: message.clone(), data: None }),
+        };
+        connection.sender.send(Message::Response(response))?;
+    }
+    Ok(())
+}

--- a/crates/lsp/src/response_pool.rs
+++ b/crates/lsp/src/response_pool.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+#![allow(clippy::mutable_key_type)]
+
 //! Small response-conversion pool for navigation requests with disk targets.
 //!
 //! Package analysis stores compact byte ranges, not retained file text. This
@@ -24,18 +26,29 @@
 use crate::{
     document_store::{DocumentStore, PackageAnalysisKey},
     features::{
-        lsp_range::{compact_range_to_location_with_line_index, read_verified_disk_text},
+        lsp_range::{byte_range_to_lsp_range, compact_range_to_location_with_line_index, read_verified_disk_text},
         references::{ReferenceQuery, resolve_targets, response_value as references_response_value},
+        rename::{RenameError, RenameQuery, resolve_targets as resolve_rename_targets},
     },
+    project_model::path_to_file_uri,
     semantics::{CachedPackageAnalysis, FileId, SourceFingerprint},
 };
 use crossbeam_channel::{Receiver, Sender, unbounded};
 use line_index::LineIndex;
 use lsp_server::RequestId;
-use lsp_types::{Location, Uri};
+use lsp_types::{
+    DocumentChanges,
+    Location,
+    OneOf,
+    OptionalVersionedTextDocumentIdentifier,
+    TextDocumentEdit,
+    TextEdit,
+    Uri,
+    WorkspaceEdit,
+};
 use serde_json::Value;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     panic::{AssertUnwindSafe, catch_unwind},
     path::{Path, PathBuf},
     sync::{
@@ -45,7 +58,11 @@ use std::{
     thread::{self, JoinHandle},
 };
 
+/// Fixed worker thread count for the response materialization pool.
 const RESPONSE_WORKERS: usize = 2;
+
+/// JSON-RPC code for `RequestFailed` (LSP 3.17 spec).
+pub const REQUEST_FAILED: i32 = -32803;
 
 /// Bounded worker pool for response materialization.
 #[derive(Debug)]
@@ -66,8 +83,21 @@ pub enum ResponseJob {
         query: Box<ReferenceQuery>,
         /// Package analysis containing compact reference ranges.
         package: Arc<CachedPackageAnalysis>,
-        /// Open-buffer line indexes captured when the job was dispatched.
-        open_line_indexes: Arc<OpenLineIndexes>,
+        /// Open-document snapshot captured when the job was dispatched.
+        open_snapshot: Arc<OpenSnapshot>,
+        /// Cancellation flag shared with the routing thread.
+        cancel: Arc<AtomicBool>,
+    },
+    /// Convert one rename query into a `WorkspaceEdit` JSON-RPC response.
+    Rename {
+        /// Original JSON-RPC request ID.
+        id: RequestId,
+        /// Cursor and validated new-name query captured by the routing thread.
+        query: Box<RenameQuery>,
+        /// Package analysis containing compact rename targets.
+        package: Arc<CachedPackageAnalysis>,
+        /// Open-document snapshot captured when the job was dispatched.
+        open_snapshot: Arc<OpenSnapshot>,
         /// Cancellation flag shared with the routing thread.
         cancel: Arc<AtomicBool>,
     },
@@ -75,11 +105,21 @@ pub enum ResponseJob {
     Shutdown,
 }
 
-/// Snapshot of open-document line indexes captured at job dispatch time.
+/// Snapshot of open-document line indexes, paths, and versions captured at
+/// job dispatch time.
+///
+/// Versions are keyed by the canonical `Arc<PathBuf>` from
+/// `OpenDocument::file_path`, not by the client-supplied URI. The client
+/// URI may differ from the canonical path on platforms where
+/// `path.canonicalize()` rewrites the prefix (macOS `/Users` →
+/// `/private/Users`, Windows verbatim paths). Path-keyed lookup keeps
+/// `OpenBuffer` files matching their `OptionalVersionedTextDocumentIdentifier`
+/// version stamp regardless of where the analysis happens to recover them.
 #[derive(Debug, Default)]
-pub struct OpenLineIndexes {
+pub struct OpenSnapshot {
     indexes: HashMap<Arc<PathBuf>, Arc<LineIndex>>,
     uri_paths: Vec<(Uri, Arc<PathBuf>)>,
+    versions: HashMap<Arc<PathBuf>, i32>,
 }
 
 /// Pool-to-routing notification sent after a job completes.
@@ -96,6 +136,17 @@ pub enum ResponseCompletion {
         /// Final response payload or error.
         result: ResponseResult,
     },
+    /// Completed rename response materialization.
+    Rename {
+        /// Original JSON-RPC request ID.
+        id: RequestId,
+        /// Package key the response was computed against.
+        key: PackageAnalysisKey,
+        /// Cancellation token captured at dispatch, used to reject reused IDs.
+        cancel: Arc<AtomicBool>,
+        /// Final rename response or error.
+        result: RenameResult,
+    },
 }
 
 /// Prepared response payload returned to the routing thread.
@@ -105,6 +156,17 @@ pub enum ResponseResult {
     Ok(Value),
     /// Internal error message to return for a failed conversion.
     InternalError(String),
+}
+
+/// Rename-scoped result returned to the routing thread.
+#[derive(Debug)]
+pub enum RenameResult {
+    /// Successful JSON-RPC result payload (`WorkspaceEdit` or `Value::Null`).
+    Ok(Value),
+    /// Internal error message returned for pool-worker panics.
+    InternalError(String),
+    /// LSP `RequestFailed` error with a stable diagnostic message.
+    RequestFailed { code: i32, message: String },
 }
 
 impl ResponsePool {
@@ -156,19 +218,21 @@ impl Default for ResponsePool {
     }
 }
 
-impl OpenLineIndexes {
-    /// Snapshot open file paths and line indexes with Arc clones only.
+impl OpenSnapshot {
+    /// Snapshot open file paths, line indexes, and document versions.
     pub fn snapshot(documents: &DocumentStore) -> Arc<Self> {
         let mut indexes = HashMap::new();
         let mut uri_paths = Vec::new();
+        let mut versions = HashMap::new();
         for (uri, document) in documents.iter_open() {
             let Some(path) = document.file_path.as_ref() else {
                 continue;
             };
             indexes.entry(Arc::clone(path)).or_insert_with(|| Arc::clone(&document.line_index));
             uri_paths.push((uri.clone(), Arc::clone(path)));
+            versions.entry(Arc::clone(path)).or_insert(document.version);
         }
-        Arc::new(Self { indexes, uri_paths })
+        Arc::new(Self { indexes, uri_paths, versions })
     }
 
     /// Return the open line index for a path, if that file is currently open.
@@ -179,6 +243,12 @@ impl OpenLineIndexes {
     /// Return the native path for an open document URI in this snapshot.
     fn path_for_uri(&self, uri: &Uri) -> Option<&Arc<PathBuf>> {
         self.uri_paths.iter().find_map(|(candidate, path)| (candidate == uri).then_some(path))
+    }
+
+    /// Return the open-buffer version for a canonical path captured at
+    /// dispatch time.
+    fn version_for_path(&self, path: &Path) -> Option<i32> {
+        self.versions.iter().find_map(|(candidate, version)| (candidate.as_path() == path).then_some(*version))
     }
 }
 
@@ -193,11 +263,11 @@ fn spawn_worker(
         .spawn(move || {
             while let Ok(job) = job_rx.recv() {
                 match job {
-                    ResponseJob::References { id, query, package, open_line_indexes, cancel } => {
+                    ResponseJob::References { id, query, package, open_snapshot, cancel } => {
                         let key = package.key.clone();
                         let completion_cancel = Arc::clone(&cancel);
                         let result = catch_unwind(AssertUnwindSafe(|| {
-                            references_response(*query, package, open_line_indexes, cancel)
+                            references_response(*query, package, open_snapshot, cancel)
                         }));
                         let result = match result {
                             Ok(Some(value)) => ResponseResult::Ok(value),
@@ -207,6 +277,25 @@ fn spawn_worker(
                             ),
                         };
                         let _ = completion_tx.send(ResponseCompletion::References {
+                            id,
+                            key,
+                            cancel: completion_cancel,
+                            result,
+                        });
+                    }
+                    ResponseJob::Rename { id, query, package, open_snapshot, cancel } => {
+                        let key = package.key.clone();
+                        let completion_cancel = Arc::clone(&cancel);
+                        let result =
+                            catch_unwind(AssertUnwindSafe(|| rename_response(*query, package, open_snapshot, cancel)));
+                        let result = match result {
+                            Ok(Some(result)) => result,
+                            Ok(None) => continue,
+                            Err(_) => RenameResult::InternalError(
+                                "rename response conversion panicked; see server logs for details".to_owned(),
+                            ),
+                        };
+                        let _ = completion_tx.send(ResponseCompletion::Rename {
                             id,
                             key,
                             cancel: completion_cancel,
@@ -224,10 +313,10 @@ fn spawn_worker(
 fn references_response(
     query: ReferenceQuery,
     package: Arc<CachedPackageAnalysis>,
-    open_line_indexes: Arc<OpenLineIndexes>,
+    open_snapshot: Arc<OpenSnapshot>,
     cancel: Arc<AtomicBool>,
 ) -> Option<Value> {
-    let Some(source_path) = open_line_indexes.path_for_uri(&query.view_key.uri) else {
+    let Some(source_path) = open_snapshot.path_for_uri(&query.view_key.uri) else {
         return Some(references_response_value(false, Vec::new()));
     };
     let targets = resolve_targets(&query, package.as_ref(), source_path.as_ref());
@@ -250,7 +339,7 @@ fn references_response(
             file,
             &targets.ranges[start..end],
             package.as_ref(),
-            open_line_indexes.as_ref(),
+            open_snapshot.as_ref(),
             &mut locations,
         );
         start = end;
@@ -264,7 +353,7 @@ fn append_file_locations(
     file_id: FileId,
     ranges: &[crate::semantics::CompactRange],
     package: &CachedPackageAnalysis,
-    open_line_indexes: &OpenLineIndexes,
+    open_snapshot: &OpenSnapshot,
     locations: &mut Vec<Location>,
 ) {
     let Some(file) = package.analyzed_files.get(file_id) else {
@@ -276,7 +365,7 @@ fn append_file_locations(
 
     match &file.fingerprint {
         SourceFingerprint::OpenBuffer => {
-            let line_index = file.open_line_index.as_ref().or_else(|| open_line_indexes.get(file.path.as_ref()));
+            let line_index = file.open_line_index.as_ref().or_else(|| open_snapshot.get(file.path.as_ref()));
             let Some(line_index) = line_index else {
                 return;
             };
@@ -307,4 +396,158 @@ fn append_locations_with_line_index(
             locations.push(Location { uri, range });
         }
     }
+}
+
+/// Resolve and materialize one rename response off the routing thread.
+///
+/// Returns `Some(RenameResult)` when the worker has produced a payload (`Ok`,
+/// `RequestFailed`, or `InternalError`). Returns `None` when cancellation
+/// flipped before materialization completed; the routing thread drops the
+/// in-flight job in that case.
+fn rename_response(
+    query: RenameQuery,
+    package: Arc<CachedPackageAnalysis>,
+    open_snapshot: Arc<OpenSnapshot>,
+    cancel: Arc<AtomicBool>,
+) -> Option<RenameResult> {
+    let Some(source_path) = open_snapshot.path_for_uri(&query.view_key.uri) else {
+        return Some(RenameResult::Ok(Value::Null));
+    };
+    let targets = match resolve_rename_targets(&query, package.as_ref(), source_path.as_ref()) {
+        Ok(targets) => targets,
+        Err(RenameError::NotRenameable) => return Some(RenameResult::Ok(Value::Null)),
+        Err(error) => return Some(rename_error_to_result(error)),
+    };
+    if targets.is_empty() {
+        return Some(RenameResult::Ok(Value::Null));
+    }
+
+    // Group occurrences by FileId to batch one disk read + one LineIndex per file.
+    let mut by_file: BTreeMap<FileId, Vec<crate::semantics::CompactRange>> = BTreeMap::new();
+    for target in &targets {
+        by_file.entry(target.file).or_default().push(target.range);
+    }
+
+    let mut document_edits: BTreeMap<Uri, (OptionalVersionedTextDocumentIdentifier, Vec<TextEdit>)> = BTreeMap::new();
+    for (file_id, ranges) in by_file {
+        if cancel.load(Ordering::SeqCst) {
+            return None;
+        }
+        let Some(file) = package.analyzed_files.get(file_id) else {
+            return Some(RenameResult::RequestFailed {
+                code: REQUEST_FAILED,
+                message: "rename target references unknown analyzed file".to_owned(),
+            });
+        };
+        let Some(uri) = path_to_file_uri(file.path.as_ref()) else {
+            return Some(RenameResult::RequestFailed {
+                code: REQUEST_FAILED,
+                message: format!("rename target '{}' cannot be expressed as an LSP URI", file.path.display()),
+            });
+        };
+
+        let (line_index, owned_index, version) = match &file.fingerprint {
+            SourceFingerprint::OpenBuffer => {
+                let line_index =
+                    file.open_line_index.as_ref().cloned().or_else(|| open_snapshot.get(file.path.as_ref()).cloned());
+                let Some(line_index) = line_index else {
+                    return Some(RenameResult::RequestFailed {
+                        code: REQUEST_FAILED,
+                        message: format!("rename target '{}' has no open-buffer line index", file.path.display()),
+                    });
+                };
+                let version = open_snapshot.version_for_path(file.path.as_ref());
+                (LineIndexRef::Shared(line_index), None, version)
+            }
+            SourceFingerprint::Disk { .. } => {
+                let Some(text) = read_verified_disk_text(file.path.as_ref(), &file.fingerprint) else {
+                    return Some(RenameResult::RequestFailed {
+                        code: REQUEST_FAILED,
+                        message: format!(
+                            "source for '{}' changed since analysis; please retry rename",
+                            file.path.display()
+                        ),
+                    });
+                };
+                let owned = LineIndex::new(text.as_str());
+                (LineIndexRef::Owned, Some(owned), None)
+            }
+            SourceFingerprint::Volatile => {
+                return Some(RenameResult::RequestFailed {
+                    code: REQUEST_FAILED,
+                    message: format!("rename target '{}' has volatile source", file.path.display()),
+                });
+            }
+        };
+
+        let line_index_ref: &LineIndex = match &line_index {
+            LineIndexRef::Shared(arc) => arc.as_ref(),
+            LineIndexRef::Owned => owned_index.as_ref().expect("owned line index"),
+        };
+
+        let mut edits: Vec<TextEdit> = Vec::with_capacity(ranges.len());
+        let mut last_end: Option<u32> = None;
+        for range in &ranges {
+            // Per-URI ranges inherit `(start, end)` order from `occurrences_for`;
+            // the worker pins that contract instead of resorting.
+            debug_assert!(
+                last_end.map(|prev| prev <= range.start).unwrap_or(true),
+                "rename ranges must be in non-decreasing order"
+            );
+            last_end = Some(range.end);
+            let Some(lsp_range) = byte_range_to_lsp_range(line_index_ref, range.start, range.end) else {
+                return Some(RenameResult::RequestFailed {
+                    code: REQUEST_FAILED,
+                    message: format!("rename target range fell outside source for '{}'", file.path.display()),
+                });
+            };
+            edits.push(TextEdit { range: lsp_range, new_text: query.new_name.clone() });
+        }
+
+        document_edits.insert(uri.clone(), (OptionalVersionedTextDocumentIdentifier { uri, version }, edits));
+    }
+
+    let text_document_edits = document_edits
+        .into_iter()
+        .map(|(_uri, (text_document, edits))| TextDocumentEdit {
+            text_document,
+            edits: edits.into_iter().map(OneOf::Left).collect(),
+        })
+        .collect::<Vec<_>>();
+
+    let workspace_edit = WorkspaceEdit {
+        changes: None,
+        document_changes: Some(DocumentChanges::Edits(text_document_edits)),
+        change_annotations: None,
+    };
+    let value = serde_json::to_value(workspace_edit).expect("WorkspaceEdit should serialize");
+    Some(RenameResult::Ok(value))
+}
+
+/// Convert a per-file rename rejection into the corresponding `RequestFailed` result.
+fn rename_error_to_result(error: RenameError) -> RenameResult {
+    match error {
+        RenameError::InvalidIdentifier(message) => RenameResult::RequestFailed { code: REQUEST_FAILED, message },
+        RenameError::NotRenameable => RenameResult::Ok(Value::Null),
+        RenameError::SourceChanged { path } => RenameResult::RequestFailed {
+            code: REQUEST_FAILED,
+            message: format!("source for '{path}' changed since analysis; please retry rename"),
+        },
+        RenameError::LeavesPackage { path } => RenameResult::RequestFailed {
+            code: REQUEST_FAILED,
+            message: format!("rename target '{path}' leaves the current package"),
+        },
+        RenameError::VolatileSource { path } => RenameResult::RequestFailed {
+            code: REQUEST_FAILED,
+            message: format!("rename target '{path}' has volatile source"),
+        },
+    }
+}
+
+/// Per-file line index slot that keeps both Arc-shared and worker-owned indexes addressable.
+enum LineIndexRef {
+    /// Open-buffer line index borrowed from `AnalyzedFile` or the snapshot.
+    Shared(Arc<LineIndex>),
+    /// Disk-backed line index built once per file by the worker.
+    Owned,
 }

--- a/crates/lsp/src/semantics.rs
+++ b/crates/lsp/src/semantics.rs
@@ -440,6 +440,10 @@ pub struct AnalyzedFile {
     pub open_line_index: Option<Arc<LineIndex>>,
     /// Virtual sentinel paths are semantic identities only, never LSP locations.
     pub is_sentinel: bool,
+    /// True when this file is a source file of the currently-analyzed package.
+    /// False for dependency stubs and any other file outside the package source
+    /// tree. Sentinel files are always `false`.
+    pub in_package_scope: bool,
 }
 
 /// Memory-light analyzed-file table owned by one package analysis.
@@ -540,6 +544,9 @@ pub struct SemanticIndex {
     pub key_occurrence_ends: Arc<[u32]>,
     /// Occurrence indices grouped by key and ordered by file/range.
     pub key_occurrence_indices: Arc<[u32]>,
+    /// Sorted compact key IDs whose source `SymbolKey` is the `Program` variant.
+    /// Used by rename to reject Program-typed cursors in O(log p).
+    pub program_keys: Arc<[SymbolKeyId]>,
 }
 
 impl SemanticIndex {
@@ -552,6 +559,7 @@ impl SemanticIndex {
         occurrences: &[SymbolOccurrence],
         mut fingerprint_for_path: impl FnMut(&Path) -> SourceFingerprint,
         mut open_line_index_for_path: impl FnMut(&Path) -> Option<Arc<LineIndex>>,
+        mut in_package_scope_for_path: impl FnMut(&Path) -> bool,
     ) -> (Self, AnalyzedFileSet) {
         let mut path_ids = HashMap::<Arc<PathBuf>, FileId>::new();
         let mut files = Vec::<Arc<PathBuf>>::new();
@@ -566,12 +574,18 @@ impl SemanticIndex {
         let mut key_ids = HashMap::<CompactSymbolKey, SymbolKeyId>::new();
         let mut compact_occurrences = Vec::<CompactOccurrence>::with_capacity(occurrences.len());
         let mut definition_pairs = Vec::<(SymbolKeyId, CompactRange)>::new();
+        let mut program_keys = Vec::<SymbolKeyId>::new();
 
         for occurrence in occurrences {
             let range = compact_range(&occurrence.range, &path_ids).expect("occurrence file interned");
             let key = occurrence.identity.key().and_then(|key| {
                 let compact = compact_symbol_key(key, &path_ids)?;
-                Some(intern_symbol_key(compact, &mut key_ids))
+                let is_program = matches!(compact, CompactSymbolKey::Program { .. });
+                let id = intern_symbol_key(compact, &mut key_ids);
+                if is_program && !program_keys.contains(&id) {
+                    program_keys.push(id);
+                }
+                Some(id)
             });
 
             compact_occurrences.push(CompactOccurrence::new(
@@ -617,14 +631,20 @@ impl SemanticIndex {
         let analyzed_files = files
             .iter()
             .enumerate()
-            .map(|(id, path)| AnalyzedFile {
-                id: id as FileId,
-                path: Arc::clone(path),
-                fingerprint: fingerprint_for_path(path.as_ref()),
-                open_line_index: open_line_index_for_path(path.as_ref()),
-                is_sentinel: is_sentinel_path(path.as_ref()),
+            .map(|(id, path)| {
+                let is_sentinel = is_sentinel_path(path.as_ref());
+                AnalyzedFile {
+                    id: id as FileId,
+                    path: Arc::clone(path),
+                    fingerprint: fingerprint_for_path(path.as_ref()),
+                    open_line_index: open_line_index_for_path(path.as_ref()),
+                    is_sentinel,
+                    in_package_scope: !is_sentinel && in_package_scope_for_path(path.as_ref()),
+                }
             })
             .collect();
+
+        program_keys.sort_unstable();
 
         (
             Self {
@@ -638,9 +658,15 @@ impl SemanticIndex {
                 key_occurrence_keys: Arc::from(key_occurrence_keys),
                 key_occurrence_ends: Arc::from(key_occurrence_ends),
                 key_occurrence_indices: Arc::from(key_occurrence_indices),
+                program_keys: Arc::from(program_keys),
             },
             AnalyzedFileSet::new(analyzed_files),
         )
+    }
+
+    /// Return whether a compact key ID corresponds to the `Program` variant.
+    pub fn is_program_key(&self, key: SymbolKeyId) -> bool {
+        self.program_keys.binary_search(&key).is_ok()
     }
 
     /// Return the navigation-grade occurrence under a cursor byte offset.
@@ -1037,7 +1063,7 @@ mod tests {
             },
         ];
 
-        let (index, _) = SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None);
+        let (index, _) = SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None, |_| true);
         let key = index.occurrences[0].key_id().expect("keyed declaration");
         let starts = index.occurrences_for(key).map(|occurrence| occurrence.range.start).collect::<Vec<_>>();
 

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -31,13 +31,23 @@ use crate::{
             resolve as resolve_definition,
             response_value as definition_response_value,
         },
-        lsp_range::position_to_offset,
+        lsp_range::{byte_range_to_lsp_range, position_to_offset},
         references::ReferenceQuery,
+        rename::{PrepareRenameQuery, RenameQuery, prepare_rename_target, validate_new_name},
         semantic_tokens::{capability as semantic_tokens_capability, empty_response_value, response_value},
     },
     panic_boundary::catch_unwind,
+    pending::{PendingFeature, PendingRequest, cancel_drained},
     project_model::{ProjectModel, uri_to_file_path},
-    response_pool::{OpenLineIndexes, ResponseCompletion, ResponseJob, ResponsePool, ResponseResult},
+    response_pool::{
+        OpenSnapshot,
+        REQUEST_FAILED,
+        RenameResult,
+        ResponseCompletion,
+        ResponseJob,
+        ResponsePool,
+        ResponseResult,
+    },
     scheduler::{PackageAnalysis, Scheduler, WorkerEvent},
     semantics::{CachedDocumentView, CachedPackageAnalysis},
 };
@@ -53,15 +63,21 @@ use lsp_types::{
     InitializeResult,
     NumberOrString,
     OneOf,
+    PrepareRenameResponse,
+    Range,
     ReferenceParams,
+    RenameOptions,
+    RenameParams,
     SemanticTokensParams,
     ServerCapabilities,
     ServerInfo,
     TextDocumentContentChangeEvent,
+    TextDocumentPositionParams,
     TextDocumentSyncCapability,
     TextDocumentSyncKind,
     TextDocumentSyncOptions,
     Uri,
+    WorkDoneProgressOptions,
 };
 use serde_json::Value;
 use std::{
@@ -99,6 +115,10 @@ const SEMANTIC_TOKENS_FULL: &str = "textDocument/semanticTokens/full";
 const TEXT_DOCUMENT_DEFINITION: &str = "textDocument/definition";
 /// LSP find-all-references request method.
 const TEXT_DOCUMENT_REFERENCES: &str = "textDocument/references";
+/// LSP rename request method.
+const TEXT_DOCUMENT_RENAME: &str = "textDocument/rename";
+/// LSP prepare-rename request method.
+const TEXT_DOCUMENT_PREPARE_RENAME: &str = "textDocument/prepareRename";
 /// Maximum package analyses retained on the routing thread.
 const MAX_PACKAGE_CACHE_ENTRIES: usize = 8;
 /// Maximum pending go-to-definition requests across all packages.
@@ -109,6 +129,14 @@ const MAX_PENDING_DEFINITIONS_PER_KEY: usize = 16;
 const MAX_PENDING_REFERENCES: usize = 128;
 /// Maximum pending references requests waiting on one package key.
 const MAX_PENDING_REFERENCES_PER_KEY: usize = 16;
+/// Maximum pending rename requests across all packages.
+const MAX_PENDING_RENAMES: usize = 128;
+/// Maximum pending rename requests waiting on one package key.
+const MAX_PENDING_RENAMES_PER_KEY: usize = 16;
+/// Maximum pending prepare-rename requests across all packages.
+const MAX_PENDING_PREPARE_RENAMES: usize = 128;
+/// Maximum pending prepare-rename requests waiting on one package key.
+const MAX_PENDING_PREPARE_RENAMES_PER_KEY: usize = 16;
 
 /// In-memory state for one running `leo-lsp` server instance.
 ///
@@ -129,6 +157,8 @@ struct ServerState {
     semantic_token_requests: SemanticTokenRequestState,
     definition_requests: DefinitionRequestState,
     reference_requests: ReferencesRequestState,
+    rename_requests: RenameRequestState,
+    prepare_rename_requests: PrepareRenameRequestState,
     client_definition_link_support: bool,
     hooks: TestHooks,
 }
@@ -201,6 +231,46 @@ struct PendingReferencesRequest {
     dispatched: bool,
 }
 
+/// Pending rename requests keyed by package analysis.
+#[derive(Debug, Default)]
+struct RenameRequestState {
+    /// Waiters and in-flight conversions grouped by package analysis.
+    pending_by_package: HashMap<PackageAnalysisKey, Vec<PendingRenameRequest>>,
+    /// Reverse lookup used to cancel or complete a request by ID.
+    pending_owner: HashMap<RequestId, PackageAnalysisKey>,
+}
+
+/// One pending rename request with cancellation state owned by routing.
+#[derive(Debug, Clone)]
+struct PendingRenameRequest {
+    /// Original LSP request ID to answer when conversion completes.
+    id: RequestId,
+    /// Cursor, view freshness, and validated new-name state.
+    query: RenameQuery,
+    /// Cancellation flag observed by the response pool.
+    cancel: Arc<AtomicBool>,
+    /// Whether this request has already been handed to the response pool.
+    dispatched: bool,
+}
+
+/// Pending prepare-rename requests keyed by package analysis.
+#[derive(Debug, Default)]
+struct PrepareRenameRequestState {
+    /// Waiters grouped by package analysis. Prepare-rename never enters the pool.
+    pending_by_package: HashMap<PackageAnalysisKey, Vec<PendingPrepareRenameRequest>>,
+    /// Reverse lookup used to cancel a request by ID.
+    pending_owner: HashMap<RequestId, PackageAnalysisKey>,
+}
+
+/// One pending prepare-rename request, answered synchronously on cache hit.
+#[derive(Debug, Clone)]
+struct PendingPrepareRenameRequest {
+    /// Original LSP request ID to answer when analysis arrives.
+    id: RequestId,
+    /// Cursor and view freshness captured when the request arrived.
+    query: PrepareRenameQuery,
+}
+
 /// Run the production LSP server with hooks loaded from the process environment.
 pub(crate) fn run(connection: Connection) -> Result<ExitCode> {
     run_with_hooks(connection, TestHooks::from_env())
@@ -238,6 +308,8 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
         semantic_token_requests: SemanticTokenRequestState::default(),
         definition_requests: DefinitionRequestState::default(),
         reference_requests: ReferencesRequestState::default(),
+        rename_requests: RenameRequestState::default(),
+        prepare_rename_requests: PrepareRenameRequestState::default(),
         client_definition_link_support,
         hooks,
     };
@@ -338,6 +410,16 @@ impl ServerState {
                 let params: ReferenceParams =
                     serde_json::from_value(params).context("failed to deserialize textDocument/references")?;
                 self.handle_references(connection, request_id, params)
+            }
+            TEXT_DOCUMENT_RENAME => {
+                let params: RenameParams =
+                    serde_json::from_value(params).context("failed to deserialize textDocument/rename")?;
+                self.handle_rename(connection, request_id, params)
+            }
+            TEXT_DOCUMENT_PREPARE_RENAME => {
+                let params: TextDocumentPositionParams =
+                    serde_json::from_value(params).context("failed to deserialize textDocument/prepareRename")?;
+                self.handle_prepare_rename(connection, request_id, params)
             }
             _ => {
                 tracing::debug!(method, "request is not implemented");
@@ -490,6 +572,27 @@ impl ServerState {
         if let Err(error) = send_reference_nulls(connection, self.reference_requests.clear_uri(&uri)) {
             tracing::error!(uri = uri.as_str(), error = %error, "failed to flush references close responses");
         }
+        // Rename and prepare-rename reply with `RequestCanceled` on close
+        // because the user closing the document is backing out of the
+        // action, not the server stating "not renameable".
+        log_drain(
+            cancel_drained(
+                connection,
+                self.rename_requests.drain_uri(&uri),
+                ErrorCode::RequestCanceled as i32,
+                "rename request cancelled by close",
+            ),
+            "rename close waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.prepare_rename_requests.drain_uri(&uri),
+                ErrorCode::RequestCanceled as i32,
+                "prepare-rename request cancelled by close",
+            ),
+            "prepare-rename close waiters",
+        );
         if let Some(bucket) = previous_bucket {
             self.analysis.invalidate_bucket(&bucket);
             self.cancel_pending_bucket_requests(connection, &bucket, "package analysis was superseded");
@@ -523,6 +626,16 @@ impl ServerState {
                 ErrorCode::RequestCanceled as i32,
                 "references request cancelled",
             )
+        } else if let Some(pending) = self.rename_requests.remove_pending_request(&request_id) {
+            pending.cancel.store(true, Ordering::SeqCst);
+            send_error_response(connection, request_id, ErrorCode::RequestCanceled as i32, "rename request cancelled")
+        } else if self.prepare_rename_requests.remove_pending_request(&request_id).is_some() {
+            send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "prepare-rename request cancelled",
+            )
         } else {
             Ok(())
         }
@@ -546,6 +659,8 @@ impl ServerState {
                     self.store_document_view(connection, result.document_view);
                     self.answer_pending_definitions(connection, &key);
                     self.answer_pending_references(&key);
+                    self.answer_pending_prepare_renames(connection, &key);
+                    self.answer_pending_renames(&key);
                     self.enqueue_pending_document_views_for_package(&key);
                     tracing::debug!(
                         uri = uri.as_str(),
@@ -595,35 +710,11 @@ impl ServerState {
                     && self.documents.package_key(&uri) == Some(key.clone())
                 {
                     self.analysis.store_failed_package(key.clone());
-                    let pending_semantic = self.semantic_token_requests.take_package(&key);
-                    if let Err(error) = send_error_responses(
+                    self.fail_pending_package_requests(
                         connection,
-                        pending_semantic,
-                        INTERNAL_ERROR,
-                        "semantic token analysis panicked; see server logs for details",
-                    ) {
-                        tracing::error!(uri = uri.as_str(), error = %error, "failed to send semantic analysis panic");
-                    }
-                    if let Err(error) = send_error_responses(
-                        connection,
-                        self.definition_requests.take_package(&key).into_iter().map(|pending| pending.id).collect(),
-                        INTERNAL_ERROR,
-                        "definition analysis panicked; see server logs for details",
-                    ) {
-                        tracing::error!(uri = uri.as_str(), error = %error, "failed to send definition analysis panic");
-                    }
-                    let references = self.reference_requests.take_package(&key);
-                    for pending in &references {
-                        pending.cancel.store(true, Ordering::SeqCst);
-                    }
-                    if let Err(error) = send_error_responses(
-                        connection,
-                        references.into_iter().map(|pending| pending.id).collect(),
-                        INTERNAL_ERROR,
-                        "references analysis panicked; see server logs for details",
-                    ) {
-                        tracing::error!(uri = uri.as_str(), error = %error, "failed to send references analysis panic");
-                    }
+                        &key,
+                        "analysis panicked; see server logs for details",
+                    );
                 } else {
                     self.cancel_pending_package_requests(connection, &key, "package analysis was superseded");
                 }
@@ -677,6 +768,27 @@ impl ServerState {
                 };
                 if let Err(error) = send_result {
                     tracing::error!(error = %error, "failed to send references response");
+                }
+            }
+            ResponseCompletion::Rename { id, key, cancel, result } => {
+                let Some(pending) = self.rename_requests.get(&id) else {
+                    return;
+                };
+                if pending.query.view_key.package != key || !Arc::ptr_eq(&pending.cancel, &cancel) {
+                    return;
+                }
+                let Some(_pending) = self.rename_requests.remove_pending_request(&id) else {
+                    return;
+                };
+                let send_result = match result {
+                    RenameResult::Ok(value) => send_ok_response(connection, id, value),
+                    RenameResult::InternalError(message) => {
+                        send_error_response(connection, id, INTERNAL_ERROR, message)
+                    }
+                    RenameResult::RequestFailed { code, message } => send_error_response(connection, id, code, message),
+                };
+                if let Err(error) = send_result {
+                    tracing::error!(error = %error, "failed to send rename response");
                 }
             }
         }
@@ -833,6 +945,117 @@ impl ServerState {
         Ok(())
     }
 
+    /// Answer or queue one prepare-rename request.
+    fn handle_prepare_rename(
+        &mut self,
+        connection: &Connection,
+        request_id: RequestId,
+        params: TextDocumentPositionParams,
+    ) -> Result<()> {
+        let uri = params.text_document.uri;
+        let position = params.position;
+        let Some(document) = self.documents.open_document(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(file_path) = document.file_path.clone() else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(offset) = position_to_offset(document.line_index.as_ref(), position) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let line_index = Arc::clone(&document.line_index);
+        let Some(view_key) = self.documents.document_view_key(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+
+        if self.analysis.failed_packages.contains(&view_key.package) {
+            return send_error_response(
+                connection,
+                request_id,
+                INTERNAL_ERROR,
+                "prepare-rename analysis panicked; see server logs for details",
+            );
+        }
+
+        let query = PrepareRenameQuery { offset, position, view_key: view_key.clone() };
+
+        if let Some(package) = self.analysis.packages.get(&view_key.package).cloned() {
+            let value =
+                prepare_rename_response_value(&query, package.as_ref(), file_path.as_ref(), line_index.as_ref());
+            return send_ok_response(connection, request_id, value);
+        }
+
+        if !self.prepare_rename_requests.queue(query, request_id.clone()) {
+            return send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "too many pending prepare-rename requests",
+            );
+        }
+        self.ensure_package_analysis(&view_key.package, &uri);
+        Ok(())
+    }
+
+    /// Answer or queue one rename request.
+    fn handle_rename(&mut self, connection: &Connection, request_id: RequestId, params: RenameParams) -> Result<()> {
+        let uri = params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let new_name = params.new_name;
+
+        // Validate the new name synchronously before allocating any pending-state
+        // slot or pool resources. Statically unrenameable inputs reject inline.
+        if let Err(error) = validate_new_name(&new_name) {
+            let crate::features::rename::RenameError::InvalidIdentifier(message) = error else {
+                // validate_new_name only ever returns InvalidIdentifier.
+                unreachable!("validate_new_name returned non-identifier error");
+            };
+            return send_error_response(connection, request_id, REQUEST_FAILED, message);
+        }
+
+        let Some(document) = self.documents.open_document(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        if document.file_path.is_none() {
+            return send_ok_response(connection, request_id, Value::Null);
+        }
+        let Some(offset) = position_to_offset(document.line_index.as_ref(), position) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+        let Some(view_key) = self.documents.document_view_key(&uri) else {
+            return send_ok_response(connection, request_id, Value::Null);
+        };
+
+        if self.analysis.failed_packages.contains(&view_key.package) {
+            return send_error_response(
+                connection,
+                request_id,
+                INTERNAL_ERROR,
+                "rename analysis panicked; see server logs for details",
+            );
+        }
+
+        let package = self.analysis.packages.get(&view_key.package).cloned();
+        let query = RenameQuery { offset, position, view_key: view_key.clone(), new_name };
+        let cancel = Arc::new(AtomicBool::new(false));
+        let dispatched = package.is_some();
+        if !self.rename_requests.queue(query, request_id.clone(), Arc::clone(&cancel), dispatched) {
+            return send_error_response(
+                connection,
+                request_id,
+                ErrorCode::RequestCanceled as i32,
+                "too many pending rename requests",
+            );
+        }
+
+        if let Some(package) = package {
+            self.dispatch_rename_job(request_id, view_key.package, package, cancel);
+        } else {
+            self.ensure_package_analysis(&view_key.package, &uri);
+        }
+        Ok(())
+    }
+
     /// Ensure the package and document-view analysis needed for a token request is queued.
     fn ensure_analysis_for_view(&mut self, view_key: &DocumentViewKey) {
         if let Some(package) = self.analysis.packages.get(&view_key.package).cloned() {
@@ -920,7 +1143,68 @@ impl ServerState {
             id: request_id,
             query: Box::new(pending.query.clone()),
             package,
-            open_line_indexes: OpenLineIndexes::snapshot(&self.documents),
+            open_snapshot: OpenSnapshot::snapshot(&self.documents),
+            cancel,
+        });
+    }
+
+    /// Dispatch queued rename requests unblocked by a cached package.
+    fn answer_pending_renames(&mut self, key: &PackageAnalysisKey) {
+        let Some(package) = self.analysis.packages.get(key).cloned() else {
+            return;
+        };
+        for pending in self.rename_requests.mark_undispatched(key) {
+            self.dispatch_rename_job(pending.id, key.clone(), Arc::clone(&package), Arc::clone(&pending.cancel));
+        }
+    }
+
+    /// Resolve queued prepare-rename requests synchronously against a cached package.
+    fn answer_pending_prepare_renames(&mut self, connection: &Connection, key: &PackageAnalysisKey) {
+        let Some(package) = self.analysis.packages.get(key).cloned() else {
+            return;
+        };
+        for pending in self.prepare_rename_requests.take_package(key) {
+            let Some(document) = self.documents.open_document(&pending.query.view_key.uri) else {
+                if let Err(error) = send_ok_response(connection, pending.id, Value::Null) {
+                    tracing::error!(error = %error, "failed to send prepare-rename response");
+                }
+                continue;
+            };
+            let Some(file_path) = document.file_path.clone() else {
+                if let Err(error) = send_ok_response(connection, pending.id, Value::Null) {
+                    tracing::error!(error = %error, "failed to send prepare-rename response");
+                }
+                continue;
+            };
+            let line_index = Arc::clone(&document.line_index);
+            let value = prepare_rename_response_value(
+                &pending.query,
+                package.as_ref(),
+                file_path.as_ref(),
+                line_index.as_ref(),
+            );
+            if let Err(error) = send_ok_response(connection, pending.id, value) {
+                tracing::error!(error = %error, "failed to send prepare-rename response");
+            }
+        }
+    }
+
+    /// Hand one rename request to the response pool.
+    fn dispatch_rename_job(
+        &self,
+        request_id: RequestId,
+        _key: PackageAnalysisKey,
+        package: Arc<CachedPackageAnalysis>,
+        cancel: Arc<AtomicBool>,
+    ) {
+        let Some(pending) = self.rename_requests.get(&request_id) else {
+            return;
+        };
+        self.response_pool.submit(ResponseJob::Rename {
+            id: request_id,
+            query: Box::new(pending.query.clone()),
+            package,
+            open_snapshot: OpenSnapshot::snapshot(&self.documents),
             cancel,
         });
     }
@@ -957,86 +1241,168 @@ impl ServerState {
         self.cancel_pending_bucket_requests(connection, current_bucket, message);
     }
 
-    /// Cancel semantic-token, definition, and references waiters tied to one analysis bucket.
+    /// Cancel every pending waiter tied to one analysis bucket.
+    ///
+    /// `cancel_drained` flips per-feature cancel flags before sending the
+    /// reply so an in-flight pool job whose bucket just bumped observes the
+    /// cancellation and drops its completion on arrival.
     fn cancel_pending_bucket_requests(
         &mut self,
         connection: &Connection,
         bucket: &AnalysisBucket,
         message: &'static str,
     ) {
-        if let Err(error) = send_error_responses(
-            connection,
-            self.semantic_token_requests.take_bucket(bucket),
-            ErrorCode::RequestCanceled as i32,
-            format!("semantic token {message}"),
-        ) {
-            tracing::error!(error = %error, "failed to cancel semantic token bucket waiters");
-        }
-
-        let definition_requests =
-            self.definition_requests.take_bucket(bucket).into_iter().map(|pending| pending.id).collect();
-        if let Err(error) = send_error_responses(
-            connection,
-            definition_requests,
-            ErrorCode::RequestCanceled as i32,
-            format!("definition {message}"),
-        ) {
-            tracing::error!(error = %error, "failed to cancel definition bucket waiters");
-        }
-
-        let reference_requests = self.reference_requests.take_bucket(bucket);
-        for pending in &reference_requests {
-            pending.cancel.store(true, Ordering::SeqCst);
-        }
-        if let Err(error) = send_error_responses(
-            connection,
-            reference_requests.into_iter().map(|pending| pending.id).collect(),
-            ErrorCode::RequestCanceled as i32,
-            format!("references {message}"),
-        ) {
-            tracing::error!(error = %error, "failed to cancel references bucket waiters");
-        }
+        let code = ErrorCode::RequestCanceled as i32;
+        log_drain(
+            cancel_drained(
+                connection,
+                self.semantic_token_requests.drain_bucket(bucket),
+                code,
+                format!("semantic token {message}"),
+            ),
+            "semantic token bucket waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.definition_requests.drain_bucket(bucket),
+                code,
+                format!("definition {message}"),
+            ),
+            "definition bucket waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.reference_requests.drain_bucket(bucket),
+                code,
+                format!("references {message}"),
+            ),
+            "references bucket waiters",
+        );
+        log_drain(
+            cancel_drained(connection, self.rename_requests.drain_bucket(bucket), code, format!("rename {message}")),
+            "rename bucket waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.prepare_rename_requests.drain_bucket(bucket),
+                code,
+                format!("prepare-rename {message}"),
+            ),
+            "prepare-rename bucket waiters",
+        );
     }
 
-    /// Cancel semantic-token, definition, and references waiters tied to one package key.
+    /// Fail every pending waiter tied to one package analysis key with `INTERNAL_ERROR`.
+    ///
+    /// Used by `PackagePanicked` for the still-current package key. Mirrors
+    /// the structure of `cancel_pending_package_requests` but maps to
+    /// `INTERNAL_ERROR` and a panic-shaped message per feature so the spec's
+    /// "shared drain helper... becomes load-bearing" goal is met for the
+    /// panic path too.
+    fn fail_pending_package_requests(
+        &mut self,
+        connection: &Connection,
+        key: &PackageAnalysisKey,
+        message: &'static str,
+    ) {
+        log_drain(
+            cancel_drained(
+                connection,
+                self.semantic_token_requests.drain_package(key),
+                INTERNAL_ERROR,
+                format!("semantic token {message}"),
+            ),
+            "semantic token panic waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.definition_requests.drain_package(key),
+                INTERNAL_ERROR,
+                format!("definition {message}"),
+            ),
+            "definition panic waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.reference_requests.drain_package(key),
+                INTERNAL_ERROR,
+                format!("references {message}"),
+            ),
+            "references panic waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.rename_requests.drain_package(key),
+                INTERNAL_ERROR,
+                format!("rename {message}"),
+            ),
+            "rename panic waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.prepare_rename_requests.drain_package(key),
+                INTERNAL_ERROR,
+                format!("prepare-rename {message}"),
+            ),
+            "prepare-rename panic waiters",
+        );
+    }
+
+    /// Cancel every pending waiter tied to one package analysis key.
     fn cancel_pending_package_requests(
         &mut self,
         connection: &Connection,
         key: &PackageAnalysisKey,
         message: &'static str,
     ) {
-        if let Err(error) = send_error_responses(
-            connection,
-            self.semantic_token_requests.take_package(key),
-            ErrorCode::RequestCanceled as i32,
-            format!("semantic token {message}"),
-        ) {
-            tracing::error!(error = %error, "failed to cancel semantic token package waiters");
-        }
-
-        let definition_requests =
-            self.definition_requests.take_package(key).into_iter().map(|pending| pending.id).collect();
-        if let Err(error) = send_error_responses(
-            connection,
-            definition_requests,
-            ErrorCode::RequestCanceled as i32,
-            format!("definition {message}"),
-        ) {
-            tracing::error!(error = %error, "failed to cancel definition package waiters");
-        }
-
-        let reference_requests = self.reference_requests.take_package(key);
-        for pending in &reference_requests {
-            pending.cancel.store(true, Ordering::SeqCst);
-        }
-        if let Err(error) = send_error_responses(
-            connection,
-            reference_requests.into_iter().map(|pending| pending.id).collect(),
-            ErrorCode::RequestCanceled as i32,
-            format!("references {message}"),
-        ) {
-            tracing::error!(error = %error, "failed to cancel references package waiters");
-        }
+        let code = ErrorCode::RequestCanceled as i32;
+        log_drain(
+            cancel_drained(
+                connection,
+                self.semantic_token_requests.drain_package(key),
+                code,
+                format!("semantic token {message}"),
+            ),
+            "semantic token package waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.definition_requests.drain_package(key),
+                code,
+                format!("definition {message}"),
+            ),
+            "definition package waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.reference_requests.drain_package(key),
+                code,
+                format!("references {message}"),
+            ),
+            "references package waiters",
+        );
+        log_drain(
+            cancel_drained(connection, self.rename_requests.drain_package(key), code, format!("rename {message}")),
+            "rename package waiters",
+        );
+        log_drain(
+            cancel_drained(
+                connection,
+                self.prepare_rename_requests.drain_package(key),
+                code,
+                format!("prepare-rename {message}"),
+            ),
+            "prepare-rename package waiters",
+        );
     }
 
     /// Cancel semantic-token waiters tied to one document-view key.
@@ -1339,6 +1705,328 @@ impl ReferencesRequestState {
     }
 }
 
+impl RenameRequestState {
+    /// Queue a rename request, enforcing global and per-package caps.
+    fn queue(&mut self, query: RenameQuery, request_id: RequestId, cancel: Arc<AtomicBool>, dispatched: bool) -> bool {
+        if self.pending_owner.len() >= MAX_PENDING_RENAMES {
+            return false;
+        }
+        let package = query.view_key.package.clone();
+        let queue = self.pending_by_package.entry(package.clone()).or_default();
+        if queue.len() >= MAX_PENDING_RENAMES_PER_KEY {
+            return false;
+        }
+        queue.push(PendingRenameRequest { id: request_id.clone(), query, cancel, dispatched });
+        self.pending_owner.insert(request_id, package);
+        true
+    }
+
+    /// Return one pending rename request without mutating ownership.
+    fn get(&self, request_id: &RequestId) -> Option<&PendingRenameRequest> {
+        let package = self.pending_owner.get(request_id)?;
+        self.pending_by_package.get(package)?.iter().find(|pending| &pending.id == request_id)
+    }
+
+    /// Remove one pending rename request by request ID.
+    fn remove_pending_request(&mut self, request_id: &RequestId) -> Option<PendingRenameRequest> {
+        let package = self.pending_owner.remove(request_id)?;
+        let queue = self.pending_by_package.get_mut(&package)?;
+        let index = queue.iter().position(|pending| &pending.id == request_id)?;
+        let pending = queue.remove(index);
+        if queue.is_empty() {
+            self.pending_by_package.remove(&package);
+        }
+        Some(pending)
+    }
+
+    /// Mark undispatched rename requests for one package as handed to the response pool.
+    fn mark_undispatched(&mut self, package: &PackageAnalysisKey) -> Vec<PendingRenameRequest> {
+        let Some(queue) = self.pending_by_package.get_mut(package) else {
+            return Vec::new();
+        };
+        let mut pending = Vec::new();
+        for request in queue.iter_mut() {
+            if !request.dispatched {
+                request.dispatched = true;
+                pending.push(request.clone());
+            }
+        }
+        pending
+    }
+
+    /// Drain rename requests whose source document has closed.
+    fn clear_uri(&mut self, uri: &Uri) -> Vec<PendingRenameRequest> {
+        let packages = self.pending_by_package.keys().cloned().collect::<Vec<_>>();
+        let mut cleared = Vec::new();
+        for package in packages {
+            let Some(queue) = self.pending_by_package.get_mut(&package) else {
+                continue;
+            };
+            let mut index = 0;
+            while index < queue.len() {
+                if &queue[index].query.view_key.uri == uri {
+                    let pending = queue.remove(index);
+                    self.pending_owner.remove(&pending.id);
+                    cleared.push(pending);
+                } else {
+                    index += 1;
+                }
+            }
+            if queue.is_empty() {
+                self.pending_by_package.remove(&package);
+            }
+        }
+        cleared
+    }
+
+    /// Drain rename requests waiting on one package key.
+    fn take_package(&mut self, package: &PackageAnalysisKey) -> Vec<PendingRenameRequest> {
+        let Some(requests) = self.pending_by_package.remove(package) else {
+            return Vec::new();
+        };
+        for request in &requests {
+            self.pending_owner.remove(&request.id);
+        }
+        requests
+    }
+
+    /// Drain rename requests waiting on any package key in a bucket.
+    fn take_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingRenameRequest> {
+        let packages =
+            self.pending_by_package.keys().filter(|package| &package.bucket == bucket).cloned().collect::<Vec<_>>();
+        packages.into_iter().flat_map(|package| self.take_package(&package)).collect()
+    }
+}
+
+impl PrepareRenameRequestState {
+    /// Queue a prepare-rename request, enforcing global and per-package caps.
+    fn queue(&mut self, query: PrepareRenameQuery, request_id: RequestId) -> bool {
+        if self.pending_owner.len() >= MAX_PENDING_PREPARE_RENAMES {
+            return false;
+        }
+        let package = query.view_key.package.clone();
+        let queue = self.pending_by_package.entry(package.clone()).or_default();
+        if queue.len() >= MAX_PENDING_PREPARE_RENAMES_PER_KEY {
+            return false;
+        }
+        queue.push(PendingPrepareRenameRequest { id: request_id.clone(), query });
+        self.pending_owner.insert(request_id, package);
+        true
+    }
+
+    /// Remove one pending prepare-rename request by request ID.
+    fn remove_pending_request(&mut self, request_id: &RequestId) -> Option<PendingPrepareRenameRequest> {
+        let package = self.pending_owner.remove(request_id)?;
+        let queue = self.pending_by_package.get_mut(&package)?;
+        let index = queue.iter().position(|pending| &pending.id == request_id)?;
+        let pending = queue.remove(index);
+        if queue.is_empty() {
+            self.pending_by_package.remove(&package);
+        }
+        Some(pending)
+    }
+
+    /// Drain prepare-rename requests whose source document has closed.
+    fn clear_uri(&mut self, uri: &Uri) -> Vec<PendingPrepareRenameRequest> {
+        let packages = self.pending_by_package.keys().cloned().collect::<Vec<_>>();
+        let mut cleared = Vec::new();
+        for package in packages {
+            let Some(queue) = self.pending_by_package.get_mut(&package) else {
+                continue;
+            };
+            let mut index = 0;
+            while index < queue.len() {
+                if &queue[index].query.view_key.uri == uri {
+                    let pending = queue.remove(index);
+                    self.pending_owner.remove(&pending.id);
+                    cleared.push(pending);
+                } else {
+                    index += 1;
+                }
+            }
+            if queue.is_empty() {
+                self.pending_by_package.remove(&package);
+            }
+        }
+        cleared
+    }
+
+    /// Drain prepare-rename requests waiting on one package key.
+    fn take_package(&mut self, package: &PackageAnalysisKey) -> Vec<PendingPrepareRenameRequest> {
+        let Some(requests) = self.pending_by_package.remove(package) else {
+            return Vec::new();
+        };
+        for request in &requests {
+            self.pending_owner.remove(&request.id);
+        }
+        requests
+    }
+
+    /// Drain prepare-rename requests waiting on any package key in a bucket.
+    fn take_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingPrepareRenameRequest> {
+        let packages =
+            self.pending_by_package.keys().filter(|package| &package.bucket == bucket).cloned().collect::<Vec<_>>();
+        packages.into_iter().flat_map(|package| self.take_package(&package)).collect()
+    }
+}
+
+impl PendingRequest for PendingDefinitionRequest {
+    /// Return the JSON-RPC request ID this definition waiter answers.
+    fn id(&self) -> &RequestId {
+        &self.id
+    }
+}
+
+impl PendingRequest for PendingReferencesRequest {
+    /// Return the JSON-RPC request ID this references waiter answers.
+    fn id(&self) -> &RequestId {
+        &self.id
+    }
+
+    /// Expose the per-request cancel flag so a routing-thread cancel path can
+    /// flip it before the in-flight pool job emits a stale response.
+    fn cancel_flag(&self) -> Option<&Arc<AtomicBool>> {
+        Some(&self.cancel)
+    }
+}
+
+impl PendingRequest for PendingRenameRequest {
+    /// Return the JSON-RPC request ID this rename waiter answers.
+    fn id(&self) -> &RequestId {
+        &self.id
+    }
+
+    /// Expose the per-request cancel flag so a routing-thread cancel path can
+    /// flip it before the in-flight pool job emits a stale `WorkspaceEdit`.
+    fn cancel_flag(&self) -> Option<&Arc<AtomicBool>> {
+        Some(&self.cancel)
+    }
+}
+
+impl PendingRequest for PendingPrepareRenameRequest {
+    /// Return the JSON-RPC request ID this prepare-rename waiter answers.
+    fn id(&self) -> &RequestId {
+        &self.id
+    }
+}
+
+impl PendingFeature for SemanticTokenRequestState {
+    /// Pending semantic-token waiters carry no per-request payload beyond the ID.
+    type Request = RequestId;
+
+    /// Drain semantic-token waiters whose source document has closed.
+    fn drain_uri(&mut self, uri: &Uri) -> Vec<RequestId> {
+        self.clear_uri(uri)
+    }
+
+    /// Drain semantic-token waiters blocked on one package key.
+    fn drain_package(&mut self, key: &PackageAnalysisKey) -> Vec<RequestId> {
+        self.take_package(key)
+    }
+
+    /// Drain semantic-token waiters blocked on one analysis bucket.
+    fn drain_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<RequestId> {
+        self.take_bucket(bucket)
+    }
+}
+
+impl PendingFeature for DefinitionRequestState {
+    /// Pending definition waiters retain their original cursor query.
+    type Request = PendingDefinitionRequest;
+
+    /// Drain definition waiters whose source document has closed.
+    fn drain_uri(&mut self, uri: &Uri) -> Vec<PendingDefinitionRequest> {
+        self.clear_uri(uri)
+    }
+
+    /// Drain definition waiters blocked on one package key.
+    fn drain_package(&mut self, key: &PackageAnalysisKey) -> Vec<PendingDefinitionRequest> {
+        self.take_package(key)
+    }
+
+    /// Drain definition waiters blocked on one analysis bucket.
+    fn drain_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingDefinitionRequest> {
+        self.take_bucket(bucket)
+    }
+}
+
+impl PendingFeature for ReferencesRequestState {
+    /// Pending references waiters carry a cancel flag observed by the response pool.
+    type Request = PendingReferencesRequest;
+
+    /// Drain references waiters whose source document has closed.
+    fn drain_uri(&mut self, uri: &Uri) -> Vec<PendingReferencesRequest> {
+        self.clear_uri(uri)
+    }
+
+    /// Drain references waiters blocked on one package key.
+    fn drain_package(&mut self, key: &PackageAnalysisKey) -> Vec<PendingReferencesRequest> {
+        self.take_package(key)
+    }
+
+    /// Drain references waiters blocked on one analysis bucket.
+    fn drain_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingReferencesRequest> {
+        self.take_bucket(bucket)
+    }
+}
+
+impl PendingFeature for RenameRequestState {
+    /// Pending rename waiters carry a cancel flag observed by the response pool.
+    type Request = PendingRenameRequest;
+
+    /// Drain rename waiters whose source document has closed.
+    fn drain_uri(&mut self, uri: &Uri) -> Vec<PendingRenameRequest> {
+        self.clear_uri(uri)
+    }
+
+    /// Drain rename waiters blocked on one package key.
+    fn drain_package(&mut self, key: &PackageAnalysisKey) -> Vec<PendingRenameRequest> {
+        self.take_package(key)
+    }
+
+    /// Drain rename waiters blocked on one analysis bucket.
+    fn drain_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingRenameRequest> {
+        self.take_bucket(bucket)
+    }
+}
+
+impl PendingFeature for PrepareRenameRequestState {
+    /// Pending prepare-rename waiters retain only cursor query state.
+    type Request = PendingPrepareRenameRequest;
+
+    /// Drain prepare-rename waiters whose source document has closed.
+    fn drain_uri(&mut self, uri: &Uri) -> Vec<PendingPrepareRenameRequest> {
+        self.clear_uri(uri)
+    }
+
+    /// Drain prepare-rename waiters blocked on one package key.
+    fn drain_package(&mut self, key: &PackageAnalysisKey) -> Vec<PendingPrepareRenameRequest> {
+        self.take_package(key)
+    }
+
+    /// Drain prepare-rename waiters blocked on one analysis bucket.
+    fn drain_bucket(&mut self, bucket: &AnalysisBucket) -> Vec<PendingPrepareRenameRequest> {
+        self.take_bucket(bucket)
+    }
+}
+
+/// Convert a prepare-rename target to the LSP wire payload.
+fn prepare_rename_response_value(
+    query: &PrepareRenameQuery,
+    package: &CachedPackageAnalysis,
+    source_path: &std::path::Path,
+    line_index: &line_index::LineIndex,
+) -> Value {
+    let Some(range) = prepare_rename_target(query, package, source_path) else {
+        return Value::Null;
+    };
+    let Some(lsp_range) = byte_range_to_lsp_range(line_index, range.start, range.end) else {
+        return Value::Null;
+    };
+    let response: Range = lsp_range;
+    serde_json::to_value(PrepareRenameResponse::Range(response)).expect("PrepareRenameResponse should serialize")
+}
+
 /// Collect initialize-time workspace roots using LSP's preferred fallback order.
 #[allow(deprecated)]
 fn collect_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
@@ -1372,6 +2060,10 @@ fn server_capabilities() -> ServerCapabilities {
         semantic_tokens_provider: Some(semantic_tokens_capability()),
         definition_provider: Some(OneOf::Left(true)),
         references_provider: Some(OneOf::Left(true)),
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: WorkDoneProgressOptions::default(),
+        })),
         ..Default::default()
     }
 }
@@ -1455,6 +2147,16 @@ fn send_reference_nulls(connection: &Connection, requests: Vec<PendingReferences
         send_ok_response(connection, request.id, Value::Null)?;
     }
     Ok(())
+}
+
+/// Log and discard a `cancel_drained` failure without surfacing it to callers.
+///
+/// The drain helpers fan out across five pending-state owners; one feature's
+/// transport failure must not short-circuit the remaining four.
+fn log_drain(result: Result<()>, what: &'static str) {
+    if let Err(error) = result {
+        tracing::error!(error = %error, "failed to cancel {what}");
+    }
 }
 
 /// Send the same error payload to every queued waiter on a URI.
@@ -1618,6 +2320,8 @@ mod tests {
             semantic_token_requests: super::SemanticTokenRequestState::default(),
             definition_requests: super::DefinitionRequestState::default(),
             reference_requests: super::ReferencesRequestState::default(),
+            rename_requests: super::RenameRequestState::default(),
+            prepare_rename_requests: super::PrepareRenameRequestState::default(),
             client_definition_link_support: false,
             hooks: TestHooks::default(),
         }
@@ -1945,6 +2649,8 @@ mod tests {
             semantic_token_requests: super::SemanticTokenRequestState::default(),
             definition_requests: super::DefinitionRequestState::default(),
             reference_requests: super::ReferencesRequestState::default(),
+            rename_requests: super::RenameRequestState::default(),
+            prepare_rename_requests: super::PrepareRenameRequestState::default(),
             client_definition_link_support: false,
             hooks: TestHooks::default(),
         };

--- a/crates/lsp/tests/protocol.rs
+++ b/crates/lsp/tests/protocol.rs
@@ -166,6 +166,7 @@ fn initialize_shutdown_exit_round_trip() {
     assert_eq!(initialize["result"]["capabilities"]["semanticTokensProvider"]["full"], json!(true));
     assert_eq!(initialize["result"]["capabilities"]["definitionProvider"], json!(true));
     assert_eq!(initialize["result"]["capabilities"]["referencesProvider"], json!(true));
+    assert_eq!(initialize["result"]["capabilities"]["renameProvider"]["prepareProvider"], json!(true));
     assert_eq!(
         initialize["result"]["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"],
         json!([
@@ -1172,4 +1173,226 @@ fn semantic_tokens_full_returns_internal_error_after_worker_panic() {
     let (status, stderr) = server.finish();
     assert!(status.success(), "stderr:\n{stderr}");
     assert!(stderr.contains("INTERNAL PANIC"), "stderr:\n{stderr}");
+}
+
+/// Send a rename request and return the raw JSON response.
+fn request_rename(
+    server: &mut TestServer,
+    id: i64,
+    document_uri: &Uri,
+    source: &str,
+    needle: &str,
+    occurrence: usize,
+    new_name: &str,
+) -> Value {
+    server.request(
+        id,
+        "textDocument/rename",
+        json!({
+            "textDocument": { "uri": document_uri },
+            "position": position_json(source, needle, occurrence),
+            "newName": new_name,
+        }),
+    )
+}
+
+/// Send a prepareRename request and return the raw JSON response.
+fn request_prepare_rename(
+    server: &mut TestServer,
+    id: i64,
+    document_uri: &Uri,
+    source: &str,
+    needle: &str,
+    occurrence: usize,
+) -> Value {
+    server.request(
+        id,
+        "textDocument/prepareRename",
+        json!({
+            "textDocument": { "uri": document_uri },
+            "position": position_json(source, needle, occurrence),
+        }),
+    )
+}
+
+/// Verifies prepareRename returns the cursor occurrence range for a renameable local.
+#[test]
+fn prepare_rename_returns_local_range() {
+    let source = concat!(
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let total: u32 = 1u32;\n",
+        "        let next: u32 = total + 1u32;\n",
+        "        return total + next;\n",
+        "    }\n",
+        "}\n",
+    );
+    let (_tempdir, document_uri, _canonical) = write_test_package(source);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    let response = request_prepare_rename(&mut server, 2, &document_uri, source, "total", 1);
+    // PrepareRenameResponse::Range serializes as the raw range payload.
+    assert_eq!(response["result"], range_json(source, "total", 1), "bad prepareRename: {response}");
+
+    let null = request_prepare_rename(&mut server, 3, &document_uri, source, "u32", 0);
+    assert_eq!(null["result"], Value::Null, "primitive type should not be renameable: {null}");
+
+    let shutdown = server.request(4, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies rename returns a versioned WorkspaceEdit covering every local occurrence.
+#[test]
+fn rename_returns_workspace_edit_for_local() {
+    let source = concat!(
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let total: u32 = 1u32;\n",
+        "        let next: u32 = total + 1u32;\n",
+        "        return total + next;\n",
+        "    }\n",
+        "}\n",
+    );
+    let (_tempdir, document_uri, canonical_uri) = write_test_package(source);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    let response = request_rename(&mut server, 2, &document_uri, source, "total", 1, "subtotal");
+    let edits = response["result"]["documentChanges"].as_array().expect("documentChanges array");
+    assert_eq!(edits.len(), 1, "single-file rename: {response}");
+    let document_edit = &edits[0];
+    assert_eq!(document_edit["textDocument"]["uri"], json!(canonical_uri.to_string()));
+    // OptionalVersionedTextDocumentIdentifier carries the open-buffer version
+    // when the analyzed fingerprint is `OpenBuffer`, or `null` when the file
+    // was read from disk. Both are LSP-correct; the client uses the version
+    // to refuse stale-buffer applies when present.
+    let version = &document_edit["textDocument"]["version"];
+    assert!(version.is_null() || version == &json!(1), "bad version: {version}");
+    let text_edits = document_edit["edits"].as_array().expect("text edits");
+    assert_eq!(text_edits.len(), 3, "three occurrences: {response}");
+    for edit in text_edits {
+        assert_eq!(edit["newText"], json!("subtotal"));
+    }
+    assert_eq!(text_edits[0]["range"], range_json(source, "total", 0));
+    assert_eq!(text_edits[1]["range"], range_json(source, "total", 1));
+    assert_eq!(text_edits[2]["range"], range_json(source, "total", 2));
+
+    let shutdown = server.request(3, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies rename rejects keyword new-names with `RequestFailed` (LSP -32803).
+#[test]
+fn rename_rejects_keyword_new_name() {
+    let source = concat!(
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let total: u32 = 1u32;\n",
+        "        return total;\n",
+        "    }\n",
+        "}\n",
+    );
+    let (_tempdir, document_uri, _canonical) = write_test_package(source);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    let response = request_rename(&mut server, 2, &document_uri, source, "total", 1, "let");
+    assert_eq!(response["error"]["code"], json!(-32803), "{response}");
+    assert!(response["error"]["message"].as_str().expect("rename keyword error").contains("keyword"), "{response}");
+
+    let invalid = request_rename(&mut server, 3, &document_uri, source, "total", 1, "1abc");
+    assert_eq!(invalid["error"]["code"], json!(-32803), "{invalid}");
+    let empty = request_rename(&mut server, 4, &document_uri, source, "total", 1, "");
+    assert_eq!(empty["error"]["code"], json!(-32803), "{empty}");
+
+    let shutdown = server.request(5, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies rename returns null when the cursor is on a non-renameable position.
+#[test]
+fn rename_returns_null_on_non_renameable_cursor() {
+    let source = concat!(
+        "program demo.aleo {\n",
+        "    fn main() -> u32 {\n",
+        "        let total: u32 = 1u32;\n",
+        "        return total;\n",
+        "    }\n",
+        "}\n",
+    );
+    let (_tempdir, document_uri, _canonical) = write_test_package(source);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+    open_document(&mut server, &document_uri, source);
+
+    // Cursor on the program identifier `demo` - Program identities are out of PR 5 scope.
+    let on_program = request_rename(&mut server, 2, &document_uri, source, "demo", 0, "renamed");
+    assert_eq!(on_program["result"], Value::Null, "{on_program}");
+
+    // Cursor on the `u32` keyword/type primitive - no occurrence.
+    let on_keyword = request_rename(&mut server, 3, &document_uri, source, "u32", 0, "renamed");
+    assert_eq!(on_keyword["result"], Value::Null, "{on_keyword}");
+
+    let shutdown = server.request(4, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies rename and prepareRename return null on unopened documents.
+#[test]
+fn rename_returns_null_for_unopened_document() {
+    let mut server = TestServer::spawn(&[]);
+    initialize(&mut server);
+    server.notify("initialized", json!({}));
+
+    let uri: Uri = "file:///does/not/exist.leo".parse().expect("uri");
+    let prepare = server.request(
+        2,
+        "textDocument/prepareRename",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 0, "character": 0 },
+        }),
+    );
+    assert_eq!(prepare["result"], Value::Null, "{prepare}");
+
+    let rename = server.request(
+        3,
+        "textDocument/rename",
+        json!({
+            "textDocument": { "uri": uri },
+            "position": { "line": 0, "character": 0 },
+            "newName": "renamed",
+        }),
+    );
+    assert_eq!(rename["result"], Value::Null, "{rename}");
+
+    let shutdown = server.request(4, "shutdown", Value::Null);
+    assert_eq!(shutdown["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
 }


### PR DESCRIPTION
## Summary
- add `textDocument/rename` and `textDocument/prepareRename` support to `leo-lsp`
- reuse the package occurrence index from find-all-references to gather every keyed occurrence in one routing-thread pass
- validate the new name through the Leo lexer; reject non-identifiers, multi-token input, and keywords
- verify on-disk fingerprints at apply time and abort the whole `WorkspaceEdit` atomically if anything drifted

## What renames

- local bindings, function parameters, loop indices
- top-level functions, structs, records, mappings, and constants in the current package
- struct and record fields, across every read/write

## What doesn't

- the program name itself — out of scope, would touch `program.json` and downstream packages
- whitespace, punctuation, comments, or any unkeyed cursor
- symbols with any occurrence outside the current package
- files marked `Volatile` or whose fingerprint moved between prepare and apply — the whole edit is dropped

Tracking issue: https://github.com/ProvableHQ/leo/issues/29264