### PR TITLE
docs: document the network.id operator in standard operators

### DIFF
--- a/documentation/code_snippets/operators/standard/src/main.leo
+++ b/documentation/code_snippets/operators/standard/src/main.leo
@@ -361,6 +361,14 @@ program standard_ops_demo.aleo {
     }
     // ANCHOR_END: block_timestamp
 
+    // ANCHOR: network_id
+    fn matches_network(id: u16) -> Final {
+        return final {
+            assert_eq(id, network.id);
+        };
+    }
+    // ANCHOR_END: network_id
+
     // ANCHOR: self_checksum
     fn matches_checksum(checksum: [u8; 32]) -> Final {
         return final {

--- a/documentation/language/operators/standard_operators.md
+++ b/documentation/language/operators/standard_operators.md
@@ -41,6 +41,7 @@ toc_max_heading_level: 3
 | [mul_wrapped](#mul_wrapped)                                | Wrapping multiplication                                   |
 | [nand](#nand)                                              | Negated conjunction                                       |
 | [neg](#neg)                                                | Additive inverse                                          |
+| [network.id](#networkid)                                   | Fetch the network id                                      |
 | [nor](#nor)                                                | Negated disjunction                                       |
 | [not](#not)                                                | Logical negation                                          |
 | [or](#or)                                                  | (Inclusive) disjunction                                   |
@@ -1003,6 +1004,24 @@ The `block.timestamp` operator is used to fetch the UNIX timestamp of the latest
 
 - The `block.timestamp` operator can only be used in on-chain context — a `final { }` block, a `final fn`, or a `constructor`. It is rejected in entry `fn` bodies, helper `fn`s, and constant initialisers, since chain state is only observable in the finalization context.
 - The `block.timestamp` operator doesn't take any parameters.
+
+  :::
+
+[Back to Top](#table-of-contents)
+
+---
+
+### `network.id`
+
+```leo file=../../code_snippets/operators/standard/src/main.leo#network_id
+```
+
+The `network.id` operator is used to fetch the id of the network on which the program is running, as a `u16`. In the above example, `network.id` is used in a `final { }` block to fetch the current network id in a program.
+
+:::info
+
+- The `network.id` operator can only be used in on-chain context — a `final { }` block, a `final fn`, or a `constructor`. It is rejected in entry `fn` bodies, helper `fn`s, and constant initialisers, since chain state is only observable in the finalization context.
+- The `network.id` operator doesn't take any parameters.
 
   :::
 


### PR DESCRIPTION
## Summary

Adds the missing `network.id` operator to the language reference: TOC row, a `### network.id` section under Context-dependent Expressions mirroring the `block.height` / `block.timestamp` structure, and a `network_id` snippet anchor in the compiled snippet program.

## Motivation

`network.id` is implemented in the compiler but missing from the language reference. #29384 (migrated from leo-docs-source#553) asks to add it to `documentation/language/operators/standard_operators.md`, mirroring the existing `block.height` / `block.timestamp` sections.

Documented semantics are verified against the source:
- returns `u16` (`crates/passes/src/type_checking/visitor.rs`, `Intrinsic::NetworkId` -> `Type::Integer(IntegerType::U16)`)
- finalize-context restriction via `check_access_allowed("network.id", AccessScope::FinalizeRead, ...)`, the same scope as `block.height`
- takes no parameters (`crates/ast/src/functions/intrinsic.rs`, `Self::NetworkId => 0`)

## Test Plan

Docs-only change. The new snippet follows the exact shape of the adjacent `matches_height` / `matches_timestamp` functions in the same compiled snippet program (`standard_ops_demo.aleo`), so the snippet build that covers those anchors covers this one. The TOC row sits alphabetically between `neg` and `nor`, and the section renders with the same TOC-row + snippet + description + `:::info` structure as `block.height`.

## Related PRs

Fixes #29384

(none)
