### PR TITLE
Increases the devnode REST body limit to 1.5mb

### DIFF
--- a/crates/leo/src/cli/commands/devnode/rest/mod.rs
+++ b/crates/leo/src/cli/commands/devnode/rest/mod.rs
@@ -186,8 +186,8 @@ impl<N: Network, C: ConsensusStorage<N>> Rest<N, C> {
             .layer(middleware::map_request(log_middleware))
             // Enable CORS.
             .layer(cors)
-            // Cap the request body size at 512KiB.
-            .layer(DefaultBodyLimit::max(512 * 1024))
+            // Cap the request body size at 1.5MiB.
+            .layer(DefaultBodyLimit::max(2 * 768 * 1024))
             .layer(governor_layer)
     }
 


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

This PR increases the Request body size from 512kb to 1.5mb. In testing, deployment transactions have exceeded the current bounds.

This also matches the limit upgrade set in - https://github.com/ProvableHQ/aleo-devnode/pull/11.