### PR TITLE
fix(fmt,lsp): support --version in standalone plugin binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,7 @@ name = "leo-lsp"
 version = "4.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "crossbeam-channel",
  "indexmap",
  "leo-ast",

--- a/crates/fmt/src/lib.rs
+++ b/crates/fmt/src/lib.rs
@@ -74,7 +74,7 @@ pub struct FormatCliArgs {
 
 /// Standalone `leo-fmt` CLI parser.
 #[derive(Debug, Parser)]
-#[command(name = "leo-fmt", about = "Format Leo source files", long_about = None)]
+#[command(name = "leo-fmt", version, about = "Format Leo source files", long_about = None)]
 pub struct LeoFmtCli {
     #[command(flatten)]
     pub format: FormatCliArgs,

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow             = { workspace = true }
+clap               = { workspace = true }
 crossbeam-channel  = { workspace = true }
 indexmap           = { workspace = true }
 leo-ast            = { workspace = true }

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -69,6 +69,15 @@ pub fn run_server(connection: Connection) -> Result<ExitCode> {
 /// This keeps the binary wrapper thin while preserving the library-oriented
 /// `Result`-returning entrypoints for tests, embeddings, and future plugins.
 pub fn run_standalone() -> ExitCode {
+    // The language server communicates over stdio and otherwise ignores its CLI
+    // arguments, so editor clients can launch it however they like. We only
+    // intercept `--version`/`-V` here so the standalone plugin binary can report
+    // its version like `leo` and `leo-fmt`, without changing how clients spawn it.
+    if std::env::args().skip(1).any(|arg| arg == "--version" || arg == "-V") {
+        println!("leo-lsp {}", env!("CARGO_PKG_VERSION"));
+        return ExitCode::SUCCESS;
+    }
+
     match run_stdio() {
         Ok(exit_code) => exit_code,
         Err(error) => {

--- a/crates/lsp/src/lib.rs
+++ b/crates/lsp/src/lib.rs
@@ -32,9 +32,20 @@ mod server;
 mod syntax_semantics;
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use lsp_server::Connection;
 use std::process::ExitCode;
 use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+
+/// Standalone `leo-lsp` CLI parser.
+///
+/// The language server communicates over stdio and takes no arguments of its
+/// own; this parser exists so the binary honors `--version`/`-V` and `--help`
+/// like the `leo` and `leo-fmt` binaries. Editor clients launch the server with
+/// no arguments, so strict parsing does not affect how they spawn it.
+#[derive(Debug, Parser)]
+#[command(name = "leo-lsp", version, about = "Language server for the Leo programming language", long_about = None)]
+struct LeoLspCli {}
 
 /// Run the Leo language server over stdio.
 ///
@@ -69,14 +80,9 @@ pub fn run_server(connection: Connection) -> Result<ExitCode> {
 /// This keeps the binary wrapper thin while preserving the library-oriented
 /// `Result`-returning entrypoints for tests, embeddings, and future plugins.
 pub fn run_standalone() -> ExitCode {
-    // The language server communicates over stdio and otherwise ignores its CLI
-    // arguments, so editor clients can launch it however they like. We only
-    // intercept `--version`/`-V` here so the standalone plugin binary can report
-    // its version like `leo` and `leo-fmt`, without changing how clients spawn it.
-    if std::env::args().skip(1).any(|arg| arg == "--version" || arg == "-V") {
-        println!("leo-lsp {}", env!("CARGO_PKG_VERSION"));
-        return ExitCode::SUCCESS;
-    }
+    // Parse CLI arguments so the binary honors `--version` and `--help`. The
+    // server itself takes no arguments and communicates over stdio.
+    LeoLspCli::parse();
 
     match run_stdio() {
         Ok(exit_code) => exit_code,


### PR DESCRIPTION
`leo-fmt --version` and `leo-lsp --version` printed nothing — `leo-fmt`'s clap parser had no `version`, and `leo-lsp` did no arg parsing at all. Both matter now that they ship as standalone binaries (`cargo binstall leo-fmt leo-lsp`).

Both now use clap's `version` attribute, printing `<name> 4.1.0` plus a real `--help`. Strict parsing in `leo-lsp` is safe: `leo-lsp-clients` launches the server over stdio with no args (`leo.languageServer.args` defaults to `[]`).
