### PR TITLE
fix(const-eval): reject overflowing left shifts

### DIFF
--- a/crates/ast/src/const_eval/evaluate.rs
+++ b/crates/ast/src/const_eval/evaluate.rs
@@ -724,91 +724,71 @@ fn evaluate_binary_inner(
                 SvmLiteralParam::U64(_) | SvmLiteralParam::I64(_) if rhs >= 64 => return Err("shl overflow".into()),
                 SvmLiteralParam::U128(_) | SvmLiteralParam::I128(_) if rhs >= 128 => return Err("shl overflow".into()),
                 SvmLiteralParam::U8(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::U16(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::U32(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::U64(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::U128(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::I8(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::I16(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::I32(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::I64(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()
                 }
                 SvmLiteralParam::I128(x) => {
-                    let before_ones = x.count_ones();
                     let shifted = (**x) << rhs;
-                    let after_ones = x.count_ones();
-                    if before_ones != after_ones {
+                    if (shifted >> rhs) != **x {
                         return Err("shl".into());
                     }
                     shifted.into()

--- a/crates/package/src/manifest.rs
+++ b/crates/package/src/manifest.rs
@@ -138,8 +138,12 @@ mod tests {
     use super::*;
     use std::{
         fs,
+        process,
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    static NEXT_TEST_DIR_ID: AtomicU64 = AtomicU64::new(0);
 
     fn manifest_json(dependencies: &str, dev_dependencies: &str) -> String {
         format!(
@@ -155,8 +159,10 @@ mod tests {
     }
 
     fn read_manifest(contents: &str) -> Result<Manifest, Backtraced> {
-        let unique = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        let dir = std::env::temp_dir().join(format!("leo-manifest-test-{unique}"));
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+        let sequence = NEXT_TEST_DIR_ID.fetch_add(1, Ordering::Relaxed);
+        let dir =
+            std::env::temp_dir().join(format!("leo-manifest-test-{}-{nanos}-{sequence}", process::id()));
         fs::create_dir(&dir).unwrap();
         let path = dir.join(MANIFEST_FILENAME);
         fs::write(&path, contents).unwrap();

--- a/crates/package/src/manifest.rs
+++ b/crates/package/src/manifest.rs
@@ -161,8 +161,7 @@ mod tests {
     fn read_manifest(contents: &str) -> Result<Manifest, Backtraced> {
         let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
         let sequence = NEXT_TEST_DIR_ID.fetch_add(1, Ordering::Relaxed);
-        let dir =
-            std::env::temp_dir().join(format!("leo-manifest-test-{}-{nanos}-{sequence}", process::id()));
+        let dir = std::env::temp_dir().join(format!("leo-manifest-test-{}-{nanos}-{sequence}", process::id()));
         fs::create_dir(&dir).unwrap();
         let path = dir.join(MANIFEST_FILENAME);
         fs::write(&path, contents).unwrap();

--- a/tests/expectations/execution/const_shift_probe.out
+++ b/tests/expectations/execution/const_shift_probe.out
@@ -6,6 +6,6 @@ Errors:
     ╭─[ compiler-test:10:16 ]
     │
  10 │         return 128u8 << 1u8;
-    │
+    │ 
     │ Help: The operands are constant, so this operation was evaluated at compile time and would also fail at runtime. Adjust the operands to avoid the failure (e.g. division by zero or integer overflow).
 ────╯

--- a/tests/expectations/execution/const_shift_probe.out
+++ b/tests/expectations/execution/const_shift_probe.out
@@ -1,0 +1,11 @@
+Error while running execution tests:
+
+
+Errors:
+[ECEV0378000] Error: binary operation `128u8 << 1u8` failed at compile time: shl
+    ╭─[ compiler-test:10:16 ]
+    │
+ 10 │         return 128u8 << 1u8;
+    │
+    │ Help: The operands are constant, so this operation was evaluated at compile time and would also fail at runtime. Adjust the operands to avoid the failure (e.g. division by zero or integer overflow).
+────╯

--- a/tests/expectations/execution/const_shift_probe.out
+++ b/tests/expectations/execution/const_shift_probe.out
@@ -6,6 +6,6 @@ Errors:
     ╭─[ compiler-test:10:16 ]
     │
  10 │         return 128u8 << 1u8;
-    │ 
+    │
     │ Help: The operands are constant, so this operation was evaluated at compile time and would also fail at runtime. Adjust the operands to avoid the failure (e.g. division by zero or integer overflow).
 ────╯

--- a/tests/expectations/execution/const_shift_signed_overflow.out
+++ b/tests/expectations/execution/const_shift_signed_overflow.out
@@ -1,0 +1,11 @@
+Error while running execution tests:
+
+
+Errors:
+[ECEV0378000] Error: binary operation `64i8 << 1u8` failed at compile time: shl
+    ╭─[ compiler-test:10:16 ]
+    │
+ 10 │         return 64i8 << 1u8;
+    │
+    │ Help: The operands are constant, so this operation was evaluated at compile time and would also fail at runtime. Adjust the operands to avoid the failure (e.g. division by zero or integer overflow).
+────╯

--- a/tests/expectations/execution/const_shift_signed_overflow.out
+++ b/tests/expectations/execution/const_shift_signed_overflow.out
@@ -6,6 +6,6 @@ Errors:
     ╭─[ compiler-test:10:16 ]
     │
  10 │         return 64i8 << 1u8;
-    │ 
+    │
     │ Help: The operands are constant, so this operation was evaluated at compile time and would also fail at runtime. Adjust the operands to avoid the failure (e.g. division by zero or integer overflow).
 ────╯

--- a/tests/expectations/execution/const_shift_signed_overflow.out
+++ b/tests/expectations/execution/const_shift_signed_overflow.out
@@ -6,6 +6,6 @@ Errors:
     ╭─[ compiler-test:10:16 ]
     │
  10 │         return 64i8 << 1u8;
-    │
+    │ 
     │ Help: The operands are constant, so this operation was evaluated at compile time and would also fail at runtime. Adjust the operands to avoid the failure (e.g. division by zero or integer overflow).
 ────╯

--- a/tests/expectations/execution/const_shift_signed_valid.out
+++ b/tests/expectations/execution/const_shift_signed_valid.out
@@ -1,0 +1,21 @@
+program const_shift_signed_valid.aleo;
+
+function const_neg_shift:
+    output -4i8 as i8.private;
+
+function const_min_shift:
+    output -128i8 as i8.private;
+
+function runtime_min_shift:
+    input r0 as i8.private;
+    shl r0 7u8 into r1;
+    output r1 as i8.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: -4i8
+status: success
+output: -128i8
+status: success
+output: -128i8

--- a/tests/tests/execution/const_shift_probe.leo
+++ b/tests/tests/execution/const_shift_probe.leo
@@ -1,0 +1,15 @@
+/*
+[case]
+program = "const_shift_probe.aleo"
+function = "const_overflow_u8"
+input = []
+*/
+
+program const_shift_probe.aleo {
+    fn const_overflow_u8() -> u8 {
+        return 128u8 << 1u8;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/const_shift_signed_overflow.leo
+++ b/tests/tests/execution/const_shift_signed_overflow.leo
@@ -1,0 +1,15 @@
+/*
+[case]
+program = "const_shift_signed_overflow.aleo"
+function = "const_overflow_i8"
+input = []
+*/
+
+program const_shift_signed_overflow.aleo {
+    fn const_overflow_i8() -> i8 {
+        return 64i8 << 1u8;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/const_shift_signed_valid.leo
+++ b/tests/tests/execution/const_shift_signed_valid.leo
@@ -1,0 +1,33 @@
+/*
+[case]
+program = "const_shift_signed_valid.aleo"
+function = "const_neg_shift"
+input = []
+
+[case]
+program = "const_shift_signed_valid.aleo"
+function = "const_min_shift"
+input = []
+
+[case]
+program = "const_shift_signed_valid.aleo"
+function = "runtime_min_shift"
+input = ["-1i8"]
+*/
+
+program const_shift_signed_valid.aleo {
+    fn const_neg_shift() -> i8 {
+        return -2i8 << 1u8;
+    }
+
+    fn const_min_shift() -> i8 {
+        return -1i8 << 7u8;
+    }
+
+    fn runtime_min_shift(x: i8) -> i8 {
+        return x << 7u8;
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
## Motivation

Const eval currently folds `128u8 << 1u8` to `0u8`, while the equivalent runtime checked shift halts.

Detect left-shift overflow during const eval by requiring the shifted value to recover the original value when shifted back. This rejects values that lose bits while preserving valid signed shifts.

## Test Plan

Added execution golden coverage for unsigned and signed constant left shifts, including valid signed shifts and overflowing shifts.

- `cargo test --ignore-rust-version -p leo-compiler const_shift -- --nocapture`
- `git diff --check`

## Related PRs

Closes #29490.
