### PR TITLE
fix(typeck): reject non-path receivers for Vector/Mapping storage ops

### DIFF
--- a/crates/passes/src/errors/type_checker.rs
+++ b/crates/passes/src/errors/type_checker.rs
@@ -1063,6 +1063,21 @@ pub(crate) fn multi_identifier_definition_requires_tuple(type_: impl Display, sp
     .with_help("Use a tuple expression, e.g. `let (a, b) = (x, y);`.")
 }
 
+pub(crate) fn storage_op_requires_path_receiver(
+    module: impl Display,
+    operation: impl Display,
+    kind: impl Display,
+    span: Span,
+) -> Formatted {
+    Formatted::error(
+        CODE_PREFIX,
+        CODE_MASK + 191,
+        format!("the receiver of `{module}::{operation}` must be a {kind}"),
+        span,
+    )
+    .with_help(format!("Call `{operation}` directly on a declared {kind}, not on a temporary expression."))
+}
+
 // TypeCheckerWarning builder functions
 
 pub(crate) fn caller_as_record_owner(record_name: impl Display, span: Span) -> Formatted {

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -84,6 +84,23 @@ impl TypeCheckingVisitor<'_> {
         self.state.handler.emit_err(err);
     }
 
+    /// Returns `true` if `expr` is a path receiver; otherwise emits a diagnostic and returns `false`.
+    /// Storage `Vector::*` and `Mapping::*` operations require a path receiver because downstream
+    /// passes look up the backing mappings by name (storage_lowering for vectors, codegen for
+    /// mappings).
+    fn check_path_receiver(&self, module: &str, operation: &str, kind: &str, expr: &Expression) -> bool {
+        if matches!(expr, Expression::Path(_)) {
+            return true;
+        }
+        self.emit_err(crate::errors::type_checker::storage_op_requires_path_receiver(
+            module,
+            operation,
+            kind,
+            expr.span(),
+        ));
+        false
+    }
+
     /// Emits an error if the two given types are not equal.
     pub fn check_eq_types(&self, t1: &Option<Type>, t2: &Option<Type>, span: Span) {
         match (t1, t2) {
@@ -966,6 +983,10 @@ impl TypeCheckingVisitor<'_> {
                 // Check that the operation is invoked in a `finalize` or `async` block.
                 self.check_access_allowed("Mapping::get", true, function_span);
 
+                if !self.check_path_receiver("Mapping", "get", "mapping", map_expr) {
+                    return Type::Err;
+                }
+
                 *value.clone()
             }
             Intrinsic::MappingSet => {
@@ -978,6 +999,10 @@ impl TypeCheckingVisitor<'_> {
 
                 // Check that the operation is invoked in a `finalize` or `async` block.
                 self.check_access_allowed("Mapping::set", true, function_span);
+
+                if !self.check_path_receiver("Mapping", "set", "mapping", map_expr) {
+                    return Type::Err;
+                }
 
                 // Argument 0 must be a local path (cannot modify external mappings).
                 if !is_local_path(map_expr) {
@@ -1005,6 +1030,10 @@ impl TypeCheckingVisitor<'_> {
                     return Type::Err;
                 };
 
+                if !self.check_path_receiver("Mapping", "get_or_use", "mapping", map_expr) {
+                    return Type::Err;
+                }
+
                 value.deref().clone()
             }
             Intrinsic::MappingRemove => {
@@ -1020,6 +1049,10 @@ impl TypeCheckingVisitor<'_> {
                     // We already handled the error in the assertion.
                     return Type::Err;
                 };
+
+                if !self.check_path_receiver("Mapping", "remove", "mapping", map_expr) {
+                    return Type::Err;
+                }
 
                 // Argument 0 must be a local path (cannot modify external mappings).
                 if !is_local_path(map_expr) {
@@ -1046,6 +1079,10 @@ impl TypeCheckingVisitor<'_> {
                     // We already handled the error in the assertion.
                     return Type::Err;
                 };
+
+                if !self.check_path_receiver("Mapping", "contains", "mapping", map_expr) {
+                    return Type::Err;
+                }
 
                 Type::Boolean
             }
@@ -1082,6 +1119,10 @@ impl TypeCheckingVisitor<'_> {
                 // Check that the operation is invoked in a `finalize` or `async` block.
                 self.check_access_allowed("Vector::get", true, function_span);
 
+                if !self.check_path_receiver("Vector", "get", "storage vector", vec_expr) {
+                    return Type::Err;
+                }
+
                 Type::Optional(OptionalType { inner: Box::new(*element_type.clone()) })
             }
             Intrinsic::VectorSet => {
@@ -1094,6 +1135,10 @@ impl TypeCheckingVisitor<'_> {
 
                 // Check that the operation is invoked in a `finalize` or `async` block.
                 self.check_access_allowed("Vector::set", true, function_span);
+
+                if !self.check_path_receiver("Vector", "set", "storage vector", vec_expr) {
+                    return Type::Err;
+                }
 
                 // Argument 0 must be a local path (cannot modify external vectors).
                 if !is_local_path(vec_expr) {
@@ -1123,6 +1168,10 @@ impl TypeCheckingVisitor<'_> {
                 // Check that the operation is invoked in a `finalize` or `async` block.
                 self.check_access_allowed("Vector::push", true, function_span);
 
+                if !self.check_path_receiver("Vector", "push", "storage vector", vec_expr) {
+                    return Type::Err;
+                }
+
                 // Argument 0 must be a local path (cannot modify external vectors).
                 if !is_local_path(vec_expr) {
                     self.state.handler.emit_err(crate::errors::type_checker::cannot_modify_external_container(
@@ -1141,12 +1190,16 @@ impl TypeCheckingVisitor<'_> {
                 // Check that the operation is invoked in a `finalize` or `async` block.
                 self.check_access_allowed("Vector::len", true, function_span);
 
-                if vec_ty.is_vector() {
-                    Type::Integer(IntegerType::U32)
-                } else {
+                if !vec_ty.is_vector() {
                     self.assert_vector_type(vec_ty, vec_expr.span());
-                    Type::Err
+                    return Type::Err;
                 }
+
+                if !self.check_path_receiver("Vector", "len", "storage vector", vec_expr) {
+                    return Type::Err;
+                }
+
+                Type::Integer(IntegerType::U32)
             }
             Intrinsic::VectorPop => {
                 let (vec_ty, vec_expr) = &arguments[0];
@@ -1158,6 +1211,10 @@ impl TypeCheckingVisitor<'_> {
                     self.assert_vector_type(vec_ty, vec_expr.span());
                     return Type::Err;
                 };
+
+                if !self.check_path_receiver("Vector", "pop", "storage vector", vec_expr) {
+                    return Type::Err;
+                }
 
                 // Argument 0 must be a local path (cannot modify external vectors).
                 if !is_local_path(vec_expr) {
@@ -1182,6 +1239,10 @@ impl TypeCheckingVisitor<'_> {
                     return Type::Err;
                 };
 
+                if !self.check_path_receiver("Vector", "swap_remove", "storage vector", vec_expr) {
+                    return Type::Err;
+                }
+
                 // Argument 0 must be a local path (cannot modify external vectors).
                 if !is_local_path(vec_expr) {
                     self.state.handler.emit_err(crate::errors::type_checker::cannot_modify_external_container(
@@ -1199,6 +1260,10 @@ impl TypeCheckingVisitor<'_> {
 
                 if !vec_ty.is_vector() {
                     self.assert_vector_type(vec_ty, vec_expr.span());
+                    return Type::Err;
+                }
+
+                if !self.check_path_receiver("Vector", "clear", "storage vector", vec_expr) {
                     return Type::Err;
                 }
 

--- a/tests/expectations/compiler/storage/ternary_mapping_receiver_fail.out
+++ b/tests/expectations/compiler/storage/ternary_mapping_receiver_fail.out
@@ -1,0 +1,21 @@
+[ETYC0372191] Error: the receiver of `Mapping::get` must be a mapping
+    ╭─[ compiler-test:12:27 ]
+    │
+ 12 │             let v: u32 = (c ? m1 : m2).get(0u32); // ❌ non-path receiver
+    │ 
+    │ Help: Call `get` directly on a declared mapping, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Mapping::contains` must be a mapping
+    ╭─[ compiler-test:19:28 ]
+    │
+ 19 │             let b: bool = (c ? m1 : m2).contains(0u32); // ❌ non-path receiver
+    │ 
+    │ Help: Call `contains` directly on a declared mapping, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Mapping::get_or_use` must be a mapping
+    ╭─[ compiler-test:26:27 ]
+    │
+ 26 │             let v: u32 = (c ? m1 : m2).get_or_use(0u32, 0u32); // ❌ non-path receiver
+    │ 
+    │ Help: Call `get_or_use` directly on a declared mapping, not on a temporary expression.
+────╯

--- a/tests/expectations/compiler/storage/ternary_vector_receiver_fail.out
+++ b/tests/expectations/compiler/storage/ternary_vector_receiver_fail.out
@@ -1,0 +1,21 @@
+[ETYC0372191] Error: the receiver of `Vector::len` must be a storage vector
+    ╭─[ compiler-test:15:27 ]
+    │
+ 15 │             let n: u32 = (c ? h1 : h2).len(); // ❌ non-path receiver
+    │ 
+    │ Help: Call `len` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Vector::get` must be a storage vector
+    ╭─[ compiler-test:22:28 ]
+    │
+ 22 │             let v: u64? = (c ? h1 : h2).get(0u32); // ❌ non-path receiver
+    │ 
+    │ Help: Call `get` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Vector::len` must be a storage vector
+    ╭─[ compiler-test:29:39 ]
+    │
+ 29 │             let n: u32 = Vector::len((c ? h1 : h2)); // ❌ non-path receiver
+    │ 
+    │ Help: Call `len` directly on a declared storage vector, not on a temporary expression.
+────╯

--- a/tests/expectations/compiler/storage/ternary_write_receiver_fail.out
+++ b/tests/expectations/compiler/storage/ternary_write_receiver_fail.out
@@ -1,0 +1,49 @@
+[ETYC0372191] Error: the receiver of `Vector::set` must be a storage vector
+    ╭─[ compiler-test:15:25 ]
+    │
+ 15 │         return final { (c ? h1 : h2).set(0u32, 1u64); }; // ❌ non-path receiver
+    │ 
+    │ Help: Call `set` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Vector::push` must be a storage vector
+    ╭─[ compiler-test:19:25 ]
+    │
+ 19 │         return final { (c ? h1 : h2).push(1u64); }; // ❌ non-path receiver
+    │ 
+    │ Help: Call `push` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Vector::pop` must be a storage vector
+    ╭─[ compiler-test:24:28 ]
+    │
+ 24 │             let x: u64? = (c ? h1 : h2).pop(); // ❌ non-path receiver
+    │ 
+    │ Help: Call `pop` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Vector::swap_remove` must be a storage vector
+    ╭─[ compiler-test:31:27 ]
+    │
+ 31 │             let x: u64 = (c ? h1 : h2).swap_remove(0u32); // ❌ non-path receiver
+    │ 
+    │ Help: Call `swap_remove` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Vector::clear` must be a storage vector
+    ╭─[ compiler-test:37:25 ]
+    │
+ 37 │         return final { (c ? h1 : h2).clear(); }; // ❌ non-path receiver
+    │ 
+    │ Help: Call `clear` directly on a declared storage vector, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Mapping::set` must be a mapping
+    ╭─[ compiler-test:41:25 ]
+    │
+ 41 │         return final { (c ? m1 : m2).set(0u32, 1u32); }; // ❌ non-path receiver
+    │ 
+    │ Help: Call `set` directly on a declared mapping, not on a temporary expression.
+────╯
+[ETYC0372191] Error: the receiver of `Mapping::remove` must be a mapping
+    ╭─[ compiler-test:45:25 ]
+    │
+ 45 │         return final { (c ? m1 : m2).remove(0u32); }; // ❌ non-path receiver
+    │ 
+    │ Help: Call `remove` directly on a declared mapping, not on a temporary expression.
+────╯

--- a/tests/tests/compiler/storage/ternary_mapping_receiver_fail.leo
+++ b/tests/tests/compiler/storage/ternary_mapping_receiver_fail.leo
@@ -1,0 +1,30 @@
+// Companion to #29428: ensure non-path receivers for `Mapping::get` /
+// `Mapping::contains` / `Mapping::get_or_use` are also caught cleanly.
+program bugpoc_map.aleo {
+    @noupgrade
+    constructor() {}
+
+    mapping m1: u32 => u32;
+    mapping m2: u32 => u32;
+
+    fn method_get(c: bool) -> Final {
+        return final {
+            let v: u32 = (c ? m1 : m2).get(0u32); // ❌ non-path receiver
+            assert(v >= 0u32);
+        };
+    }
+
+    fn method_contains(c: bool) -> Final {
+        return final {
+            let b: bool = (c ? m1 : m2).contains(0u32); // ❌ non-path receiver
+            assert(b == b);
+        };
+    }
+
+    fn method_get_or_use(c: bool) -> Final {
+        return final {
+            let v: u32 = (c ? m1 : m2).get_or_use(0u32, 0u32); // ❌ non-path receiver
+            assert(v >= 0u32);
+        };
+    }
+}

--- a/tests/tests/compiler/storage/ternary_vector_receiver_fail.leo
+++ b/tests/tests/compiler/storage/ternary_vector_receiver_fail.leo
@@ -1,0 +1,33 @@
+// Regression test for https://github.com/ProvableHQ/leo/issues/29428
+// `Vector::len` / `Vector::get` on a non-path receiver (e.g. a ternary over
+// storage vectors) used to ICE in storage_lowering. Now caught cleanly by
+// type-checking.
+program bugpoc.aleo {
+    @noupgrade
+    constructor() {}
+
+    storage h1: [u64];
+    storage h2: [u64];
+    mapping seen: u32 => u32;
+
+    fn method_len(c: bool) -> Final {
+        return final {
+            let n: u32 = (c ? h1 : h2).len(); // ❌ non-path receiver
+            Mapping::set(seen, 0u32, n);
+        };
+    }
+
+    fn method_get(c: bool) -> Final {
+        return final {
+            let v: u64? = (c ? h1 : h2).get(0u32); // ❌ non-path receiver
+            Mapping::set(seen, 0u32, v.unwrap_or(0u64) as u32);
+        };
+    }
+
+    fn explicit_len(c: bool) -> Final {
+        return final {
+            let n: u32 = Vector::len((c ? h1 : h2)); // ❌ non-path receiver
+            Mapping::set(seen, 0u32, n);
+        };
+    }
+}

--- a/tests/tests/compiler/storage/ternary_write_receiver_fail.leo
+++ b/tests/tests/compiler/storage/ternary_write_receiver_fail.leo
@@ -1,0 +1,47 @@
+// Companion to #29428: mutating storage Vector/Mapping ops on a non-path
+// receiver (e.g. a ternary over local storage) used to be reported as
+// "on external vectors/mappings", which is misleading when the receiver
+// is local. Now reported with the dedicated non-path diagnostic.
+program bugpoc_write.aleo {
+    @noupgrade
+    constructor() {}
+
+    storage h1: [u64];
+    storage h2: [u64];
+    mapping m1: u32 => u32;
+    mapping m2: u32 => u32;
+
+    fn vec_set(c: bool) -> Final {
+        return final { (c ? h1 : h2).set(0u32, 1u64); }; // ❌ non-path receiver
+    }
+
+    fn vec_push(c: bool) -> Final {
+        return final { (c ? h1 : h2).push(1u64); }; // ❌ non-path receiver
+    }
+
+    fn vec_pop(c: bool) -> Final {
+        return final {
+            let x: u64? = (c ? h1 : h2).pop(); // ❌ non-path receiver
+            assert(x != none);
+        };
+    }
+
+    fn vec_swap_remove(c: bool) -> Final {
+        return final {
+            let x: u64 = (c ? h1 : h2).swap_remove(0u32); // ❌ non-path receiver
+            assert(x >= 0u64);
+        };
+    }
+
+    fn vec_clear(c: bool) -> Final {
+        return final { (c ? h1 : h2).clear(); }; // ❌ non-path receiver
+    }
+
+    fn map_set(c: bool) -> Final {
+        return final { (c ? m1 : m2).set(0u32, 1u32); }; // ❌ non-path receiver
+    }
+
+    fn map_remove(c: bool) -> Final {
+        return final { (c ? m1 : m2).remove(0u32); }; // ❌ non-path receiver
+    }
+}


### PR DESCRIPTION
## Summary
- `Vector::{len,get,set,push,pop,swap_remove,clear}` and `Mapping::{get,get_or_use,contains,set,remove}` assume an `Expression::Path` receiver downstream (storage_lowering for vectors, codegen for mappings), but type-checking only verified the receiver's type.
- Read ops had no path check, so a ternary of two storage vectors ICEd in storage_lowering and a ternary of two mappings produced invalid bytecode that failed late at disassembly.
- Write ops already had an `is_local_path` check, but emitted the "external vectors/mappings" diagnostic for a local ternary receiver, which is misleading.
- Add an `Expression::Path` pre-check to all eleven arms and emit a new `ETYC0372191`. The existing "external" diagnostic now only fires when the receiver is an actual external path.

Fixes #29428.