### PR TITLE
Validate program.json dependency fields

### DIFF
--- a/crates/package/src/errors.rs
+++ b/crates/package/src/errors.rs
@@ -90,6 +90,15 @@ pub(crate) fn invalid_network_name(name: impl Display) -> Backtraced {
         .with_help("Valid network names are `testnet`, `mainnet`, and `canary`.")
 }
 
+pub(crate) fn invalid_manifest_dependency(dep_name: impl Display, reason: impl Display) -> Backtraced {
+    Backtraced::error(
+        CODE_PREFIX,
+        CODE_MASK + 75,
+        format!("invalid dependency `{dep_name}` in `program.json`: {reason}"),
+    )
+    .with_help("Use `edition` only for `network` dependencies, `path` only for `local` and `test`, and neither for `workspace`.")
+}
+
 pub(crate) fn failed_path(path: impl Display, err: impl Display) -> Backtraced {
     Backtraced::error(CODE_PREFIX, CODE_MASK + 57, format!("cannot find path `{path}`: {err}"))
         .with_help("Verify the path exists and is accessible from the current working directory.")

--- a/crates/package/src/manifest.rs
+++ b/crates/package/src/manifest.rs
@@ -50,18 +50,161 @@ impl Manifest {
         std::fs::write(path, contents).map_err(crate::errors::failed_to_write_manifest)
     }
 
-    /// Read a Manifest from the given file as a JSON string.
+    /// Read and validate a Manifest from the given JSON file.
     pub fn read_from_file<P: AsRef<Path>>(path: P) -> Result<Self, Backtraced> {
         // Read the manifest file.
         let contents = std::fs::read_to_string(&path)
             .map_err(|_| crate::errors::failed_to_load_package(path.as_ref().display()))?;
         // Deserialize the manifest.
-        serde_json::from_str(&contents)
-            .map_err(|err| crate::errors::failed_to_deserialize_manifest_file(path.as_ref().display(), err))
+        let manifest: Self = serde_json::from_str(&contents)
+            .map_err(|err| crate::errors::failed_to_deserialize_manifest_file(path.as_ref().display(), err))?;
+        manifest.validate_dependencies()?;
+        Ok(manifest)
+    }
+
+    fn validate_dependencies(&self) -> Result<(), Backtraced> {
+        for dependency in self.dependencies.iter().flatten().chain(self.dev_dependencies.iter().flatten()) {
+            dependency.validate_manifest_shape()?;
+        }
+        Ok(())
     }
 }
 
 // Returns the current version of Leo.
 fn current_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+impl Dependency {
+    fn validate_manifest_shape(&self) -> Result<(), Backtraced> {
+        match self.location {
+            Location::Network => {
+                if self.path.is_some() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`network` dependencies cannot specify `path`",
+                    ));
+                }
+            }
+            Location::Local => {
+                if self.path.is_none() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`local` dependencies must specify `path`",
+                    ));
+                }
+                if self.edition.is_some() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`local` dependencies cannot specify `edition`",
+                    ));
+                }
+            }
+            Location::Workspace => {
+                if self.path.is_some() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`workspace` dependencies cannot specify `path`",
+                    ));
+                }
+                if self.edition.is_some() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`workspace` dependencies cannot specify `edition`",
+                    ));
+                }
+            }
+            Location::Test => {
+                if self.path.is_none() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`test` dependencies must specify `path`",
+                    ));
+                }
+                if self.edition.is_some() {
+                    return Err(crate::errors::invalid_manifest_dependency(
+                        &self.name,
+                        "`test` dependencies cannot specify `edition`",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn manifest_json(dependencies: &str, dev_dependencies: &str) -> String {
+        format!(
+            r#"{{
+  "program": "test.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "dependencies": {dependencies},
+  "dev_dependencies": {dev_dependencies}
+}}"#
+        )
+    }
+
+    fn read_manifest(contents: &str) -> Result<Manifest, Backtraced> {
+        let unique = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let dir = std::env::temp_dir().join(format!("leo-manifest-test-{unique}"));
+        fs::create_dir(&dir).unwrap();
+        let path = dir.join(MANIFEST_FILENAME);
+        fs::write(&path, contents).unwrap();
+        let result = Manifest::read_from_file(&path);
+        fs::remove_dir_all(dir).unwrap();
+        result
+    }
+
+    #[test]
+    fn manifest_rejects_network_dependency_with_path() {
+        let err =
+            read_manifest(&manifest_json(r#"[{"name":"foo.aleo","location":"network","path":"../foo"}]"#, "null"))
+                .unwrap_err();
+
+        assert!(err.to_string().contains("invalid dependency `foo.aleo`"));
+        assert!(err.to_string().contains("`network` dependencies cannot specify `path`"));
+    }
+
+    #[test]
+    fn manifest_rejects_local_dependency_without_path() {
+        let err = read_manifest(&manifest_json(r#"[{"name":"foo.aleo","location":"local"}]"#, "null")).unwrap_err();
+
+        assert!(err.to_string().contains("invalid dependency `foo.aleo`"));
+        assert!(err.to_string().contains("`local` dependencies must specify `path`"));
+    }
+
+    #[test]
+    fn manifest_rejects_invalid_dev_dependency_shape() {
+        let err =
+            read_manifest(&manifest_json("null", r#"[{"name":"foo.aleo","location":"workspace","path":"../foo"}]"#))
+                .unwrap_err();
+
+        assert!(err.to_string().contains("invalid dependency `foo.aleo`"));
+        assert!(err.to_string().contains("`workspace` dependencies cannot specify `path`"));
+    }
+
+    #[test]
+    fn manifest_accepts_location_specific_dependency_fields() {
+        let manifest = read_manifest(&manifest_json(
+            r#"[
+  {"name":"network_dep.aleo","location":"network","edition":1},
+  {"name":"local_dep.aleo","location":"local","path":"../local_dep"},
+  {"name":"workspace_dep.aleo","location":"workspace"}
+]"#,
+            "null",
+        ))
+        .unwrap();
+
+        assert_eq!(manifest.dependencies.unwrap().len(), 3);
+    }
 }


### PR DESCRIPTION
## Motivation

Reject malformed `program.json` dependency entries during manifest loading, before package graph construction or network resolution.

This gives a direct manifest error for cases such as a `network` dependency that also specifies `path`.

Closes #28748.

## Test Plan

- `cargo fmt --package leo-package`
- `cargo test -p leo-package manifest_ --locked`
- `git diff --check`

## Related PRs

N/A
