### PR TITLE
fix(codegen): filter empty-typed members in clone_register composite cast

### DIFF
--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -1196,9 +1196,13 @@ impl CodeGeneratingVisitor<'_> {
                     .lookup_record(current_program, composite_location)
                     .or_else(|| self.state.symbol_table.lookup_struct(current_program, composite_location))
                     .unwrap();
+                // Empty-typed members (Type::Unit, zero-length arrays) are omitted by the
+                // record/struct declaration emitters in `program.rs`, so omit them here too
+                // to keep the cast operand list consistent with the declared schema.
                 let elems = comp
                     .members
                     .iter()
+                    .filter(|member| !member.type_.is_empty())
                     .map(|member| {
                         AleoExpr::MemberAccess(Box::new(register.clone()), member.identifier.name.to_string())
                     })

--- a/tests/expectations/compiler/bugs/b29425.out
+++ b/tests/expectations/compiler/bugs/b29425.out
@@ -1,0 +1,12 @@
+program bugpoc.aleo;
+
+record Token:
+    owner as address.private;
+
+function pass:
+    input r0 as Token.record;
+    cast r0.owner into r1 as Token.record;
+    output r1 as Token.record;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/bugs/b29425.leo
+++ b/tests/tests/compiler/bugs/b29425.leo
@@ -1,0 +1,20 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29425.
+// The codegen `clone_register` Type::Composite arm previously emitted a
+// MemberAccess operand for every member, including empty-typed members
+// (Type::Unit or zero-length Type::Array). The record declaration emitter
+// omits empty-typed fields, so the cast operand list disagreed with the
+// declared schema and snarkVM rejected the bytecode with
+// `ECLI0377047: Leo generated invalid Aleo bytecode`.
+program bugpoc.aleo {
+    @noupgrade
+    constructor() {}
+
+    record Token {
+        owner: address,
+        blob: [u64; 0],
+    }
+
+    fn pass(t: Token) -> Token {
+        return t;
+    }
+}


### PR DESCRIPTION
Closes #29425.

The `Type::Composite` arm in `clone_register` was emitting a `MemberAccess` operand for every member of the source record/struct, including empty-typed fields (`Type::Unit` or zero-length `Type::Array`). The record/struct declaration emitters in `program.rs` omit such fields, so the cast operand list disagreed with the declared schema and snarkVM rejected the bytecode (`ECLI0377047`).

Fix: filter `member.type_.is_empty()` before mapping, matching the existing pattern in `visit_struct`, `visit_record`, and `visit_composite_init`.

Regression test: `tests/tests/compiler/bugs/b29425.leo` reproduces the `record Token { owner, blob: [u64; 0] }` + `fn pass(t: Token) -> Token { return t; }` case.