### PR TITLE
ci(release): force `<cstdint>` in musl RocksDB build

### DIFF
--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -244,6 +244,8 @@ jobs:
               # The RocksDB version pulled in transitively (via snarkVM) predates
               # GCC 13, which stopped transitively including <cstdint>; force it so
               # the bundled C++ compiles. Append to the image's hardening flags.
+              # Remove once snarkVM bumps `rocksdb` past `librocksdb-sys 0.11`
+              # (tracked upstream by the snarkVM `rocksdb` bump PR).
               export TARGET_CXXFLAGS=\"\$TARGET_CXXFLAGS -include cstdint\" &&
               cargo build \
                 --package ${{ needs.prepare.outputs.crate-name }} \

--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -241,6 +241,10 @@ jobs:
             bash -lc "
               rustup target add x86_64-unknown-linux-musl &&
               cd /home/rust/src &&
+              # The RocksDB version pulled in transitively (via snarkVM) predates
+              # GCC 13, which stopped transitively including <cstdint>; force it so
+              # the bundled C++ compiles. Append to the image's hardening flags.
+              export TARGET_CXXFLAGS=\"\$TARGET_CXXFLAGS -include cstdint\" &&
               cargo build \
                 --package ${{ needs.prepare.outputs.crate-name }} \
                 --target x86_64-unknown-linux-musl \


### PR DESCRIPTION
## Summary

- Append `-include cstdint` to `TARGET_CXXFLAGS` inside the musl Docker build step in `.github/workflows/release-crate.yml`, so the bundled C++ in
  `librocksdb-sys 0.11.0+8.1.1` (pulled transitively via snarkVM) compiles under GCC 13+.
- Add an inline removal-trigger note so a future maintainer knows the workaround can be deleted once snarkVM bumps `rocksdb` past `librocksdb-sys 0.11`.

Resolves item 3 of #29462.

The first commit is @mohammadfawaz's original fix from `fix/musl-rocksdb-cstdint`, cherry-picked here (authorship preserved). The second is a small follow-up that adds the removal-trigger comment.

## Parallel Work

- [x] Open up a snarkvm PR bumping `rocksdb` version explaining the situation to resolve this (in progress).
    - https://github.com/ProvableHQ/snarkVM/pull/3282