### PR TITLE
feat(tree-sitter): add brackets and outline queries

### DIFF
--- a/tree-sitter/queries/brackets.scm
+++ b/tree-sitter/queries/brackets.scm
@@ -1,0 +1,16 @@
+; Bracket pairs for Leo.
+;
+; Consumed by editors that match/auto-surround delimiters from tree-sitter
+; (e.g. Zed's `brackets.scm`, nvim-treesitter). Each pattern captures an
+; opening token as @open and its matching closing token as @close among the
+; siblings of a single parent node, so blocks, arrays, parameter lists, and
+; grouped expressions all pair correctly.
+;
+; Mirrors the structural bracket pairs declared for the VS Code client in
+; `language-configuration.json` ("brackets": [], i.e. {} [] ()). String quotes
+; are intentionally omitted here (they are an auto-closing pair, not a
+; structural bracket).
+
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/tree-sitter/queries/outline.scm
+++ b/tree-sitter/queries/outline.scm
@@ -1,0 +1,74 @@
+; Outline / symbol queries for Leo.
+;
+; Consumed by editors that build their symbol outline from tree-sitter
+; (e.g. Zed's `outline.scm`). Each top-level declaration is captured as an
+; @item whose label is built from the keyword(s) (@context) and the
+; declaration name (@name). This drives the outline panel with or without the
+; language server, so it must cover every program-level declaration form.
+
+; Program + imports.
+(program_declaration
+  "program" @context
+  name: (program_id) @name) @item
+
+(import_declaration
+  "import" @context
+  name: (program_id) @name) @item
+
+; Functions (plain / final / view) — show keyword(s), name, and signature.
+(function_definition
+  "fn" @context
+  name: (identifier) @name
+  parameters: (parameter_list) @context) @item
+
+(final_function_definition
+  "final" @context
+  "fn" @context
+  name: (identifier) @name
+  parameters: (parameter_list) @context) @item
+
+(view_function_definition
+  "view" @context
+  "fn" @context
+  name: (identifier) @name
+  parameters: (parameter_list) @context) @item
+
+; The constructor has no name; label it with its keyword.
+(constructor_definition
+  "constructor" @name) @item
+
+; Types.
+(struct_definition
+  "struct" @context
+  name: (identifier) @name) @item
+
+(record_definition
+  "record" @context
+  name: (identifier) @name) @item
+
+(interface_declaration
+  "interface" @context
+  name: (identifier) @name) @item
+
+; Program state.
+(mapping_definition
+  "mapping" @context
+  name: (identifier) @name) @item
+
+(storage_definition
+  "storage" @context
+  name: (identifier) @name) @item
+
+(const_declaration
+  "const" @context
+  name: (identifier) @name) @item
+
+; Interface members (prototypes) — nest under their interface in the outline.
+(function_prototype
+  "fn" @context
+  name: (identifier) @name
+  parameters: (parameter_list) @context) @item
+
+(record_prototype
+  "record" @context
+  name: (identifier) @name) @item


### PR DESCRIPTION
## Summary

Add `brackets.scm` and `outline.scm` to the Leo tree-sitter grammar.

- **`brackets.scm`** captures the `()` `[]` `{}` delimiter pairs so editors that derive bracket matching / auto-surround from tree-sitter (Zed, nvim-treesitter) pair them correctly. Mirrors the structural brackets the VS Code Leo client declares in `language-configuration.json`.
- **`outline.scm`** captures every program-level declaration — `program`, `import`, `const`, `mapping`, `storage`, `struct`, `record`, `interface` + its prototypes, `constructor`, and plain/`final`/`view` functions — as `@item` with `@context` + `@name`, driving the editor outline/symbol panel directly from the syntax tree, with or without the language server.

## Motivation

The upcoming Zed Leo extension consumes its tree-sitter queries verbatim from this directory under a "never hand-edit; regenerate from upstream" lifecycle. It needs `brackets.scm` and `outline.scm`, which did not yet exist here. Authoring them upstream keeps every downstream client on one source of truth.

## Validation

Validated with `tree-sitter query` (tree-sitter-cli 0.25.10, the grammar's declared devDep) against a fixture exercising all 14 declaration forms; every capture resolves as expected. No changes to generated parser output, `tree-sitter.json`, or `package.json` — only the two new `.scm` query files.
