### PR TITLE
chore(release): drop version pin from leo-test-framework workspace dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ leo-parser          = { path = "./crates/parser",           version = "=4.1.0" }
 leo-parser-rowan    = { path = "./crates/parser-rowan",     version = "=4.1.0" }
 leo-passes          = { path = "./crates/passes",           version = "=4.1.0" }
 leo-span            = { path = "./crates/span",             version = "=4.1.0" }
-leo-test-framework  = { path = "./crates/test-framework",   version = "=4.1.0" }
+leo-test-framework  = { path = "./crates/test-framework" }
 # third party dependencies
 aleo-std           = { version = "1.0.3"}
 aleo-std-storage   = { version = "1.0.3", default-features = false }


### PR DESCRIPTION
`release-plz` publishes crates in normal-dependency order, so it reaches crates like `leo-parser`, `leo-passes` and `leo-compiler` before `leo-test-framework`. Those crates only use leo-test-framework as a `[dev-dependencies]` entry inherited from the workspace, where it was pinned to an exact version (`=X.Y.Z`). cargo publish then tries to resolve leo-test-framework `=X.Y.Z` against the registry, the version is not there yet, and the run aborts. The 4.1.0 release had to be unblocked by publishing `leo-test-framework` manually first.

Cargo strips path-only `[dev-dependencies]` entries entirely from a published Cargo.toml, so removing the version requirement from the workspace declaration makes the dependency disappear from the published packages and breaks the publish-order constraint. Local builds keep resolving `leo-test-framework` via the workspace path.

Verified by packaging `leo-parser`, `leo-passes` and `leo-compiler` and confirming `leo-test-framework` no longer appears in the generated `Cargo.toml` of any of them.

Refs #29462.