### PR TITLE
fix(dce): preserve unused deserialization

### DIFF
--- a/crates/ast/src/functions/intrinsic.rs
+++ b/crates/ast/src/functions/intrinsic.rs
@@ -1359,17 +1359,20 @@ impl Intrinsic {
             | Intrinsic::DynamicContains
             | Intrinsic::DynamicGet
             | Intrinsic::DynamicGetOrUse
+            // These intrinsics can halt.
+            | Intrinsic::Commit(_, _)
+            | Intrinsic::ECDSAVerify(_)
+            | Intrinsic::SnarkVerify
+            | Intrinsic::SnarkVerifyBatch
             // Deserialization can halt on invalid encodings.
             | Intrinsic::Deserialize(_, _) => false,
 
             Intrinsic::ChaChaRand(_)
-            | Intrinsic::ECDSAVerify(_)
             | Intrinsic::ProgramChecksum
             | Intrinsic::ProgramEdition
             | Intrinsic::ProgramOwner
             | Intrinsic::VectorLen
             | Intrinsic::VectorGet
-            | Intrinsic::Commit(_, _)
             | Intrinsic::Hash(_, _)
             | Intrinsic::OptionalUnwrap
             | Intrinsic::OptionalUnwrapOr
@@ -1389,14 +1392,13 @@ impl Intrinsic {
             | Intrinsic::BlockTimestamp
             | Intrinsic::NetworkId
             | Intrinsic::SignatureVerify
-            | Intrinsic::SnarkVerify
-            | Intrinsic::SnarkVerifyBatch
             | Intrinsic::Serialize(_) => true,
         }
     }
 
     /// Returns whether or not this function can be evaluated at compile time.
     pub fn can_const_evaluate(&self) -> bool {
-        self.is_pure() || matches!(self, Intrinsic::Deserialize(_, _))
+        self.is_pure()
+            || matches!(self, Intrinsic::Commit(_, _) | Intrinsic::ECDSAVerify(_) | Intrinsic::Deserialize(_, _))
     }
 }

--- a/crates/ast/src/functions/intrinsic.rs
+++ b/crates/ast/src/functions/intrinsic.rs
@@ -1358,7 +1358,9 @@ impl Intrinsic {
             | Intrinsic::DynamicCall
             | Intrinsic::DynamicContains
             | Intrinsic::DynamicGet
-            | Intrinsic::DynamicGetOrUse => false,
+            | Intrinsic::DynamicGetOrUse
+            // Deserialization can halt on invalid encodings.
+            | Intrinsic::Deserialize(_, _) => false,
 
             Intrinsic::ChaChaRand(_)
             | Intrinsic::ECDSAVerify(_)
@@ -1389,8 +1391,7 @@ impl Intrinsic {
             | Intrinsic::SignatureVerify
             | Intrinsic::SnarkVerify
             | Intrinsic::SnarkVerifyBatch
-            | Intrinsic::Serialize(_)
-            | Intrinsic::Deserialize(_, _) => true,
+            | Intrinsic::Serialize(_) => true,
         }
     }
 }

--- a/crates/ast/src/functions/intrinsic.rs
+++ b/crates/ast/src/functions/intrinsic.rs
@@ -1394,4 +1394,9 @@ impl Intrinsic {
             | Intrinsic::Serialize(_) => true,
         }
     }
+
+    /// Returns whether or not this function can be evaluated at compile time.
+    pub fn can_const_evaluate(&self) -> bool {
+        self.is_pure() || matches!(self, Intrinsic::Deserialize(_, _))
+    }
 }

--- a/crates/passes/src/const_propagation/ast.rs
+++ b/crates/passes/src/const_propagation/ast.rs
@@ -208,9 +208,8 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
         let intrinsic = Intrinsic::from_symbol(input.name, &input.type_parameters)
             .expect("Type checking guarantees this is valid.");
 
-        if values.len() == input.arguments.len() && intrinsic.is_pure() {
-            // We've evaluated every argument, and this function has no side
-            // effects, so maybe we can compute the result at compile time.
+        if values.len() == input.arguments.len() && intrinsic.can_const_evaluate() {
+            // We've evaluated every argument, and this function can be computed at compile time.
 
             match const_eval::evaluate_intrinsic(&mut values, intrinsic, &[], input.span()) {
                 Ok(Some(value)) => {

--- a/tests/expectations/compiler/core/algorithms/deserialize_unused_dce.out
+++ b/tests/expectations/compiler/core/algorithms/deserialize_unused_dce.out
@@ -5,6 +5,39 @@ function unused_deserialize:
     deserialize.bits.raw r0 ([boolean; 253u32]) into r1 (field);
     output 1u8 as u8.private;
 
+function unused_commit:
+    input r0 as field.private;
+    input r1 as scalar.private;
+    commit.bhp256 r0 r1 into r2 as field;
+    output 1u8 as u8.private;
+
+function unused_finalize_intrinsics:
+    input r0 as [u8; 65u32].private;
+    input r1 as [u8; 33u32].private;
+    input r2 as [u8; 32u32].private;
+    input r3 as [u8; 128u32].private;
+    input r4 as u8.private;
+    input r5 as [field; 4u32].private;
+    input r6 as [u8; 256u32].private;
+    input r7 as [[u8; 128u32]; 2u32].private;
+    input r8 as [[[field; 4u32]; 3u32]; 2u32].private;
+    async unused_finalize_intrinsics r0 r1 r2 r3 r4 r5 r6 r7 r8 into r9;
+    output r9 as test.aleo/unused_finalize_intrinsics.future;
+
+finalize unused_finalize_intrinsics:
+    input r0 as [u8; 65u32].public;
+    input r1 as [u8; 33u32].public;
+    input r2 as [u8; 32u32].public;
+    input r3 as [u8; 128u32].public;
+    input r4 as u8.public;
+    input r5 as [field; 4u32].public;
+    input r6 as [u8; 256u32].public;
+    input r7 as [[u8; 128u32]; 2u32].public;
+    input r8 as [[[field; 4u32]; 3u32]; 2u32].public;
+    ecdsa.verify.digest r0 r1 r2 into r9;
+    snark.verify r3 r4 r5 r6 into r10;
+    snark.verify.batch r7 r4 r8 r6 into r11;
+
 function used_deserialize:
     input r0 as [boolean; 253u32].private;
     deserialize.bits.raw r0 ([boolean; 253u32]) into r1 (field);

--- a/tests/expectations/compiler/core/algorithms/deserialize_unused_dce.out
+++ b/tests/expectations/compiler/core/algorithms/deserialize_unused_dce.out
@@ -1,0 +1,11 @@
+program test.aleo;
+
+function unused_deserialize:
+    input r0 as [boolean; 253u32].private;
+    deserialize.bits.raw r0 ([boolean; 253u32]) into r1 (field);
+    output 1u8 as u8.private;
+
+function used_deserialize:
+    input r0 as [boolean; 253u32].private;
+    deserialize.bits.raw r0 ([boolean; 253u32]) into r1 (field);
+    output r1 as field.private;

--- a/tests/tests/compiler/core/algorithms/deserialize_unused_dce.leo
+++ b/tests/tests/compiler/core/algorithms/deserialize_unused_dce.leo
@@ -4,8 +4,43 @@ program test.aleo {
         return 1u8;
     }
 
+    fn unused_commit(value: field, randomness: scalar) -> u8 {
+        let commitment: field = BHP256::commit_to_field(value, randomness);
+        return 1u8;
+    }
+
+    fn unused_finalize_intrinsics(
+        sig: [u8; 65],
+        addr: [u8; 33],
+        digest: [u8; 32],
+        vk: [u8; 128],
+        varuna_version: u8,
+        inputs: [field; 4],
+        proof: [u8; 256],
+        vks: [[u8; 128]; 2],
+        batch_inputs: [[[field; 4]; 3]; 2],
+    ) -> Final {
+        return final { finalize(sig, addr, digest, vk, varuna_version, inputs, proof, vks, batch_inputs); };
+    }
+
     fn used_deserialize(bits: [bool; 253]) -> field {
         let value: field = Deserialize::from_bits_raw::[field](bits);
         return value;
     }
+}
+
+final fn finalize(
+    sig: [u8; 65],
+    addr: [u8; 33],
+    digest: [u8; 32],
+    vk: [u8; 128],
+    varuna_version: u8,
+    inputs: [field; 4],
+    proof: [u8; 256],
+    vks: [[u8; 128]; 2],
+    batch_inputs: [[[field; 4]; 3]; 2],
+) {
+    let ecdsa_result: bool = ECDSA::verify_digest(sig, addr, digest);
+    let snark_result: bool = Snark::verify(vk, varuna_version, inputs, proof);
+    let batch_result: bool = Snark::verify_batch(vks, varuna_version, batch_inputs, proof);
 }

--- a/tests/tests/compiler/core/algorithms/deserialize_unused_dce.leo
+++ b/tests/tests/compiler/core/algorithms/deserialize_unused_dce.leo
@@ -1,0 +1,11 @@
+program test.aleo {
+    fn unused_deserialize(bits: [bool; 253]) -> u8 {
+        let value: field = Deserialize::from_bits_raw::[field](bits);
+        return 1u8;
+    }
+
+    fn used_deserialize(bits: [bool; 253]) -> field {
+        let value: field = Deserialize::from_bits_raw::[field](bits);
+        return value;
+    }
+}


### PR DESCRIPTION
## Motivation

Dead code elimination currently treats `Deserialize` intrinsics as pure, so an unused `Deserialize::from_bits_raw` expression can be removed even though deserialization may halt on invalid encodings.

Mark `Deserialize` as non-pure so DCE preserves the operation before Aleo code generation.

## Test Plan

Added compiler golden coverage for unused deserialization. The expected bytecode keeps `deserialize.bits.raw` emitted for both unused and used deserialization paths.

## Related PRs

Closes #29474.
