### PR TITLE
Remove four unwired `leo` CLI flags

### DIFF
--- a/crates/leo/src/cli/commands/common/options.rs
+++ b/crates/leo/src/cli/commands/common/options.rs
@@ -31,18 +31,10 @@ pub const DEFAULT_ENDPOINT: &str = "https://api.explorer.provable.com/v1";
 
 /// Compiler Options wrapper for Build command. Also used by other commands which
 /// require Build command output as their input.
-#[derive(Parser, Clone, Debug)]
+#[derive(Parser, Clone, Debug, Default)]
 pub struct BuildOptions {
-    #[clap(long, help = "Enables offline mode.")]
-    pub offline: bool,
     #[clap(long, help = "Enable spans in AST snapshots.")]
     pub enable_ast_spans: bool,
-    #[clap(long, help = "Enables dead code elimination in the compiler.", default_value = "true")]
-    pub enable_dce: bool,
-    #[clap(long, help = "Max depth to type check nested conditionals.", default_value = "10")]
-    pub conditional_block_max_depth: usize,
-    #[clap(long, help = "Disable type checking of nested conditional branches in finalize scope.")]
-    pub disable_conditional_branch_type_checking: bool,
     #[clap(long, help = "Write an AST snapshot immediately after parsing.")]
     pub enable_initial_ast_snapshot: bool,
     #[clap(long, help = "Writes all AST snapshots for the different compiler phases.")]
@@ -55,24 +47,6 @@ pub struct BuildOptions {
     pub no_cache: bool,
     #[clap(long, help = "Don't use the local source code.")]
     pub no_local: bool,
-}
-
-impl Default for BuildOptions {
-    fn default() -> Self {
-        Self {
-            offline: false,
-            enable_ast_spans: false,
-            enable_dce: true,
-            conditional_block_max_depth: 10,
-            disable_conditional_branch_type_checking: false,
-            enable_initial_ast_snapshot: false,
-            enable_all_ast_snapshots: false,
-            ast_snapshots: Vec::new(),
-            build_tests: false,
-            no_cache: false,
-            no_local: false,
-        }
-    }
 }
 
 /// Overrides for the `.env` file.

--- a/crates/passes/src/errors/static_analyzer.rs
+++ b/crates/passes/src/errors/static_analyzer.rs
@@ -98,7 +98,7 @@ pub(crate) fn some_paths_do_not_run_all_finals(
         format!("not all paths through the function run every `Final` ({num_unawaited_paths}/{num_total_paths} paths leave at least one `Final` un-run)"),
         span,
     )
-    .with_help("Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.")
+    .with_help("Add `.run()` calls so every path consumes each `Final` exactly once.")
 }
 
 pub(crate) fn some_paths_contain_duplicate_final_runs(
@@ -112,7 +112,7 @@ pub(crate) fn some_paths_contain_duplicate_final_runs(
         format!("some paths through the function contain duplicate `Final` runs ({num_duplicate_await_paths}/{num_total_paths} paths run at least one `Final` more than once)"),
         span,
     )
-    .with_help("Remove the redundant `.run()` calls, or pass `--disable-conditional-branch-type-checking` to silence the warning.")
+    .with_help("Remove the redundant `.run()` calls.")
 }
 
 pub(crate) fn final_not_awaited_in_order(future_name: impl Display, span: Span) -> Formatted {

--- a/documentation/cli/03_build.md
+++ b/documentation/cli/03_build.md
@@ -31,16 +31,8 @@ The build also generates an **ABI file** at `build/{PROGRAM_NAME}/abi.json` desc
 ## Flags
 
 ```text
---offline
-    Enables offline mode.
 --enable-ast-spans
     Enable spans in AST snapshots.
---enable-dce
-    Enables dead code elimination in the compiler.
---conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-    Max depth to type check nested conditionals. [default: 10]
---disable-conditional-branch-type-checking
-    Disable type checking of nested conditional branches in finalize scope.
 --enable-initial-ast-snapshot
     Write an AST snapshot immediately after parsing.
 --enable-all-ast-snapshots

--- a/documentation/cli/06_deploy.md
+++ b/documentation/cli/06_deploy.md
@@ -231,16 +231,8 @@ Options:
   [UNUSED] Base fees in microcredits, delimited by `|`, and used in order. The fees must either be valid `u64` or `default`. Defaults to automatic calculation.
 --skip <SKIP>...
   Skips deployment of any program that contains one of the given substrings.
---offline
-    Enables offline mode.
 --enable-ast-spans
     Enable spans in AST snapshots.
---enable-dce
-    Enables dead code elimination in the compiler.
---conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-    Max depth to type check nested conditionals. [default: 10]
---disable-conditional-branch-type-checking
-    Disable type checking of nested conditional branches in finalize scope.
 --enable-initial-ast-snapshot
     Write an AST snapshot immediately after parsing.
 --enable-all-ast-snapshots

--- a/documentation/cli/09_execute.md
+++ b/documentation/cli/09_execute.md
@@ -199,16 +199,8 @@ Specifies the number of blocks to look at when searching for a transaction. Defa
 Options:
 --base-fees <BASE_FEES>
   [UNUSED] Base fees in microcredits, delimited by `|`, and used in order. The fees must either be valid `u64` or `default`. Defaults to automatic calculation.
---offline
-    Enables offline mode.
 --enable-ast-spans
     Enable spans in AST snapshots.
---enable-dce
-    Enables dead code elimination in the compiler.
---conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-    Max depth to type check nested conditionals. [default: 10]
---disable-conditional-branch-type-checking
-    Disable type checking of nested conditional branches in finalize scope.
 --enable-initial-ast-snapshot
     Write an AST snapshot immediately after parsing.
 --enable-all-ast-snapshots

--- a/documentation/cli/13_run.md
+++ b/documentation/cli/13_run.md
@@ -56,16 +56,8 @@ leo run <FUNCTION_NAME> -- <INPUT_0> -- <INPUT_1> ...
     remote program to fetch (with its transitive dependencies) from the network
     endpoint. Local files must be listed in topological order (dependencies
     before the programs that depend on them).
---offline
-    Enables offline mode.
 --enable-ast-spans
     Enable spans in AST snapshots.
---enable-dce
-    Enables dead code elimination in the compiler.
---conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-    Max depth to type check nested conditionals. [default: 10]
---disable-conditional-branch-type-checking
-    Disable type checking of nested conditional branches in finalize scope.
 --enable-initial-ast-snapshot
     Write an AST snapshot immediately after parsing.
 --enable-all-ast-snapshots

--- a/documentation/cli/14_test.md
+++ b/documentation/cli/14_test.md
@@ -25,16 +25,8 @@ Check out the [**Testing**](./../guides/09_testing.md) guide for more informatio
 ## Flags
 
 ```text
---offline
-    Enables offline mode.
 --enable-ast-spans
     Enable spans in AST snapshots.
---enable-dce
-    Enables dead code elimination in the compiler.
---conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-    Max depth to type check nested conditionals. [default: 10]
---disable-conditional-branch-type-checking
-    Disable type checking of nested conditional branches in finalize scope.
 --enable-initial-ast-snapshot
     Write an AST snapshot immediately after parsing.
 --enable-all-ast-snapshots

--- a/documentation/cli/16_upgrade.md
+++ b/documentation/cli/16_upgrade.md
@@ -116,16 +116,8 @@ Options:
   [UNUSED] Base fees in microcredits, delimited by `|`, and used in order. The fees must either be valid `u64` or `default`. Defaults to automatic calculation.
 --skip <SKIP>...
   Skips the upgrade of any program that contains one of the given substrings.
---offline
-    Enables offline mode.
 --enable-ast-spans
     Enable spans in AST snapshots.
---enable-dce
-    Enables dead code elimination in the compiler.
---conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-    Max depth to type check nested conditionals. [default: 10]
---disable-conditional-branch-type-checking
-    Disable type checking of nested conditional branches in finalize scope.
 --enable-initial-ast-snapshot
     Write an AST snapshot immediately after parsing.
 --enable-all-ast-snapshots

--- a/documentation/cli/18_fmt.md
+++ b/documentation/cli/18_fmt.md
@@ -69,3 +69,9 @@ Check if files are formatted without modifying them. Prints a diff and exits wit
 #### `[PATH]...`
 
 Files or directories to format. Defaults to the project `src/` directory if not specified.
+
+#### `--version`
+
+#### `-V`
+
+Print the `leo-fmt` plugin version. Works both standalone (`leo-fmt --version`) and through the CLI (`leo fmt --version`).

--- a/documentation/guides/04_deploying.md
+++ b/documentation/guides/04_deploying.md
@@ -61,20 +61,12 @@ Options:
           Number of blocks to look at when searching for a transaction. [default: 12]
       --skip <SKIP>...
           Skips deployment of any program that contains one of the given substrings.
-      --offline
-          Enables offline mode.
       --enable-ast-spans
           Enable spans in AST snapshots.
       --path <PATH>
           Path to Leo program root folder
-      --enable-dce
-          Enables dead code elimination in the compiler.
       --home <HOME>
           Path to aleo program registry
-      --conditional-block-max-depth <CONDITIONAL_BLOCK_MAX_DEPTH>
-          Max depth to type check nested conditionals. [default: 10]
-      --disable-conditional-branch-type-checking
-          Disable type checking of nested conditional branches in finalize scope.
       --enable-initial-ast-snapshot
           Write an AST snapshot immediately after parsing.
       --enable-all-ast-snapshots

--- a/tests/expectations/compiler/async_blocks/nested.out
+++ b/tests/expectations/compiler/async_blocks/nested.out
@@ -25,7 +25,7 @@
     │ │                
     │ ╰──────────────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program test_dep.aleo;
 

--- a/tests/expectations/compiler/async_blocks/partial_type_specification.out
+++ b/tests/expectations/compiler/async_blocks/partial_type_specification.out
@@ -25,7 +25,7 @@
     │ │                
     │ ╰──────────────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program test_dep.aleo;
 

--- a/tests/expectations/compiler/cei/conditional_interaction_warn.out
+++ b/tests/expectations/compiler/cei/conditional_interaction_warn.out
@@ -16,7 +16,7 @@
     │ │       
     │ ╰─────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program dep.aleo;
 

--- a/tests/expectations/compiler/cei/deep_nesting_interaction.out
+++ b/tests/expectations/compiler/cei/deep_nesting_interaction.out
@@ -16,7 +16,7 @@
     │ │       
     │ ╰─────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program dep.aleo;
 

--- a/tests/expectations/compiler/cei/interaction_only_in_else_branch.out
+++ b/tests/expectations/compiler/cei/interaction_only_in_else_branch.out
@@ -16,7 +16,7 @@
     │ │       
     │ ╰─────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program dep.aleo;
 

--- a/tests/expectations/compiler/cei/nested_conditional_interaction.out
+++ b/tests/expectations/compiler/cei/nested_conditional_interaction.out
@@ -16,7 +16,7 @@
     │ │       
     │ ╰─────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program dep.aleo;
 

--- a/tests/expectations/compiler/futures/nested.out
+++ b/tests/expectations/compiler/futures/nested.out
@@ -25,7 +25,7 @@
     │ │       
     │ ╰─────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program test_dep.aleo;
 

--- a/tests/expectations/compiler/futures/partial_type_specification.out
+++ b/tests/expectations/compiler/futures/partial_type_specification.out
@@ -25,7 +25,7 @@
     │ │       
     │ ╰─────── here
     │     
-    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once, or pass `--disable-conditional-branch-type-checking` to silence the warning.
+    │     Help: Add `.run()` calls so every path consumes each `Final` exactly once.
 ────╯
 program test_dep.aleo;
 


### PR DESCRIPTION
Remove four `leo` CLI flags that clap parsed but no code read: `--offline`, `--enable-dce`, `--conditional-block-max-depth`, `--disable-conditional-branch-type-checking`.

Also drops the dead `--disable-conditional-branch-type-checking` suggestion from two static-analyzer warnings, strips the flags from the CLI docs, and documents `leo fmt --version`.