### PR TITLE
Fix broken links in documentation

### DIFF
--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -4,6 +4,7 @@
   "fallbackRetryDelay": "30s",
   "ignorePatterns": [
     { "pattern": "^https://api\\.explorer\\.provable\\.com" },
-    { "pattern": "^https://faucet\\.aleo\\.org" }
+    { "pattern": "^https://faucet\\.aleo\\.org" },
+    { "pattern": "^https://docs\\.aleo\\.org" }
   ]
 }

--- a/documentation/01_new.md
+++ b/documentation/01_new.md
@@ -12,8 +12,8 @@ sidebar_label: What's new?
 
 ## [**🚀 Upgrade Guide**](./guides/10_program_upgradability.md) - Learn how to upgrade your Leo programs
 
-## [**🤝 Core Developers Call**](https://developer.aleo.org/guides/how_to_get_help) - Collaborate with the Leo development team and ecosystem on the future of Leo
+## [**🤝 Core Developers Call**](https://docs.aleo.org/participate/community-calls) - Collaborate with the Leo development team and ecosystem on the future of Leo
 
-## [**⚛️ Create Leo App**](https://developer.aleo.org/category/create-leo-app) - A full stack application written in Typescript using Leo and React
+## [**⚛️ Create Leo App**](https://docs.aleo.org/build/sdk/getting_started#create-leo-app) - A full stack application written in Typescript using Leo and React
 
 :::

--- a/documentation/02_where.md
+++ b/documentation/02_where.md
@@ -14,6 +14,6 @@ While a deep dive through the Leo documentation is a useful exercise, we realize
 
 - If you're designing a dApp, we recommend checking out **Leo By Example** for a reference.
 
-- If you're interested in tutorials, check out [**Guides**](./guides/00_overview.md). Also be sure to check out the [**Core Aleo Concepts**](https://developer.aleo.org/guides/faqs).
+- If you're interested in tutorials, check out [**Guides**](./guides/00_overview.md). Also be sure to check out the [**Core Aleo Concepts**](https://docs.aleo.org/learn/core-concepts/public-and-private-state).
 
 - If you're deploying or running your programs, [**CLI**](./cli/00_overview.md) will be helpful.

--- a/documentation/guides/05_executing.md
+++ b/documentation/guides/05_executing.md
@@ -74,4 +74,4 @@ Finally, an execution cost breakdown will be printed alongside any outputs from 
   ...
 ```
 
-Under the hood, `leo execute` produces a JSON object. This is a [`Transaction`](https://developer.aleo.org/concepts/fundamentals/transactions) that can be broadcast to the Aleo network. You can view this JSON by passing the `--print` flag to `leo execute`.
+Under the hood, `leo execute` produces a JSON object. This is a [`Transaction`](https://docs.aleo.org/learn/core-concepts/transactions/index.html) that can be broadcast to the Aleo network. You can view this JSON by passing the `--print` flag to `leo execute`.

--- a/documentation/language/02_structure.md
+++ b/documentation/language/02_structure.md
@@ -131,7 +131,7 @@ Structs contain component declarations `{name}: {type},`.
 
 ### Record
 
-A [record](https://developer.aleo.org/concepts/fundamentals/records) data type is declared as `record {name} {}`. A record name must not contain the keyword `aleo`, and must not be a prefix of any other record name.
+A [record](https://docs.aleo.org/learn/core-concepts/public-and-private-state#private-state) data type is declared as `record {name} {}`. A record name must not contain the keyword `aleo`, and must not be a prefix of any other record name.
 
 Records contain component declarations `{visibility} {name}: {type},`. Names of record components must not contain the keyword `aleo`.
 

--- a/documentation/language/03_data_types.md
+++ b/documentation/language/03_data_types.md
@@ -166,7 +166,7 @@ Acceptable types for const generic parameters include integer types, `bool`, `sc
 
 ### Records
 
-A [record](https://developer.aleo.org/concepts/fundamentals/records) data type is the method of encoding private state on Aleo. Records are declared as `record {name} {}`. A record name must not contain the keyword `aleo`, and must not be a prefix of any other record name.
+A [record](https://docs.aleo.org/learn/core-concepts/public-and-private-state#private-state) data type is the method of encoding private state on Aleo. Records are declared as `record {name} {}`. A record name must not contain the keyword `aleo`, and must not be a prefix of any other record name.
 
 Records contain component declarations `{visibility} {name}: {type},`. Names of record components must not contain the keyword `aleo`. The visibility qualifier may be specified as `constant`, `public`, or `private`. If no qualifier is provided, Leo defaults to `private`.
 

--- a/documentation/language/04_operators.md
+++ b/documentation/language/04_operators.md
@@ -17,7 +17,7 @@ For cases where wrapping semantics are needed for integer types, see the wrapped
 ```
 
 :::note
-The Leo operators compile down to [`Aleo Instructions`](https://developer.aleo.org/guides/aleo/opcodes) opcodes executable by the Aleo Virtual Machine (AVM).
+The Leo operators compile down to [`Aleo Instructions`](https://docs.aleo.org/build/aleo-instructions/overview) opcodes executable by the Aleo Virtual Machine (AVM).
 :::
 
 ### Operator Precedence

--- a/documentation/language/programs_in_practice/private_storage.md
+++ b/documentation/language/programs_in_practice/private_storage.md
@@ -8,7 +8,7 @@ sidebar_label: Private State
 
 ## Records
 
-A [record](https://developer.aleo.org/concepts/fundamentals/records) data type is the method of encoding private state on Aleo. Records are declared as `record {name} {}`. A record name must not contain the keyword `aleo`, and must not be a prefix of any other record name.
+A [record](https://docs.aleo.org/learn/core-concepts/public-and-private-state#private-state) data type is the method of encoding private state on Aleo. Records are declared as `record {name} {}`. A record name must not contain the keyword `aleo`, and must not be a prefix of any other record name.
 
 Records contain component declarations `{visibility} {name}: {type},`. Names of record components must not contain the keyword `aleo`. The visibility qualifier may be specified as `constant`, `public`, or `private`. If no qualifier is provided, Leo defaults to `private`.
 


### PR DESCRIPTION
Redirect broken links in the docs to the closest semantic matches following the documentation migration.
