### PR TITLE
chore(release): ungate leo-lsp and leo-aleo-abi-wasm

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,15 +1,2 @@
 [workspace]
 git_release_enable = false
-
-# `leo-lsp` and `leo-aleo-abi-wasm` are not yet on crates.io. crates.io Trusted
-# Publishing cannot perform the first-ever publish of a new crate name, so they
-# are skipped here for this release and bootstrapped manually at 4.1.0 once their
-# dependencies are published. Remove these entries afterwards so future releases
-# publish them automatically.
-[[package]]
-name = "leo-lsp"
-release = false
-
-[[package]]
-name = "leo-aleo-abi-wasm"
-release = false

--- a/tests/expectations/cli/test_add/STDOUT
+++ b/tests/expectations/cli/test_add/STDOUT
@@ -90,7 +90,7 @@ Attempting to determine the consensus version from the latest block height at ht
   Address:            aleo1rhgdu77hgyqd3xjj8uc...
   Endpoint:           https://api.explorer.provable.com/v1
   Network:            testnet
-  Consensus Version:  14
+  Consensus Version:  15
 
 🎯 Execution Target:
   Program:        some_sample_leo_program.aleo


### PR DESCRIPTION
Both crates were skipped from release-plz because crates.io Trusted Publishing cannot perform a first-ever publish of a new crate name. They are now published at 4.1.0 with TP configured, so the manual `release = false` overrides can be removed; future releases will publish them automatically.

Addresses item 2 of #29462.