### PR TITLE
feat(workspaces): globs, --workspace, auto-add member (Phase 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ dependencies = [
 name = "leo-package"
 version = "4.0.2"
 dependencies = [
+ "glob",
  "indexmap",
  "leo-ast",
  "leo-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ dotenvy            = "0.15"
 dunce              = "1.0"
 expect-test        = "1.5"
 fxhash             = "0.2"
+glob               = "0.3"
 http               = "1"
 indexmap           = { version = "2.6", features = [ "serde" ] }
 line-index         = "0.1"

--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -306,6 +306,7 @@ mod tests {
         cli::{Commands, test_helpers},
         run_with_args,
     };
+    use clap::Parser;
     use leo_ast::NetworkName;
     use leo_span::create_session_if_not_set_then;
     use serial_test::serial;
@@ -506,7 +507,7 @@ mod tests {
             json_output: None,
             disable_update_check: false,
             command: Commands::New {
-                command: crate::cli::commands::LeoNew { name: lib_name.to_string(), library: true },
+                command: crate::cli::commands::LeoNew { name: lib_name.to_string(), library: true, workspace: false },
             },
             path: Some(lib_directory.clone()),
             home: None,
@@ -533,6 +534,142 @@ mod tests {
         // Best-effort cleanup. On Windows the directory may still be held open briefly
         // by the OS, so we ignore errors here rather than failing an otherwise-passing test.
         let _ = std::fs::remove_dir_all(&lib_directory);
+    }
+
+    #[test]
+    #[serial]
+    fn new_workspace_test() {
+        let temp_dir = temp_dir();
+        let ws_name = "my_test_workspace";
+        let ws_directory = temp_dir.join(ws_name);
+
+        if ws_directory.exists() {
+            std::fs::remove_dir_all(&ws_directory).unwrap();
+        }
+
+        let new_cmd = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::New {
+                command: crate::cli::commands::LeoNew { name: ws_name.to_string(), library: false, workspace: true },
+            },
+            path: Some(ws_directory.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(new_cmd).expect("Failed to execute `leo new --workspace`");
+        });
+
+        assert!(ws_directory.is_dir(), "Workspace directory should exist");
+        let manifest_path = ws_directory.join(leo_package::WORKSPACE_MANIFEST_FILENAME);
+        assert!(manifest_path.exists(), "workspace.json should exist");
+        let manifest = leo_package::WorkspaceManifest::read_from_file(&manifest_path).unwrap();
+        assert!(manifest.members.is_empty(), "newly created workspace should have an empty members list");
+        assert!(!ws_directory.join("src").exists(), "workspace skeleton should not have a src directory");
+        assert!(
+            !ws_directory.join(leo_package::MANIFEST_FILENAME).exists(),
+            "workspace skeleton should not have a program.json"
+        );
+
+        let _ = std::fs::remove_dir_all(&ws_directory);
+    }
+
+    #[test]
+    #[serial]
+    fn new_workspace_with_library_flag_rejected() {
+        // The clap `conflicts_with` constraint between `--workspace` and `--library` should
+        // surface as a parse error rather than running either path.
+        let result = CLI::try_parse_from(["leo", "new", "--workspace", "--library", "anything"]);
+        assert!(result.is_err(), "leo new --workspace --library should fail parsing");
+    }
+
+    #[test]
+    #[serial]
+    fn new_inside_workspace_auto_registers() {
+        let temp_dir = temp_dir();
+        let ws_root = temp_dir.join("ws_new_inside_test");
+        if ws_root.exists() {
+            std::fs::remove_dir_all(&ws_root).unwrap();
+        }
+        std::fs::create_dir_all(&ws_root).unwrap();
+
+        // Seed the workspace with a single literal member that actually exists.
+        test_helpers::scaffold_minimal_member(&ws_root, "existing");
+        let manifest = leo_package::WorkspaceManifest { members: vec!["existing".to_string()] };
+        manifest.write_to_file(ws_root.join(leo_package::WORKSPACE_MANIFEST_FILENAME)).unwrap();
+
+        let new_pkg = "my_pkg";
+        let pkg_dir = ws_root.join(new_pkg);
+        let new_cmd = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::New {
+                command: crate::cli::commands::LeoNew { name: new_pkg.to_string(), library: false, workspace: false },
+            },
+            path: Some(pkg_dir.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(new_cmd).expect("Failed to execute `leo new` inside a workspace");
+        });
+
+        assert!(pkg_dir.join(leo_package::MANIFEST_FILENAME).exists(), "package should be scaffolded");
+        let manifest =
+            leo_package::WorkspaceManifest::read_from_file(ws_root.join(leo_package::WORKSPACE_MANIFEST_FILENAME))
+                .unwrap();
+        assert_eq!(manifest.members, vec!["existing".to_string(), new_pkg.to_string()]);
+
+        let _ = std::fs::remove_dir_all(&ws_root);
+    }
+
+    #[test]
+    #[serial]
+    fn new_inside_workspace_with_glob_does_not_modify_manifest() {
+        let temp_dir = temp_dir();
+        let ws_root = temp_dir.join("ws_new_inside_glob_test");
+        if ws_root.exists() {
+            std::fs::remove_dir_all(&ws_root).unwrap();
+        }
+        std::fs::create_dir_all(&ws_root).unwrap();
+
+        // A `*` pattern in `members` covers anything created at the workspace root.
+        let manifest = leo_package::WorkspaceManifest { members: vec!["*".to_string()] };
+        manifest.write_to_file(ws_root.join(leo_package::WORKSPACE_MANIFEST_FILENAME)).unwrap();
+
+        let new_pkg = "my_pkg";
+        let pkg_dir = ws_root.join(new_pkg);
+        let new_cmd = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::New {
+                command: crate::cli::commands::LeoNew { name: new_pkg.to_string(), library: false, workspace: false },
+            },
+            path: Some(pkg_dir.clone()),
+            home: None,
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(new_cmd).expect("Failed to execute `leo new` inside a globbed workspace");
+        });
+
+        assert!(pkg_dir.join(leo_package::MANIFEST_FILENAME).exists(), "package should be scaffolded");
+        let manifest =
+            leo_package::WorkspaceManifest::read_from_file(ws_root.join(leo_package::WORKSPACE_MANIFEST_FILENAME))
+                .unwrap();
+        assert_eq!(manifest.members, vec!["*".to_string()], "glob-covered workspace manifest should be untouched");
+
+        let _ = std::fs::remove_dir_all(&ws_root);
     }
 
     #[test]
@@ -1038,7 +1175,7 @@ mod tests {
             json_output: None,
             disable_update_check: false,
             command: Commands::New {
-                command: crate::cli::commands::LeoNew { name: pkg_name.to_string(), library: false },
+                command: crate::cli::commands::LeoNew { name: pkg_name.to_string(), library: false, workspace: false },
             },
             path: Some(pkg_dir.clone()),
             home: None,
@@ -1083,6 +1220,35 @@ mod test_helpers {
     use crate::cli::{CLI, DependencySource, LeoAdd, LeoNew, cli::Commands, run_with_args};
     use leo_span::create_session_if_not_set_then;
     use std::path::{Path, PathBuf};
+
+    /// Scaffold a minimal program package named `name` at `<parent>/<name>`.
+    ///
+    /// Writes a no-deps `program.json` and a trivial `src/main.leo`. Useful as
+    /// a lightweight workspace member when a test only needs the directory to
+    /// pass validation.
+    pub(crate) fn scaffold_minimal_member(parent: &Path, name: &str) {
+        let member_dir = parent.join(name);
+        std::fs::create_dir_all(member_dir.join("src")).unwrap();
+        std::fs::write(
+            member_dir.join("src/main.leo"),
+            format!("program {name}.aleo {{\n    @noupgrade\n    constructor() {{}}\n}}\n"),
+        )
+        .unwrap();
+        std::fs::write(
+            member_dir.join(leo_package::MANIFEST_FILENAME),
+            serde_json::to_string_pretty(&serde_json::json!({
+                "program": format!("{name}.aleo"),
+                "version": "0.1.0",
+                "description": "",
+                "license": "MIT",
+                "leo": env!("CARGO_PKG_VERSION"),
+                "dependencies": null,
+                "dev_dependencies": null
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
 
     /// Create a workspace with two members: `token` (no deps) and `swap` (depends on token).
     ///
@@ -1523,7 +1689,7 @@ program app.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: name.to_string(), library: false } },
+            command: Commands::New { command: LeoNew { name: name.to_string(), library: false, workspace: false } },
             path: Some(project_directory.clone()),
             home: None,
             package: None,
@@ -1642,7 +1808,9 @@ function external_nested_function:
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "grandparent".to_string(), library: false } },
+            command: Commands::New {
+                command: LeoNew { name: "grandparent".to_string(), library: false, workspace: false },
+            },
             path: Some(grandparent_directory.clone()),
             home: None,
             package: None,
@@ -1653,7 +1821,7 @@ function external_nested_function:
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "parent".to_string(), library: false } },
+            command: Commands::New { command: LeoNew { name: "parent".to_string(), library: false, workspace: false } },
             path: Some(parent_directory.clone()),
             home: None,
             package: None,
@@ -1664,7 +1832,7 @@ function external_nested_function:
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "child".to_string(), library: false } },
+            command: Commands::New { command: LeoNew { name: "child".to_string(), library: false, workspace: false } },
             path: Some(child_directory.clone()),
             home: None,
             package: None,
@@ -1815,7 +1983,7 @@ program child.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "outer".to_string(), library: false } },
+            command: Commands::New { command: LeoNew { name: "outer".to_string(), library: false, workspace: false } },
             path: Some(outer_directory.clone()),
             home: None,
             package: None,
@@ -1826,7 +1994,9 @@ program child.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "inner_1".to_string(), library: false } },
+            command: Commands::New {
+                command: LeoNew { name: "inner_1".to_string(), library: false, workspace: false },
+            },
             path: Some(inner_1_directory.clone()),
             home: None,
             package: None,
@@ -1837,7 +2007,9 @@ program child.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "inner_2".to_string(), library: false } },
+            command: Commands::New {
+                command: LeoNew { name: "inner_2".to_string(), library: false, workspace: false },
+            },
             path: Some(inner_2_directory.clone()),
             home: None,
             package: None,
@@ -1987,7 +2159,9 @@ program inner_2.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "outer_2".to_string(), library: false } },
+            command: Commands::New {
+                command: LeoNew { name: "outer_2".to_string(), library: false, workspace: false },
+            },
             path: Some(outer_directory.clone()),
             home: None,
             package: None,
@@ -1998,7 +2172,9 @@ program inner_2.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "inner_1".to_string(), library: false } },
+            command: Commands::New {
+                command: LeoNew { name: "inner_1".to_string(), library: false, workspace: false },
+            },
             path: Some(inner_1_directory.clone()),
             home: None,
             package: None,
@@ -2009,7 +2185,9 @@ program inner_2.aleo {
             quiet: false,
             json_output: None,
             disable_update_check: false,
-            command: Commands::New { command: LeoNew { name: "inner_2".to_string(), library: false } },
+            command: Commands::New {
+                command: LeoNew { name: "inner_2".to_string(), library: false, workspace: false },
+            },
             path: Some(inner_2_directory.clone()),
             home: None,
             package: None,

--- a/crates/leo/src/cli/commands/new.rs
+++ b/crates/leo/src/cli/commands/new.rs
@@ -16,15 +16,17 @@
 
 use super::*;
 
-use leo_package::Package;
+use leo_package::{Package, Workspace};
 
 /// Create new Leo project
 #[derive(Parser, Debug)]
 pub struct LeoNew {
     #[clap(name = "NAME", help = "Set package name")]
     pub(crate) name: String,
-    #[clap(long, help = "Create the package as a library instead of a program")]
+    #[clap(long, help = "Create the package as a library instead of a program", conflicts_with = "workspace")]
     pub(crate) library: bool,
+    #[clap(long, help = "Create a workspace skeleton instead of a package", conflicts_with = "library")]
+    pub(crate) workspace: bool,
 }
 
 impl Command for LeoNew {
@@ -43,13 +45,21 @@ impl Command for LeoNew {
         // Derive the location of the parent directory to the project.
         let package_path = context.parent_dir()?;
 
-        // Change the cwd to the Leo package directory to initialize all files.
+        // Change the cwd to the parent directory so subsequent commands resolve sensibly.
         std::env::set_current_dir(&package_path)
             .map_err(|err| crate::errors::failed_to_set_cwd(package_path.display(), err))?;
 
-        let full_path = Package::initialize(&self.name, &package_path, self.library)?;
+        if self.workspace {
+            let full_path = Workspace::initialize_skeleton(&self.name, &package_path)?;
+            println!("Created workspace {} at `{}`.", self.name.bold(), full_path.display());
+        } else {
+            let full_path = Package::initialize(&self.name, &package_path, self.library)?;
+            println!("Created program {} at `{}`.", self.name.bold(), full_path.display());
 
-        println!("Created program {} at `{}`.", self.name.bold(), full_path.display());
+            if Workspace::auto_register_member(&full_path)? {
+                println!("Added {} to the enclosing workspace.", self.name.bold());
+            }
+        }
 
         Ok(())
     }

--- a/crates/leo/tests/integration.rs
+++ b/crates/leo/tests/integration.rs
@@ -201,7 +201,8 @@ fn run_test(test: &Test, force_rewrite: bool, port: u16) -> Option<String> {
     fs::write(&stdout_path, filter_stdout(stdout_utf8).as_bytes()).expect("Failed to write STDOUT");
     let stderr_path = test_context_directory.path().join("STDERR");
     let stderr_utf8 = std::str::from_utf8(&output.stderr).expect("stderr should be utf8");
-    fs::write(&stderr_path, filter_stderr(stderr_utf8).as_bytes()).expect("Failed to write STDERR");
+    fs::write(&stderr_path, filter_stderr(stderr_utf8, test_context_directory.path()).as_bytes())
+        .expect("Failed to write STDERR");
 
     let exitcode_path = test_context_directory.path().join("EXITCODE");
     if let Some(code) = output.status.code() {
@@ -291,9 +292,14 @@ fn filter_stdout(data: &str) -> String {
 }
 
 /// Replace strings in the stderr of a Leo execution that we don't need to match exactly.
-fn filter_stderr(data: &str) -> String {
+fn filter_stderr(data: &str, temp_dir: &Path) -> String {
     use regex::Regex;
     use std::borrow::Cow;
+
+    // Rewrite the test's temp directory to a stable `TMPDIR` placeholder. The
+    // harness created this directory, so substitute its exact path rather than
+    // guessing the shape with a regex - `$TMPDIR` varies by environment.
+    let data = redact_temp_dir(data, temp_dir);
 
     let regexes = [
         // Strip ANSI color codes so downstream regexes match cleanly.
@@ -302,15 +308,6 @@ fn filter_stderr(data: &str) -> String {
         (Regex::new(r"-->\s+.*?/([^/]+\.leo:\d+:\d+)").unwrap(), "--> SOURCE_DIRECTORY/$1"),
         // Match ariadne's `╭─[ path:line:col ]` header, normalize the path portion.
         (Regex::new(r"╭─\[\s*.*?/([^/]+\.leo:\d+:\d+)\s*\]").unwrap(), "╭─[ SOURCE_DIRECTORY/$1 ]"),
-        // Normalize tempdir prefixes written by `tempfile::TempDir::new()` so expectations
-        // are stable across machines and OSes, regardless of surrounding quoting:
-        //   /tmp/.tmpXXX/contents/                         (Linux)
-        //   /private/var/folders/XX/XXXX/T/.tmpXXX/contents/ (macOS)
-        // → TMPDIR/contents/
-        (
-            Regex::new(r"(?:/tmp|/private/var/folders/[^/]+/[^/]+/T)/\.tmp[A-Za-z0-9]+/contents/").unwrap(),
-            "TMPDIR/contents/",
-        ),
         // Normalize dynamic devnode ports back to 3030 for stable expectations.
         (Regex::new(r"http://localhost:\d+").unwrap(), "http://localhost:3030"),
         // snarkVM prints parameter download warnings to stderr on fresh runners.
@@ -323,7 +320,7 @@ fn filter_stderr(data: &str) -> String {
         (Regex::new(r"⚠️  Network request failed, retrying in \d+s \(attempt \d+/\d+\)\.\.\.\n").unwrap(), ""),
     ];
 
-    let mut cow = Cow::Borrowed(data);
+    let mut cow = Cow::Borrowed(data.as_str());
     for (regex, replacement) in regexes {
         if let Cow::Owned(s) = regex.replace_all(&cow, replacement) {
             cow = Cow::Owned(s);
@@ -331,6 +328,23 @@ fn filter_stderr(data: &str) -> String {
     }
 
     cow.into_owned()
+}
+
+/// Rewrite every occurrence of the test's temporary directory in `data` to a
+/// stable `TMPDIR` placeholder, so expectations don't depend on where `$TMPDIR`
+/// points (it varies by environment - e.g. nix-shell uses `/tmp/nix-shell.XXX`).
+///
+/// Both the directory as created and its canonicalized form are rewritten: Leo
+/// canonicalizes paths before printing them, and the canonical form differs from
+/// the created path under a symlinked root (e.g. macOS, where `/var/folders/...`
+/// resolves to `/private/var/folders/...`). The canonical form is rewritten
+/// first since it can contain the created path as a substring.
+fn redact_temp_dir(data: &str, temp_dir: &Path) -> String {
+    let mut out = data.to_owned();
+    if let Ok(canonical) = temp_dir.canonicalize() {
+        out = out.replace(&*canonical.to_string_lossy(), "TMPDIR");
+    }
+    out.replace(&*temp_dir.to_string_lossy(), "TMPDIR")
 }
 
 /// Filter dynamic values in JSON output files to allow comparison across runs.

--- a/crates/package/Cargo.toml
+++ b/crates/package/Cargo.toml
@@ -23,6 +23,7 @@ leo-ast     = { workspace = true }
 leo-errors  = { workspace = true }
 leo-span    = { workspace = true }
 # third party dependencies
+glob        = { workspace = true }
 indexmap    = { workspace = true }
 serde       = { workspace = true }
 serde_json  = { workspace = true }

--- a/crates/package/src/errors.rs
+++ b/crates/package/src/errors.rs
@@ -188,6 +188,16 @@ pub(crate) fn workspace_member_not_found(member: impl Display, workspace_root: i
     .with_help("Ensure the member directory exists and contains a `program.json` manifest.")
 }
 
+/// For when a workspace member entry resolves to a path outside the workspace root.
+pub(crate) fn workspace_member_outside_root(member: impl Display, workspace_root: impl Display) -> Backtraced {
+    Backtraced::error(
+        CODE_PREFIX,
+        CODE_MASK + 70,
+        format!("workspace member `{member}` resolves to a path outside the workspace root `{workspace_root}`"),
+    )
+    .with_help("Workspace members must live inside the workspace root. Remove `..` components from the member entry.")
+}
+
 /// For when workspace.json cannot be read or parsed.
 pub(crate) fn workspace_manifest_error(path: impl Display, error: impl Display) -> Backtraced {
     Backtraced::error(CODE_PREFIX, CODE_MASK + 72, format!("failed to read workspace manifest at `{path}`: {error}"))

--- a/crates/package/src/errors.rs
+++ b/crates/package/src/errors.rs
@@ -195,7 +195,7 @@ pub(crate) fn workspace_member_outside_root(member: impl Display, workspace_root
         CODE_MASK + 70,
         format!("workspace member `{member}` resolves to a path outside the workspace root `{workspace_root}`"),
     )
-    .with_help("Workspace members must live inside the workspace root. Remove `..` components from the member entry.")
+    .with_help("Ensure the member entry resolves to a directory inside the workspace root; remove any `..` components.")
 }
 
 /// For when workspace.json cannot be read or parsed.

--- a/crates/package/src/workspace.rs
+++ b/crates/package/src/workspace.rs
@@ -186,13 +186,15 @@ impl Workspace {
         };
         let entry = relative_str.replace('\\', "/");
 
-        if pattern_matches_relative(&ws.manifest.members, &entry) {
+        // Re-read from disk in case the manifest was modified between discover and write,
+        // and check coverage against those fresh entries rather than the stale snapshot.
+        let manifest_path = ws.root_directory.join(WORKSPACE_MANIFEST_FILENAME);
+        let mut manifest = WorkspaceManifest::read_from_file(&manifest_path)?;
+
+        if pattern_matches_relative(&manifest.members, &entry) {
             return Ok(false);
         }
 
-        // Re-read from disk in case the manifest was modified between discover and write.
-        let manifest_path = ws.root_directory.join(WORKSPACE_MANIFEST_FILENAME);
-        let mut manifest = WorkspaceManifest::read_from_file(&manifest_path)?;
         manifest.members.push(entry);
         manifest.write_to_file(&manifest_path)?;
         Ok(true)
@@ -274,9 +276,12 @@ fn expand_member_pattern(root: &Path, pattern: &str) -> Result<Vec<String>> {
 /// Check whether any of `patterns` matches `relative` either as a literal
 /// entry or as a glob pattern.
 fn pattern_matches_relative(patterns: &[String], relative: &str) -> bool {
+    // Match with `require_literal_separator` so `*`/`?`/`[]` stop at `/`, mirroring
+    // how `glob::glob` enumerates the filesystem (and leaving `**` free to cross).
+    let options = glob::MatchOptions { require_literal_separator: true, ..Default::default() };
     patterns.iter().any(|p| {
         if is_glob_pattern(p) {
-            glob::Pattern::new(p).map(|pat| pat.matches(relative)).unwrap_or(false)
+            glob::Pattern::new(p).map(|pat| pat.matches_with(relative, options)).unwrap_or(false)
         } else {
             p == relative
         }
@@ -296,6 +301,11 @@ fn load_member_record(root: &Path, entry: &str) -> Result<(PathBuf, String)> {
     }
     let member_manifest = Manifest::read_from_file(&member_manifest_path)?;
     let canonical = member_dir.canonicalize().map_err(|e| errors::workspace_manifest_error(member_dir.display(), e))?;
+    // `root` is the canonicalized workspace root; reject members (e.g. `../sibling`)
+    // that resolve outside it.
+    if canonical.strip_prefix(root).is_err() {
+        return Err(errors::workspace_member_outside_root(entry, root.display()).into());
+    }
     Ok((canonical, member_manifest.program.clone()))
 }
 
@@ -771,6 +781,44 @@ mod tests {
     }
 
     #[test]
+    fn auto_register_registers_glob_subdir() {
+        let dir = temp_dir().join("ws_test_auto_register_glob_subdir");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("packages/sub")).unwrap();
+
+        create_workspace(&dir, &["packages/*"]);
+        create_member(&dir.join("packages/sub"), "foo", &[]);
+        let foo_dir = dir.join("packages/sub/foo");
+
+        let registered = Workspace::auto_register_member(&foo_dir).unwrap();
+        assert!(registered, "`packages/*` does not cover a nested package, so it should be registered");
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        assert_eq!(manifest.members, vec!["packages/*".to_string(), "packages/sub/foo".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn auto_register_skips_when_recursive_glob_matches() {
+        let dir = temp_dir().join("ws_test_auto_register_glob_recursive");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("packages/sub")).unwrap();
+
+        create_workspace(&dir, &["packages/**"]);
+        create_member(&dir.join("packages/sub"), "foo", &[]);
+        let foo_dir = dir.join("packages/sub/foo");
+
+        let registered = Workspace::auto_register_member(&foo_dir).unwrap();
+        assert!(!registered, "`packages/**` crosses `/` and covers nested packages, so it should be skipped");
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        assert_eq!(manifest.members, vec!["packages/**".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
     fn initialize_skeleton_creates_workspace_json() {
         let dir = temp_dir().join("ws_test_init_skeleton_basic");
         let _ = std::fs::remove_dir_all(&dir);
@@ -955,6 +1003,25 @@ mod tests {
         assert!(result.is_err(), "malformed glob pattern should produce a structured error");
 
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_member_outside_root_errors() {
+        let parent = temp_dir().join("ws_test_member_outside_root");
+        let _ = std::fs::remove_dir_all(&parent);
+        std::fs::create_dir_all(&parent).unwrap();
+
+        // A package that lives next to the workspace, not inside it.
+        create_member(&parent, "sibling", &[]);
+
+        let ws_dir = parent.join("ws");
+        std::fs::create_dir_all(&ws_dir).unwrap();
+        create_workspace(&ws_dir, &["../sibling"]);
+
+        let result = Workspace::from_directory(&ws_dir);
+        assert!(result.is_err(), "a member resolving outside the workspace root should be rejected");
+
+        std::fs::remove_dir_all(&parent).unwrap();
     }
 
     #[test]

--- a/crates/package/src/workspace.rs
+++ b/crates/package/src/workspace.rs
@@ -50,8 +50,6 @@ impl WorkspaceManifest {
 pub struct Workspace {
     /// The canonicalized root directory containing `workspace.json`.
     pub root_directory: PathBuf,
-    /// The workspace manifest.
-    pub manifest: WorkspaceManifest,
     /// Member directories in dependency order, each an absolute path.
     pub member_paths: Vec<PathBuf>,
     /// Member program names (from each member's `program.json`), in the same order.
@@ -107,23 +105,17 @@ impl Workspace {
         let member_paths = ordered.iter().map(|(p, _)| p.clone()).collect();
         let member_names = ordered.into_iter().map(|(_, n)| n).collect();
 
-        Ok(Some(Workspace { root_directory, manifest, member_paths, member_names }))
+        Ok(Some(Workspace { root_directory, member_paths, member_names }))
     }
 
-    /// Walk up from `start_dir` looking for `workspace.json`.
+    /// Walk up from `start_dir` looking for `workspace.json`, returning the
+    /// fully resolved workspace.
     ///
     /// Returns `Ok(None)` if no workspace root is found.
     pub fn discover(start_dir: &Path) -> Result<Option<Self>> {
-        let start = start_dir.canonicalize().map_err(|e| errors::workspace_manifest_error(start_dir.display(), e))?;
-        let mut dir = start.as_path();
-        loop {
-            if let Some(ws) = Self::from_directory(dir)? {
-                return Ok(Some(ws));
-            }
-            match dir.parent() {
-                Some(parent) => dir = parent,
-                None => return Ok(None),
-            }
+        match discover_root(start_dir)? {
+            Some(root) => Self::from_directory(&root),
+            None => Ok(None),
         }
     }
 
@@ -165,17 +157,20 @@ impl Workspace {
         let Some(parent) = canonical_member.parent() else {
             return Ok(false);
         };
-        let Some(ws) = Self::discover(parent)? else {
+        // Only the workspace root is needed here, so locate it without resolving
+        // members; that keeps `leo new` from failing when an unrelated existing
+        // member is broken.
+        let Some(root_directory) = discover_root(parent)? else {
             return Ok(false);
         };
 
-        let relative = match canonical_member.strip_prefix(&ws.root_directory) {
+        let relative = match canonical_member.strip_prefix(&root_directory) {
             Ok(rel) => rel,
             Err(_) => {
                 tracing::warn!(
                     "new package at `{}` is not inside the discovered workspace root `{}`; skipping auto-add",
                     canonical_member.display(),
-                    ws.root_directory.display(),
+                    root_directory.display(),
                 );
                 return Ok(false);
             }
@@ -188,7 +183,7 @@ impl Workspace {
 
         // Re-read from disk in case the manifest was modified between discover and write,
         // and check coverage against those fresh entries rather than the stale snapshot.
-        let manifest_path = ws.root_directory.join(WORKSPACE_MANIFEST_FILENAME);
+        let manifest_path = root_directory.join(WORKSPACE_MANIFEST_FILENAME);
         let mut manifest = WorkspaceManifest::read_from_file(&manifest_path)?;
 
         if pattern_matches_relative(&manifest.members, &entry) {
@@ -224,6 +219,24 @@ impl Workspace {
         manifest.write_to_file(full_path.join(WORKSPACE_MANIFEST_FILENAME))?;
 
         Ok(full_path)
+    }
+}
+
+/// Walk up from `start_dir` to find the directory containing `workspace.json`.
+///
+/// Returns the canonicalized workspace root, or `Ok(None)` if none is found.
+/// Unlike [`Workspace::discover`], this does not resolve or validate members.
+fn discover_root(start_dir: &Path) -> Result<Option<PathBuf>> {
+    let start = start_dir.canonicalize().map_err(|e| errors::workspace_manifest_error(start_dir.display(), e))?;
+    let mut dir = start.as_path();
+    loop {
+        if dir.join(WORKSPACE_MANIFEST_FILENAME).exists() {
+            return Ok(Some(dir.to_path_buf()));
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => return Ok(None),
+        }
     }
 }
 
@@ -781,6 +794,30 @@ mod tests {
     }
 
     #[test]
+    fn auto_register_succeeds_despite_broken_member() {
+        // A new package must register even when a sibling member listed in
+        // `workspace.json` is broken: auto-registration only needs the workspace
+        // root, not a fully resolved member list.
+        let dir = temp_dir().join("ws_test_auto_register_broken_member");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        // `ghost` is listed but never created - resolving the workspace would fail.
+        create_workspace(&dir, &["alpha", "ghost"]);
+
+        create_member(&dir, "beta", &[]);
+        let beta_dir = dir.join("beta");
+        let registered = Workspace::auto_register_member(&beta_dir).unwrap();
+        assert!(registered, "a new package should register despite a broken sibling member");
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        assert_eq!(manifest.members, vec!["alpha".to_string(), "ghost".to_string(), "beta".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
     fn auto_register_registers_glob_subdir() {
         let dir = temp_dir().join("ws_test_auto_register_glob_subdir");
         let _ = std::fs::remove_dir_all(&dir);
@@ -1020,6 +1057,8 @@ mod tests {
 
         let result = Workspace::from_directory(&ws_dir);
         assert!(result.is_err(), "a member resolving outside the workspace root should be rejected");
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("outside the workspace root"), "error should be the outside-root error: {err_msg}");
 
         std::fs::remove_dir_all(&parent).unwrap();
     }

--- a/crates/package/src/workspace.rs
+++ b/crates/package/src/workspace.rs
@@ -74,21 +74,31 @@ impl Workspace {
 
         let manifest = WorkspaceManifest::read_from_file(&manifest_path)?;
 
-        // Resolve and validate each member.
+        // Resolve and validate each member entry, expanding glob patterns relative to the root.
         let mut dir_to_name: Vec<(PathBuf, String)> = Vec::with_capacity(manifest.members.len());
+        let mut seen: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
         for member in &manifest.members {
-            let member_dir = root_directory.join(member);
-            if !member_dir.is_dir() {
-                return Err(errors::workspace_member_not_found(member, root_directory.display()).into());
+            if is_glob_pattern(member) {
+                let expanded = expand_member_pattern(&root_directory, member)?;
+                if expanded.is_empty() {
+                    tracing::warn!(
+                        "workspace member glob `{member}` in {} matched no packages",
+                        root_directory.display(),
+                    );
+                    continue;
+                }
+                for entry in expanded {
+                    let record = load_member_record(&root_directory, &entry)?;
+                    if seen.insert(record.0.clone()) {
+                        dir_to_name.push(record);
+                    }
+                }
+            } else {
+                let record = load_member_record(&root_directory, member)?;
+                if seen.insert(record.0.clone()) {
+                    dir_to_name.push(record);
+                }
             }
-            let member_manifest_path = member_dir.join(MANIFEST_FILENAME);
-            if !member_manifest_path.exists() {
-                return Err(errors::workspace_member_not_found(member, root_directory.display()).into());
-            }
-            let member_manifest = Manifest::read_from_file(&member_manifest_path)?;
-            let canonical =
-                member_dir.canonicalize().map_err(|e| errors::workspace_manifest_error(member_dir.display(), e))?;
-            dir_to_name.push((canonical, member_manifest.program.clone()));
         }
 
         // Build a dependency graph to determine the correct build order.
@@ -142,6 +152,77 @@ impl Workspace {
         };
         self.member_paths.iter().any(|p| p == &canonical)
     }
+
+    /// If a workspace contains `member_dir`, append `member_dir` to its
+    /// `workspace.json` (unless already covered by a literal entry or a glob).
+    ///
+    /// Returns `Ok(true)` if the workspace manifest was modified. Returns
+    /// `Ok(false)` if there is no enclosing workspace, `member_dir` is outside
+    /// the workspace root, or the path is already covered.
+    pub fn auto_register_member(member_dir: &Path) -> Result<bool> {
+        let canonical_member = member_dir.canonicalize().map_err(|e| errors::failed_path(member_dir.display(), e))?;
+
+        let Some(parent) = canonical_member.parent() else {
+            return Ok(false);
+        };
+        let Some(ws) = Self::discover(parent)? else {
+            return Ok(false);
+        };
+
+        let relative = match canonical_member.strip_prefix(&ws.root_directory) {
+            Ok(rel) => rel,
+            Err(_) => {
+                tracing::warn!(
+                    "new package at `{}` is not inside the discovered workspace root `{}`; skipping auto-add",
+                    canonical_member.display(),
+                    ws.root_directory.display(),
+                );
+                return Ok(false);
+            }
+        };
+        let Some(relative_str) = relative.to_str() else {
+            tracing::warn!("new package path `{}` is not valid UTF-8; skipping auto-add", canonical_member.display(),);
+            return Ok(false);
+        };
+        let entry = relative_str.replace('\\', "/");
+
+        if pattern_matches_relative(&ws.manifest.members, &entry) {
+            return Ok(false);
+        }
+
+        // Re-read from disk in case the manifest was modified between discover and write.
+        let manifest_path = ws.root_directory.join(WORKSPACE_MANIFEST_FILENAME);
+        let mut manifest = WorkspaceManifest::read_from_file(&manifest_path)?;
+        manifest.members.push(entry);
+        manifest.write_to_file(&manifest_path)?;
+        Ok(true)
+    }
+
+    /// Create a fresh workspace skeleton named `name` inside `parent`.
+    ///
+    /// Writes a `workspace.json` with an empty `members` array. The caller is
+    /// responsible for ensuring `parent` exists.
+    ///
+    /// Returns the absolute path of the new workspace directory.
+    pub fn initialize_skeleton(name: &str, parent: &Path) -> Result<PathBuf> {
+        if !crate::is_valid_library_name(name) {
+            return Err(errors::cli_invalid_package_name("workspace", name).into());
+        }
+
+        let parent = parent.canonicalize().map_err(|e| errors::failed_path(parent.display(), e))?;
+        let full_path = parent.join(name);
+
+        if full_path.exists() {
+            return Err(errors::failed_to_initialize_package(name, &full_path, "Directory already exists").into());
+        }
+
+        std::fs::create_dir(&full_path).map_err(|e| errors::failed_to_initialize_package(name, &full_path, e))?;
+
+        let manifest = WorkspaceManifest { members: Vec::new() };
+        manifest.write_to_file(full_path.join(WORKSPACE_MANIFEST_FILENAME))?;
+
+        Ok(full_path)
+    }
 }
 
 /// Resolve a `Location::Workspace` dependency by looking up its name in the
@@ -156,6 +237,66 @@ pub fn resolve_workspace_dependency(package_dir: &Path, dep: Dependency) -> Resu
         .find_member(&dep.name)
         .ok_or_else(|| errors::workspace_dep_member_not_found(&dep.name, workspace.root_directory.display()))?;
     Ok(Dependency { location: Location::Local, path: Some(member_path.clone()), ..dep })
+}
+
+/// Returns `true` if `s` contains any glob metacharacters (`*`, `?`, `[`).
+fn is_glob_pattern(s: &str) -> bool {
+    s.contains(['*', '?', '['])
+}
+
+/// Expand a glob pattern relative to `root` into a list of member directory
+/// entries, each a forward-slash path relative to `root`.
+///
+/// Only directories containing a `program.json` are returned. Other matches
+/// (files, directories without a manifest, non-UTF8 paths) are silently skipped.
+fn expand_member_pattern(root: &Path, pattern: &str) -> Result<Vec<String>> {
+    let absolute_pattern = root.join(pattern);
+    let pattern_str = absolute_pattern.to_string_lossy();
+    let entries = glob::glob(&pattern_str).map_err(|e| errors::workspace_manifest_error(pattern, e))?;
+
+    let mut out = Vec::new();
+    for entry in entries {
+        let Ok(path) = entry else { continue };
+        if !path.is_dir() {
+            continue;
+        }
+        if !path.join(MANIFEST_FILENAME).exists() {
+            continue;
+        }
+        let Ok(relative) = path.strip_prefix(root) else { continue };
+        let Some(relative_str) = relative.to_str() else { continue };
+        // Normalize to forward slashes so the entry round-trips cleanly on Windows.
+        out.push(relative_str.replace('\\', "/"));
+    }
+    Ok(out)
+}
+
+/// Check whether any of `patterns` matches `relative` either as a literal
+/// entry or as a glob pattern.
+fn pattern_matches_relative(patterns: &[String], relative: &str) -> bool {
+    patterns.iter().any(|p| {
+        if is_glob_pattern(p) {
+            glob::Pattern::new(p).map(|pat| pat.matches(relative)).unwrap_or(false)
+        } else {
+            p == relative
+        }
+    })
+}
+
+/// Load a single member's `(canonical_path, program_name)` pair, erroring if
+/// the directory or its `program.json` is missing.
+fn load_member_record(root: &Path, entry: &str) -> Result<(PathBuf, String)> {
+    let member_dir = root.join(entry);
+    if !member_dir.is_dir() {
+        return Err(errors::workspace_member_not_found(entry, root.display()).into());
+    }
+    let member_manifest_path = member_dir.join(MANIFEST_FILENAME);
+    if !member_manifest_path.exists() {
+        return Err(errors::workspace_member_not_found(entry, root.display()).into());
+    }
+    let member_manifest = Manifest::read_from_file(&member_manifest_path)?;
+    let canonical = member_dir.canonicalize().map_err(|e| errors::workspace_manifest_error(member_dir.display(), e))?;
+    Ok((canonical, member_manifest.program.clone()))
 }
 
 /// Determine the build order for workspace members by analysing cross-member
@@ -530,6 +671,288 @@ mod tests {
         };
         let result = resolve_workspace_dependency(&dir.join("alpha"), dep);
         assert!(result.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn auto_register_appends_new_member() {
+        let dir = temp_dir().join("ws_test_auto_register_basic");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        create_workspace(&dir, &["alpha"]);
+
+        create_member(&dir, "beta", &[]);
+        let beta_dir = dir.join("beta");
+        let registered = Workspace::auto_register_member(&beta_dir).unwrap();
+        assert!(registered);
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        assert_eq!(manifest.members, vec!["alpha".to_string(), "beta".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn auto_register_skips_when_glob_matches() {
+        let dir = temp_dir().join("ws_test_auto_register_glob");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("packages")).unwrap();
+
+        create_workspace(&dir, &["packages/*"]);
+        create_member(&dir.join("packages"), "foo", &[]);
+        let foo_dir = dir.join("packages/foo");
+
+        let registered = Workspace::auto_register_member(&foo_dir).unwrap();
+        assert!(!registered, "should skip when a glob already covers the new member");
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        assert_eq!(manifest.members, vec!["packages/*".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn auto_register_skips_when_already_listed() {
+        let dir = temp_dir().join("ws_test_auto_register_dup");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "foo", &[]);
+        create_workspace(&dir, &["foo"]);
+        let foo_dir = dir.join("foo");
+
+        let registered = Workspace::auto_register_member(&foo_dir).unwrap();
+        assert!(!registered);
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        assert_eq!(manifest.members, vec!["foo".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn auto_register_skips_outside_workspace() {
+        let dir = temp_dir().join("ws_test_auto_register_outside");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // No workspace.json - the member directory has no enclosing workspace.
+        create_member(&dir, "foo", &[]);
+        let foo_dir = dir.join("foo");
+
+        let registered = Workspace::auto_register_member(&foo_dir).unwrap();
+        assert!(!registered, "auto-register should be a no-op when no workspace exists");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn auto_register_preserves_existing_order() {
+        let dir = temp_dir().join("ws_test_auto_register_order");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_member(&dir, "alpha", &[]);
+        create_member(&dir, "charlie", &[]);
+        create_workspace(&dir, &["alpha", "charlie"]);
+
+        create_member(&dir, "beta", &[]);
+        let beta_dir = dir.join("beta");
+        Workspace::auto_register_member(&beta_dir).unwrap();
+
+        let manifest = WorkspaceManifest::read_from_file(dir.join(WORKSPACE_MANIFEST_FILENAME)).unwrap();
+        // New entry appended at the end; existing order preserved.
+        assert_eq!(manifest.members, vec!["alpha".to_string(), "charlie".to_string(), "beta".to_string()]);
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn initialize_skeleton_creates_workspace_json() {
+        let dir = temp_dir().join("ws_test_init_skeleton_basic");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let full_path = Workspace::initialize_skeleton("my_workspace", &dir).unwrap();
+        assert!(full_path.is_dir());
+        assert_eq!(full_path.file_name().and_then(|n| n.to_str()), Some("my_workspace"));
+
+        let manifest_path = full_path.join(WORKSPACE_MANIFEST_FILENAME);
+        assert!(manifest_path.exists());
+        let manifest = WorkspaceManifest::read_from_file(&manifest_path).unwrap();
+        assert!(manifest.members.is_empty());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn initialize_skeleton_rejects_existing_dir() {
+        let dir = temp_dir().join("ws_test_init_skeleton_existing");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("my_workspace")).unwrap();
+
+        let result = Workspace::initialize_skeleton("my_workspace", &dir);
+        assert!(result.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn initialize_skeleton_rejects_invalid_name() {
+        let dir = temp_dir().join("ws_test_init_skeleton_invalid_name");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Underscore-prefixed names are rejected by `is_valid_package_name`.
+        let result = Workspace::initialize_skeleton("_oops", &dir);
+        assert!(result.is_err());
+        // Empty names are rejected.
+        let result = Workspace::initialize_skeleton("", &dir);
+        assert!(result.is_err());
+        // Names containing "aleo" are rejected.
+        let result = Workspace::initialize_skeleton("my_aleo_ws", &dir);
+        assert!(result.is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_member_basic() {
+        let dir = temp_dir().join("ws_test_glob_basic");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("programs")).unwrap();
+
+        let programs = dir.join("programs");
+        create_member(&programs, "alpha", &[]);
+        create_member(&programs, "beta", &[]);
+        create_workspace(&dir, &["programs/*"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        assert_eq!(ws.member_paths.len(), 2);
+        let names: Vec<&str> = ws.member_names.iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"alpha.aleo"));
+        assert!(names.contains(&"beta.aleo"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_member_recursive() {
+        let dir = temp_dir().join("ws_test_glob_recursive");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("programs/sub")).unwrap();
+
+        create_member(&dir.join("programs"), "alpha", &[]);
+        create_member(&dir.join("programs/sub"), "beta", &[]);
+        create_workspace(&dir, &["programs/**"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        let names: Vec<&str> = ws.member_names.iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"alpha.aleo"));
+        assert!(names.contains(&"beta.aleo"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_member_no_match() {
+        let dir = temp_dir().join("ws_test_glob_no_match");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_workspace(&dir, &["programs/*"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        assert!(ws.member_paths.is_empty());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_member_mixed() {
+        let dir = temp_dir().join("ws_test_glob_mixed");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("programs")).unwrap();
+
+        create_member(&dir, "literal_one", &[]);
+        create_member(&dir.join("programs"), "globbed", &[]);
+        create_workspace(&dir, &["literal_one", "programs/*"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        let names: Vec<&str> = ws.member_names.iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"literal_one.aleo"));
+        assert!(names.contains(&"globbed.aleo"));
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_skips_non_packages() {
+        let dir = temp_dir().join("ws_test_glob_skip_non_pkg");
+        let _ = std::fs::remove_dir_all(&dir);
+        let programs = dir.join("programs");
+        std::fs::create_dir_all(programs.join("junk")).unwrap();
+
+        create_member(&programs, "real", &[]);
+        std::fs::write(programs.join("notes.txt"), "scratch").unwrap();
+
+        create_workspace(&dir, &["programs/*"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        assert_eq!(ws.member_paths.len(), 1);
+        assert_eq!(ws.member_names[0], "real.aleo");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_dep_ordering() {
+        let dir = temp_dir().join("ws_test_glob_dep_order");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("programs")).unwrap();
+
+        let programs = dir.join("programs");
+        create_member(&programs, "alpha", &[]);
+        create_member_with_workspace_deps(&programs, "beta", &["alpha"]);
+        create_workspace(&dir, &["programs/*"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        let names: Vec<&str> = ws.member_names.iter().map(|s| s.as_str()).collect();
+        let alpha_pos = names.iter().position(|n| *n == "alpha.aleo").unwrap();
+        let beta_pos = names.iter().position(|n| *n == "beta.aleo").unwrap();
+        assert!(alpha_pos < beta_pos, "alpha should be ordered before beta even when discovered via glob");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_dedup() {
+        let dir = temp_dir().join("ws_test_glob_dedup");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("programs")).unwrap();
+
+        create_member(&dir.join("programs"), "alpha", &[]);
+        create_workspace(&dir, &["programs/alpha", "programs/*"]);
+
+        let ws = Workspace::from_directory(&dir).unwrap().unwrap();
+        assert_eq!(ws.member_paths.len(), 1, "duplicate member from literal + glob should be deduplicated");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn workspace_glob_invalid_pattern() {
+        let dir = temp_dir().join("ws_test_glob_invalid");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        create_workspace(&dir, &["[invalid"]);
+
+        let result = Workspace::from_directory(&dir);
+        assert!(result.is_err(), "malformed glob pattern should produce a structured error");
 
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/documentation/cli/10_new.md
+++ b/documentation/cli/10_new.md
@@ -25,8 +25,14 @@ This command will create a new directory with the given name.
 
 See [Project Layout](./../language/01_layout.md) for more details.
 
+When `leo new <NAME>` is run from inside a [workspace](../guides/03_workspaces.md), the new package is appended to the enclosing `workspace.json` automatically. See [Adding Members](../guides/03_workspaces.md#adding-members) for the exact behavior.
+
 ## Flags
 
 ### `--library`
 
 Creates a new Leo library instead of a program. A library provides reusable logic that can be imported by other Leo programs or libraries using `leo add --local`, but cannot be deployed or executed on its own. The generated project includes a `tests/` directory with a starter test file.
+
+### `--workspace`
+
+Creates a workspace skeleton instead of a package. The generated directory contains only a `workspace.json` with an empty `members` array; populate it by listing member paths or globs, or by running `leo new` from within the workspace (see [Workspaces](../guides/03_workspaces.md)). Conflicts with `--library`.

--- a/documentation/guides/03_workspaces.md
+++ b/documentation/guides/03_workspaces.md
@@ -12,7 +12,15 @@ Workspaces are useful when your application is made up of several interacting pr
 
 ## Creating a Workspace
 
-Create a `workspace.json` file in your project root. It contains a `members` array listing the relative paths to each member package:
+The quickest way to start a workspace is to scaffold one with `leo new`:
+
+```bash
+leo new --workspace my_project
+```
+
+This creates `my_project/` containing a `workspace.json` with an empty `members` array. The `--workspace` flag is mutually exclusive with `--library` - a workspace is just a root that groups packages, not a package itself, so it has no `src/`, `program.json`, or `tests/` directory.
+
+Equivalently, you can create `workspace.json` by hand in any directory. It contains a `members` array listing the relative paths to each member package:
 
 ```json
 {
@@ -21,6 +29,42 @@ Create a `workspace.json` file in your project root. It contains a `members` arr
 ```
 
 Each entry is a path to a directory containing a standard Leo package with its own `program.json` and `src/main.leo`.
+
+### Glob Members
+
+Entries in `members` can also be glob patterns, resolved relative to the workspace root:
+
+```json
+{
+  "members": ["libraries/core", "programs/*"]
+}
+```
+
+Standard `glob` syntax is supported, including `*` (matches a single path segment), `**` (matches recursively across directories), `?`, and character classes like `[abc]`. A glob match is included only if the matched directory contains a `program.json`; other matches (files, directories without a manifest, non-UTF-8 paths) are silently skipped.
+
+A glob that matches zero packages logs a warning and continues - it is not an error:
+
+```text
+workspace member glob `programs/*` in <root> matched no packages
+```
+
+A literal entry pointing at a missing directory still errors, so explicit paths remain strictly validated. Literal entries are resolved before globs and members are deduplicated by canonical path, so a directory matched by both a literal entry and a glob is only included once.
+
+### Adding Members
+
+When `leo new <name>` is run anywhere inside a workspace, the new package's path is appended to the enclosing `workspace.json` automatically and Leo prints:
+
+```text
+Added <name> to the enclosing workspace.
+```
+
+The append is skipped silently if the new package is already covered by an existing entry - either a literal path equal to the new package's relative path, or a glob that matches it. If the new package ends up outside the discovered workspace root (for example, `leo new ../sibling`), Leo prints a warning and leaves `workspace.json` untouched:
+
+```text
+new package at `...` is not inside the discovered workspace root `...`; skipping auto-add
+```
+
+Existing `members` order is preserved; new entries are appended at the end. If you would rather not edit `members` by hand at all, use a glob entry such as `programs/*` (see [Glob Members](#glob-members)) - new packages created inside that directory are picked up without modifying `workspace.json`.
 
 ## Directory Structure
 


### PR DESCRIPTION
Three ergonomics improvements for `workspace.json`-driven projects:

- Glob members: entries in `workspace.json` can now be glob patterns (e.g. `programs/*`, `programs/**`) that expand to all directories containing a `program.json`. Non-package matches are silently skipped; literal entries still error on missing dirs; zero-match globs warn and continue.
- `leo new --workspace`: scaffolds a fresh workspace skeleton - `<name>/workspace.json` with an empty `members` array. Conflicts with `--library` at the clap level.
- Auto-add member: `leo new <name>` from within a workspace appends the new package to `workspace.json` unless the path is already covered by a literal entry or a glob. Outside-tree creations warn and skip.

Adds `glob = "0.3"` to workspace deps, `Workspace::initialize_skeleton` and `Workspace::auto_register_member` to `leo-package`, plus 16 new workspace unit tests and 4 new CLI e2e tests.

The shared workspace-level build directory sub-feature is deferred to a follow-up PR.

Part of #29140 