### PR TITLE
ci(release-crate): fix musl strip permission failure

### DIFF
--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -183,6 +183,9 @@ jobs:
                 --release --locked \
                 ${{ steps.flags.outputs.features }}
             "
+          # Container writes outputs as its own user; reclaim ownership so
+          # subsequent host steps (strip, zip) can write into target/.
+          sudo chown -R $(id -u):$(id -g) target
 
       - name: Collect Binaries
         id: bins


### PR DESCRIPTION
The musl build runs inside a Docker container that writes outputs as its internal user, leaving target/ owned by a UID the host runner cannot write to. The subsequent host-side strip step then fails with "could not create temporary file to hold stripped copy: Permission denied".

Reclaim ownership of target/ after the docker build so strip and zip behave the same as on the other Unix targets.