### PR TITLE
docs: include leo-lsp in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ We recommend installing Rust using [rustup](https://www.rustup.rs/). You can ins
 If you don't intend to work on the Leo compiler itself, you can install the latest Leo release with:
 
 ```bash
-cargo install leo-lang leo-fmt
+cargo install leo-lang leo-fmt leo-lsp
 ```
 
 Now to use leo, in your terminal, run:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -82,7 +82,9 @@ Release tags use:
 {crate-name}-v{version}
 ```
 
-Examples: `leo-lang-v4.0.1`, `leo-fmt-v1.0.0`, `leo-lsp-v4.0.1`.
+Examples: `leo-lang-v4.0.1`, `leo-fmt-v4.1.0`, `leo-lsp-v4.0.2`. Because each crate
+is tagged independently, its version can differ from `leo-lang` (e.g. `leo-fmt-v4.1.0`
+shipping while `leo-lang` is still at `4.0.1`).
 
 Tags use the crate name from `Cargo.toml` (for example, `leo-lang`, not `leo`).
 release-plz creates package tags for published crates. `release-crate.yml` runs

--- a/documentation/cli/19_plugins.md
+++ b/documentation/cli/19_plugins.md
@@ -67,7 +67,7 @@ cargo install leo-fmt leo-lsp
 cargo binstall leo-fmt leo-lsp
 ```
 
-Pre-built binaries are also available from [Leo releases](https://github.com/ProvableHQ/leo/releases). Each plugin crate is released independently under its own git tag (e.g. `leo-fmt-v1.0.0`).
+Pre-built binaries are also available from [Leo releases](https://github.com/ProvableHQ/leo/releases). Each plugin crate is released independently under its own git tag (e.g. `leo-fmt-v4.1.0`), so a plugin's version may differ from `leo-lang`.
 
 For details on release artifacts, target platforms, and packaging guidelines, see the [Binary Distribution Reference](../guides/12_binary_distribution.md).
 

--- a/documentation/getting_started/01_installation.md
+++ b/documentation/getting_started/01_installation.md
@@ -31,10 +31,10 @@ The easiest way to install Cargo is to install the latest stable release of [Rus
 ## Install Leo
 
 ```bash
-cargo install leo-lang leo-fmt
+cargo install leo-lang leo-fmt leo-lsp
 ```
 
-This will install the `leo` and `leo-fmt` executables at `~/.cargo/bin/`.
+This will install the `leo`, `leo-fmt`, and `leo-lsp` executables at `~/.cargo/bin/`.
 </TabItem>
 <TabItem value="binstall">
 
@@ -49,13 +49,13 @@ cargo install cargo-binstall
 ## Install Leo via binstall
 
 ```bash
-cargo binstall leo-lang leo-fmt
+cargo binstall leo-lang leo-fmt leo-lsp
 ```
 
 To install a specific version:
 
 ```bash
-cargo binstall leo-lang@4.0.1 leo-fmt@1.0.0
+cargo binstall leo-lang@4.1.0 leo-fmt@4.1.0 leo-lsp@4.1.0
 ```
 
 :::note
@@ -92,8 +92,8 @@ Archives are named `leo-lang-v{version}-{target}.zip` (e.g. `leo-lang-v4.0.1-aar
 1. On macOS/Linux, make the binaries executable and move them onto your PATH:
 
    ```bash
-   chmod +x leo leo-fmt
-   mv leo leo-fmt /usr/local/bin/
+   chmod +x leo leo-fmt leo-lsp
+   mv leo leo-fmt leo-lsp /usr/local/bin/
    ```
 
 1. Verify the installation:
@@ -103,7 +103,7 @@ Archives are named `leo-lang-v{version}-{target}.zip` (e.g. `leo-lang-v4.0.1-aar
    ```
 
 :::note
-Plugin binaries such as `leo-fmt` are released separately under their own crate tags (e.g. `leo-fmt-v1.0.0`). Download the matching plugin archives from the same [releases page](https://github.com/ProvableHQ/leo/releases).
+Plugin binaries such as `leo-fmt` and `leo-lsp` are released under their own crate tags (e.g. `leo-fmt-v4.1.0`, `leo-lsp-v4.1.0`). Download the matching plugin archives from the same [releases page](https://github.com/ProvableHQ/leo/releases).
 :::
 
 </TabItem>
@@ -135,9 +135,11 @@ cd leo
 cargo install --path crates/leo
 # Build and install the formatter plugin
 cargo install --path crates/fmt
+# Build and install the language server plugin
+cargo install --path crates/lsp
 ```
 
-This will install the `leo` and `leo-fmt` executables at `~/.cargo/bin/`.
+This will install the `leo`, `leo-fmt`, and `leo-lsp` executables at `~/.cargo/bin/`.
 
 ### To use Leo, run
 

--- a/documentation/guides/12_binary_distribution.md
+++ b/documentation/guides/12_binary_distribution.md
@@ -12,7 +12,7 @@ For installation instructions, see [Getting Started - Installation](../getting_s
 
 ## Release Model
 
-Leo uses a per-crate release model. Each publishable crate in the [Leo repository](https://github.com/ProvableHQ/leo) is released independently via git tags matching the pattern `{crate-name}-v{version}` (e.g. `leo-lang-v4.0.1`, `leo-fmt-v1.0.0`).
+Leo uses a per-crate release model. Each publishable crate in the [Leo repository](https://github.com/ProvableHQ/leo) is released independently via git tags matching the pattern `{crate-name}-v{version}` (e.g. `leo-lang-v4.0.1`, `leo-fmt-v4.1.0`).
 
 When a tag is pushed, CI builds cross-platform binaries and publishes them as a GitHub Release under that tag.
 
@@ -66,7 +66,7 @@ Future plugin crates will follow the same pattern.
 
 ## Plugin Versioning
 
-Plugin crates (`leo-fmt`, `leo-lsp`) are versioned independently from `leo-lang`. Each crate has its own git tag and release cadence, allowing tooling updates to ship without requiring a new compiler release.
+Plugin crates (`leo-fmt`, `leo-lsp`) are versioned independently from `leo-lang`. Each crate has its own git tag and release cadence, allowing tooling updates to ship without requiring a new compiler release. As a result, the installed versions need not match — for example, a formatter fix can ship as `leo-fmt` 4.1.0 while `leo-lang` is still at 4.0.1 (`cargo binstall leo-lang@4.0.1 leo-fmt@4.1.0`).
 
 When packaging Leo, ensure the installed plugin versions are compatible with the installed `leo-lang` version.
 


### PR DESCRIPTION
The install instructions only mentioned `leo-lang` and `leo-fmt`, omitting `leo-lsp`.

- Add `leo-lsp` to every install command in the README and getting-started guide (cargo, binstall, pre-built binaries, build-from-source).
- Correct stale `leo-fmt` version examples (now 4.x, not 1.0.0) in `RELEASING.md`, the binary-distribution guide, and the plugins doc.