### PR TITLE
docs: fix Tabs rendering; drop stale .env

### DIFF
--- a/documentation/getting_started/01_installation.md
+++ b/documentation/getting_started/01_installation.md
@@ -4,6 +4,8 @@ title: Installation
 sidebar: Installation
 toc_min_heading_level: 5
 toc_max_heading_level: 5
+mdx:
+  format: mdx
 ---
 
 [general tags]: # "installation, install_leo"

--- a/documentation/getting_started/03_hello.md
+++ b/documentation/getting_started/03_hello.md
@@ -21,7 +21,6 @@ This creates a directory with the following structure:
 ```bash
 hello/
 ├── .gitignore # A default `.gitignore` file for Leo projects
-├── .env # The environment, containing the `NETWORK` and `PRIVATE_KEY` variables.
 ├── program.json # The manifest for the Leo project
 ├── tests/
   └── test_hello.leo # The Leo source code for unit tests

--- a/documentation/guides/08_devnet.md
+++ b/documentation/guides/08_devnet.md
@@ -2,9 +2,14 @@
 id: devnet
 title: Running a Devnet
 sidebar_label: Devnet
+mdx:
+  format: mdx
 ---
 
 [general tags]: # "guides, devnet local_devnet, snarkos"
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 A local devnet can be a heavyweight but reliable way to test your application on Aleo.
 


### PR DESCRIPTION
- Add `mdx: { format: mdx }` to the installation and devnet guides so `<Tabs>` actually renders.
- Drop the `.env` line from the `leo new` file tree (never created).