### PR TITLE
fix install command

### DIFF
--- a/documentation/getting_started/01_installation.md
+++ b/documentation/getting_started/01_installation.md
@@ -132,7 +132,7 @@ git --version
 git clone https://github.com/ProvableHQ/leo
 cd leo
 # Build and install Leo
-cargo install --path .
+cargo install --path crates/leo
 # Build and install the formatter plugin
 cargo install --path crates/fmt
 ```


### PR DESCRIPTION
Cherry-picks #29436 by @mimoo.

The root `Cargo.toml` is a workspace, so `cargo install --path .` fails. The `leo-lang` binary package lives at `crates/leo`.