### PR TITLE
Reject visibility modes on record and Final function I/O

### DIFF
--- a/crates/passes/src/errors/type_checker.rs
+++ b/crates/passes/src/errors/type_checker.rs
@@ -1078,6 +1078,12 @@ pub(crate) fn storage_op_requires_path_receiver(
     .with_help(format!("Call `{operation}` directly on a declared {kind}, not on a temporary expression."))
 }
 
+pub(crate) fn record_or_final_cannot_have_mode(kind: impl Display, span: Span) -> Formatted {
+    Formatted::error(CODE_PREFIX, CODE_MASK + 192, format!("a {kind} cannot have a visibility mode"), span).with_help(
+        "Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.",
+    )
+}
+
 // TypeCheckerWarning builder functions
 
 pub(crate) fn caller_as_record_owner(record_name: impl Display, span: Span) -> Formatted {

--- a/crates/passes/src/errors/type_checker.rs
+++ b/crates/passes/src/errors/type_checker.rs
@@ -1078,10 +1078,12 @@ pub(crate) fn storage_op_requires_path_receiver(
     .with_help(format!("Call `{operation}` directly on a declared {kind}, not on a temporary expression."))
 }
 
-pub(crate) fn record_or_final_cannot_have_mode(kind: impl Display, span: Span) -> Formatted {
-    Formatted::error(CODE_PREFIX, CODE_MASK + 192, format!("a {kind} cannot have a visibility mode"), span).with_help(
-        "Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.",
-    )
+pub(crate) fn cannot_have_mode(kind: impl Display, span: Span) -> Formatted {
+    Formatted::error(CODE_PREFIX, CODE_MASK + 192, format!("a {kind} cannot have a visibility mode"), span)
+        .with_help("Remove the `public` or `private` modifier.")
+        .with_note(
+            "Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.",
+        )
 }
 
 // TypeCheckerWarning builder functions

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -2323,7 +2323,7 @@ impl TypeCheckingVisitor<'_> {
                     None
                 };
                 if let Some(kind) = kind {
-                    self.emit_err(crate::errors::type_checker::record_or_final_cannot_have_mode(kind, input.span()));
+                    self.emit_err(crate::errors::type_checker::cannot_have_mode(kind, input.span()));
                 }
             }
 
@@ -2404,10 +2404,7 @@ impl TypeCheckingVisitor<'_> {
             };
             if let Some(kind) = record_or_final_output {
                 if function.variant.is_entry() && function_output.mode != Mode::None {
-                    self.emit_err(crate::errors::type_checker::record_or_final_cannot_have_mode(
-                        kind,
-                        function_output.span,
-                    ));
+                    self.emit_err(crate::errors::type_checker::cannot_have_mode(kind, function_output.span));
                 }
             } else if function_output.mode == Mode::Constant {
                 // For other types, only public and private outputs are allowed.

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -2311,6 +2311,22 @@ impl TypeCheckingVisitor<'_> {
                 _ => {} // Do nothing.
             }
 
+            // Records and `Final`s lower to `.record`/`.future` markers, neither of which carries a
+            // visibility, so an explicit mode on such an input is meaningless. (Non-entry variants
+            // already reject all input modes above, so this only adds the record/`Final` cases.)
+            if function.variant.is_entry() && input.mode() != Mode::None {
+                let kind = if self.type_is_record(table_type) {
+                    Some("record")
+                } else if matches!(table_type, Type::Future(_)) {
+                    Some("`Final`")
+                } else {
+                    None
+                };
+                if let Some(kind) = kind {
+                    self.emit_err(crate::errors::type_checker::record_or_final_cannot_have_mode(kind, input.span()));
+                }
+            }
+
             if matches!(table_type, Type::Future(..)) {
                 // Future parameters may only appear in onchain functions.
                 // TODO: we may want to relax this
@@ -2376,8 +2392,25 @@ impl TypeCheckingVisitor<'_> {
             }
 
             // Check that the mode of the output is valid.
-            // For functions, only public and private outputs are allowed
-            if function_output.mode == Mode::Constant {
+            // Records and `Final`s lower to `.record`/`.future` markers, neither of which carries a
+            // visibility, so an explicit mode on such an output is meaningless. These types are only
+            // valid as outputs on entry points (other variants already error above).
+            let record_or_final_output = if self.type_is_record(&function_output.type_) {
+                Some("record")
+            } else if matches!(function_output.type_, Type::Future(_)) {
+                Some("`Final`")
+            } else {
+                None
+            };
+            if let Some(kind) = record_or_final_output {
+                if function.variant.is_entry() && function_output.mode != Mode::None {
+                    self.emit_err(crate::errors::type_checker::record_or_final_cannot_have_mode(
+                        kind,
+                        function_output.span,
+                    ));
+                }
+            } else if function_output.mode == Mode::Constant {
+                // For other types, only public and private outputs are allowed.
                 self.emit_err(crate::errors::type_checker::cannot_have_constant_output_mode(function_output.span));
             }
             // View outputs lower to `.public` from the variant alone, same as their inputs.
@@ -2426,6 +2459,17 @@ impl TypeCheckingVisitor<'_> {
             }
         } else if !lhs.eq_user(rhs) {
             *lhs = Type::Err;
+        }
+    }
+
+    /// Returns `true` if `type_` resolves to a record, including dynamic interface records.
+    pub fn type_is_record(&mut self, type_: &Type) -> bool {
+        match type_ {
+            Type::DynRecord => true,
+            Type::Composite(composite) => {
+                self.lookup_composite(composite.path.expect_global_location()).is_some_and(|comp| comp.is_record)
+            }
+            _ => false,
         }
     }
 

--- a/documentation/language/programs_in_practice/functions.md
+++ b/documentation/language/programs_in_practice/functions.md
@@ -20,6 +20,8 @@ Inputs are declared as `{visibility} {name}: {type}`. They must be declared just
 ```leo file=../../code_snippets/functions/entry_input/src/main.leo#snippet showLineNumbers
 ```
 
+A visibility modifier may not be applied to a record or `Final` parameter. Records are passed by their `.record` marker and `Final`s carry no visibility, so a `public` or `private` mode on them is meaningless and is rejected.
+
 ### Outputs
 
 The return type of the function is declared as `-> {expression}` and must be declared just after the function inputs.
@@ -27,6 +29,8 @@ A function output is calculated as `return {expression};`. Returning an output e
 
 ```leo file=../../code_snippets/functions/entry_output/src/main.leo#snippet showLineNumbers
 ```
+
+As with inputs, a record or `Final` output cannot carry a visibility modifier.
 
 ## On-chain State with `final { }`
 

--- a/tests/expectations/compiler/function/record_and_final_io_modes.out
+++ b/tests/expectations/compiler/function/record_and_final_io_modes.out
@@ -1,0 +1,33 @@
+program test.aleo;
+
+record Token:
+    owner as address.private;
+    amount as u64.private;
+
+struct Pair:
+    a as u32;
+    b as u32;
+
+mapping Yo:
+    key as u32.public;
+    value as u32.public;
+
+function rec_io:
+    input r0 as Token.record;
+    cast r0.owner r0.amount into r1 as Token.record;
+    output r1 as Token.record;
+
+function struct_io:
+    input r0 as Pair.public;
+    output r0 as Pair.public;
+
+function dyn_io:
+    input r0 as dynamic.record;
+    output r0 as dynamic.record;
+
+function fut_io:
+    async fut_io into r0;
+    output r0 as test.aleo/fut_io.future;
+
+finalize fut_io:
+    set 1u32 into Yo[1u32];

--- a/tests/expectations/compiler/function/record_and_final_io_modes_fail.out
+++ b/tests/expectations/compiler/function/record_and_final_io_modes_fail.out
@@ -1,0 +1,133 @@
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:19:22 ]
+    │
+ 19 │     fn rec_in_public(public t: Token) -> u64 { return t.amount; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:20:23 ]
+    │
+ 20 │     fn rec_in_private(private t: Token) -> u64 { return t.amount; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372039] Error: entry point functions cannot have constant inputs
+    ╭─[ compiler-test:21:24 ]
+    │
+ 21 │     fn rec_in_constant(constant t: Token) -> u64 { return t.amount; }
+    │ 
+    │ Help: Remove the `constant` modifier from the input, or make this function a regular `fn` instead of an entry point.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:21:24 ]
+    │
+ 21 │     fn rec_in_constant(constant t: Token) -> u64 { return t.amount; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:24:55 ]
+    │
+ 24 │     fn rec_out_public(owner: address, amount: u64) -> public Token { return Token { owner, amount }; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:25:56 ]
+    │
+ 25 │     fn rec_out_private(owner: address, amount: u64) -> private Token { return Token { owner, amount }; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:26:57 ]
+    │
+ 26 │     fn rec_out_constant(owner: address, amount: u64) -> constant Token { return Token { owner, amount }; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:29:15 ]
+    │
+ 29 │     fn dyn_in(public t: dyn record) -> u8 { return 1u8; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a record cannot have a visibility mode
+    ╭─[ compiler-test:30:34 ]
+    │
+ 30 │     fn dyn_out(t: dyn record) -> public dyn record { return t; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a `Final` cannot have a visibility mode
+    ╭─[ compiler-test:33:15 ]
+    │
+ 33 │     fn fut_in(public f: Final) -> u8 { return 1u8; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372116] Error: `Final`s may only appear as parameters to a `final fn`
+    ╭─[ compiler-test:33:15 ]
+    │
+ 33 │     fn fut_in(public f: Final) -> u8 { return 1u8; }
+    │ 
+    │ Help: Remove the `Final` parameter, or change the function to a `final fn` if it is consuming a `Final`.
+────╯
+[ETYC0372192] Error: a `Final` cannot have a visibility mode
+    ╭─[ compiler-test:36:28 ]
+    │
+ 36 │     fn fut_out_public() -> public Final { return final { fin(1u32, 1u32); }; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a `Final` cannot have a visibility mode
+    ╭─[ compiler-test:37:29 ]
+    │
+ 37 │     fn fut_out_private() -> private Final { return final { fin(1u32, 1u32); }; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372192] Error: a `Final` cannot have a visibility mode
+    ╭─[ compiler-test:38:30 ]
+    │
+ 38 │     fn fut_out_constant() -> constant Final { return final { fin(1u32, 1u32); }; }
+    │ 
+    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+────╯
+[ETYC0372028] Error: `view fn` inputs cannot have visibility modes
+    ╭─[ compiler-test:42:15 ]
+    │
+ 42 │     view fn v(public x: u32) -> private u32 { return x; }
+    │ 
+    │ Help: Remove the `public`, `private`, or `constant` modifier.
+────╯
+[ETYC0372032] Error: `view fn` outputs cannot have visibility modes
+    ╭─[ compiler-test:42:33 ]
+    │
+ 42 │     view fn v(public x: u32) -> private u32 { return x; }
+    │ 
+    │ Help: Remove the `public`, `private`, or `constant` modifier.
+────╯
+[ETYC0372057] Error: only entry point fns can have a record as input or output
+    ╭─[ compiler-test:50:11 ]
+    │
+ 50 │ fn helper(public t: Token) -> u8 { return 1u8; }
+    │ 
+    │ Help: Move the function inside the `program` block to make it an entry point fn, or change its signature to avoid records.
+────╯
+[ETYC0372028] Error: regular `fn` inputs cannot have visibility modes
+    ╭─[ compiler-test:50:11 ]
+    │
+ 50 │ fn helper(public t: Token) -> u8 { return 1u8; }
+    │ 
+    │ Help: Remove the `public`, `private`, or `constant` modifier.
+────╯
+[ETYC0372028] Error: `final fn` inputs cannot have visibility modes
+    ╭─[ compiler-test:59:20 ]
+    │
+ 59 │ final fn fin_moded(public f: Final) {}
+    │ 
+    │ Help: Remove the `public`, `private`, or `constant` modifier.
+────╯

--- a/tests/expectations/compiler/function/record_and_final_io_modes_fail.out
+++ b/tests/expectations/compiler/function/record_and_final_io_modes_fail.out
@@ -3,14 +3,18 @@
     │
  19 │     fn rec_in_public(public t: Token) -> u64 { return t.amount; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a record cannot have a visibility mode
     ╭─[ compiler-test:20:23 ]
     │
  20 │     fn rec_in_private(private t: Token) -> u64 { return t.amount; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372039] Error: entry point functions cannot have constant inputs
     ╭─[ compiler-test:21:24 ]
@@ -24,49 +28,63 @@
     │
  21 │     fn rec_in_constant(constant t: Token) -> u64 { return t.amount; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a record cannot have a visibility mode
     ╭─[ compiler-test:24:55 ]
     │
  24 │     fn rec_out_public(owner: address, amount: u64) -> public Token { return Token { owner, amount }; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a record cannot have a visibility mode
     ╭─[ compiler-test:25:56 ]
     │
  25 │     fn rec_out_private(owner: address, amount: u64) -> private Token { return Token { owner, amount }; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a record cannot have a visibility mode
     ╭─[ compiler-test:26:57 ]
     │
  26 │     fn rec_out_constant(owner: address, amount: u64) -> constant Token { return Token { owner, amount }; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a record cannot have a visibility mode
     ╭─[ compiler-test:29:15 ]
     │
  29 │     fn dyn_in(public t: dyn record) -> u8 { return 1u8; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a record cannot have a visibility mode
     ╭─[ compiler-test:30:34 ]
     │
  30 │     fn dyn_out(t: dyn record) -> public dyn record { return t; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a `Final` cannot have a visibility mode
     ╭─[ compiler-test:33:15 ]
     │
  33 │     fn fut_in(public f: Final) -> u8 { return 1u8; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372116] Error: `Final`s may only appear as parameters to a `final fn`
     ╭─[ compiler-test:33:15 ]
@@ -80,21 +98,27 @@
     │
  36 │     fn fut_out_public() -> public Final { return final { fin(1u32, 1u32); }; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a `Final` cannot have a visibility mode
     ╭─[ compiler-test:37:29 ]
     │
  37 │     fn fut_out_private() -> private Final { return final { fin(1u32, 1u32); }; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372192] Error: a `Final` cannot have a visibility mode
     ╭─[ compiler-test:38:30 ]
     │
  38 │     fn fut_out_constant() -> constant Final { return final { fin(1u32, 1u32); }; }
     │ 
-    │ Help: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility. Remove the `public` or `private` modifier.
+    │ Help: Remove the `public` or `private` modifier.
+    │ 
+    │ Note: Records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a visibility.
 ────╯
 [ETYC0372028] Error: `view fn` inputs cannot have visibility modes
     ╭─[ compiler-test:42:15 ]

--- a/tests/tests/compiler/function/record_and_final_io_modes.leo
+++ b/tests/tests/compiler/function/record_and_final_io_modes.leo
@@ -1,0 +1,32 @@
+// PASS: records and `Final`s WITHOUT a visibility mode are accepted on entry points, and a mode on a
+// non-record / non-`Final` type (e.g. a `struct`) is still accepted. This guards against the
+// record/`Final` mode check over-firing on the types it should leave alone.
+program test.aleo {
+    mapping Yo: u32 => u32;
+
+    record Token {
+        owner: address,
+        amount: u64,
+    }
+
+    struct Pair {
+        a: u32,
+        b: u32,
+    }
+
+    // Record I/O without a mode: OK.
+    fn rec_io(t: Token) -> Token { return t; }
+
+    // A struct (not a record) may carry a visibility mode: OK.
+    fn struct_io(public p: Pair) -> public Pair { return p; }
+
+    // `dyn record` I/O without a mode: OK.
+    fn dyn_io(t: dyn record) -> dyn record { return t; }
+
+    // `Final` output without a mode: OK.
+    fn fut_io() -> Final { return final { fin(1u32, 1u32); }; }
+}
+
+final fn fin(a: u32, b: u32) {
+    Mapping::set(Yo, a, b);
+}

--- a/tests/tests/compiler/function/record_and_final_io_modes_fail.leo
+++ b/tests/tests/compiler/function/record_and_final_io_modes_fail.leo
@@ -1,0 +1,59 @@
+// FAIL: records lower to a `.record` marker and `Final`s to a `.future`, neither of which carries a
+// visibility, so a `public` / `private` / `constant` mode on a record or `Final` input or output of
+// an entry point is meaningless and is rejected. This covers every entry-point position (record
+// inputs, record outputs, `dyn record` inputs/outputs, `Final` inputs/outputs across all three
+// modes), and then confirms the rule is scoped to entry points: on a `view fn`, a helper `fn`, and a
+// `final fn`, the existing variant-specific diagnostics fire instead of this one.
+//
+// (A `constant` input additionally trips the entry-point const-input rule, and a `Final` input
+// additionally trips the "`Final`s cannot be parameters here" rule; both extra errors are expected.)
+program test.aleo {
+    mapping Yo: u32 => u32;
+
+    record Token {
+        owner: address,
+        amount: u64,
+    }
+
+    // Record inputs with a mode (entry point).
+    fn rec_in_public(public t: Token) -> u64 { return t.amount; }
+    fn rec_in_private(private t: Token) -> u64 { return t.amount; }
+    fn rec_in_constant(constant t: Token) -> u64 { return t.amount; }
+
+    // Record outputs with a mode (entry point).
+    fn rec_out_public(owner: address, amount: u64) -> public Token { return Token { owner, amount }; }
+    fn rec_out_private(owner: address, amount: u64) -> private Token { return Token { owner, amount }; }
+    fn rec_out_constant(owner: address, amount: u64) -> constant Token { return Token { owner, amount }; }
+
+    // `dyn record` inputs/outputs with a mode (the dynamic-record form of the same rule).
+    fn dyn_in(public t: dyn record) -> u8 { return 1u8; }
+    fn dyn_out(t: dyn record) -> public dyn record { return t; }
+
+    // `Final` input with a mode (entry point).
+    fn fut_in(public f: Final) -> u8 { return 1u8; }
+
+    // `Final` outputs with a mode (entry point).
+    fn fut_out_public() -> public Final { return final { fin(1u32, 1u32); }; }
+    fn fut_out_private() -> private Final { return final { fin(1u32, 1u32); }; }
+    fn fut_out_constant() -> constant Final { return final { fin(1u32, 1u32); }; }
+
+    // Non-entry position: view fn input/output modes are rejected as view-mode errors, not the
+    // record/`Final` mode error.
+    view fn v(public x: u32) -> private u32 { return x; }
+
+    @noupgrade
+    constructor() {}
+}
+
+// Non-entry position: a helper `fn` with a moded record input gets the regular-`fn` mode error and
+// the "only entry point fns can have a record" error, not the record/`Final` mode error.
+fn helper(public t: Token) -> u8 { return 1u8; }
+
+// The finalize function invoked by the entry points' `final` blocks above.
+final fn fin(a: u32, b: u32) {
+    Mapping::set(Yo, a, b);
+}
+
+// Non-entry position: a `final fn` with a moded `Final` input gets the final-fn input-mode error
+// (`Final`s are valid parameters there), not the record/`Final` mode error.
+final fn fin_moded(public f: Final) {}


### PR DESCRIPTION
Closes #29485.

Records lower to a `.record` marker and `Final` (futures) to a `.future`, neither of which carries a visibility. A `public`/`private`/`constant` mode on a record or future input or output of an entry point is therefore meaningless and was being silently dropped. The type checker now rejects it.

## Changes
- Add a `type_is_record` helper and reject a non-`None` mode on record/`dyn record` and future I/O of entry points, in `check_function_signature`. The rule is scoped to entry points; other variants already reject (or repurpose) I/O modes on their own.
- New error `ETYC0372192` (`a record/future cannot have a visibility mode`).
- Document the restriction in the function Inputs/Outputs reference.

## Tests
- `record_and_final_io_modes_fail.leo` — every entry-point position (record/`dyn record`/future inputs and outputs across modes) is rejected, and view/helper/`final fn` positions emit their existing variant errors instead.
- `record_and_final_io_modes.leo` — no-mode record/future I/O and a moded `struct` still compile.