### PR TITLE
feat(LSP) Implement diagnostics and error publishing.

### DIFF
--- a/crates/errors/src/common/backtraced.rs
+++ b/crates/errors/src/common/backtraced.rs
@@ -117,6 +117,14 @@ impl Backtraced {
     pub fn warning_code(&self) -> String {
         format_warning_code(&self.type_, 37, self.code)
     }
+
+    /// Return whether this diagnostic represents an error rather than a warning.
+    ///
+    /// LSP severity mapping inspects this flag rather than the rendered prefix
+    /// in the diagnostic's `Display` output.
+    pub fn is_error(&self) -> bool {
+        self.error
+    }
 }
 
 impl fmt::Display for Backtraced {

--- a/crates/errors/src/common/formatted.rs
+++ b/crates/errors/src/common/formatted.rs
@@ -47,6 +47,22 @@ impl Label {
         self.color = color;
         self
     }
+
+    /// Borrow the secondary label's message without copying.
+    ///
+    /// Surfaced for `Formatted::diagnostic_view`, which lowers labels into
+    /// LSP-facing related-information entries without re-parsing rendered text.
+    pub fn message(&self) -> &str {
+        &self.msg
+    }
+
+    /// Return the secondary label's source span.
+    ///
+    /// Used by structured diagnostic consumers (notably `leo-lsp`) to convert
+    /// labels into UTF-16 ranges while the session source map is still alive.
+    pub fn span(&self) -> Span {
+        self.span
+    }
 }
 
 /// Helper span for Ariadne that includes the source file start index.
@@ -173,6 +189,83 @@ impl Formatted {
         format_warning_code(&self.inner.type_, 37, self.inner.code)
     }
 
+    /// Return the diagnostic's primary message without ariadne rendering.
+    ///
+    /// Used by tooling consumers (notably `leo-lsp`) that need the bare message
+    /// text rather than the formatted report. The returned slice borrows from
+    /// the same allocation as the rest of the diagnostic and therefore stays
+    /// valid for the lifetime of the `Formatted` value.
+    pub fn message(&self) -> &str {
+        &self.inner.message
+    }
+
+    /// Return the diagnostic's optional help text, if any.
+    ///
+    /// `leo-lsp` appends this to the LSP diagnostic message so editor clients
+    /// see the same hint that the CLI report would render.
+    pub fn help(&self) -> Option<&str> {
+        self.inner.help.as_deref()
+    }
+
+    /// Return the diagnostic's optional follow-up note text, if any.
+    ///
+    /// `leo-lsp` appends this to the LSP diagnostic message for parity with
+    /// CLI-rendered reports.
+    pub fn note(&self) -> Option<&str> {
+        self.inner.note.as_deref()
+    }
+
+    /// Return whether this diagnostic was raised as an error rather than a
+    /// warning.
+    ///
+    /// LSP severity mapping depends on this flag instead of inspecting the
+    /// rendered `Error`/`Warning` prefix in the formatted message.
+    pub fn is_error(&self) -> bool {
+        self.inner.error
+    }
+
+    /// Return the diagnostic's primary span.
+    ///
+    /// Callers must resolve this span against `leo_span` session globals to
+    /// recover the originating source file before the surrounding session is
+    /// torn down.
+    pub fn span(&self) -> Span {
+        self.inner.span
+    }
+
+    /// Iterate the diagnostic's secondary labels in declaration order.
+    ///
+    /// Labels carry their own span and human-readable message, which `leo-lsp`
+    /// surfaces as `Diagnostic.relatedInformation` when the client supports it.
+    pub fn labels(&self) -> impl Iterator<Item = &Label> {
+        self.inner.labels.iter()
+    }
+
+    /// Borrow this diagnostic as a plain structured view.
+    ///
+    /// The returned [`DiagnosticView`] exposes the same fields that are used
+    /// when rendering the ariadne report, without round-tripping through a
+    /// formatted string. Consumers like `leo-lsp` use the view to build LSP
+    /// `Diagnostic` payloads without parsing rendered output.
+    pub fn diagnostic_view(&self) -> DiagnosticView<'_> {
+        let code = if self.inner.error { self.error_code() } else { self.warning_code() };
+        let labels = self
+            .inner
+            .labels
+            .iter()
+            .map(|label| DiagnosticLabelView { message: label.message().to_owned(), span: label.span() })
+            .collect();
+        DiagnosticView {
+            message: &self.inner.message,
+            help: self.inner.help.as_deref(),
+            note: self.inner.note.as_deref(),
+            code,
+            is_error: self.inner.error,
+            span: Some(self.inner.span),
+            labels,
+        }
+    }
+
     /// Resolve a Leo `Span` to an `AriadneSpan` using the source map.
     fn resolve_span(span: Span, source_map: &leo_span::source_map::SourceMap) -> AriadneSpan {
         let file_start_index = source_map.find_source_file(span.lo).unwrap().absolute_start;
@@ -263,5 +356,93 @@ impl fmt::Display for Formatted {
 impl std::error::Error for Formatted {
     fn description(&self) -> &str {
         &self.inner.message
+    }
+}
+
+/// LSP-agnostic structured view of a compiler diagnostic.
+///
+/// Exposed so editor tooling — currently `leo-lsp` — can lower errors and
+/// warnings into editor-facing diagnostics without parsing rendered ariadne
+/// output. The view borrows from the originating [`Formatted`] for cheap
+/// strings while owning a small per-label `Vec`, which is the smallest shape
+/// that keeps secondary-label messages alive across an `extract_errs` call.
+#[derive(Debug, Clone)]
+pub struct DiagnosticView<'a> {
+    /// Primary human-readable message.
+    pub message: &'a str,
+    /// Optional help hint shown beneath the diagnostic on the CLI.
+    pub help: Option<&'a str>,
+    /// Optional follow-up note shown beneath the help line on the CLI.
+    pub note: Option<&'a str>,
+    /// Fully formatted code identifier (e.g. `EPAR0001` or `WTYC0001`).
+    pub code: String,
+    /// Whether the diagnostic is an error (`true`) or a warning (`false`).
+    pub is_error: bool,
+    /// Primary span, when the diagnostic ties to a concrete source location.
+    pub span: Option<Span>,
+    /// Secondary spans annotated with their own human-readable messages.
+    pub labels: Vec<DiagnosticLabelView>,
+}
+
+/// One secondary label paired with its source span.
+///
+/// `leo-lsp` lowers each label into `Diagnostic.relatedInformation` when the
+/// client advertises support, so it captures both the span and the message.
+#[derive(Debug, Clone)]
+pub struct DiagnosticLabelView {
+    /// Human-readable description for the label.
+    pub message: String,
+    /// Span associated with the label, resolved against session source globals.
+    pub span: Span,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Color, Formatted, Label};
+    use leo_span::{Span, create_session_if_not_set_then};
+
+    /// Verifies the structured view round-trips primary message, code, help, and note.
+    #[test]
+    fn diagnostic_view_exposes_primary_fields() {
+        create_session_if_not_set_then(|_| {
+            let span = Span::default();
+            let error = Formatted::error("TST", 1, "boom", span).with_help("try again").with_note("note text");
+
+            let view = error.diagnostic_view();
+            assert_eq!(view.message, "boom");
+            assert_eq!(view.help, Some("try again"));
+            assert_eq!(view.note, Some("note text"));
+            assert_eq!(view.code, error.error_code());
+            assert!(view.is_error);
+            assert_eq!(view.span, Some(span));
+            assert!(view.labels.is_empty());
+        });
+    }
+
+    /// Verifies labels are exposed with their messages and spans intact.
+    #[test]
+    fn diagnostic_view_exposes_secondary_labels() {
+        create_session_if_not_set_then(|_| {
+            let primary = Span::new(0, 4);
+            let label_span = Span::new(5, 10);
+            let error = Formatted::error("TST", 2, "boom", primary)
+                .with_label(Label::new(label_span).with_message("see also").with_color(Color::Blue));
+
+            let view = error.diagnostic_view();
+            assert_eq!(view.labels.len(), 1);
+            assert_eq!(view.labels[0].message, "see also");
+            assert_eq!(view.labels[0].span, label_span);
+        });
+    }
+
+    /// Verifies warnings round-trip through the structured view with severity preserved.
+    #[test]
+    fn diagnostic_view_marks_warnings() {
+        create_session_if_not_set_then(|_| {
+            let warning = Formatted::warning("TST", 3, "watch out", Span::default());
+            let view = warning.diagnostic_view();
+            assert!(!view.is_error);
+            assert_eq!(view.code, warning.warning_code());
+        });
     }
 }

--- a/crates/errors/src/errors/mod.rs
+++ b/crates/errors/src/errors/mod.rs
@@ -56,6 +56,36 @@ impl LeoError {
             SnarkVM(_) => 11000,
         }
     }
+
+    /// Borrow a structured, LSP-agnostic view of this error.
+    ///
+    /// Only [`LeoError::Formatted`] variants carry a span and labeled
+    /// secondary information, so other variants return `None`. The caller is
+    /// expected to fall back to a synthetic package-level diagnostic in that
+    /// case; see the `leo-lsp` diagnostics module for an example.
+    ///
+    /// [`LeoError::LastErrorCode`] is a sentinel used to signal that an error
+    /// has already been emitted through a handler. It deliberately returns
+    /// `None` so it is never published as a separate diagnostic.
+    pub fn diagnostic_view(&self) -> Option<crate::DiagnosticView<'_>> {
+        match self {
+            LeoError::Formatted(formatted) => Some(formatted.diagnostic_view()),
+            LeoError::Backtraced(_)
+            | LeoError::ConstEvalError(_)
+            | LeoError::LastErrorCode(_)
+            | LeoError::SnarkVM(_) => None,
+        }
+    }
+
+    /// Return whether this error is the sentinel raised after a handler emit.
+    ///
+    /// `Handler::last_err` produces [`LeoError::LastErrorCode`] when the
+    /// emitter has already buffered a real diagnostic. Consumers should skip
+    /// the sentinel when collecting structured diagnostics so the original
+    /// error is published exactly once.
+    pub fn is_last_error_code(&self) -> bool {
+        matches!(self, LeoError::LastErrorCode(_))
+    }
 }
 
 /// The LeoWarning type that contains all sub warning types.
@@ -70,6 +100,18 @@ impl LeoWarning {
         use LeoWarning::*;
         match self {
             Formatted(w) => w.warning_code(),
+        }
+    }
+
+    /// Borrow a structured, LSP-agnostic view of this warning.
+    ///
+    /// Every variant currently wraps a [`Formatted`] payload, so the view is
+    /// always available. The signature is kept symmetric with
+    /// [`LeoError::diagnostic_view`] so future variants that lack span data
+    /// can opt out without breaking call sites.
+    pub fn diagnostic_view(&self) -> Option<crate::DiagnosticView<'_>> {
+        match self {
+            LeoWarning::Formatted(formatted) => Some(formatted.diagnostic_view()),
         }
     }
 }

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -43,5 +43,6 @@ tracing-subscriber = { workspace = true }
 xxhash-rust        = { workspace = true }
 
 [dev-dependencies]
-serde_json = { workspace = true }
-tempfile   = { workspace = true }
+crossbeam-channel = { workspace = true }
+serde_json        = { workspace = true }
+tempfile          = { workspace = true }

--- a/crates/lsp/src/compiler_bridge.rs
+++ b/crates/lsp/src/compiler_bridge.rs
@@ -27,7 +27,7 @@
 
 use crate::{
     document_store::{AnalysisBucket, DocumentSnapshot, DocumentViewSnapshot, OpenFileOverlay},
-    features::{lsp_range::hash_text, semantic_tokens::encode_tokens},
+    features::{diagnostics::CompilerDiagnostic, lsp_range::hash_text, semantic_tokens::encode_tokens},
     project_model::ProjectContext,
     semantics::{
         CachedDocumentView,
@@ -200,11 +200,17 @@ enum WatchedPathStamp {
     Directory { modified_nanos: u128 },
 }
 
-/// Compiler occurrences plus source fingerprints captured by the file source.
+/// Compiler frontend outputs lowered into LSP-friendly shapes.
+///
+/// `occurrences` is `None` when the frontend bailed before walking the AST;
+/// the caller falls back to syntax-only highlighting but still publishes the
+/// buffered diagnostics. Span resolution happens here, inside the live Leo
+/// session, because the source map is gone once the session ends.
 #[derive(Debug)]
 struct CompilerOutput {
-    occurrences: Vec<SymbolOccurrence>,
+    occurrences: Option<Vec<SymbolOccurrence>>,
     fingerprints: HashMap<PathBuf, SourceFingerprint>,
+    diagnostic_entries: Vec<crate::features::diagnostics::DiagnosticEntry>,
 }
 
 /// Program roots available to one compiler semantic collection pass.
@@ -269,8 +275,8 @@ impl ProgramRoots {
 /// Syntax analysis always runs first so the server can return a best-effort
 /// token stream even when package discovery, dependency loading, or compiler
 /// analysis fail. Compiler-backed occurrences then replace matching syntax
-/// ranges when available so navigation reuses the same semantic truth as
-/// highlighting.
+/// ranges when available, and any buffered diagnostics from the same compiler
+/// pass are threaded through to the cached package result.
 pub fn analyze_package_snapshot(
     snapshot: &DocumentSnapshot,
     package_cache: &mut PackageAnalysisCache,
@@ -283,6 +289,7 @@ pub fn analyze_package_snapshot(
             syntax.tokens,
             SemanticSource::SyntaxOnly,
             HashMap::new(),
+            Vec::new(),
         );
     }
 
@@ -294,11 +301,12 @@ pub fn analyze_package_snapshot(
             syntax.tokens,
             SemanticSource::SyntaxOnly,
             HashMap::new(),
+            Vec::new(),
         );
     }
 
-    let (occurrences, lexical_tokens, source, fingerprints) = match compiler_occurrences {
-        Some(CompilerOutput { occurrences, fingerprints }) => {
+    let (occurrences, lexical_tokens, source, fingerprints, diagnostic_entries) = match compiler_occurrences {
+        Some(CompilerOutput { occurrences: Some(occurrences), fingerprints, diagnostic_entries }) => {
             let mut merged_fingerprints = syntax.fingerprints;
             merged_fingerprints.extend(fingerprints);
             (
@@ -306,15 +314,28 @@ pub fn analyze_package_snapshot(
                 syntax.tokens,
                 SemanticSource::CompilerEnhanced,
                 merged_fingerprints,
+                diagnostic_entries,
             )
         }
-        None => {
+        Some(CompilerOutput { occurrences: None, diagnostic_entries, .. }) => {
+            // The compiler buffered diagnostics but did not produce usable
+            // AST occurrences (typical when the parser bailed). Use the
+            // package-fallback syntax tokens — they cover the full module
+            // listing — and still publish the buffered diagnostics so users
+            // see the parse error.
             let syntax = syntax_semantics::collect_package_fallback(snapshot);
-            (syntax.occurrences, syntax.tokens, SemanticSource::SyntaxOnly, syntax.fingerprints)
+            (syntax.occurrences, syntax.tokens, SemanticSource::SyntaxOnly, syntax.fingerprints, diagnostic_entries)
+        }
+        None => {
+            // Compiler analysis declined to run at all (no usable file
+            // source). Fall back to syntax tokens with no diagnostics;
+            // "compiler unavailable" is not a user-facing condition.
+            let syntax = syntax_semantics::collect_package_fallback(snapshot);
+            (syntax.occurrences, syntax.tokens, SemanticSource::SyntaxOnly, syntax.fingerprints, Vec::new())
         }
     };
 
-    package_analysis(snapshot, occurrences, lexical_tokens, source, fingerprints)
+    package_analysis(snapshot, occurrences, lexical_tokens, source, fingerprints, diagnostic_entries)
 }
 
 /// Compatibility helper retained for PR 2 tests and callers.
@@ -341,13 +362,15 @@ pub fn build_document_view(snapshot: &DocumentViewSnapshot, package: Arc<CachedP
     CachedDocumentView { key: snapshot.key.clone(), encoded_tokens }
 }
 
-/// Lower merged occurrences into a shared package index and trigger-document view.
+/// Lower merged occurrences and lowered diagnostic entries into a shared
+/// package index, document view, and immutable diagnostic set.
 fn package_analysis(
     snapshot: &DocumentSnapshot,
     mut occurrences: Vec<SymbolOccurrence>,
     lexical_tokens: Vec<SemanticTokenOccurrence>,
     source: SemanticSource,
     recorded_fingerprints: HashMap<PathBuf, SourceFingerprint>,
+    diagnostic_entries: Vec<crate::features::diagnostics::DiagnosticEntry>,
 ) -> PackageWorkerAnalysis {
     let package_source_files = PackageSourceFiles::from_snapshot(snapshot);
     retain_in_scope_occurrences(&mut occurrences, &package_source_files);
@@ -365,11 +388,16 @@ fn package_analysis(
         |path| package_source_files.contains(path),
     );
     let index = Arc::new(index);
+    let diagnostics = Arc::new(crate::features::diagnostics::DiagnosticSet {
+        key: snapshot.package_key.clone(),
+        entries: Arc::from(crate::features::diagnostics::finalize_entries(diagnostic_entries)),
+    });
     let package = Arc::new(CachedPackageAnalysis {
         key: snapshot.package_key.clone(),
         index: Arc::clone(&index),
         analyzed_files: Arc::new(analyzed_files),
         source,
+        diagnostics,
     });
 
     let package_tokens =
@@ -445,8 +473,9 @@ fn semantic_token_occurrences(
 
 /// Try to refine syntax occurrences with compiler frontend analysis.
 ///
-/// Failures stay local to this helper so callers can fall back to syntax-only
-/// highlighting without treating compiler analysis as fatal.
+/// Dependency-stub failures and handler-buffered errors both flow back as
+/// `CompilerOutput` so the caller can publish them as diagnostics even when
+/// no AST was produced.
 fn compiler_occurrences(
     snapshot: &DocumentSnapshot,
     package_cache: &mut PackageAnalysisCache,
@@ -457,20 +486,34 @@ fn compiler_occurrences(
 
     let input = compiler_input(snapshot)?;
 
+    let trigger_path = snapshot.file_path.clone();
     let result = create_session_if_not_set_then(|_| {
         // Dependency resolution and parsing intern symbols, so the worker must
         // enter a Leo session before it asks the compiler for frontend state.
         let file_source = RecordingFileSource::new(Arc::clone(&snapshot.open_overlays));
         match input {
             CompilerInput::ManagedPackage { project } => {
-                let import_stubs = package_cache.import_stubs_for(project.as_ref(), &file_source).map_err(|error| {
-                    tracing::debug!(
-                        package = project.package_root.display().to_string(),
-                        error,
-                        "dependency stub loading failed"
-                    );
-                    error
-                })?;
+                let import_stubs = match package_cache.import_stubs_for(project.as_ref(), &file_source) {
+                    Ok(import_stubs) => import_stubs,
+                    Err(error) => {
+                        tracing::debug!(
+                            package = project.package_root.display().to_string(),
+                            error = error.as_str(),
+                            "dependency stub loading failed"
+                        );
+                        // Surface stub-loading errors as a synthetic
+                        // package-level diagnostic. Falling back to syntax-only
+                        // analysis is still useful, but the user needs to see
+                        // why their import graph cannot be resolved.
+                        let synthetic = vec![dependency_load_error(&error)];
+                        let diagnostic_entries = lower_compiler_diagnostics(&synthetic, &[], trigger_path.as_ref());
+                        return Ok::<_, String>(CompilerOutput {
+                            occurrences: None,
+                            fingerprints: file_source.fingerprints_with(&[]),
+                            diagnostic_entries,
+                        });
+                    }
+                };
                 let program_roots = ProgramRoots::for_package(
                     Arc::clone(&project.package_root),
                     Arc::clone(&import_stubs.dependency_roots),
@@ -482,7 +525,7 @@ fn compiler_occurrences(
                 // Run the compiler against every open same-package editor
                 // buffer while recording fingerprints for disk files at the
                 // exact read boundary.
-                let output = run_compiler_analysis(
+                let outcome = run_compiler_analysis(
                     Some(project.program_name.to_string()),
                     project.entry_file.as_ref(),
                     project.source_directory.as_ref(),
@@ -490,13 +533,15 @@ fn compiler_occurrences(
                     import_stubs.import_stubs.as_ref().clone(),
                     program_roots,
                     || check_snapshot_current(snapshot),
-                )
-                .map_err(|error| error.to_string())?;
+                );
 
+                let diagnostic_entries =
+                    lower_compiler_diagnostics(&outcome.errors, &outcome.warnings, trigger_path.as_ref());
                 check_snapshot_current(snapshot).map_err(|error| error.to_string())?;
                 Ok::<_, String>(CompilerOutput {
-                    occurrences: output,
+                    occurrences: outcome.occurrences,
                     fingerprints: file_source.fingerprints_with(import_stubs.fingerprints.as_ref()),
+                    diagnostic_entries,
                 })
             }
             CompilerInput::StandaloneProgram { file_path, source_directory } => {
@@ -510,7 +555,7 @@ fn compiler_occurrences(
                 // Loose editor buffers should be analyzed as exactly one file.
                 // Scanning the parent directory would accidentally treat
                 // formatter fixtures or unrelated scratch files as Leo modules.
-                let output = run_compiler_analysis(
+                let outcome = run_compiler_analysis(
                     None,
                     file_path.as_ref(),
                     source_directory.as_ref(),
@@ -518,13 +563,15 @@ fn compiler_occurrences(
                     IndexMap::new(),
                     program_roots,
                     || check_snapshot_current(snapshot),
-                )
-                .map_err(|error| error.to_string())?;
+                );
 
+                let diagnostic_entries =
+                    lower_compiler_diagnostics(&outcome.errors, &outcome.warnings, trigger_path.as_ref());
                 check_snapshot_current(snapshot).map_err(|error| error.to_string())?;
                 Ok::<_, String>(CompilerOutput {
-                    occurrences: output,
+                    occurrences: outcome.occurrences,
                     fingerprints: file_source.fingerprints_with(&[]),
+                    diagnostic_entries,
                 })
             }
         }
@@ -537,6 +584,35 @@ fn compiler_occurrences(
             None
         }
     }
+}
+
+/// Wrap a dependency-stub load failure as a `Backtraced` error so it lowers
+/// into a synthetic diagnostic on the saved trigger document.
+fn dependency_load_error(message: &str) -> leo_errors::LeoError {
+    leo_errors::Backtraced::new_from_backtrace(
+        format!("Leo dependency analysis failed: {message}"),
+        None,
+        0,
+        "LSP".to_owned(),
+        true,
+        leo_errors::Backtrace::new(),
+    )
+    .into()
+}
+
+/// Lower buffered compiler errors and warnings into LSP-ready entries.
+///
+/// Must run inside `create_session_if_not_set_then` because span resolution
+/// reads the source map through `with_session_globals`.
+fn lower_compiler_diagnostics(
+    errors: &[leo_errors::LeoError],
+    warnings: &[leo_errors::LeoWarning],
+    trigger_path: Option<&Arc<PathBuf>>,
+) -> Vec<crate::features::diagnostics::DiagnosticEntry> {
+    let mut diagnostics: Vec<CompilerDiagnostic<'_>> = Vec::with_capacity(errors.len() + warnings.len());
+    diagnostics.extend(errors.iter().map(CompilerDiagnostic::Error));
+    diagnostics.extend(warnings.iter().map(CompilerDiagnostic::Warning));
+    crate::features::diagnostics::lower_diagnostic_entries(trigger_path, diagnostics)
 }
 
 /// Compiler frontend input shape selected for a document snapshot.
@@ -562,7 +638,23 @@ fn compiler_input(snapshot: &DocumentSnapshot) -> Option<CompilerInput> {
     })
 }
 
-/// Run frontend analysis and immediately collect semantic occurrences.
+/// Result of running the compiler frontend for one LSP analysis pass.
+///
+/// `occurrences` is `None` when analysis failed before the AST walker ran;
+/// `errors` and `warnings` may still be populated in that case.
+struct CompilerAnalysisOutcome {
+    occurrences: Option<Vec<SymbolOccurrence>>,
+    errors: Vec<leo_errors::LeoError>,
+    warnings: Vec<leo_errors::LeoWarning>,
+}
+
+/// Run frontend analysis with a buffered handler and capture both semantic
+/// occurrences and diagnostics.
+///
+/// After the frontend runs we drain both buffers and merge in any
+/// final `LeoError` that the analysis call returned, taking care to drop the
+/// `LastErrorCode` sentinel because the real diagnostic has already been
+/// emitted through the handler.
 fn run_compiler_analysis(
     expected_unit_name: Option<String>,
     entry_file: &StdPath,
@@ -571,11 +663,12 @@ fn run_compiler_analysis(
     import_stubs: IndexMap<Symbol, leo_ast::Stub>,
     program_roots: ProgramRoots,
     mut should_continue: impl FnMut() -> leo_errors::Result<()>,
-) -> leo_errors::Result<Vec<SymbolOccurrence>> {
+) -> CompilerAnalysisOutcome {
+    let (handler, emitter) = Handler::new_with_buf();
     let mut compiler = Compiler::new(
         expected_unit_name,
         false,
-        Handler::default(),
+        handler,
         Rc::new(leo_ast::NodeBuilder::default()),
         PathBuf::default(),
         Some(leo_compiler::CompilerOptions::default()),
@@ -583,15 +676,39 @@ fn run_compiler_analysis(
         leo_ast::NetworkName::TestnetV0,
     );
 
-    let frontend = compiler.analyze_frontend_from_directory_with_file_source_and_check(
+    let frontend_result = compiler.analyze_frontend_from_directory_with_file_source_and_check(
         entry_file,
         source_directory,
         file_source,
         &mut should_continue,
-    )?;
+    );
 
-    let FrontendAnalysis { ast, symbol_table, type_table } = frontend;
-    Ok(CompilerSemanticCollector::new(symbol_table, type_table, program_roots).collect(ast))
+    // Collect AST-derived occurrences when the frontend ran to completion;
+    // diagnostics flow through the handler regardless.
+    let mut returned_error: Option<leo_errors::LeoError> = None;
+    let occurrences = match frontend_result {
+        Ok(FrontendAnalysis { ast, symbol_table, type_table }) => {
+            Some(CompilerSemanticCollector::new(symbol_table, type_table, program_roots).collect(ast))
+        }
+        Err(error) => {
+            returned_error = Some(error);
+            None
+        }
+    };
+
+    let mut errors = emitter.extract_errs().into_inner();
+    let warnings = emitter.extract_warnings().into_inner();
+    if let Some(returned) = returned_error
+        && !returned.is_last_error_code()
+    {
+        // `LastErrorCode` is the handler's way of saying "I already buffered
+        // the real diagnostic," so we drop it here to avoid double-publishing
+        // the same error. Any other `LeoError` represents a failure path the
+        // frontend never had a chance to push through the handler — keep it.
+        errors.push(returned);
+    }
+
+    CompilerAnalysisOutcome { occurrences, errors, warnings }
 }
 
 /// File source that serves all open same-package buffers and records read fingerprints.

--- a/crates/lsp/src/document_store.rs
+++ b/crates/lsp/src/document_store.rs
@@ -161,6 +161,17 @@ pub struct DocumentViewSnapshot {
     pub cancel_token: Arc<AtomicU64>,
 }
 
+/// One open document captured for diagnostic publishing.
+///
+/// `package_key` is captured at lookup time so the publisher can reject paths
+/// whose owning document has drifted to a different bucket since analysis.
+#[derive(Debug, Clone)]
+pub(crate) struct OpenDocumentTarget {
+    pub uri: Uri,
+    pub version: i32,
+    pub package_key: PackageAnalysisKey,
+}
+
 /// Fully prepared document mutation ready to be committed atomically.
 ///
 /// Preparing a mutation never changes visible server state. Only the
@@ -361,6 +372,30 @@ impl DocumentStore {
             project: document.project.clone(),
             cancel_token: Arc::clone(&document.cancel_token),
         })
+    }
+
+    /// Return every currently open document whose `file_path` matches `path`.
+    ///
+    /// Used by the diagnostics publisher to map compiler error paths back to
+    /// the LSP URIs and versions the client opened the file under, preserving
+    /// the client-supplied URI shape rather than synthesizing a canonical one.
+    /// A single path may match more than one URI when the client opens the
+    /// same file twice; callers should treat the result as authoritative.
+    pub(crate) fn open_documents_for_path(&self, path: &Path) -> Vec<OpenDocumentTarget> {
+        self.documents
+            .iter()
+            .filter_map(|(uri, document)| {
+                if document.file_path.as_deref().is_some_and(|candidate| candidate.as_path() == path) {
+                    Some(OpenDocumentTarget {
+                        uri: uri.clone(),
+                        version: document.version,
+                        package_key: self.package_key_for_bucket(&document.analysis_bucket),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 
     /// Return the line index for an open path captured by current document state.

--- a/crates/lsp/src/features/diagnostics.rs
+++ b/crates/lsp/src/features/diagnostics.rs
@@ -1,0 +1,468 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Internal diagnostics model and LSP wire-format conversion.
+//!
+//! Worker lowering happens in [`compiler_bridge::lower_compiler_diagnostics`]
+//! while the Leo session source map is still alive; the routing thread reads
+//! the resulting [`DiagnosticSet`] off `CachedPackageAnalysis` and converts
+//! it to `lsp_types::Diagnostic` payloads at publish time.
+
+use crate::document_store::PackageAnalysisKey;
+use leo_errors::{DiagnosticView, LeoError, LeoWarning};
+use leo_span::{Span, source_map::FileName, with_session_globals};
+use line_index::{LineIndex, TextSize, WideEncoding, WideLineCol};
+use lsp_types::{Diagnostic, DiagnosticRelatedInformation, DiagnosticSeverity, Location, Position, Range};
+use std::{path::PathBuf, sync::Arc};
+
+/// `Diagnostic.source` value shared by every Leo-emitted entry.
+const DIAGNOSTIC_SOURCE: &str = "leo";
+
+/// UTF-16 LSP range carried by internal diagnostic entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct DiagnosticRange {
+    pub(crate) start_line: u32,
+    pub(crate) start_character: u32,
+    pub(crate) end_line: u32,
+    pub(crate) end_character: u32,
+}
+
+impl DiagnosticRange {
+    fn to_lsp_range(self) -> Range {
+        Range::new(
+            Position::new(self.start_line, self.start_character),
+            Position::new(self.end_line, self.end_character),
+        )
+    }
+
+    /// Zero-width range anchored at the start of the document, used by
+    /// spanless package- and dependency-level errors.
+    fn document_start() -> Self {
+        Self { start_line: 0, start_character: 0, end_line: 0, end_character: 0 }
+    }
+}
+
+/// Internal severity decoupled from the LSP wire enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum DiagnosticSeverityInternal {
+    Error,
+    Warning,
+}
+
+/// One compiler diagnostic plus its LSP-ready range, severity, and labels.
+#[derive(Debug, Clone)]
+pub(crate) struct DiagnosticEntry {
+    pub(crate) path: Arc<PathBuf>,
+    pub(crate) range: DiagnosticRange,
+    pub(crate) severity: DiagnosticSeverityInternal,
+    /// Message with help/note appendices already folded in.
+    pub(crate) message: Arc<str>,
+    pub(crate) related: Arc<[DiagnosticRelatedEntry]>,
+    /// Synthetic entries lack a usable source span and are pinned to the
+    /// saved trigger document by the publish path.
+    pub(crate) synthetic: bool,
+}
+
+/// One secondary label keyed by file path and UTF-16 range.
+#[derive(Debug, Clone)]
+pub(crate) struct DiagnosticRelatedEntry {
+    pub(crate) path: Arc<PathBuf>,
+    pub(crate) range: DiagnosticRange,
+    pub(crate) message: Arc<str>,
+}
+
+/// Immutable package-keyed diagnostic set shared with the routing thread.
+#[derive(Debug, Clone)]
+pub(crate) struct DiagnosticSet {
+    pub(crate) key: PackageAnalysisKey,
+    pub(crate) entries: Arc<[DiagnosticEntry]>,
+}
+
+#[cfg(test)]
+impl DiagnosticSet {
+    /// Empty set placeholder used by feature unit tests that build a
+    /// `CachedPackageAnalysis` directly.
+    pub(crate) fn empty(key: PackageAnalysisKey) -> Self {
+        Self { key, entries: Arc::from(Vec::<DiagnosticEntry>::new()) }
+    }
+}
+
+/// Snapshot of `textDocument.publishDiagnostics` capabilities captured at
+/// initialize.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DiagnosticClientCapabilitySnapshot {
+    pub(crate) related_information: bool,
+}
+
+impl DiagnosticClientCapabilitySnapshot {
+    pub(crate) fn from_initialize(params: &lsp_types::InitializeParams) -> Self {
+        let related_information = params
+            .capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.publish_diagnostics.as_ref())
+            .and_then(|publish| publish.related_information)
+            .unwrap_or(false);
+        Self { related_information }
+    }
+}
+
+/// Borrowed view of a single buffered compiler error or warning.
+pub(crate) enum CompilerDiagnostic<'a> {
+    Error(&'a LeoError),
+    Warning(&'a LeoWarning),
+}
+
+/// Resolved source-file context for a Leo span.
+struct ResolvedSpan {
+    path: Arc<PathBuf>,
+    range: DiagnosticRange,
+}
+
+/// Lower buffered compiler diagnostics into LSP-ready entries.
+///
+/// Must run while the Leo session is still active because span resolution
+/// reads the source map through `with_session_globals`. Diagnostics whose
+/// primary span cannot resolve to a real file produce a synthetic entry on
+/// `trigger_path` (if any); the publish path pins those to the saved
+/// document.
+pub(crate) fn lower_diagnostic_entries<'a, I>(
+    trigger_path: Option<&Arc<PathBuf>>,
+    diagnostics: I,
+) -> Vec<DiagnosticEntry>
+where
+    I: IntoIterator<Item = CompilerDiagnostic<'a>>,
+{
+    let mut entries = Vec::new();
+    for diagnostic in diagnostics {
+        let (view, severity) = match diagnostic {
+            CompilerDiagnostic::Error(error) => {
+                // `LastErrorCode` is a sentinel for an already-emitted error.
+                if error.is_last_error_code() {
+                    continue;
+                }
+                match error.diagnostic_view() {
+                    Some(view) => (view, DiagnosticSeverityInternal::Error),
+                    None => {
+                        if let Some(path) = trigger_path {
+                            entries.push(make_synthetic_entry(
+                                Arc::clone(path),
+                                error.to_string(),
+                                DiagnosticSeverityInternal::Error,
+                            ));
+                        }
+                        continue;
+                    }
+                }
+            }
+            CompilerDiagnostic::Warning(warning) => match warning.diagnostic_view() {
+                Some(view) => (view, DiagnosticSeverityInternal::Warning),
+                None => {
+                    if let Some(path) = trigger_path {
+                        entries.push(make_synthetic_entry(
+                            Arc::clone(path),
+                            warning.to_string(),
+                            DiagnosticSeverityInternal::Warning,
+                        ));
+                    }
+                    continue;
+                }
+            },
+        };
+        if let Some(entry) = lower_view(view, severity, trigger_path) {
+            entries.push(entry);
+        }
+    }
+    entries
+}
+
+/// Sort and dedupe entries into the canonical order used at publish time.
+///
+/// Ordering: path → range → severity (errors first) → message. Duplicates
+/// compare on the same tuple.
+pub(crate) fn finalize_entries(mut entries: Vec<DiagnosticEntry>) -> Vec<DiagnosticEntry> {
+    entries.sort_by(|left, right| {
+        left.path
+            .as_path()
+            .cmp(right.path.as_path())
+            .then_with(|| left.range.start_line.cmp(&right.range.start_line))
+            .then_with(|| left.range.start_character.cmp(&right.range.start_character))
+            .then_with(|| left.range.end_line.cmp(&right.range.end_line))
+            .then_with(|| left.range.end_character.cmp(&right.range.end_character))
+            .then_with(|| severity_rank(left.severity).cmp(&severity_rank(right.severity)))
+            .then_with(|| left.message.as_ref().cmp(right.message.as_ref()))
+    });
+    entries.dedup_by(|left, right| {
+        left.path == right.path
+            && left.range == right.range
+            && left.severity == right.severity
+            && left.message.as_ref() == right.message.as_ref()
+    });
+    entries
+}
+
+/// Lower a structured view into an entry, falling back to a synthetic entry
+/// when the span cannot resolve and a trigger path is available.
+fn lower_view(
+    view: DiagnosticView<'_>,
+    severity: DiagnosticSeverityInternal,
+    trigger_path: Option<&Arc<PathBuf>>,
+) -> Option<DiagnosticEntry> {
+    let related = view
+        .labels
+        .iter()
+        .filter_map(|label| {
+            let span = resolve_span(label.span)?;
+            Some(DiagnosticRelatedEntry {
+                path: span.path,
+                range: span.range,
+                message: Arc::from(label.message.as_str()),
+            })
+        })
+        .collect::<Vec<_>>();
+    let message = Arc::from(build_message(&view).as_str());
+
+    match view.span.and_then(resolve_span) {
+        Some(resolved) => Some(DiagnosticEntry {
+            path: resolved.path,
+            range: resolved.range,
+            severity,
+            message,
+            related: Arc::from(related),
+            synthetic: false,
+        }),
+        None => trigger_path.map(|trigger| DiagnosticEntry {
+            path: Arc::clone(trigger),
+            range: DiagnosticRange::document_start(),
+            severity,
+            message,
+            related: Arc::from(related),
+            synthetic: true,
+        }),
+    }
+}
+
+/// Build a synthetic entry directly from a diagnostic's `Display` text.
+///
+/// Used for non-`Formatted` errors (`Backtraced`, etc.) that carry no
+/// structured view; the rendered string is the best fidelity available.
+fn make_synthetic_entry(path: Arc<PathBuf>, message: String, severity: DiagnosticSeverityInternal) -> DiagnosticEntry {
+    DiagnosticEntry {
+        path,
+        range: DiagnosticRange::document_start(),
+        severity,
+        message: Arc::from(message.as_str()),
+        related: Arc::from(Vec::<DiagnosticRelatedEntry>::new()),
+        synthetic: true,
+    }
+}
+
+/// Append help and note text to the primary message. Severity is published
+/// independently, so no severity prefix is added.
+fn build_message(view: &DiagnosticView<'_>) -> String {
+    let mut message = String::from(view.message);
+    if let Some(help) = view.help {
+        message.push_str("\nhelp: ");
+        message.push_str(help);
+    }
+    if let Some(note) = view.note {
+        message.push_str("\nnote: ");
+        message.push_str(note);
+    }
+    message
+}
+
+/// Resolve a Leo span to a `(path, UTF-16 range)` pair via session globals.
+fn resolve_span(span: Span) -> Option<ResolvedSpan> {
+    if span.is_dummy() {
+        return None;
+    }
+    with_session_globals(|session| {
+        let start_file = session.source_map.find_source_file(span.lo)?;
+        if span.hi > start_file.absolute_end {
+            // Span crosses a source-file boundary; not expressible as one LSP range.
+            return None;
+        }
+        let FileName::Real(path) = &start_file.name else {
+            return None;
+        };
+        let line_index = LineIndex::new(&start_file.src);
+        let range = byte_range_to_diagnostic_range(
+            &line_index,
+            start_file.relative_offset(span.lo),
+            start_file.relative_offset(span.hi),
+        )?;
+        Some(ResolvedSpan { path: Arc::new(path.clone()), range })
+    })
+}
+
+/// Convert UTF-8 byte offsets within one file into a UTF-16 LSP range.
+pub(crate) fn byte_range_to_diagnostic_range(line_index: &LineIndex, start: u32, end: u32) -> Option<DiagnosticRange> {
+    let (start_line, start_character) = byte_offset_to_utf16(line_index, start)?;
+    let (end_line, end_character) = byte_offset_to_utf16(line_index, end)?;
+    Some(DiagnosticRange { start_line, start_character, end_line, end_character })
+}
+
+fn byte_offset_to_utf16(line_index: &LineIndex, offset: u32) -> Option<(u32, u32)> {
+    let utf8 = line_index.try_line_col(TextSize::from(offset))?;
+    let WideLineCol { line, col } = line_index.to_wide(WideEncoding::Utf16, utf8)?;
+    Some((line, col))
+}
+
+fn severity_rank(severity: DiagnosticSeverityInternal) -> u8 {
+    match severity {
+        DiagnosticSeverityInternal::Error => 0,
+        DiagnosticSeverityInternal::Warning => 1,
+    }
+}
+
+/// Build the LSP wire payload for one entry.
+///
+/// `Diagnostic.code`, `codeDescription`, and `data` are intentionally
+/// omitted from the wire — they have no consumer yet and would just clutter
+/// editors. Related-information is gated by the client capability snapshot.
+pub(crate) fn entry_to_lsp_diagnostic(
+    entry: &DiagnosticEntry,
+    capabilities: &DiagnosticClientCapabilitySnapshot,
+) -> Diagnostic {
+    let mut diagnostic = Diagnostic {
+        range: entry.range.to_lsp_range(),
+        severity: Some(internal_to_lsp_severity(entry.severity)),
+        code: None,
+        code_description: None,
+        source: Some(DIAGNOSTIC_SOURCE.to_owned()),
+        message: entry.message.as_ref().to_owned(),
+        related_information: None,
+        tags: None,
+        data: None,
+    };
+
+    if capabilities.related_information && !entry.related.is_empty() {
+        let related = entry
+            .related
+            .iter()
+            .filter_map(|label| {
+                let uri = crate::project_model::path_to_file_uri(label.path.as_path())?;
+                Some(DiagnosticRelatedInformation {
+                    location: Location { uri, range: label.range.to_lsp_range() },
+                    message: label.message.as_ref().to_owned(),
+                })
+            })
+            .collect::<Vec<_>>();
+        if !related.is_empty() {
+            diagnostic.related_information = Some(related);
+        }
+    }
+
+    diagnostic
+}
+
+fn internal_to_lsp_severity(severity: DiagnosticSeverityInternal) -> DiagnosticSeverity {
+    match severity {
+        DiagnosticSeverityInternal::Error => DiagnosticSeverity::ERROR,
+        DiagnosticSeverityInternal::Warning => DiagnosticSeverity::WARNING,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn sort_orders_by_path_range_severity_message() {
+        let path_a = Arc::new(PathBuf::from("/tmp/a.leo"));
+        let path_b = Arc::new(PathBuf::from("/tmp/b.leo"));
+        let entries = finalize_entries(vec![
+            entry(Arc::clone(&path_b), 0, 0, 0, 1, DiagnosticSeverityInternal::Error, "msg"),
+            entry(Arc::clone(&path_a), 0, 0, 0, 1, DiagnosticSeverityInternal::Warning, "msg"),
+            entry(Arc::clone(&path_a), 0, 0, 0, 1, DiagnosticSeverityInternal::Error, "z"),
+            entry(Arc::clone(&path_a), 0, 0, 0, 1, DiagnosticSeverityInternal::Error, "msg"),
+        ]);
+
+        assert_eq!(entries.len(), 4);
+        assert_eq!(entries[0].path, path_a);
+        assert_eq!(entries[0].severity, DiagnosticSeverityInternal::Error);
+        assert_eq!(entries[0].message.as_ref(), "msg");
+        assert_eq!(entries[1].message.as_ref(), "z");
+        assert_eq!(entries[2].severity, DiagnosticSeverityInternal::Warning);
+        assert_eq!(entries[3].path, path_b);
+    }
+
+    #[test]
+    fn dedup_removes_exact_duplicates() {
+        let path = Arc::new(PathBuf::from("/tmp/a.leo"));
+        let entries = finalize_entries(vec![
+            entry(Arc::clone(&path), 0, 0, 0, 1, DiagnosticSeverityInternal::Error, "msg"),
+            entry(Arc::clone(&path), 0, 0, 0, 1, DiagnosticSeverityInternal::Error, "msg"),
+        ]);
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn related_information_requires_advertised_support() {
+        let path = Arc::new(PathBuf::from("/tmp/a.leo"));
+        let mut entry = entry(Arc::clone(&path), 1, 0, 1, 5, DiagnosticSeverityInternal::Error, "msg");
+        entry.related = Arc::from(vec![DiagnosticRelatedEntry {
+            path: Arc::clone(&path),
+            range: DiagnosticRange { start_line: 2, start_character: 0, end_line: 2, end_character: 4 },
+            message: Arc::from("see also"),
+        }]);
+
+        let without = entry_to_lsp_diagnostic(&entry, &DiagnosticClientCapabilitySnapshot::default());
+        assert!(without.related_information.is_none());
+
+        let with = entry_to_lsp_diagnostic(&entry, &DiagnosticClientCapabilitySnapshot { related_information: true });
+        assert!(with.related_information.is_some());
+    }
+
+    #[test]
+    fn byte_range_uses_utf16_columns_for_multibyte_text() {
+        let text = "é a\nb 🦀";
+        let line_index = LineIndex::new(text);
+
+        // `é` is two UTF-8 bytes but one UTF-16 code unit; the space after it lands at column 1.
+        let space_after_e = byte_range_to_diagnostic_range(&line_index, 2, 3).expect("e acute range");
+        assert_eq!((space_after_e.start_line, space_after_e.start_character), (0, 1));
+        assert_eq!(space_after_e.end_character, 2);
+
+        // `🦀` is four UTF-8 bytes but two UTF-16 code units (surrogate pair).
+        let crab_start = text.find('🦀').expect("crab in text") as u32;
+        let crab_end = crab_start + '🦀'.len_utf8() as u32;
+        let crab = byte_range_to_diagnostic_range(&line_index, crab_start, crab_end).expect("crab range");
+        assert_eq!((crab.start_line, crab.start_character), (1, 2));
+        assert_eq!(crab.end_character, 4);
+    }
+
+    fn entry(
+        path: Arc<PathBuf>,
+        start_line: u32,
+        start_character: u32,
+        end_line: u32,
+        end_character: u32,
+        severity: DiagnosticSeverityInternal,
+        message: &str,
+    ) -> DiagnosticEntry {
+        DiagnosticEntry {
+            path,
+            range: DiagnosticRange { start_line, start_character, end_line, end_character },
+            severity,
+            message: Arc::from(message),
+            related: Arc::from(Vec::<DiagnosticRelatedEntry>::new()),
+            synthetic: false,
+        }
+    }
+}

--- a/crates/lsp/src/features/mod.rs
+++ b/crates/lsp/src/features/mod.rs
@@ -21,6 +21,8 @@
 //! feature modules consume snapshot-safe semantic data and return LSP-ready
 //! values.
 
+/// Diagnostic lowering and LSP wire-format conversion.
+pub mod diagnostics;
 /// Go-to-definition query resolution.
 pub mod goto_definition;
 /// Shared LSP range and URI conversion helpers.

--- a/crates/lsp/src/features/references.rs
+++ b/crates/lsp/src/features/references.rs
@@ -115,10 +115,11 @@ mod tests {
             SemanticIndex::build(&occurrences, |_| SourceFingerprint::Volatile, |_| None, |_| true);
         (
             CachedPackageAnalysis {
-                key,
+                key: key.clone(),
                 index: Arc::new(index),
                 analyzed_files: Arc::new(analyzed_files),
                 source: SemanticSource::CompilerEnhanced,
+                diagnostics: Arc::new(crate::features::diagnostics::DiagnosticSet::empty(key)),
             },
             view_key,
             path,

--- a/crates/lsp/src/features/rename.rs
+++ b/crates/lsp/src/features/rename.rs
@@ -236,10 +236,11 @@ mod tests {
             |path| in_scope(path),
         );
         CachedPackageAnalysis {
-            key,
+            key: key.clone(),
             index: Arc::new(index),
             analyzed_files: Arc::new(analyzed_files),
             source: SemanticSource::CompilerEnhanced,
+            diagnostics: Arc::new(crate::features::diagnostics::DiagnosticSet::empty(key)),
         }
     }
 

--- a/crates/lsp/src/semantics.rs
+++ b/crates/lsp/src/semantics.rs
@@ -760,7 +760,9 @@ impl SemanticIndex {
     }
 }
 
-/// Package-level semantic analysis shared by navigation and semantic tokens.
+/// Package-level semantic analysis shared by navigation, semantic tokens, and
+/// diagnostics. All three are package-keyed and invalidated together when the
+/// bucket generation changes.
 #[derive(Debug, Clone)]
 pub struct CachedPackageAnalysis {
     /// Freshness key for this package analysis.
@@ -772,6 +774,8 @@ pub struct CachedPackageAnalysis {
     /// Whether compiler analysis refined the syntax fallback.
     #[allow(dead_code)]
     pub source: SemanticSource,
+    /// Diagnostics collected during this analysis; always present, possibly empty.
+    pub diagnostics: Arc<crate::features::diagnostics::DiagnosticSet>,
 }
 
 /// Small per-document semantic-token view built from a package analysis.

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -26,6 +26,7 @@
 use crate::{
     document_store::{AnalysisBucket, DocumentStore, DocumentViewKey, PackageAnalysisKey},
     features::{
+        diagnostics::{DiagnosticClientCapabilitySnapshot, DiagnosticEntry, DiagnosticSet, entry_to_lsp_diagnostic},
         goto_definition::{
             DefinitionQuery,
             resolve as resolve_definition,
@@ -55,19 +56,23 @@ use anyhow::{Context, Result};
 use lsp_server::{Connection, ErrorCode, Message, Notification, Request, RequestId, Response, ResponseError};
 use lsp_types::{
     CancelParams,
+    Diagnostic,
     DidChangeTextDocumentParams,
     DidCloseTextDocumentParams,
     DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams,
     GotoDefinitionParams,
     InitializeParams,
     InitializeResult,
     NumberOrString,
     OneOf,
     PrepareRenameResponse,
+    PublishDiagnosticsParams,
     Range,
     ReferenceParams,
     RenameOptions,
     RenameParams,
+    SaveOptions,
     SemanticTokensParams,
     ServerCapabilities,
     ServerInfo,
@@ -76,6 +81,7 @@ use lsp_types::{
     TextDocumentSyncCapability,
     TextDocumentSyncKind,
     TextDocumentSyncOptions,
+    TextDocumentSyncSaveOptions,
     Uri,
     WorkDoneProgressOptions,
 };
@@ -105,8 +111,12 @@ const SHUTDOWN: &str = "shutdown";
 const DID_OPEN: &str = "textDocument/didOpen";
 /// LSP full-document change notification method.
 const DID_CHANGE: &str = "textDocument/didChange";
+/// LSP save-document notification method.
+const DID_SAVE: &str = "textDocument/didSave";
 /// LSP close-document notification method.
 const DID_CLOSE: &str = "textDocument/didClose";
+/// LSP push-diagnostics notification method.
+const PUBLISH_DIAGNOSTICS: &str = "textDocument/publishDiagnostics";
 /// LSP request-cancellation notification method.
 const CANCEL_REQUEST: &str = "$/cancelRequest";
 /// LSP semantic-token request method.
@@ -159,8 +169,32 @@ struct ServerState {
     reference_requests: ReferencesRequestState,
     rename_requests: RenameRequestState,
     prepare_rename_requests: PrepareRenameRequestState,
+    /// Diagnostic publish bookkeeping that enforces the staleness invariant.
+    diagnostics: DiagnosticPublishState,
+    /// Snapshot of the client's diagnostic capabilities captured at initialize.
+    diagnostic_capabilities: DiagnosticClientCapabilitySnapshot,
     client_definition_link_support: bool,
     hooks: TestHooks,
+}
+
+/// Routing-thread bookkeeping for the diagnostics publish path.
+#[derive(Debug, Default)]
+struct DiagnosticPublishState {
+    /// Save-triggered publishes waiting on an in-flight worker job. At most
+    /// one pending publish per package key; later saves overwrite the trigger.
+    pending_by_package: HashMap<PackageAnalysisKey, PendingDiagnosticPublish>,
+    /// URIs currently published into each bucket; used to clear stale URIs
+    /// when a later publish drops one out of the visible set.
+    published_by_bucket: HashMap<AnalysisBucket, HashSet<Uri>>,
+    /// URIs marked diagnostics-untrusted by a malformed full-sync `didChange`.
+    /// While present, the URI cannot receive non-empty diagnostics.
+    untrusted_uris: HashSet<Uri>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingDiagnosticPublish {
+    /// URI that requested the save and receives any synthetic spanless entries.
+    trigger_uri: Uri,
 }
 
 /// Shared semantic analysis and encoded document views.
@@ -283,6 +317,7 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
         serde_json::from_value(params).context("failed to deserialize initialize params")?;
     let workspace_roots = collect_workspace_roots(&initialize_params);
     let client_definition_link_support = client_supports_definition_links(&initialize_params);
+    let diagnostic_capabilities = DiagnosticClientCapabilitySnapshot::from_initialize(&initialize_params);
 
     // Finish the initialize handshake before any main-loop state exists so the
     // steady-state server only has to reason about post-initialize traffic.
@@ -310,6 +345,8 @@ fn run_with_hooks(connection: Connection, hooks: TestHooks) -> Result<ExitCode> 
         reference_requests: ReferencesRequestState::default(),
         rename_requests: RenameRequestState::default(),
         prepare_rename_requests: PrepareRenameRequestState::default(),
+        diagnostics: DiagnosticPublishState::default(),
+        diagnostic_capabilities,
         client_definition_link_support,
         hooks,
     };
@@ -471,6 +508,12 @@ impl ServerState {
                 self.handle_did_change(connection, params);
                 Ok(false)
             }
+            DID_SAVE => {
+                let params: DidSaveTextDocumentParams =
+                    serde_json::from_value(notification.params).context("failed to deserialize didSave")?;
+                self.handle_did_save(connection, params);
+                Ok(false)
+            }
             DID_CLOSE => {
                 let params: DidCloseTextDocumentParams =
                     serde_json::from_value(notification.params).context("failed to deserialize didClose")?;
@@ -521,11 +564,29 @@ impl ServerState {
     }
 
     /// Commit a full-document change and refresh package ownership before analysis.
+    ///
+    /// Every observed edit clears previously published diagnostics for the
+    /// affected bucket in the same routing turn, so a stale worker completion
+    /// cannot restore old ranges. Malformed full-sync payloads additionally
+    /// flag the URI diagnostics-untrusted until trusted text is committed.
     fn handle_did_change(&mut self, connection: &Connection, params: DidChangeTextDocumentParams) {
         let DidChangeTextDocumentParams { text_document, content_changes } = params;
         let previous_bucket = self.documents.package_key(&text_document.uri).map(|key| key.bucket);
+        let incoming_version = text_document.version;
 
         let Some(text) = extract_full_sync_text(content_changes) else {
+            // Malformed payload: clear current diagnostics and mark the URI
+            // untrusted so a later save cannot reuse the cached analysis.
+            self.clear_diagnostics_for_did_change(
+                connection,
+                &text_document.uri,
+                incoming_version,
+                previous_bucket.as_ref(),
+                previous_bucket.as_ref(),
+            );
+            if previous_bucket.is_some() {
+                self.diagnostics.untrusted_uris.insert(text_document.uri.clone());
+            }
             return;
         };
         // Re-resolve package ownership on every committed edit so semantic
@@ -534,7 +595,7 @@ impl ServerState {
         let (file_path, project) = self.project_model.resolve_document_context(&text_document.uri);
 
         let Some(prepared) =
-            self.documents.prepare_full_change(&text_document.uri, text_document.version, text, file_path, project)
+            self.documents.prepare_full_change(&text_document.uri, incoming_version, text, file_path, project)
         else {
             tracing::debug!(uri = text_document.uri.as_str(), "ignoring didChange for unopened document");
             return;
@@ -543,6 +604,15 @@ impl ServerState {
         self.hooks.maybe_panic_notification(DID_CHANGE);
 
         let snapshot = self.documents.commit_change(prepared);
+        // Trusted text resets the diagnostics-untrusted flag.
+        self.diagnostics.untrusted_uris.remove(&text_document.uri);
+        self.clear_diagnostics_for_did_change(
+            connection,
+            &text_document.uri,
+            incoming_version,
+            previous_bucket.as_ref(),
+            Some(&snapshot.package_key.bucket),
+        );
         self.invalidate_bucket_for_new_snapshot(
             connection,
             previous_bucket.as_ref(),
@@ -554,11 +624,91 @@ impl ServerState {
         self.scheduler.enqueue_package(snapshot);
     }
 
+    /// Handle a `textDocument/didSave` by publishing or queuing diagnostics.
+    ///
+    /// Save is the only event that produces a non-empty publish. The handler
+    /// publishes immediately from the cached package result when available,
+    /// records a pending marker if analysis is still in flight, and
+    /// short-circuits if the URI is diagnostics-untrusted or the package
+    /// analysis has failed.
+    fn handle_did_save(&mut self, connection: &Connection, params: DidSaveTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let Some(document) = self.documents.open_document(&uri) else {
+            return;
+        };
+        if document.file_path.is_none() {
+            // Unmanaged buffers without a file path cannot resolve compiler
+            // spans to a real path, so we cannot reasonably publish anything
+            // beyond a clear.
+            self.clear_uri_only(connection, &uri);
+            return;
+        }
+        if self.diagnostics.untrusted_uris.contains(&uri) {
+            self.clear_uri_only(connection, &uri);
+            return;
+        }
+        let Some(package_key) = self.documents.package_key(&uri) else {
+            return;
+        };
+
+        self.hooks.maybe_panic_notification(DID_SAVE);
+
+        if self.analysis.failed_packages.contains(&package_key) {
+            // Analysis crashed; drop any visible diagnostics and bail.
+            self.clear_bucket(connection, &package_key.bucket, None);
+            self.diagnostics.pending_by_package.remove(&package_key);
+            return;
+        }
+
+        if let Some(package) = self.analysis.packages.get(&package_key).cloned() {
+            if self.package_freshness_ok(&package_key) {
+                self.diagnostics.pending_by_package.remove(&package_key);
+                self.publish_diagnostic_set(connection, &uri, package.diagnostics.as_ref());
+                return;
+            }
+            // The cached analysis exists but at least one open sibling has
+            // drifted; throw it away and enqueue a fresh analysis with a
+            // pending publish marker so the next completion satisfies the
+            // save.
+            self.analysis.invalidate_bucket(&package_key.bucket);
+            self.cancel_pending_bucket_requests(connection, &package_key.bucket, "package analysis was superseded");
+        }
+
+        self.diagnostics
+            .pending_by_package
+            .insert(package_key.clone(), PendingDiagnosticPublish { trigger_uri: uri.clone() });
+        self.ensure_package_analysis(&package_key, &uri);
+    }
+
+    /// Verify every open document in the bucket still resolves to the same package key.
+    ///
+    /// Cached package diagnostics may only be reused on `didSave` when every
+    /// open sibling in the bucket still claims the same package generation.
+    /// This catches the race where a sibling close/open changed the bucket
+    /// generation between the worker completion and the save.
+    fn package_freshness_ok(&self, key: &PackageAnalysisKey) -> bool {
+        let mut saw_any = false;
+        for (uri, document) in self.documents.iter_open() {
+            if document.analysis_bucket != key.bucket {
+                continue;
+            }
+            saw_any = true;
+            let Some(open_key) = self.documents.package_key(uri) else {
+                return false;
+            };
+            if &open_key != key {
+                return false;
+            }
+        }
+        saw_any
+    }
+
     /// Close a document and flush or cancel any waiters tied to its bucket.
     fn handle_did_close(&mut self, connection: &Connection, params: DidCloseTextDocumentParams) {
         self.hooks.maybe_panic_notification(DID_CLOSE);
         let uri = params.text_document.uri;
         let previous_bucket = self.documents.package_key(&uri).map(|key| key.bucket);
+        self.clear_diagnostics_for_did_close(connection, &uri);
         self.documents.close(&uri);
         self.scheduler.set_open_buckets(self.documents.open_buckets());
         if let Err(error) =
@@ -596,6 +746,7 @@ impl ServerState {
         if let Some(bucket) = previous_bucket {
             self.analysis.invalidate_bucket(&bucket);
             self.cancel_pending_bucket_requests(connection, &bucket, "package analysis was superseded");
+            self.diagnostics.pending_by_package.retain(|key, _| key.bucket != bucket);
         } else {
             self.analysis.invalidate_uri(&uri);
         }
@@ -655,6 +806,7 @@ impl ServerState {
                             &evicted,
                             "package analysis was evicted from cache",
                         );
+                        self.diagnostics.pending_by_package.remove(&evicted);
                     }
                     self.store_document_view(connection, result.document_view);
                     self.answer_pending_definitions(connection, &key);
@@ -662,6 +814,9 @@ impl ServerState {
                     self.answer_pending_prepare_renames(connection, &key);
                     self.answer_pending_renames(&key);
                     self.enqueue_pending_document_views_for_package(&key);
+                    // Diagnostics are published last so any pending save
+                    // marker observes the freshly cached package result.
+                    self.publish_pending_diagnostics(connection, &key);
                     tracing::debug!(
                         uri = uri.as_str(),
                         generation,
@@ -670,6 +825,7 @@ impl ServerState {
                     );
                 } else {
                     self.cancel_pending_package_requests(connection, &key, "package analysis was superseded");
+                    self.diagnostics.pending_by_package.remove(&key);
                     tracing::debug!(uri = uri.as_str(), generation, "dropping stale package worker completion");
                 }
             }
@@ -688,6 +844,7 @@ impl ServerState {
             WorkerEvent::PackageCancelled { key, uri, generation } => {
                 self.analysis.in_flight_packages.remove(&key);
                 self.cancel_pending_package_requests(connection, &key, "package analysis was cancelled");
+                self.diagnostics.pending_by_package.remove(&key);
                 tracing::debug!(uri = uri.as_str(), generation, "worker cancelled stale package analysis");
             }
             WorkerEvent::DocumentViewCancelled { key } => {
@@ -706,6 +863,7 @@ impl ServerState {
             WorkerEvent::PackagePanicked { key, uri, generation, report } => {
                 report.log();
                 self.analysis.in_flight_packages.remove(&key);
+                self.diagnostics.pending_by_package.remove(&key);
                 if self.documents.generation(&uri) == Some(generation)
                     && self.documents.package_key(&uri) == Some(key.clone())
                 {
@@ -715,6 +873,9 @@ impl ServerState {
                         &key,
                         "analysis panicked; see server logs for details",
                     );
+                    // Drop visible diagnostics so the editor stops showing
+                    // stale errors after the analysis panicked.
+                    self.clear_bucket(connection, &key.bucket, None);
                 } else {
                     self.cancel_pending_package_requests(connection, &key, "package analysis was superseded");
                 }
@@ -1221,6 +1382,10 @@ impl ServerState {
     }
 
     /// Invalidate stale analysis state when a document enters a new package snapshot.
+    ///
+    /// Diagnostic publishes pending against the affected buckets are dropped
+    /// here so a stale worker completion that arrives after the edit cannot
+    /// resurrect old diagnostic ranges.
     fn invalidate_bucket_for_new_snapshot(
         &mut self,
         connection: &Connection,
@@ -1231,14 +1396,18 @@ impl ServerState {
         // Package analysis spans all open buffers in the bucket. Any committed
         // edit or bucket move invalidates package-level state, document views,
         // in-flight markers, and pending waiters that depended on old inputs.
+        let mut buckets: HashSet<AnalysisBucket> = HashSet::new();
         if let Some(previous_bucket) = previous_bucket
             && previous_bucket != current_bucket
         {
             self.analysis.invalidate_bucket(previous_bucket);
             self.cancel_pending_bucket_requests(connection, previous_bucket, message);
+            buckets.insert(previous_bucket.clone());
         }
         self.analysis.invalidate_bucket(current_bucket);
         self.cancel_pending_bucket_requests(connection, current_bucket, message);
+        buckets.insert(current_bucket.clone());
+        self.diagnostics.pending_by_package.retain(|key, _| !buckets.contains(&key.bucket));
     }
 
     /// Cancel every pending waiter tied to one analysis bucket.
@@ -1420,6 +1589,180 @@ impl ServerState {
         ) {
             tracing::error!(uri = key.uri.as_str(), error = %error, "failed to cancel semantic token view waiters");
         }
+    }
+
+    /// Clear stale diagnostics for the buckets affected by a `didChange`.
+    ///
+    /// The edited URI clears with the incoming version; sibling URIs use
+    /// their own current open versions. Pending save publishes for the
+    /// affected buckets are dropped too.
+    fn clear_diagnostics_for_did_change(
+        &mut self,
+        connection: &Connection,
+        edited_uri: &Uri,
+        incoming_version: i32,
+        previous_bucket: Option<&AnalysisBucket>,
+        current_bucket: Option<&AnalysisBucket>,
+    ) {
+        let mut buckets: HashSet<AnalysisBucket> = HashSet::new();
+        if let Some(bucket) = previous_bucket {
+            buckets.insert(bucket.clone());
+        }
+        if let Some(bucket) = current_bucket {
+            buckets.insert(bucket.clone());
+        }
+        for bucket in &buckets {
+            self.clear_bucket(connection, bucket, Some((edited_uri, incoming_version)));
+        }
+        self.diagnostics.pending_by_package.retain(|key, _| !buckets.contains(&key.bucket));
+    }
+
+    /// Clear a single previously-published URI without touching its siblings.
+    fn clear_uri_only(&mut self, connection: &Connection, uri: &Uri) {
+        let Some(bucket) = self.documents.package_key(uri).map(|key| key.bucket) else {
+            return;
+        };
+        let was_published = self.diagnostics.published_by_bucket.get(&bucket).is_some_and(|uris| uris.contains(uri));
+        if !was_published {
+            return;
+        }
+        let version = self.documents.open_document(uri).map(|document| document.version);
+        if let Err(error) = send_publish_diagnostics(connection, uri, version, Vec::new()) {
+            tracing::error!(uri = uri.as_str(), error = %error, "failed to clear diagnostics for uri");
+        }
+        if let Some(uris) = self.diagnostics.published_by_bucket.get_mut(&bucket) {
+            uris.remove(uri);
+            if uris.is_empty() {
+                self.diagnostics.published_by_bucket.remove(&bucket);
+            }
+        }
+    }
+
+    /// Clear every previously-published URI in a bucket.
+    ///
+    /// When `edited_uri` is supplied, that URI's clear is stamped with the
+    /// supplied incoming `didChange` version; all other URIs use their own
+    /// current open versions (or none if no longer open).
+    fn clear_bucket(&mut self, connection: &Connection, bucket: &AnalysisBucket, edited_uri: Option<(&Uri, i32)>) {
+        let Some(uris) = self.diagnostics.published_by_bucket.remove(bucket) else {
+            return;
+        };
+        for uri in &uris {
+            let version = match edited_uri {
+                Some((edited, version)) if uri == edited => Some(version),
+                _ => self.documents.open_document(uri).map(|document| document.version),
+            };
+            if let Err(error) = send_publish_diagnostics(connection, uri, version, Vec::new()) {
+                tracing::error!(uri = uri.as_str(), error = %error, "failed to clear diagnostics for bucket uri");
+            }
+        }
+    }
+
+    /// Drop diagnostic state for a closed URI.
+    fn clear_diagnostics_for_did_close(&mut self, connection: &Connection, uri: &Uri) {
+        if let Err(error) = send_publish_diagnostics(connection, uri, None, Vec::new()) {
+            tracing::error!(uri = uri.as_str(), error = %error, "failed to clear diagnostics on close");
+        }
+        for uris in self.diagnostics.published_by_bucket.values_mut() {
+            uris.remove(uri);
+        }
+        self.diagnostics.published_by_bucket.retain(|_, uris| !uris.is_empty());
+        self.diagnostics.pending_by_package.retain(|_, pending| &pending.trigger_uri != uri);
+        self.diagnostics.untrusted_uris.remove(uri);
+    }
+
+    /// Publish a cached diagnostic set.
+    ///
+    /// Entries are grouped by the open URI their path resolves to;
+    /// diagnostics whose path is not currently open are suppressed.
+    /// Synthetic spanless entries are pinned to `trigger_uri`. After the
+    /// new publish lands, any URI from the bucket's previous publish set
+    /// that is no longer present receives an empty clear.
+    fn publish_diagnostic_set(&mut self, connection: &Connection, trigger_uri: &Uri, set: &DiagnosticSet) {
+        let bucket = set.key.bucket.clone();
+        let mut grouped: HashMap<Uri, (Option<i32>, Vec<Diagnostic>)> = HashMap::new();
+        for entry in set.entries.iter() {
+            let targets = self.entry_publish_targets(entry, &set.key, trigger_uri);
+            if targets.is_empty() {
+                continue;
+            }
+            let payload = entry_to_lsp_diagnostic(entry, &self.diagnostic_capabilities);
+            for (uri, version) in targets {
+                let bucket = grouped.entry(uri).or_insert_with(|| (Some(version), Vec::new()));
+                bucket.0 = Some(version);
+                bucket.1.push(payload.clone());
+            }
+        }
+
+        for (uri, (version, diagnostics)) in &grouped {
+            if let Err(error) = send_publish_diagnostics(connection, uri, *version, diagnostics.clone()) {
+                tracing::error!(uri = uri.as_str(), error = %error, "failed to publish diagnostics");
+            }
+        }
+
+        let previous = self.diagnostics.published_by_bucket.remove(&bucket).unwrap_or_default();
+        for uri in &previous {
+            if grouped.contains_key(uri) {
+                continue;
+            }
+            let version = self.documents.open_document(uri).map(|document| document.version);
+            if let Err(error) = send_publish_diagnostics(connection, uri, version, Vec::new()) {
+                tracing::error!(uri = uri.as_str(), error = %error, "failed to clear stale uri");
+            }
+        }
+
+        if !grouped.is_empty() {
+            self.diagnostics.published_by_bucket.insert(bucket, grouped.into_keys().collect());
+        }
+    }
+
+    /// Resolve one diagnostic entry to the open URI/version pairs that should
+    /// receive it. Returns at most one target per URI.
+    fn entry_publish_targets(
+        &self,
+        entry: &DiagnosticEntry,
+        key: &PackageAnalysisKey,
+        trigger_uri: &Uri,
+    ) -> Vec<(Uri, i32)> {
+        if entry.synthetic {
+            // Synthetic entries are pinned to the saved document.
+            return self
+                .documents
+                .open_document(trigger_uri)
+                .map(|document| vec![(trigger_uri.clone(), document.version)])
+                .unwrap_or_default();
+        }
+        let mut targets: Vec<(Uri, i32)> = self
+            .documents
+            .open_documents_for_path(entry.path.as_path())
+            .into_iter()
+            .filter(|target| target.package_key == *key)
+            .filter(|target| !self.diagnostics.untrusted_uris.contains(&target.uri))
+            .map(|target| (target.uri, target.version))
+            .collect();
+        targets.sort_by(|left, right| left.0.as_str().cmp(right.0.as_str()));
+        targets.dedup_by(|left, right| left.0 == right.0);
+        targets
+    }
+
+    /// Satisfy any pending save-triggered publish for a freshly cached package.
+    fn publish_pending_diagnostics(&mut self, connection: &Connection, key: &PackageAnalysisKey) {
+        let Some(pending) = self.diagnostics.pending_by_package.remove(key) else {
+            return;
+        };
+        if self.diagnostics.untrusted_uris.contains(&pending.trigger_uri) {
+            return;
+        }
+        let Some(current_key) = self.documents.package_key(&pending.trigger_uri) else {
+            return;
+        };
+        if &current_key != key || !self.package_freshness_ok(key) {
+            return;
+        }
+        let Some(package) = self.analysis.packages.get(key).cloned() else {
+            return;
+        };
+        self.publish_diagnostic_set(connection, &pending.trigger_uri, package.diagnostics.as_ref());
     }
 }
 
@@ -2048,6 +2391,10 @@ fn collect_workspace_roots(params: &InitializeParams) -> Vec<PathBuf> {
 }
 
 /// Advertise the LSP capabilities implemented by this server.
+///
+/// `save.includeText = false` because the server has authoritative content
+/// from full-sync `didChange` already. `diagnosticProvider` is intentionally
+/// absent: this server ships push diagnostics only.
 fn server_capabilities() -> ServerCapabilities {
     ServerCapabilities {
         text_document_sync: Some(TextDocumentSyncCapability::Options(TextDocumentSyncOptions {
@@ -2055,7 +2402,7 @@ fn server_capabilities() -> ServerCapabilities {
             change: Some(TextDocumentSyncKind::FULL),
             will_save: None,
             will_save_wait_until: None,
-            save: None,
+            save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions { include_text: Some(false) })),
         })),
         semantic_tokens_provider: Some(semantic_tokens_capability()),
         definition_provider: Some(OneOf::Left(true)),
@@ -2108,6 +2455,26 @@ fn request_id_from_cancel(id: NumberOrString) -> RequestId {
 fn send_ok_response(connection: &Connection, id: RequestId, result: Value) -> Result<()> {
     let response = Response { id, result: Some(result), error: None };
     connection.sender.send(Message::Response(response))?;
+    Ok(())
+}
+
+/// Send a `textDocument/publishDiagnostics` notification.
+///
+/// `version` is wired through verbatim so empty clears for previously open
+/// URIs can carry their open version while clears for never-opened URIs omit
+/// the version entirely.
+fn send_publish_diagnostics(
+    connection: &Connection,
+    uri: &Uri,
+    version: Option<i32>,
+    diagnostics: Vec<Diagnostic>,
+) -> Result<()> {
+    let params = PublishDiagnosticsParams { uri: uri.clone(), diagnostics, version };
+    let notification = Notification {
+        method: PUBLISH_DIAGNOSTICS.to_owned(),
+        params: serde_json::to_value(params).context("failed to serialize publishDiagnostics params")?,
+    };
+    connection.sender.send(Message::Notification(notification))?;
     Ok(())
 }
 
@@ -2322,6 +2689,8 @@ mod tests {
             reference_requests: super::ReferencesRequestState::default(),
             rename_requests: super::RenameRequestState::default(),
             prepare_rename_requests: super::PrepareRenameRequestState::default(),
+            diagnostics: super::DiagnosticPublishState::default(),
+            diagnostic_capabilities: super::DiagnosticClientCapabilitySnapshot::default(),
             client_definition_link_support: false,
             hooks: TestHooks::default(),
         }
@@ -2364,6 +2733,105 @@ mod tests {
         assert!(state.analysis.in_flight_packages.is_empty());
         assert!(state.analysis.failed_views.is_empty());
         assert!(state.analysis.in_flight_views.is_empty());
+        state.scheduler.shutdown();
+    }
+
+    /// Build a one-entry `DiagnosticSet` keyed to the document at `uri`.
+    fn diagnostic_set_for_path(
+        state: &super::ServerState,
+        uri: &Uri,
+        path: &std::path::Path,
+        synthetic: bool,
+    ) -> super::DiagnosticSet {
+        use crate::features::diagnostics::{
+            DiagnosticEntry,
+            DiagnosticRange,
+            DiagnosticRelatedEntry,
+            DiagnosticSet,
+            DiagnosticSeverityInternal,
+        };
+        let key = state.documents.package_key(uri).expect("package key");
+        let entry = DiagnosticEntry {
+            path: Arc::new(path.to_path_buf()),
+            range: DiagnosticRange { start_line: 0, start_character: 0, end_line: 0, end_character: 1 },
+            severity: DiagnosticSeverityInternal::Error,
+            message: Arc::from("boom"),
+            related: Arc::from(Vec::<DiagnosticRelatedEntry>::new()),
+            synthetic,
+        };
+        DiagnosticSet { key, entries: Arc::from(vec![entry]) }
+    }
+
+    /// Drain the publishDiagnostics notifications observed on `client`.
+    fn drain_publish_notifications(client: &Connection) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        while let Ok(message) = client.receiver.recv_timeout(Duration::from_millis(20)) {
+            match message {
+                Message::Notification(notification) if notification.method == "textDocument/publishDiagnostics" => {
+                    out.push(notification.params)
+                }
+                Message::Notification(_) | Message::Response(_) | Message::Request(_) => {}
+            }
+        }
+        out
+    }
+
+    /// Path-only diagnostic with no matching open document is suppressed.
+    #[test]
+    fn publish_suppresses_entries_without_open_uri() {
+        let (server, client) = Connection::memory();
+        let mut state = test_state();
+        let uri: Uri = "file:///tmp/a.leo".parse().expect("uri");
+        open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+
+        let unrelated = std::path::PathBuf::from("/tmp/elsewhere.leo");
+        let set = diagnostic_set_for_path(&state, &uri, &unrelated, false);
+        state.publish_diagnostic_set(&server, &uri, &set);
+
+        assert!(drain_publish_notifications(&client).is_empty());
+        state.scheduler.shutdown();
+    }
+
+    /// A URI flagged untrusted does not receive a non-empty publish.
+    #[test]
+    fn publish_suppresses_untrusted_uris() {
+        let (server, client) = Connection::memory();
+        let mut state = test_state();
+        let path = std::path::PathBuf::from("/tmp/lsp-publish-test/main.leo");
+        let uri: Uri = "file:///tmp/lsp-publish-test/main.leo".parse().expect("uri");
+        state.documents.commit_open(state.documents.prepare_open(
+            uri.clone(),
+            "leo".to_owned(),
+            1,
+            "program test.aleo {}\n".to_owned(),
+            Some(Arc::new(path.clone())),
+            None,
+        ));
+        state.diagnostics.untrusted_uris.insert(uri.clone());
+
+        let set = diagnostic_set_for_path(&state, &uri, &path, false);
+        state.publish_diagnostic_set(&server, &uri, &set);
+
+        assert!(drain_publish_notifications(&client).is_empty());
+        state.scheduler.shutdown();
+    }
+
+    /// Synthetic entries always land on the trigger URI.
+    #[test]
+    fn publish_pins_synthetic_entries_to_trigger_uri() {
+        let (server, client) = Connection::memory();
+        let mut state = test_state();
+        let uri: Uri = "untitled:main.leo".parse().expect("uri");
+        open_unmanaged_document(&mut state, &uri, 1, "program test.aleo {}\n");
+        let path = std::path::PathBuf::from("/tmp/vfs/synthetic.leo");
+
+        let set = diagnostic_set_for_path(&state, &uri, &path, true);
+        state.publish_diagnostic_set(&server, &uri, &set);
+
+        let publishes = drain_publish_notifications(&client);
+        assert_eq!(publishes.len(), 1);
+        assert_eq!(publishes[0]["uri"], json!(uri.to_string()));
+        assert_eq!(publishes[0]["version"], json!(1));
         state.scheduler.shutdown();
     }
 
@@ -2651,6 +3119,8 @@ mod tests {
             reference_requests: super::ReferencesRequestState::default(),
             rename_requests: super::RenameRequestState::default(),
             prepare_rename_requests: super::PrepareRenameRequestState::default(),
+            diagnostics: super::DiagnosticPublishState::default(),
+            diagnostic_capabilities: super::DiagnosticClientCapabilitySnapshot::default(),
             client_definition_link_support: false,
             hooks: TestHooks::default(),
         };

--- a/crates/lsp/tests/common/mod.rs
+++ b/crates/lsp/tests/common/mod.rs
@@ -14,10 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use crossbeam_channel::{Receiver, RecvTimeoutError, unbounded};
 use serde_json::{Value, json};
 use std::{
+    collections::VecDeque,
     io::{BufRead, BufReader, Read, Write},
-    process::{Child, ChildStdin, ChildStdout, Command, ExitStatus, Stdio},
+    process::{Child, ChildStdin, Command, ExitStatus, Stdio},
     sync::{Arc, Mutex},
     thread::{self, JoinHandle},
     time::{Duration, Instant},
@@ -25,12 +27,18 @@ use std::{
 
 /// Helper for driving the `leo-lsp` binary in integration tests.
 ///
-/// Stderr is drained continuously on a background thread so tests can wait on
-/// observable server behavior instead of relying on timing sleeps.
+/// Stdout and stderr are drained continuously on dedicated background threads
+/// so tests can wait on observable server behavior with proper timeouts. PR 6
+/// added the stdout reader thread because the server now sends notifications
+/// (notably `textDocument/publishDiagnostics`) independently of any request;
+/// the reader pushes parsed JSON frames into a channel so tests can wait for
+/// notifications without blocking on a frame that may never come.
 pub(crate) struct TestServer {
     child: Child,
     stdin: ChildStdin,
-    stdout: BufReader<ChildStdout>,
+    stdout_rx: Receiver<Value>,
+    stdout_reader: Option<JoinHandle<()>>,
+    pending_notifications: VecDeque<Value>,
     stderr: Arc<Mutex<String>>,
     stderr_reader: Option<JoinHandle<()>>,
 }
@@ -47,7 +55,29 @@ impl TestServer {
 
         let mut child = command.spawn().expect("spawn leo-lsp");
         let stdin = child.stdin.take().expect("child stdin");
-        let stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+        let mut stdout = BufReader::new(child.stdout.take().expect("child stdout"));
+        let (stdout_tx, stdout_rx) = unbounded::<Value>();
+        let stdout_reader = thread::spawn(move || {
+            // Best-effort frame read; on EOF or malformed input we exit the
+            // loop and drop the sender, which makes subsequent `recv_timeout`
+            // calls return `Disconnected` so tests can assert clean shutdown
+            // without hanging.
+            while let Some(header) = try_read_header_block(&mut stdout) {
+                let Some(content_length) = parse_content_length_opt(&header) else {
+                    break;
+                };
+                let mut body = vec![0_u8; content_length];
+                if stdout.read_exact(&mut body).is_err() {
+                    break;
+                }
+                let Ok(value) = serde_json::from_slice::<Value>(&body) else {
+                    break;
+                };
+                if stdout_tx.send(value).is_err() {
+                    break;
+                }
+            }
+        });
         let stderr = Arc::new(Mutex::new(String::new()));
         let mut stderr_pipe = BufReader::new(child.stderr.take().expect("child stderr"));
         let stderr_buffer = Arc::clone(&stderr);
@@ -68,10 +98,23 @@ impl TestServer {
             }
         });
 
-        Self { child, stdin, stdout, stderr, stderr_reader: Some(stderr_reader) }
+        Self {
+            child,
+            stdin,
+            stdout_rx,
+            stdout_reader: Some(stdout_reader),
+            pending_notifications: VecDeque::new(),
+            stderr,
+            stderr_reader: Some(stderr_reader),
+        }
     }
 
-    /// Send a JSON-RPC request and wait for the next response frame.
+    /// Send a JSON-RPC request and wait for the matching response.
+    ///
+    /// Any notifications observed while waiting for the response are stashed
+    /// in `pending_notifications` so the test can drain them afterwards. Tests
+    /// that need to assert the relative ordering of notifications and
+    /// responses must use [`Self::recv_message_kind`] directly.
     pub(crate) fn request(&mut self, id: i64, method: &str, params: Value) -> Value {
         self.send_message(&json!({
             "jsonrpc": "2.0",
@@ -79,8 +122,64 @@ impl TestServer {
             "method": method,
             "params": params,
         }));
+        self.read_response()
+    }
 
-        self.read_message()
+    /// Block until the server emits a notification with the requested method.
+    ///
+    /// Returns `Some` on success and `None` if no matching notification
+    /// arrives before `timeout`. Notifications with other methods that arrive
+    /// before the target are stashed back into the queue so subsequent calls
+    /// can still observe them in arrival order.
+    #[allow(dead_code)]
+    pub(crate) fn recv_notification(&mut self, method: &str, timeout: Duration) -> Option<Value> {
+        let deadline = Instant::now() + timeout;
+        // Look at the already-queued notifications first to keep the original
+        // ordering intact.
+        let mut skipped: VecDeque<Value> = VecDeque::new();
+        while let Some(notification) = self.pending_notifications.pop_front() {
+            if notification.get("method").and_then(Value::as_str) == Some(method) {
+                while let Some(returned) = skipped.pop_back() {
+                    self.pending_notifications.push_front(returned);
+                }
+                return Some(notification);
+            }
+            skipped.push_back(notification);
+        }
+        for entry in skipped {
+            self.pending_notifications.push_back(entry);
+        }
+
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return None;
+            }
+            match self.stdout_rx.recv_timeout(remaining) {
+                Ok(message) => {
+                    if message.get("id").is_some() {
+                        // Unexpected response; stash it for later assertions.
+                        self.pending_notifications.push_back(message);
+                        continue;
+                    }
+                    if message.get("method").and_then(Value::as_str) == Some(method) {
+                        return Some(message);
+                    }
+                    self.pending_notifications.push_back(message);
+                }
+                Err(RecvTimeoutError::Timeout) => return None,
+                Err(RecvTimeoutError::Disconnected) => return None,
+            }
+        }
+    }
+
+    /// Drain every notification observed since the last call.
+    ///
+    /// Useful for assertions that need to inspect the complete notification
+    /// stream emitted while a request was in flight.
+    #[allow(dead_code)]
+    pub(crate) fn take_notifications(&mut self) -> Vec<Value> {
+        self.pending_notifications.drain(..).collect()
     }
 
     /// Send a JSON-RPC notification without waiting for a response.
@@ -94,11 +193,12 @@ impl TestServer {
 
     /// Wait for the child process to exit and collect stderr output.
     ///
-    /// This also joins the background stderr reader so no log output is lost at
-    /// shutdown.
+    /// Joins both reader threads so no output is lost at shutdown and the
+    /// channels backing `recv_notification` close cleanly.
     pub(crate) fn finish(mut self) -> (ExitStatus, String) {
         drop(self.stdin);
         let status = self.child.wait().expect("wait for leo-lsp");
+        self.stdout_reader.take().expect("stdout reader").join().expect("join stdout reader");
         self.stderr_reader.take().expect("stderr reader").join().expect("join stderr reader");
         let stderr = self.stderr.lock().expect("lock stderr buffer").clone();
 
@@ -138,40 +238,55 @@ impl TestServer {
         self.stdin.flush().expect("flush stdin");
     }
 
-    fn read_message(&mut self) -> Value {
-        let header = read_header_block(&mut self.stdout);
-        let content_length = parse_content_length(&header);
-
-        // Read exactly one response frame so tests stay synchronized with the
-        // server's stdout stream.
-        let mut body = vec![0_u8; content_length];
-        self.stdout.read_exact(&mut body).expect("read message body");
-        serde_json::from_slice(&body).expect("deserialize response")
+    /// Read messages until the next response frame, stashing any notifications.
+    fn read_response(&mut self) -> Value {
+        // Allow up to thirty seconds for a response — generous enough for the
+        // slowest CI runs but tight enough that hung subprocesses surface as
+        // test failures instead of stalling the suite.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let message = match self.stdout_rx.recv_timeout(remaining) {
+                Ok(message) => message,
+                Err(RecvTimeoutError::Timeout) => panic!("timed out waiting for response from server"),
+                Err(RecvTimeoutError::Disconnected) => panic!("server stdout closed without response"),
+            };
+            if message.get("id").is_some() {
+                return message;
+            }
+            self.pending_notifications.push_back(message);
+        }
     }
 }
 
-fn read_header_block(reader: &mut impl Read) -> String {
+/// Read one LSP-framed header block, returning `None` on EOF or read error.
+///
+/// Used by the background stdout reader thread, which is also responsible
+/// for never panicking on shutdown — a frame ending in EOF is a normal
+/// termination signal rather than a test failure.
+fn try_read_header_block(reader: &mut impl Read) -> Option<String> {
     let mut bytes = Vec::new();
 
     loop {
         let mut byte = [0_u8; 1];
-        reader.read_exact(&mut byte).expect("read header byte");
+        if reader.read_exact(&mut byte).is_err() {
+            return None;
+        }
         bytes.push(byte[0]);
 
-        // LSP frames end the HTTP-style header section with a blank CRLF line.
         if bytes.ends_with(b"\r\n\r\n") {
             break;
         }
     }
 
-    String::from_utf8(bytes).expect("utf8 header block")
+    String::from_utf8(bytes).ok()
 }
 
-fn parse_content_length(header_block: &str) -> usize {
-    // The harness only needs the mandatory LSP framing header here.
+/// Parse `Content-Length:` out of an LSP header block, returning `None` on
+/// malformed input. Used by the background reader thread.
+fn parse_content_length_opt(header_block: &str) -> Option<usize> {
     header_block
         .lines()
         .find_map(|line| line.strip_prefix("Content-Length: "))
         .and_then(|value| value.trim().parse().ok())
-        .expect("Content-Length header")
 }

--- a/crates/lsp/tests/diagnostics.rs
+++ b/crates/lsp/tests/diagnostics.rs
@@ -1,0 +1,535 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! End-to-end protocol coverage for save-triggered LSP diagnostics.
+//!
+//! These tests drive the real `leo-lsp` subprocess and assert on the wire
+//! payload of `textDocument/publishDiagnostics`: save publishes structured
+//! diagnostics, edits clear stale ranges before any new publish, malformed
+//! full-sync change payloads block cached republish, and the initialize
+//! handshake advertises save support but withholds the pull-diagnostics
+//! provider.
+
+mod common;
+
+use self::common::TestServer;
+use lsp_types::Uri;
+use serde_json::{Value, json};
+use std::{fs, path::Path, time::Duration};
+use tempfile::{TempDir, tempdir};
+
+/// Maximum time to wait for a notification or worker completion in these tests.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Source guaranteed to trigger a compiler error.
+const ERROR_SOURCE: &str = "program demo.aleo {\n    fn main() -> u32 {\n        return undefined_symbol;\n    }\n}\n";
+
+/// Source that emits a labeled compiler error (duplicate function name).
+///
+/// `name_defined_multiple_times` carries both a primary span and a "previous
+/// definition here" secondary label, so the diagnostic lowering produces a
+/// non-empty `relatedInformation` payload that integration tests can probe.
+const LABELED_ERROR_SOURCE: &str = concat!(
+    "program demo.aleo {\n",
+    "    fn collide() -> u32 { return 0u32; }\n",
+    "    fn collide() -> u32 { return 1u32; }\n",
+    "    fn main() -> u32 { return collide(); }\n",
+    "    @noupgrade\n",
+    "    constructor() {}\n",
+    "}\n",
+);
+
+/// Source that compiles cleanly.
+const CLEAN_SOURCE: &str = "program demo.aleo { fn main() {} }\n";
+
+/// Send `initialize` followed by `initialized` with the maximal capability set.
+fn initialize(server: &mut TestServer) {
+    initialize_with_capabilities(
+        server,
+        json!({
+            "textDocument": {
+                "publishDiagnostics": {
+                    "relatedInformation": true,
+                    "versionSupport": true,
+                    "codeDescriptionSupport": true,
+                    "dataSupport": true,
+                    "tagSupport": {
+                        "valueSet": [1, 2],
+                    }
+                }
+            }
+        }),
+    );
+}
+
+/// Initialize with explicit client capabilities so tests can vary the snapshot.
+fn initialize_with_capabilities(server: &mut TestServer, capabilities: Value) {
+    let response = server.request(
+        1,
+        "initialize",
+        json!({
+            "processId": null,
+            "rootUri": null,
+            "capabilities": capabilities,
+        }),
+    );
+    assert_eq!(response["id"], 1);
+    server.notify("initialized", json!({}));
+}
+
+/// Build a `file:` URI from a native path.
+fn file_uri(path: &Path) -> Uri {
+    #[cfg(target_os = "windows")]
+    let path = {
+        let display = path.display().to_string();
+        let display = display.strip_prefix(r"\\?\").unwrap_or(display.as_str());
+        format!("/{}", display).replace('\\', "/")
+    };
+
+    #[cfg(not(target_os = "windows"))]
+    let path = path.display().to_string();
+
+    format!("file://{path}").parse().expect("file uri")
+}
+
+/// Write a minimal Leo package and return its tempdir plus the document URI.
+fn write_test_package(source: &str) -> (TempDir, Uri) {
+    let tempdir = tempdir().expect("tempdir");
+    write_package_into(tempdir.path(), source, true);
+    let canonical =
+        tempdir.path().join("example").join("src").join("main.leo").canonicalize().expect("canonical main path");
+    (tempdir, file_uri(&canonical))
+}
+
+/// Write the package layout at `root` with `main.leo` containing `source` and
+/// optionally include a `program.json` manifest.
+fn write_package_into(root: &Path, source: &str, with_manifest: bool) {
+    let package_root = root.join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    if with_manifest {
+        fs::write(
+            package_root.join("program.json"),
+            r#"{ "program": "demo.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+        )
+        .expect("write manifest");
+    }
+    let main_path = source_dir.join("main.leo");
+    fs::write(&main_path, source).expect("write source");
+}
+
+/// Write a package with two source files and return their canonical URIs.
+fn write_two_file_package(main_source: &str, sibling_source: &str) -> (TempDir, Uri, Uri) {
+    let tempdir = tempdir().expect("tempdir");
+    let package_root = tempdir.path().join("example");
+    let source_dir = package_root.join("src");
+    fs::create_dir_all(&source_dir).expect("create source dir");
+    fs::write(
+        package_root.join("program.json"),
+        r#"{ "program": "demo.aleo", "version": "0.1.0", "description": "", "license": "MIT", "leo": "4.0.0" }"#,
+    )
+    .expect("write manifest");
+    fs::write(source_dir.join("main.leo"), main_source).expect("write main");
+    fs::write(source_dir.join("helper.leo"), sibling_source).expect("write helper");
+    let main = source_dir.join("main.leo").canonicalize().expect("canonical main");
+    let helper = source_dir.join("helper.leo").canonicalize().expect("canonical helper");
+    (tempdir, file_uri(&main), file_uri(&helper))
+}
+
+/// Open a document on the server with version 1.
+fn open_document(server: &mut TestServer, uri: &Uri, source: &str) {
+    server.notify(
+        "textDocument/didOpen",
+        json!({
+            "textDocument": {
+                "uri": uri,
+                "languageId": "leo",
+                "version": 1,
+                "text": source,
+            }
+        }),
+    );
+}
+
+/// Send a full-sync `didChange` with a new text and version.
+fn did_change(server: &mut TestServer, uri: &Uri, version: i32, new_text: &str) {
+    server.notify(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": version },
+            "contentChanges": [ { "text": new_text } ]
+        }),
+    );
+}
+
+/// Send a malformed `didChange` (no full-document text) for a URI.
+fn did_change_malformed(server: &mut TestServer, uri: &Uri, version: i32) {
+    server.notify(
+        "textDocument/didChange",
+        json!({
+            "textDocument": { "uri": uri, "version": version },
+            "contentChanges": []
+        }),
+    );
+}
+
+/// Send a `didSave` notification for a URI.
+fn did_save(server: &mut TestServer, uri: &Uri) {
+    server.notify("textDocument/didSave", json!({ "textDocument": { "uri": uri } }));
+}
+
+/// Send a `didClose` notification for a URI.
+fn did_close(server: &mut TestServer, uri: &Uri) {
+    server.notify("textDocument/didClose", json!({ "textDocument": { "uri": uri } }));
+}
+
+/// Wait until the next `publishDiagnostics` whose params satisfy the predicate.
+fn wait_for_diagnostics(
+    server: &mut TestServer,
+    timeout: Duration,
+    predicate: impl Fn(&Value) -> bool,
+) -> Option<Value> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return None;
+        }
+        let notification = server.recv_notification("textDocument/publishDiagnostics", remaining)?;
+        if predicate(&notification["params"]) {
+            return Some(notification);
+        }
+    }
+}
+
+/// Wait until the worker logs a completion. Required before any `didSave` so
+/// the routing thread has already stored the package result we expect to read.
+fn wait_for_worker_completion(server: &TestServer) {
+    assert!(
+        server.wait_for_stderr_contains("worker completed latest document", WAIT_TIMEOUT),
+        "worker did not finish in {WAIT_TIMEOUT:?}; stderr:\n{}",
+        server.stderr_contents(),
+    );
+}
+
+/// Shut the server down cleanly.
+fn shutdown(server: TestServer, request_id: i64) {
+    let mut server = server;
+    let response = server.request(request_id, "shutdown", Value::Null);
+    assert_eq!(response["result"], Value::Null);
+    server.notify("exit", json!({}));
+    let (status, stderr) = server.finish();
+    assert!(status.success(), "stderr:\n{stderr}");
+}
+
+/// Verifies `initialize` advertises full-sync save without `diagnosticProvider`.
+#[test]
+fn initialize_advertises_save_but_not_pull_diagnostics() {
+    let mut server = TestServer::spawn(&[]);
+    let response = server.request(
+        1,
+        "initialize",
+        json!({
+            "processId": null,
+            "rootUri": null,
+            "capabilities": {},
+        }),
+    );
+    assert_eq!(response["id"], 1);
+    assert_eq!(response["result"]["capabilities"]["textDocumentSync"]["save"]["includeText"], json!(false));
+    assert!(response["result"]["capabilities"].get("diagnosticProvider").is_none());
+    server.notify("initialized", json!({}));
+    shutdown(server, 99);
+}
+
+/// Verifies a saved file with a type error publishes a structured diagnostic.
+#[test]
+fn save_publishes_compiler_diagnostics() {
+    let (_tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+
+    did_save(&mut server, &uri);
+    let publish = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics)
+        .expect("expected non-empty diagnostic publish");
+    let diagnostics = publish["params"]["diagnostics"].as_array().expect("diagnostics array");
+    assert!(!diagnostics.is_empty(), "expected at least one diagnostic: {publish}");
+    assert!(diagnostics.iter().all(|diagnostic| diagnostic["source"] == json!("leo")));
+    assert!(diagnostics.iter().all(|diagnostic| diagnostic["severity"] == json!(1)));
+    // The compiler's internal code (e.g. `ETYC0372005`) is intentionally
+    // omitted from the wire payload; see entry_to_lsp_diagnostic.
+    assert!(diagnostics.iter().all(|diagnostic| diagnostic.get("code").is_none()));
+    assert_eq!(publish["params"]["version"], json!(1));
+
+    shutdown(server, 99);
+}
+
+/// Verifies an unrelated edit clears stale diagnostics before the next save.
+#[test]
+fn edit_after_save_clears_diagnostics_with_incoming_version() {
+    let (_tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &uri);
+    let initial = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics);
+    assert!(initial.is_some(), "expected initial parser diagnostic");
+
+    did_change(&mut server, &uri, 7, CLEAN_SOURCE);
+    let cleared =
+        wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear after didChange");
+    assert_eq!(cleared["params"]["diagnostics"], json!([]));
+    assert_eq!(cleared["params"]["version"], json!(7));
+
+    shutdown(server, 99);
+}
+
+/// Verifies didClose clears diagnostics for the closed URI.
+#[test]
+fn close_clears_diagnostics_for_closed_uri() {
+    let (_tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &uri);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("non-empty diagnostic");
+
+    did_close(&mut server, &uri);
+    let cleared = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear after close");
+    assert_eq!(cleared["params"]["diagnostics"], json!([]));
+
+    shutdown(server, 99);
+}
+
+/// Verifies a malformed `didChange` clears diagnostics and blocks cached publish.
+#[test]
+fn malformed_change_marks_uri_untrusted() {
+    let (_tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &uri);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("non-empty diagnostic");
+
+    did_change_malformed(&mut server, &uri, 2);
+    let cleared =
+        wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear after malformed change");
+    assert_eq!(cleared["params"]["diagnostics"], json!([]));
+    assert_eq!(cleared["params"]["version"], json!(2));
+
+    did_save(&mut server, &uri);
+    let unexpected = wait_for_diagnostics(&mut server, Duration::from_millis(300), has_non_empty_diagnostics);
+    assert!(unexpected.is_none(), "non-empty diagnostic should not publish while URI is untrusted: {unexpected:?}");
+
+    shutdown(server, 99);
+}
+
+/// Verifies a clean save clears diagnostics previously published for the bucket.
+#[test]
+fn clean_save_clears_previously_published_diagnostics() {
+    let (_tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &uri);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("initial diagnostics");
+
+    did_change(&mut server, &uri, 2, CLEAN_SOURCE);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear after edit");
+
+    did_save(&mut server, &uri);
+    // After a clean save we should see another empty publish (or simply no
+    // new non-empty publish for the remaining window).
+    let unexpected = wait_for_diagnostics(&mut server, Duration::from_millis(500), has_non_empty_diagnostics);
+    assert!(unexpected.is_none(), "clean save should not publish new diagnostics: {unexpected:?}");
+
+    shutdown(server, 99);
+}
+
+/// Verifies a labeled diagnostic ships its `relatedInformation` only when the
+/// client advertises support. Uses a duplicate-function-name error so the
+/// underlying compiler diagnostic actually carries a secondary label.
+#[test]
+fn related_information_requires_client_capability() {
+    let (without_dir, without_uri) = write_test_package(LABELED_ERROR_SOURCE);
+    let mut without = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize_with_capabilities(
+        &mut without,
+        json!({
+            "textDocument": { "publishDiagnostics": { "relatedInformation": false } }
+        }),
+    );
+    open_document(&mut without, &without_uri, LABELED_ERROR_SOURCE);
+    wait_for_worker_completion(&without);
+    did_save(&mut without, &without_uri);
+    let no_caps = wait_for_diagnostics(&mut without, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("diagnostics");
+    for diagnostic in no_caps["params"]["diagnostics"].as_array().expect("diagnostics") {
+        assert!(
+            diagnostic.get("relatedInformation").is_none(),
+            "clients without relatedInformation should not receive it: {diagnostic}",
+        );
+        assert!(diagnostic.get("codeDescription").is_none());
+        assert!(diagnostic.get("data").is_none());
+        assert!(diagnostic.get("tags").is_none());
+    }
+    shutdown(without, 99);
+    drop(without_dir);
+
+    let (_with_dir, with_uri) = write_test_package(LABELED_ERROR_SOURCE);
+    let mut with = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut with);
+    open_document(&mut with, &with_uri, LABELED_ERROR_SOURCE);
+    wait_for_worker_completion(&with);
+    did_save(&mut with, &with_uri);
+    let with_caps = wait_for_diagnostics(&mut with, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("diagnostics");
+    assert!(
+        with_caps["params"]["diagnostics"]
+            .as_array()
+            .expect("diagnostics")
+            .iter()
+            .any(|diagnostic| diagnostic.get("relatedInformation").is_some()),
+        "labeled diagnostic should carry relatedInformation when the client advertises support: {with_caps}",
+    );
+    shutdown(with, 99);
+}
+
+/// Verifies the publish carries the open document's version.
+#[test]
+fn save_publish_carries_open_document_version() {
+    let (_tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &uri);
+    let publish = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("diagnostics");
+    assert_eq!(publish["params"]["version"], json!(1));
+
+    // After an edit + clean save, the version on subsequent clears reflects the
+    // new open-document version.
+    did_change(&mut server, &uri, 5, CLEAN_SOURCE);
+    let cleared = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear on edit");
+    assert_eq!(cleared["params"]["version"], json!(5));
+
+    shutdown(server, 99);
+}
+
+/// Verifies an error originating in a sibling open file publishes against
+/// that sibling's URI and version, not the saved trigger's.
+#[test]
+fn save_publishes_diagnostics_for_open_sibling_file() {
+    let main_source = "program demo.aleo {\n    fn main() -> u32 { return helper::go(); }\n}\n";
+    let bad_helper = concat!("module helper {\n", "    pub fn go() -> u32 { return undefined_symbol; }\n", "}\n",);
+    let (_tempdir, main_uri, helper_uri) = write_two_file_package(main_source, bad_helper);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &main_uri, main_source);
+    open_document(&mut server, &helper_uri, bad_helper);
+    wait_for_worker_completion(&server);
+
+    // Save the main file even though the error lives in `helper.leo`. The
+    // publish should still land on the helper URI (and only the helper URI).
+    did_save(&mut server, &main_uri);
+    let publish = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, |params| {
+        params["uri"] == json!(helper_uri.to_string()) && has_non_empty_diagnostics(params)
+    })
+    .expect("expected diagnostic on the sibling helper URI");
+    assert_eq!(publish["params"]["uri"], json!(helper_uri.to_string()));
+    assert_eq!(publish["params"]["version"], json!(1));
+
+    shutdown(server, 99);
+}
+
+/// Verifies that bucket reclassification (managed → unmanaged via a manifest
+/// removal observed on `didChange`) clears diagnostics from the old bucket
+/// before any new ones can land.
+#[test]
+fn bucket_reclassification_clears_old_bucket_diagnostics() {
+    let (tempdir, uri) = write_test_package(ERROR_SOURCE);
+
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &uri);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("initial diagnostics");
+
+    // Removing `program.json` flips the file from a managed package to an
+    // unmanaged buffer on the next `didChange`. The bucket changes and the
+    // previous bucket's diagnostics must clear in the same routing turn.
+    fs::remove_file(tempdir.path().join("example").join("program.json")).expect("remove manifest");
+    did_change(&mut server, &uri, 2, ERROR_SOURCE);
+    let cleared = wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear after move");
+    assert_eq!(cleared["params"]["diagnostics"], json!([]));
+    assert_eq!(cleared["params"]["version"], json!(2));
+
+    shutdown(server, 99);
+}
+
+/// Verifies a worker panic on the current-key analysis clears any visible
+/// diagnostics for the bucket and leaves the server alive.
+#[test]
+fn worker_panic_clears_bucket_diagnostics() {
+    let (_initial_dir, initial_uri) = write_test_package(ERROR_SOURCE);
+
+    // Two-phase setup: get a non-empty publish, then close and re-spawn with
+    // the worker-panic injection enabled so the next save provokes a panic.
+    let mut server = TestServer::spawn(&[("RUST_LOG", "debug")]);
+    initialize(&mut server);
+    open_document(&mut server, &initial_uri, ERROR_SOURCE);
+    wait_for_worker_completion(&server);
+    did_save(&mut server, &initial_uri);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_non_empty_diagnostics).expect("initial diagnostics");
+
+    // Force the next worker job to panic and watch the bucket clear.
+    did_close(&mut server, &initial_uri);
+    wait_for_diagnostics(&mut server, WAIT_TIMEOUT, has_empty_diagnostics).expect("clear on close");
+    shutdown(server, 99);
+
+    let (_panic_dir, panic_uri) = write_test_package(ERROR_SOURCE);
+    let mut paniced = TestServer::spawn(&[("RUST_LOG", "debug"), ("LEO_LSP_TEST_PANIC_WORKER", "1")]);
+    initialize(&mut paniced);
+    open_document(&mut paniced, &panic_uri, ERROR_SOURCE);
+    // First open enqueues analysis; worker panics. We expect no non-empty
+    // diagnostic to ever arrive, and the server stays alive long enough to
+    // accept the shutdown handshake.
+    let publish = wait_for_diagnostics(&mut paniced, Duration::from_millis(500), has_non_empty_diagnostics);
+    assert!(publish.is_none(), "panicking worker must not publish diagnostics: {publish:?}");
+    shutdown(paniced, 99);
+}
+
+/// Predicate: `params.diagnostics` is a non-empty array.
+fn has_non_empty_diagnostics(params: &Value) -> bool {
+    params["diagnostics"].as_array().map(|entries| !entries.is_empty()).unwrap_or(false)
+}
+
+/// Predicate: `params.diagnostics` is an empty array.
+fn has_empty_diagnostics(params: &Value) -> bool {
+    params["diagnostics"].as_array().map(|entries| entries.is_empty()).unwrap_or(false)
+}

--- a/crates/lsp/tests/protocol.rs
+++ b/crates/lsp/tests/protocol.rs
@@ -161,8 +161,11 @@ fn initialize_shutdown_exit_round_trip() {
         json!({
             "openClose": true,
             "change": 1,
+            "save": { "includeText": false },
         })
     );
+    // PR 6 ships push diagnostics only, so `diagnosticProvider` must remain absent.
+    assert!(initialize["result"]["capabilities"].get("diagnosticProvider").is_none());
     assert_eq!(initialize["result"]["capabilities"]["semanticTokensProvider"]["full"], json!(true));
     assert_eq!(initialize["result"]["capabilities"]["definitionProvider"], json!(true));
     assert_eq!(initialize["result"]["capabilities"]["referencesProvider"], json!(true));


### PR DESCRIPTION
## Summary
- add `textDocument/didSave` and `textDocument/publishDiagnostics` to `leo-lsp`
- capture parser, name, path, interface, type-checker, and warning diagnostics through a buffered compiler handler and lower compiler `Span`s to UTF-16 LSP ranges
- store the resulting diagnostic set on the existing `CachedPackageAnalysis` and publish save-fenced, version-stamped diagnostics for every currently open file in the same package
- clear stale diagnostics on every observed edit, close, bucket move, and worker panic so no diagnostic ever outlives the text it was computed for

Tracking issue: https://github.com/ProvableHQ/leo/issues/29264

https://github.com/user-attachments/assets/b687e475-9b08-4f3a-8a9a-035a0fa7be94