### PR TITLE
Add standard library base

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,10 +231,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-test-windows-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-test-windows-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-test-windows-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-test-windows-{{ arch }}-master-
+            - cargo-v3-test-windows-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-windows-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-test-windows-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-windows-{{ arch }}-master-
       - install-rust-windows
       - run:
           name: Update Submodules
@@ -242,7 +242,7 @@ jobs:
       - build-and-test:
           is_windows: true
       - save_cache:
-          key: cargo-v2-test-windows-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-test-windows-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - C:\Users\circleci\.cargo
             - C:\Users\circleci\.aleo\resources
@@ -255,10 +255,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-test-macos-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-test-macos-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-test-macos-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-test-macos-{{ arch }}-master-
+            - cargo-v3-test-macos-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-macos-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-test-macos-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-macos-{{ arch }}-master-
       - install-rust
       - install-libclang
       - install-snarkos
@@ -267,7 +267,7 @@ jobs:
           command: git submodule update --init --recursive
       - build-and-test
       - save_cache:
-          key: cargo-v2-test-macos-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-test-macos-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.aleo/resources
@@ -280,10 +280,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-test-linux-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-test-linux-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-test-linux-{{ arch }}-master-
+            - cargo-v3-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-linux-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-test-linux-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-linux-{{ arch }}-master-
       - install-rust
       - install-libclang
       - install-snarkos
@@ -292,7 +292,7 @@ jobs:
             command: git submodule update --init --recursive
       - build-and-test
       - save_cache:
-          key: cargo-v2-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.aleo/resources
@@ -346,10 +346,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-clippy-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-clippy-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-clippy-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-clippy-{{ arch }}-master-
+            - cargo-v3-clippy-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-clippy-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-clippy-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-clippy-{{ arch }}-master-
       - install-libclang
       - run:
           name: Update Submodules
@@ -359,7 +359,7 @@ jobs:
           no_output_timeout: 35m
           command: cargo clippy --workspace --all-targets --all-features -- -D warnings
       - save_cache:
-          key: cargo-v2-clippy-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-clippy-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.cache/mtimes
@@ -373,10 +373,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-fmt-validate-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-fmt-validate-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-fmt-validate-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-fmt-validate-{{ arch }}-master-
+            - cargo-v3-fmt-validate-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-fmt-validate-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-fmt-validate-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-fmt-validate-{{ arch }}-master-
       - install-libclang
       - restore_cache:
           keys:
@@ -406,7 +406,7 @@ jobs:
             cargo nextest run -p leo-fmt --locked --cargo-profile ci --features validate \
               -E 'test(/validate_/) - test(validate_ast_equivalence_repos)'
       - save_cache:
-          key: cargo-v2-fmt-validate-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-fmt-validate-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.cache/mtimes
@@ -420,10 +420,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-cargo-doc-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-cargo-doc-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-cargo-doc-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-cargo-doc-{{ arch }}-master-
+            - cargo-v3-cargo-doc-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-cargo-doc-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-cargo-doc-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-cargo-doc-{{ arch }}-master-
       - install-libclang
       - run:
           name: Update Submodules
@@ -437,7 +437,7 @@ jobs:
             RUSTDOCFLAGS: "--enable-index-page -Zunstable-options"
             RUSTC_BOOTSTRAP: "1"
       - save_cache:
-          key: cargo-v2-cargo-doc-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-cargo-doc-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.cache/mtimes
@@ -472,10 +472,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v2-leo-exec-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-leo-exec-{{ arch }}-{{ .Branch }}-
-            - cargo-v2-leo-exec-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v2-leo-exec-{{ arch }}-master-
+            - cargo-v3-leo-exec-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-leo-exec-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-leo-exec-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-leo-exec-{{ arch }}-master-
       - install-libclang
       - run:
           name: Update Submodules
@@ -492,7 +492,7 @@ jobs:
             - project/examples
             - project/documentation
       - save_cache:
-          key: cargo-v2-leo-exec-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-leo-exec-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.cache/mtimes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2403,6 +2403,7 @@ dependencies = [
  "leo-parser",
  "leo-passes",
  "leo-span",
+ "leo-std",
  "leo-test-framework",
  "rand_chacha 0.10.0",
  "rayon",
@@ -2489,6 +2490,7 @@ dependencies = [
  "leo-errors",
  "leo-package",
  "leo-span",
+ "leo-std",
  "libc",
  "nix 0.30.1",
  "num-format",
@@ -2625,6 +2627,10 @@ dependencies = [
  "scoped-tls",
  "serde",
 ]
+
+[[package]]
+name = "leo-std"
+version = "4.2.0"
 
 [[package]]
 name = "leo-test-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ leo-parser          = { path = "./crates/parser",           version = "=4.2.0" }
 leo-parser-rowan    = { path = "./crates/parser-rowan",     version = "=4.2.0" }
 leo-passes          = { path = "./crates/passes",           version = "=4.2.0" }
 leo-span            = { path = "./crates/span",             version = "=4.2.0" }
+leo-std             = { path = "./crates/leo-std",          version = "=4.2.0" }
 leo-test-framework  = { path = "./crates/test-framework" }
 # third party dependencies
 aleo-std           = { version = "1.0.3"}

--- a/crates/ast/src/stub/mod.rs
+++ b/crates/ast/src/stub/mod.rs
@@ -20,7 +20,7 @@ pub mod function_stub;
 pub use function_stub::*;
 
 use crate::{Composite, ConstDeclaration, Identifier, Indent, Library, Mapping, NodeID, Program, ProgramId};
-use indexmap::IndexSet;
+use indexmap::{IndexMap, IndexSet};
 use leo_span::{Span, Symbol};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -115,7 +115,8 @@ impl From<AleoProgram> for Stub {
 }
 
 impl From<Library> for Stub {
-    fn from(library: Library) -> Self {
+    fn from(mut library: Library) -> Self {
+        library.stubs = IndexMap::new();
         Stub::FromLibrary { library, parents: IndexSet::new() }
     }
 }

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -30,6 +30,7 @@ leo-package       = { workspace = true }
 leo-passes        = { workspace = true }
 leo-parser        = { workspace = true }
 leo-span          = { workspace = true }
+leo-std           = { workspace = true }
 # third party dependencies
 aleo-std          = { workspace = true }
 aleo-std-storage  = { workspace = true }

--- a/crates/compiler/src/compiler.rs
+++ b/crates/compiler/src/compiler.rs
@@ -730,6 +730,9 @@ impl Compiler {
     pub fn add_import_stubs(&mut self) -> Result<()> {
         use indexmap::IndexSet;
 
+        // Inject the implicit standard library as a dependency of the current unit.
+        self.inject_std_library()?;
+
         // Track which programs we've already processed.
         let mut explored = IndexSet::<Symbol>::new();
 
@@ -828,6 +831,65 @@ impl Compiler {
             Ast::Library(library) => library.stubs = reachable,
         }
 
+        Ok(())
+    }
+
+    /// Builds the implicit `std` library and returns it as a `Stub` with an empty parent set.
+    ///
+    /// Callers that compile multiple units against a shared `NodeBuilder` can invoke this once
+    /// and pass the resulting stub into each per-unit `Compiler` via `import_stubs`, avoiding
+    /// re-parsing and re-type-checking `std` for every unit.
+    pub fn build_std_stub(handler: Handler, node_builder: Rc<NodeBuilder>, network: NetworkName) -> Result<Stub> {
+        let std_name = Symbol::intern(leo_std::library_name());
+
+        let mut sub_compiler = Compiler::new(
+            Some(leo_std::library_name().to_string()),
+            false,
+            handler,
+            node_builder,
+            PathBuf::new(),
+            Some(CompilerOptions {
+                // avoid infinite recursion
+                no_std: true,
+                ..CompilerOptions::default()
+            }),
+            IndexMap::new(),
+            network,
+        );
+
+        let module_refs: Vec<(&str, FileName)> =
+            leo_std::modules().iter().map(|(path, source)| (*source, FileName::Custom((*path).to_string()))).collect();
+
+        let library = sub_compiler.build_library(
+            std_name,
+            leo_std::entry_source(),
+            FileName::Custom(format!("<{}>", leo_std::library_name())),
+            &module_refs,
+        )?;
+
+        Ok(library.into())
+    }
+
+    /// Registers the implicit `std` library on `self.import_stubs`.
+    ///
+    /// Reuses an existing entry if one was preloaded
+    fn inject_std_library(&mut self) -> Result<()> {
+        if self.compiler_options.no_std {
+            return Ok(());
+        }
+
+        let std_name = Symbol::intern(leo_std::library_name());
+        let parent = Symbol::intern(self.unit_name.as_deref().expect("Cannot get unit name"));
+
+        if let Some(existing) = self.import_stubs.get_mut(&std_name) {
+            existing.add_parent(parent);
+            return Ok(());
+        }
+
+        let mut stub =
+            Self::build_std_stub(self.state.handler.clone(), Rc::clone(&self.state.node_builder), self.state.network)?;
+        stub.add_parent(parent);
+        self.import_stubs.insert(std_name, stub);
         Ok(())
     }
 

--- a/crates/compiler/src/options.rs
+++ b/crates/compiler/src/options.rs
@@ -26,6 +26,8 @@ pub struct CompilerOptions {
     pub ast_snapshots: AstSnapshots,
 
     pub initial_ast: bool,
+
+    pub no_std: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/leo-std/Cargo.toml
+++ b/crates/leo-std/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "leo-std"
+version = "4.2.0"
+authors = [ "The Leo Team <leo@provable.com>" ]
+description = "Embedded Leo standard library source"
+homepage = "https://leo-lang.org"
+repository = "https://github.com/ProvableHQ/leo"
+keywords = [
+  "aleo",
+  "cryptography",
+  "leo",
+  "programming-language",
+  "zero-knowledge"
+]
+categories = [ "compilers", "cryptography", "web-programming" ]
+include = [ "Cargo.toml", "src", "LICENSE.md" ]
+license = "GPL-3.0"
+edition = "2024"
+
+[dependencies]

--- a/crates/leo-std/src/leo/dummy.leo
+++ b/crates/leo-std/src/leo/dummy.leo
@@ -1,0 +1,5 @@
+// Dummy submodule used to verify std submodule wiring end-to-end.
+
+fn dummy_u32(x: u32) -> u32 {
+    return x;
+}

--- a/crates/leo-std/src/leo/lib.leo
+++ b/crates/leo-std/src/leo/lib.leo
@@ -1,0 +1,5 @@
+// Leo standard library entry source.
+
+fn identity_u32(x: u32) -> u32 {
+    return x;
+}

--- a/crates/leo-std/src/lib.rs
+++ b/crates/leo-std/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+//! Embedded source for the Leo standard library.
+//!
+//! Compiler and tooling crates depend on this to inject `std` into every
+//! Leo build without requiring users to declare it in `program.json`.
+
+/// The Leo identifier under which the standard library is exposed
+/// (`std::foo(...)`).
+pub const LIBRARY_NAME: &str = "std";
+
+const LIB_LEO: &str = include_str!("leo/lib.leo");
+const DUMMY_LEO: &str = include_str!("leo/dummy.leo");
+
+/// Entry source of the standard library (contents of `lib.leo`).
+pub fn entry_source() -> &'static str {
+    LIB_LEO
+}
+
+/// Submodule sources, returned as `(virtual_path, source)` pairs.
+///
+/// The format matches what `leo_compiler::Compiler::build_library` expects:
+/// the first element of each tuple is a label used in span/error reporting,
+/// and the second is the Leo source for that submodule.
+pub fn modules() -> &'static [(&'static str, &'static str)] {
+    &[("dummy.leo", DUMMY_LEO)]
+}
+
+/// The Leo identifier under which the standard library is exposed.
+pub fn library_name() -> &'static str {
+    LIBRARY_NAME
+}

--- a/crates/leo/Cargo.toml
+++ b/crates/leo/Cargo.toml
@@ -56,6 +56,7 @@ leo-disassembler  = { workspace = true }
 leo-errors        = { workspace = true }
 leo-package       = { workspace = true }
 leo-span          = { workspace = true }
+leo-std           = { workspace = true }
 # third party dependencies
 aleo-std           = { workspace = true }
 aleo-std-storage   = { workspace = true }

--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -62,6 +62,7 @@ impl From<BuildOptions> for CompilerOptions {
                 AstSnapshots::Some(options.ast_snapshots.into_iter().collect())
             },
             initial_ast: options.enable_all_ast_snapshots | options.enable_initial_ast_snapshot,
+            no_std: options.no_std,
         }
     }
 }
@@ -179,7 +180,20 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
     let handler = Handler::default();
     let node_builder = Rc::new(NodeBuilder::default());
 
+    // Manifest opt-out for the implicit `std` library. Propagated to every
+    // unit's `Compiler` via `CompilerOptions::no_std`.
+    let mut build_options = command.options.clone();
+    build_options.no_std = package.manifest.no_std;
+
     let mut stubs: IndexMap<Symbol, Stub> = IndexMap::new();
+
+    // Prebuild the implicit `std` library once. Every per-unit `Compiler` clones `stubs`,
+    // so the prebuilt stub is shared across the build instead of recompiled per unit.
+    // `inject_std_library` short-circuits when it finds this entry.
+    if !build_options.no_std {
+        let std_stub = Compiler::build_std_stub(handler.clone(), Rc::clone(&node_builder), network)?;
+        stubs.insert(Symbol::intern(leo_std::library_name()), std_stub);
+    }
 
     // All programs to validate through snarkVM's bytecode validator, in dependency order
     // (imports must be loaded before the programs that depend on them).
@@ -276,7 +290,7 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
                         &snapshots_directory,
                         &handler,
                         &node_builder,
-                        command.options.clone(),
+                        build_options.clone(),
                         stubs.clone(),
                         network,
                     )?;
@@ -345,7 +359,7 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
                             &snapshots_directory,
                             &handler,
                             &node_builder,
-                            command.options.clone(),
+                            build_options.clone(),
                             stubs.clone(),
                             network,
                         )?;
@@ -362,7 +376,7 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
                             unit.name,
                             &handler,
                             &node_builder,
-                            command.options.clone(),
+                            build_options.clone(),
                             network,
                         )?
                     };
@@ -385,7 +399,7 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
                         unit.name,
                         &handler,
                         &node_builder,
-                        command.options.clone(),
+                        build_options.clone(),
                         network,
                     )?;
 
@@ -417,7 +431,7 @@ fn handle_build(command: &LeoBuild, context: Context) -> Result<<LeoBuild as Com
             &snapshots_directory,
             &handler,
             &node_builder,
-            command.options.clone(),
+            build_options.clone(),
             stubs.clone(),
             network,
         )?;

--- a/crates/leo/src/cli/commands/common/options.rs
+++ b/crates/leo/src/cli/commands/common/options.rs
@@ -47,6 +47,8 @@ pub struct BuildOptions {
     pub no_cache: bool,
     #[clap(long, help = "Don't use the local source code.")]
     pub no_local: bool,
+    #[clap(skip)]
+    pub no_std: bool,
 }
 
 /// Overrides for the `.env` file.

--- a/crates/package/src/errors.rs
+++ b/crates/package/src/errors.rs
@@ -249,3 +249,14 @@ pub(crate) fn workspace_duplicate_program_name(
         "Rename one of the programs in its `program.json`; every workspace member must have a unique program name.",
     )
 }
+
+/// The user named a program/library/dependency `std`, which is reserved for
+/// the implicit standard library injected by the compiler.
+pub(crate) fn reserved_std_name(context: impl Display) -> Backtraced {
+    Backtraced::error(
+        CODE_PREFIX,
+        CODE_MASK + 76,
+        format!("`std` is a reserved name and cannot be used as a {context}"),
+    )
+    .with_help("Pick a different name.")
+}

--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -215,6 +215,11 @@ fn is_valid_package_name(name: &str) -> bool {
         return false;
     }
 
+    if name == "std" {
+        tracing::error!("`{name}` is reserved by Leo and cannot be used as a package, program, or library name.");
+        return false;
+    }
+
     // Disallow "aleo"
     if name.contains("aleo") {
         tracing::error!("Aleo names cannot contain the keyword `aleo`.");

--- a/crates/package/src/manifest.rs
+++ b/crates/package/src/manifest.rs
@@ -34,6 +34,8 @@ pub struct Manifest {
     pub leo: String,
     pub dependencies: Option<Vec<Dependency>>,
     pub dev_dependencies: Option<Vec<Dependency>>,
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub no_std: bool,
 }
 
 impl Manifest {
@@ -59,12 +61,27 @@ impl Manifest {
         let manifest: Self = serde_json::from_str(&contents)
             .map_err(|err| crate::errors::failed_to_deserialize_manifest_file(path.as_ref().display(), err))?;
         manifest.validate_dependencies()?;
+        manifest.validate_reserved_names()?;
         Ok(manifest)
     }
 
     fn validate_dependencies(&self) -> Result<(), Backtraced> {
         for dependency in self.dependencies.iter().flatten().chain(self.dev_dependencies.iter().flatten()) {
             dependency.validate_manifest_shape()?;
+        }
+        Ok(())
+    }
+
+    fn validate_reserved_names(&self) -> Result<(), Backtraced> {
+        let program_bare = crate::bare_unit_name(&self.program);
+        if program_bare == "std" {
+            return Err(crate::errors::reserved_std_name("program name"));
+        }
+        for dep in self.dependencies.iter().flatten().chain(self.dev_dependencies.iter().flatten()) {
+            let dep_bare = crate::bare_unit_name(&dep.name);
+            if dep_bare == "std" {
+                return Err(crate::errors::reserved_std_name("dependency name"));
+            }
         }
         Ok(())
     }

--- a/crates/package/src/package.rs
+++ b/crates/package/src/package.rs
@@ -183,6 +183,7 @@ impl Package {
             leo: env!("CARGO_PKG_VERSION").to_string(),
             dependencies: None,
             dev_dependencies: None,
+            no_std: false,
         };
 
         let manifest_path = full_path.join(MANIFEST_FILENAME);
@@ -670,6 +671,7 @@ mod tests {
                 leo: "0.0.0".to_string(),
                 dependencies: None,
                 dev_dependencies: None,
+                no_std: false,
             },
             dep_graph: DiGraph::default(),
         }

--- a/crates/package/src/workspace.rs
+++ b/crates/package/src/workspace.rs
@@ -473,6 +473,7 @@ mod tests {
             leo: "0.0.0".to_string(),
             dependencies: if dependencies.is_empty() { None } else { Some(dependencies) },
             dev_dependencies: None,
+            no_std: false,
         };
 
         manifest.write_to_file(member_dir.join(MANIFEST_FILENAME)).unwrap();
@@ -631,6 +632,7 @@ mod tests {
             leo: "0.0.0".to_string(),
             dependencies: if dependencies.is_empty() { None } else { Some(dependencies) },
             dev_dependencies: None,
+            no_std: false,
         };
 
         manifest.write_to_file(member_dir.join(MANIFEST_FILENAME)).unwrap();
@@ -959,6 +961,7 @@ mod tests {
             description: String::new(),
             license: "MIT".to_string(),
             leo: "0.0.0".to_string(),
+            no_std: false,
             dependencies: None,
             dev_dependencies: None,
         };

--- a/tests/expectations/cli/aleo_dep_imports_local_dep/STDOUT
+++ b/tests/expectations/cli/aleo_dep_imports_local_dep/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'main.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[203u8, 225u8, 133u8, 199u8, 160u8, 30u8, 237u8, 217u8, 56u8, 143u8, 65u8, 19u8, 169u8, 14u8, 161u8, 134u8, 37u8, 166u8, 179u8, 103u8, 22u8, 172u8, 38u8, 186u8, 41u8, 137u8, 226u8, 74u8, 193u8, 16u8, 131u8, 198u8]'.
        Leo     Program size: 0.21 KB / 500.00 KB
        Leo ✅ Compiled 'main.aleo' into Aleo instructions.

--- a/tests/expectations/cli/aleo_dep_reversed_order/STDOUT
+++ b/tests/expectations/cli/aleo_dep_reversed_order/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'main.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[203u8, 225u8, 133u8, 199u8, 160u8, 30u8, 237u8, 217u8, 56u8, 143u8, 65u8, 19u8, 169u8, 14u8, 161u8, 134u8, 37u8, 166u8, 179u8, 103u8, 22u8, 172u8, 38u8, 186u8, 41u8, 137u8, 226u8, 74u8, 193u8, 16u8, 131u8, 198u8]'.
        Leo     Program size: 0.21 KB / 500.00 KB
        Leo ✅ Compiled 'main.aleo' into Aleo instructions.

--- a/tests/expectations/cli/broadcast_error/STDOUT
+++ b/tests/expectations/cli/broadcast_error/STDOUT
@@ -1,7 +1,7 @@
 
        Leo 🔨 Compiling 'broadcast_error.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[65u8, 89u8, 187u8, 94u8, 189u8, 162u8, 9u8, 5u8, 82u8, 113u8, 145u8, 228u8, 159u8, 225u8, 53u8, 52u8, 194u8, 213u8, 69u8, 110u8, 78u8, 244u8, 159u8, 99u8, 80u8, 151u8, 122u8, 38u8, 220u8, 73u8, 200u8, 114u8]'.
        Leo     Program size: 0.26 KB / 500.00 KB
        Leo ✅ Compiled 'broadcast_error.aleo' into Aleo instructions.
@@ -77,8 +77,8 @@ Transaction accepted.
 ✅ Deployment confirmed!
 
        Leo 🔨 Compiling 'broadcast_error.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[65u8, 89u8, 187u8, 94u8, 189u8, 162u8, 9u8, 5u8, 82u8, 113u8, 145u8, 228u8, 159u8, 225u8, 53u8, 52u8, 194u8, 213u8, 69u8, 110u8, 78u8, 244u8, 159u8, 99u8, 80u8, 151u8, 122u8, 38u8, 220u8, 73u8, 200u8, 114u8]'.
        Leo     Program size: 0.26 KB / 500.00 KB
        Leo ✅ Compiled 'broadcast_error.aleo' into Aleo instructions.

--- a/tests/expectations/cli/local_aleo_dependency/STDOUT
+++ b/tests/expectations/cli/local_aleo_dependency/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'complex.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[100u8, 207u8, 87u8, 107u8, 187u8, 153u8, 95u8, 22u8, 31u8, 75u8, 125u8, 95u8, 119u8, 144u8, 156u8, 19u8, 111u8, 156u8, 213u8, 202u8, 101u8, 112u8, 208u8, 87u8, 81u8, 218u8, 221u8, 118u8, 35u8, 125u8, 183u8, 157u8]'.
        Leo     Program size: 0.22 KB / 500.00 KB
        Leo ✅ Compiled 'complex.aleo' into Aleo instructions.

--- a/tests/expectations/cli/multiple_leo_deps/STDOUT
+++ b/tests/expectations/cli/multiple_leo_deps/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'parent.aleo'
-       Leo     9 statements before dead code elimination.
-       Leo     9 statements after dead code elimination.
+       Leo     11 statements before dead code elimination.
+       Leo     11 statements after dead code elimination.
        Leo     The program checksum is: '[36u8, 42u8, 7u8, 48u8, 36u8, 141u8, 90u8, 111u8, 93u8, 3u8, 27u8, 112u8, 152u8, 129u8, 88u8, 13u8, 223u8, 75u8, 216u8, 223u8, 25u8, 10u8, 48u8, 182u8, 189u8, 54u8, 128u8, 147u8, 96u8, 174u8, 215u8, 57u8]'.
        Leo     Program size: 0.29 KB / 500.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.

--- a/tests/expectations/cli/network_dependency/STDOUT
+++ b/tests/expectations/cli/network_dependency/STDOUT
@@ -1,8 +1,8 @@
 DEPLOYMENT 1
 
        Leo 🔨 Compiling 'test_program1.aleo'
-       Leo     1 statements before dead code elimination.
-       Leo     1 statements after dead code elimination.
+       Leo     3 statements before dead code elimination.
+       Leo     3 statements after dead code elimination.
        Leo     The program checksum is: '[192u8, 225u8, 38u8, 151u8, 139u8, 155u8, 148u8, 209u8, 105u8, 110u8, 246u8, 83u8, 90u8, 243u8, 78u8, 35u8, 155u8, 186u8, 242u8, 17u8, 196u8, 169u8, 179u8, 144u8, 71u8, 227u8, 34u8, 207u8, 121u8, 158u8, 34u8, 25u8]'.
        Leo     Program size: 0.14 KB / 500.00 KB
        Leo ✅ Compiled 'test_program1.aleo' into Aleo instructions.
@@ -79,8 +79,8 @@ Transaction accepted.
 DEPLOYMENT 2
 
        Leo 🔨 Compiling 'test_program2.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[206u8, 255u8, 111u8, 48u8, 59u8, 85u8, 122u8, 166u8, 182u8, 205u8, 10u8, 141u8, 58u8, 23u8, 70u8, 232u8, 105u8, 221u8, 83u8, 216u8, 186u8, 14u8, 207u8, 24u8, 13u8, 221u8, 236u8, 0u8, 143u8, 199u8, 151u8, 2u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_program2.aleo' into Aleo instructions.
@@ -161,8 +161,8 @@ Transaction accepted.
 EXECUTION
 
        Leo 🔨 Compiling 'test_program2.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[206u8, 255u8, 111u8, 48u8, 59u8, 85u8, 122u8, 166u8, 182u8, 205u8, 10u8, 141u8, 58u8, 23u8, 70u8, 232u8, 105u8, 221u8, 83u8, 216u8, 186u8, 14u8, 207u8, 24u8, 13u8, 221u8, 236u8, 0u8, 143u8, 199u8, 151u8, 2u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_program2.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_abi_comprehensive/STDOUT
+++ b/tests/expectations/cli/test_abi_comprehensive/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'abi_test.aleo'
-       Leo     73 statements before dead code elimination.
-       Leo     67 statements after dead code elimination.
+       Leo     75 statements before dead code elimination.
+       Leo     69 statements after dead code elimination.
        Leo     The program checksum is: '[147u8, 105u8, 236u8, 139u8, 183u8, 167u8, 83u8, 66u8, 169u8, 230u8, 240u8, 183u8, 226u8, 65u8, 221u8, 93u8, 124u8, 254u8, 215u8, 43u8, 81u8, 204u8, 98u8, 180u8, 105u8, 144u8, 195u8, 133u8, 20u8, 100u8, 141u8, 55u8]'.
        Leo     Program size: 4.09 KB / 500.00 KB
        Leo ✅ Compiled 'abi_test.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_add/STDOUT
+++ b/tests/expectations/cli/test_add/STDOUT
@@ -3,16 +3,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[208u8, 46u8, 107u8, 120u8, 67u8, 35u8, 254u8, 232u8, 167u8, 173u8, 0u8, 130u8, 249u8, 123u8, 65u8, 159u8, 169u8, 93u8, 168u8, 232u8, 33u8, 125u8, 49u8, 130u8, 118u8, 142u8, 183u8, 31u8, 60u8, 106u8, 136u8, 65u8]'.
        Leo     Program size: 0.18 KB / 500.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'some_sample_leo_program.aleo'.
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[208u8, 46u8, 107u8, 120u8, 67u8, 35u8, 254u8, 232u8, 167u8, 173u8, 0u8, 130u8, 249u8, 123u8, 65u8, 159u8, 169u8, 93u8, 168u8, 232u8, 33u8, 125u8, 49u8, 130u8, 118u8, 142u8, 183u8, 31u8, 60u8, 106u8, 136u8, 65u8]'.
        Leo     Program size: 0.18 KB / 500.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
@@ -71,8 +71,8 @@ Attempting to determine the consensus version from the latest block height at ht
 
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[208u8, 46u8, 107u8, 120u8, 67u8, 35u8, 254u8, 232u8, 167u8, 173u8, 0u8, 130u8, 249u8, 123u8, 65u8, 159u8, 169u8, 93u8, 168u8, 232u8, 33u8, 125u8, 49u8, 130u8, 118u8, 142u8, 183u8, 31u8, 60u8, 106u8, 136u8, 65u8]'.
        Leo     Program size: 0.18 KB / 500.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_command_shortcuts/STDOUT
+++ b/tests/expectations/cli/test_command_shortcuts/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_shortcuts.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[243u8, 135u8, 116u8, 66u8, 246u8, 27u8, 131u8, 192u8, 145u8, 195u8, 150u8, 1u8, 217u8, 146u8, 63u8, 42u8, 159u8, 224u8, 25u8, 105u8, 240u8, 197u8, 236u8, 236u8, 115u8, 219u8, 254u8, 62u8, 5u8, 44u8, 74u8, 93u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_shortcuts.aleo' into Aleo instructions.
@@ -12,8 +12,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_shortcuts.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[243u8, 135u8, 116u8, 66u8, 246u8, 27u8, 131u8, 192u8, 145u8, 195u8, 150u8, 1u8, 217u8, 146u8, 63u8, 42u8, 159u8, 224u8, 25u8, 105u8, 240u8, 197u8, 236u8, 236u8, 115u8, 219u8, 254u8, 62u8, 5u8, 44u8, 74u8, 93u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_shortcuts.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_deploy/STDOUT
+++ b/tests/expectations/cli/test_deploy/STDOUT
@@ -1,7 +1,7 @@
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     8 statements before dead code elimination.
-       Leo     8 statements after dead code elimination.
+       Leo     10 statements before dead code elimination.
+       Leo     10 statements after dead code elimination.
        Leo     The program checksum is: '[109u8, 115u8, 37u8, 36u8, 104u8, 211u8, 71u8, 47u8, 167u8, 121u8, 76u8, 58u8, 12u8, 161u8, 114u8, 2u8, 167u8, 69u8, 23u8, 209u8, 243u8, 251u8, 90u8, 233u8, 85u8, 135u8, 145u8, 25u8, 18u8, 86u8, 72u8, 144u8]'.
        Leo     Program size: 0.68 KB / 500.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_devnode_persistent_storage/STDOUT
+++ b/tests/expectations/cli/test_devnode_persistent_storage/STDOUT
@@ -2,8 +2,8 @@
 --- leo deploy ---
 
        Leo 🔨 Compiling 'persistent_counter.aleo'
-       Leo     8 statements before dead code elimination.
-       Leo     8 statements after dead code elimination.
+       Leo     10 statements before dead code elimination.
+       Leo     10 statements after dead code elimination.
        Leo     The program checksum is: '[157u8, 110u8, 134u8, 241u8, 199u8, 123u8, 101u8, 60u8, 76u8, 81u8, 214u8, 240u8, 161u8, 15u8, 182u8, 89u8, 168u8, 174u8, 52u8, 164u8, 13u8, 189u8, 147u8, 8u8, 177u8, 156u8, 172u8, 39u8, 150u8, 195u8, 225u8, 113u8]'.
        Leo     Program size: 0.40 KB / 500.00 KB
        Leo ✅ Compiled 'persistent_counter.aleo' into Aleo instructions.
@@ -80,8 +80,8 @@ Transaction accepted.
 --- leo execute ---
 
        Leo 🔨 Compiling 'persistent_counter.aleo'
-       Leo     8 statements before dead code elimination.
-       Leo     8 statements after dead code elimination.
+       Leo     10 statements before dead code elimination.
+       Leo     10 statements after dead code elimination.
        Leo     The program checksum is: '[157u8, 110u8, 134u8, 241u8, 199u8, 123u8, 101u8, 60u8, 76u8, 81u8, 214u8, 240u8, 161u8, 15u8, 182u8, 89u8, 168u8, 174u8, 52u8, 164u8, 13u8, 189u8, 147u8, 8u8, 177u8, 156u8, 172u8, 39u8, 150u8, 195u8, 225u8, 113u8]'.
        Leo     Program size: 0.40 KB / 500.00 KB
        Leo ✅ Compiled 'persistent_counter.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_dynamic_call_with_flag/STDOUT
+++ b/tests/expectations/cli/test_dynamic_call_with_flag/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_dynamic_call_with_flag.aleo'
-       Leo     5 statements before dead code elimination.
-       Leo     5 statements after dead code elimination.
+       Leo     7 statements before dead code elimination.
+       Leo     7 statements after dead code elimination.
        Leo     The program checksum is: '[203u8, 83u8, 231u8, 99u8, 242u8, 232u8, 142u8, 120u8, 137u8, 67u8, 48u8, 180u8, 69u8, 43u8, 75u8, 168u8, 40u8, 142u8, 61u8, 33u8, 104u8, 230u8, 30u8, 43u8, 252u8, 234u8, 221u8, 27u8, 184u8, 148u8, 151u8, 71u8]'.
        Leo     Program size: 0.42 KB / 500.00 KB
        Leo ✅ Compiled 'test_dynamic_call_with_flag.aleo' into Aleo instructions.
@@ -21,8 +21,8 @@ Error [ECLI0377045]: Failed to authorize execution: Process authorization failed
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_dynamic_call_with_flag.aleo'
-       Leo     5 statements before dead code elimination.
-       Leo     5 statements after dead code elimination.
+       Leo     7 statements before dead code elimination.
+       Leo     7 statements after dead code elimination.
        Leo     The program checksum is: '[203u8, 83u8, 231u8, 99u8, 242u8, 232u8, 142u8, 120u8, 137u8, 67u8, 48u8, 180u8, 69u8, 43u8, 75u8, 168u8, 40u8, 142u8, 61u8, 33u8, 104u8, 230u8, 30u8, 43u8, 252u8, 234u8, 221u8, 27u8, 184u8, 148u8, 151u8, 71u8]'.
        Leo     Program size: 0.42 KB / 500.00 KB
        Leo ✅ Compiled 'test_dynamic_call_with_flag.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_execute_view_rejected/STDOUT
+++ b/tests/expectations/cli/test_execute_view_rejected/STDOUT
@@ -1,8 +1,8 @@
 --- execute on a view fn should fail with a clear message ---
 
        Leo 🔨 Compiling 'test_execute_view_rejected.aleo'
-       Leo     4 statements before dead code elimination.
-       Leo     4 statements after dead code elimination.
+       Leo     6 statements before dead code elimination.
+       Leo     6 statements after dead code elimination.
        Leo     The program checksum is: '[164u8, 227u8, 239u8, 85u8, 158u8, 211u8, 176u8, 226u8, 23u8, 120u8, 188u8, 240u8, 23u8, 13u8, 140u8, 193u8, 191u8, 32u8, 242u8, 13u8, 202u8, 30u8, 230u8, 20u8, 35u8, 63u8, 224u8, 175u8, 163u8, 59u8, 169u8, 138u8]'.
        Leo     Program size: 0.34 KB / 500.00 KB
        Leo ✅ Compiled 'test_execute_view_rejected.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_external_program_submodule/STDOUT
+++ b/tests/expectations/cli/test_external_program_submodule/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'consumer.aleo'
-       Leo     79 statements before dead code elimination.
-       Leo     79 statements after dead code elimination.
+       Leo     81 statements before dead code elimination.
+       Leo     81 statements after dead code elimination.
        Leo     The program checksum is: '[180u8, 223u8, 5u8, 182u8, 121u8, 236u8, 70u8, 205u8, 63u8, 169u8, 165u8, 193u8, 163u8, 145u8, 151u8, 8u8, 17u8, 113u8, 67u8, 189u8, 228u8, 154u8, 198u8, 1u8, 132u8, 217u8, 135u8, 148u8, 97u8, 216u8, 215u8, 171u8]'.
        Leo     Program size: 1.69 KB / 500.00 KB
        Leo ✅ Compiled 'consumer.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_external_toplevel_closure/STDOUT
+++ b/tests/expectations/cli/test_external_toplevel_closure/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'parent.aleo'
-       Leo     4 statements before dead code elimination.
-       Leo     4 statements after dead code elimination.
+       Leo     6 statements before dead code elimination.
+       Leo     6 statements after dead code elimination.
        Leo     The program checksum is: '[222u8, 3u8, 196u8, 87u8, 184u8, 192u8, 111u8, 151u8, 134u8, 128u8, 255u8, 10u8, 60u8, 187u8, 32u8, 83u8, 93u8, 218u8, 173u8, 214u8, 123u8, 88u8, 83u8, 83u8, 224u8, 167u8, 54u8, 208u8, 36u8, 210u8, 109u8, 69u8]'.
        Leo     Program size: 0.13 KB / 500.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_failure_exit_code/STDOUT
+++ b/tests/expectations/cli/test_failure_exit_code/STDOUT
@@ -2,16 +2,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_failure_exit_code.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[221u8, 98u8, 184u8, 91u8, 106u8, 23u8, 100u8, 225u8, 172u8, 241u8, 136u8, 60u8, 210u8, 232u8, 121u8, 251u8, 30u8, 86u8, 109u8, 166u8, 1u8, 21u8, 133u8, 255u8, 216u8, 171u8, 227u8, 187u8, 160u8, 103u8, 226u8, 24u8]'.
        Leo     Program size: 0.20 KB / 500.00 KB
        Leo ✅ Compiled 'test_failure_exit_code.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'test_failure_exit_code.aleo'.
 
        Leo 🔨 Compiling 'test_test_failure_exit_code.aleo'
-       Leo     5 statements before dead code elimination.
-       Leo     5 statements after dead code elimination.
+       Leo     7 statements before dead code elimination.
+       Leo     7 statements after dead code elimination.
        Leo     The program checksum is: '[185u8, 33u8, 18u8, 122u8, 175u8, 186u8, 59u8, 143u8, 75u8, 65u8, 116u8, 16u8, 136u8, 225u8, 79u8, 51u8, 200u8, 205u8, 183u8, 214u8, 13u8, 103u8, 165u8, 115u8, 97u8, 193u8, 12u8, 172u8, 191u8, 3u8, 30u8, 36u8]'.
        Leo     Program size: 0.17 KB / 500.00 KB
        Leo ✅ Compiled 'test_test_failure_exit_code.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_identifier_input/STDOUT
+++ b/tests/expectations/cli/test_identifier_input/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_identifier_input.aleo'
-       Leo     1 statements before dead code elimination.
-       Leo     1 statements after dead code elimination.
+       Leo     3 statements before dead code elimination.
+       Leo     3 statements after dead code elimination.
        Leo     The program checksum is: '[200u8, 34u8, 31u8, 160u8, 160u8, 5u8, 214u8, 94u8, 17u8, 191u8, 238u8, 77u8, 70u8, 159u8, 140u8, 96u8, 168u8, 29u8, 157u8, 146u8, 108u8, 148u8, 23u8, 106u8, 105u8, 12u8, 36u8, 52u8, 136u8, 73u8, 4u8, 233u8]'.
        Leo     Program size: 0.16 KB / 500.00 KB
        Leo ✅ Compiled 'test_identifier_input.aleo' into Aleo instructions.
@@ -21,8 +21,8 @@
 --- leo execute with identifier input ---
 
        Leo 🔨 Compiling 'test_identifier_input.aleo'
-       Leo     1 statements before dead code elimination.
-       Leo     1 statements after dead code elimination.
+       Leo     3 statements before dead code elimination.
+       Leo     3 statements after dead code elimination.
        Leo     The program checksum is: '[200u8, 34u8, 31u8, 160u8, 160u8, 5u8, 214u8, 94u8, 17u8, 191u8, 238u8, 77u8, 70u8, 159u8, 140u8, 96u8, 168u8, 29u8, 157u8, 146u8, 108u8, 148u8, 23u8, 106u8, 105u8, 12u8, 36u8, 52u8, 136u8, 73u8, 4u8, 233u8]'.
        Leo     Program size: 0.16 KB / 500.00 KB
        Leo ✅ Compiled 'test_identifier_input.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_interface_abi_from_library/STDOUT
+++ b/tests/expectations/cli/test_interface_abi_from_library/STDOUT
@@ -5,8 +5,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'my_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[226u8, 34u8, 235u8, 95u8, 27u8, 197u8, 219u8, 39u8, 65u8, 192u8, 228u8, 78u8, 1u8, 103u8, 68u8, 8u8, 67u8, 148u8, 90u8, 69u8, 68u8, 50u8, 132u8, 203u8, 93u8, 12u8, 125u8, 21u8, 184u8, 187u8, 65u8, 251u8]'.
        Leo     Program size: 0.15 KB / 500.00 KB
        Leo ✅ Compiled 'my_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_interface_abi_inheritance/STDOUT
+++ b/tests/expectations/cli/test_interface_abi_inheritance/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'bar.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[211u8, 240u8, 72u8, 85u8, 185u8, 143u8, 54u8, 240u8, 0u8, 154u8, 86u8, 74u8, 240u8, 249u8, 117u8, 179u8, 7u8, 254u8, 207u8, 143u8, 11u8, 135u8, 51u8, 139u8, 136u8, 189u8, 114u8, 73u8, 206u8, 159u8, 119u8, 186u8]'.
        Leo     Program size: 0.18 KB / 500.00 KB
        Leo ✅ Compiled 'bar.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_interface_abi_local/STDOUT
+++ b/tests/expectations/cli/test_interface_abi_local/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'foo.aleo'
-       Leo     4 statements before dead code elimination.
-       Leo     4 statements after dead code elimination.
+       Leo     6 statements before dead code elimination.
+       Leo     6 statements after dead code elimination.
        Leo     The program checksum is: '[19u8, 92u8, 200u8, 0u8, 59u8, 132u8, 136u8, 114u8, 118u8, 24u8, 197u8, 212u8, 163u8, 107u8, 30u8, 114u8, 154u8, 45u8, 217u8, 136u8, 90u8, 134u8, 43u8, 162u8, 243u8, 207u8, 241u8, 28u8, 81u8, 119u8, 140u8, 57u8]'.
        Leo     Program size: 0.29 KB / 500.00 KB
        Leo ✅ Compiled 'foo.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_invalid_literal_rejection/STDOUT
+++ b/tests/expectations/cli/test_invalid_literal_rejection/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_invalid_literal_rejection.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[133u8, 110u8, 242u8, 38u8, 0u8, 63u8, 166u8, 81u8, 74u8, 170u8, 47u8, 166u8, 54u8, 103u8, 147u8, 165u8, 131u8, 58u8, 105u8, 248u8, 98u8, 169u8, 174u8, 77u8, 177u8, 247u8, 59u8, 83u8, 77u8, 7u8, 112u8, 221u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_invalid_literal_rejection.aleo' into Aleo instructions.
@@ -23,8 +23,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_invalid_literal_rejection.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[133u8, 110u8, 242u8, 38u8, 0u8, 63u8, 166u8, 81u8, 74u8, 170u8, 47u8, 166u8, 54u8, 103u8, 147u8, 165u8, 131u8, 58u8, 105u8, 248u8, 98u8, 169u8, 174u8, 77u8, 177u8, 247u8, 59u8, 83u8, 77u8, 7u8, 112u8, 221u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_invalid_literal_rejection.aleo' into Aleo instructions.
@@ -36,8 +36,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_invalid_literal_rejection.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[133u8, 110u8, 242u8, 38u8, 0u8, 63u8, 166u8, 81u8, 74u8, 170u8, 47u8, 166u8, 54u8, 103u8, 147u8, 165u8, 131u8, 58u8, 105u8, 248u8, 98u8, 169u8, 174u8, 77u8, 177u8, 247u8, 59u8, 83u8, 77u8, 7u8, 112u8, 221u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_invalid_literal_rejection.aleo' into Aleo instructions.
@@ -49,8 +49,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_invalid_literal_rejection.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[133u8, 110u8, 242u8, 38u8, 0u8, 63u8, 166u8, 81u8, 74u8, 170u8, 47u8, 166u8, 54u8, 103u8, 147u8, 165u8, 131u8, 58u8, 105u8, 248u8, 98u8, 169u8, 174u8, 77u8, 177u8, 247u8, 59u8, 83u8, 77u8, 7u8, 112u8, 221u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_invalid_literal_rejection.aleo' into Aleo instructions.
@@ -62,8 +62,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_invalid_literal_rejection.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[133u8, 110u8, 242u8, 38u8, 0u8, 63u8, 166u8, 81u8, 74u8, 170u8, 47u8, 166u8, 54u8, 103u8, 147u8, 165u8, 131u8, 58u8, 105u8, 248u8, 98u8, 169u8, 174u8, 77u8, 177u8, 247u8, 59u8, 83u8, 77u8, 7u8, 112u8, 221u8]'.
        Leo     Program size: 0.19 KB / 500.00 KB
        Leo ✅ Compiled 'test_invalid_literal_rejection.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_lib_program_test/STDOUT
+++ b/tests/expectations/cli/test_lib_program_test/STDOUT
@@ -3,16 +3,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'my_program.aleo'
-       Leo     31 statements before dead code elimination.
-       Leo     31 statements after dead code elimination.
+       Leo     33 statements before dead code elimination.
+       Leo     33 statements after dead code elimination.
        Leo     The program checksum is: '[106u8, 110u8, 195u8, 22u8, 179u8, 122u8, 162u8, 160u8, 221u8, 236u8, 9u8, 111u8, 202u8, 246u8, 155u8, 195u8, 105u8, 115u8, 23u8, 190u8, 127u8, 125u8, 146u8, 111u8, 253u8, 158u8, 178u8, 185u8, 206u8, 163u8, 205u8, 126u8]'.
        Leo     Program size: 0.50 KB / 500.00 KB
        Leo ✅ Compiled 'my_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_program.aleo'.
 
        Leo 🔨 Compiling 'test_my_program.aleo'
-       Leo     47 statements before dead code elimination.
-       Leo     47 statements after dead code elimination.
+       Leo     49 statements before dead code elimination.
+       Leo     49 statements after dead code elimination.
        Leo     The program checksum is: '[4u8, 124u8, 54u8, 134u8, 211u8, 152u8, 51u8, 49u8, 229u8, 90u8, 29u8, 193u8, 151u8, 50u8, 140u8, 238u8, 59u8, 250u8, 133u8, 40u8, 175u8, 6u8, 104u8, 233u8, 57u8, 242u8, 101u8, 56u8, 76u8, 4u8, 192u8, 24u8]'.
        Leo     Program size: 0.48 KB / 500.00 KB
        Leo ✅ Compiled 'test_my_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_lib_submodule_with_tests/STDOUT
+++ b/tests/expectations/cli/test_lib_submodule_with_tests/STDOUT
@@ -6,8 +6,8 @@
        Leo ✅ Validated 'my_lib'.
 
        Leo 🔨 Compiling 'test_my_lib.aleo'
-       Leo     16 statements before dead code elimination.
-       Leo     13 statements after dead code elimination.
+       Leo     18 statements before dead code elimination.
+       Leo     15 statements after dead code elimination.
        Leo     The program checksum is: '[34u8, 88u8, 110u8, 242u8, 211u8, 56u8, 190u8, 44u8, 124u8, 219u8, 145u8, 57u8, 111u8, 12u8, 53u8, 204u8, 53u8, 130u8, 94u8, 102u8, 56u8, 81u8, 184u8, 255u8, 181u8, 119u8, 74u8, 123u8, 192u8, 188u8, 0u8, 132u8]'.
        Leo     Program size: 0.27 KB / 500.00 KB
        Leo ✅ Compiled 'test_my_lib.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_lib_with_tests/STDOUT
+++ b/tests/expectations/cli/test_lib_with_tests/STDOUT
@@ -6,8 +6,8 @@
        Leo ✅ Validated 'my_lib'.
 
        Leo 🔨 Compiling 'test_my_lib.aleo'
-       Leo     14 statements before dead code elimination.
-       Leo     11 statements after dead code elimination.
+       Leo     16 statements before dead code elimination.
+       Leo     13 statements after dead code elimination.
        Leo     The program checksum is: '[131u8, 185u8, 83u8, 151u8, 158u8, 198u8, 120u8, 198u8, 76u8, 12u8, 0u8, 87u8, 98u8, 73u8, 139u8, 227u8, 197u8, 98u8, 156u8, 130u8, 229u8, 79u8, 192u8, 83u8, 168u8, 185u8, 36u8, 24u8, 40u8, 220u8, 47u8, 178u8]'.
        Leo     Program size: 0.22 KB / 500.00 KB
        Leo ✅ Compiled 'test_my_lib.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_library/STDOUT
+++ b/tests/expectations/cli/test_library/STDOUT
@@ -45,8 +45,8 @@ upgrade exit code: 213
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'program_using_lib.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[86u8, 217u8, 255u8, 231u8, 41u8, 239u8, 85u8, 168u8, 115u8, 159u8, 206u8, 101u8, 87u8, 132u8, 55u8, 19u8, 88u8, 121u8, 28u8, 27u8, 19u8, 151u8, 169u8, 2u8, 26u8, 92u8, 58u8, 254u8, 31u8, 190u8, 12u8, 24u8]'.
        Leo     Program size: 0.17 KB / 500.00 KB
        Leo ✅ Compiled 'program_using_lib.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_library_build/STDOUT
+++ b/tests/expectations/cli/test_library_build/STDOUT
@@ -5,8 +5,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'my_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[171u8, 183u8, 139u8, 18u8, 243u8, 22u8, 24u8, 14u8, 163u8, 35u8, 58u8, 129u8, 221u8, 133u8, 125u8, 156u8, 181u8, 62u8, 243u8, 26u8, 146u8, 143u8, 8u8, 110u8, 162u8, 66u8, 191u8, 125u8, 94u8, 4u8, 134u8, 86u8]'.
        Leo     Program size: 0.11 KB / 500.00 KB
        Leo ✅ Compiled 'my_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_library_submodule_access/STDOUT
+++ b/tests/expectations/cli/test_library_submodule_access/STDOUT
@@ -5,16 +5,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'my_app.aleo'
-       Leo     56 statements before dead code elimination.
-       Leo     56 statements after dead code elimination.
+       Leo     58 statements before dead code elimination.
+       Leo     58 statements after dead code elimination.
        Leo     The program checksum is: '[24u8, 44u8, 204u8, 243u8, 73u8, 18u8, 55u8, 114u8, 139u8, 108u8, 57u8, 162u8, 92u8, 228u8, 93u8, 111u8, 120u8, 13u8, 185u8, 3u8, 174u8, 223u8, 8u8, 225u8, 195u8, 48u8, 47u8, 173u8, 184u8, 83u8, 34u8, 126u8]'.
        Leo     Program size: 1.05 KB / 500.00 KB
        Leo ✅ Compiled 'my_app.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_app.aleo'.
 
        Leo 🔨 Compiling 'test_my_app.aleo'
-       Leo     74 statements before dead code elimination.
-       Leo     74 statements after dead code elimination.
+       Leo     76 statements before dead code elimination.
+       Leo     76 statements after dead code elimination.
        Leo     The program checksum is: '[150u8, 104u8, 238u8, 132u8, 190u8, 173u8, 251u8, 218u8, 96u8, 144u8, 117u8, 39u8, 6u8, 175u8, 168u8, 83u8, 61u8, 70u8, 145u8, 182u8, 239u8, 25u8, 219u8, 129u8, 210u8, 207u8, 218u8, 112u8, 73u8, 150u8, 126u8, 26u8]'.
        Leo     Program size: 0.64 KB / 500.00 KB
        Leo ✅ Compiled 'test_my_app.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_run_view_rejected/STDOUT
+++ b/tests/expectations/cli/test_run_view_rejected/STDOUT
@@ -3,8 +3,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'test_run_view_rejected.aleo'
-       Leo     4 statements before dead code elimination.
-       Leo     4 statements after dead code elimination.
+       Leo     6 statements before dead code elimination.
+       Leo     6 statements after dead code elimination.
        Leo     The program checksum is: '[1u8, 43u8, 21u8, 138u8, 213u8, 227u8, 250u8, 18u8, 2u8, 90u8, 97u8, 212u8, 0u8, 159u8, 18u8, 119u8, 199u8, 226u8, 137u8, 197u8, 2u8, 164u8, 98u8, 134u8, 100u8, 134u8, 88u8, 242u8, 18u8, 177u8, 87u8, 118u8]'.
        Leo     Program size: 0.34 KB / 500.00 KB
        Leo ✅ Compiled 'test_run_view_rejected.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_simple_build/STDOUT
+++ b/tests/expectations/cli/test_simple_build/STDOUT
@@ -2,8 +2,8 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[95u8, 99u8, 136u8, 243u8, 82u8, 169u8, 200u8, 72u8, 133u8, 227u8, 122u8, 161u8, 195u8, 178u8, 69u8, 37u8, 167u8, 114u8, 104u8, 192u8, 161u8, 175u8, 195u8, 180u8, 120u8, 4u8, 192u8, 16u8, 86u8, 199u8, 76u8, 235u8]'.
        Leo     Program size: 0.20 KB / 500.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_simple_test/STDOUT
+++ b/tests/expectations/cli/test_simple_test/STDOUT
@@ -2,16 +2,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'some_sample_leo_program.aleo'
-       Leo     2 statements before dead code elimination.
-       Leo     2 statements after dead code elimination.
+       Leo     4 statements before dead code elimination.
+       Leo     4 statements after dead code elimination.
        Leo     The program checksum is: '[95u8, 99u8, 136u8, 243u8, 82u8, 169u8, 200u8, 72u8, 133u8, 227u8, 122u8, 161u8, 195u8, 178u8, 69u8, 37u8, 167u8, 114u8, 104u8, 192u8, 161u8, 175u8, 195u8, 180u8, 120u8, 4u8, 192u8, 16u8, 86u8, 199u8, 76u8, 235u8]'.
        Leo     Program size: 0.20 KB / 500.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'some_sample_leo_program.aleo'.
 
        Leo 🔨 Compiling 'test_some_sample_leo_program.aleo'
-       Leo     11 statements before dead code elimination.
-       Leo     11 statements after dead code elimination.
+       Leo     13 statements before dead code elimination.
+       Leo     13 statements after dead code elimination.
        Leo     The program checksum is: '[11u8, 59u8, 203u8, 68u8, 38u8, 145u8, 107u8, 115u8, 158u8, 199u8, 204u8, 247u8, 229u8, 233u8, 128u8, 227u8, 78u8, 28u8, 96u8, 77u8, 42u8, 32u8, 253u8, 143u8, 68u8, 66u8, 222u8, 29u8, 33u8, 9u8, 199u8, 189u8]'.
        Leo     Program size: 0.33 KB / 500.00 KB
        Leo ✅ Compiled 'test_some_sample_leo_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_storage_from_unit_test/STDOUT
+++ b/tests/expectations/cli/test_storage_from_unit_test/STDOUT
@@ -2,16 +2,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'storage_demo.aleo'
-       Leo     119 statements before dead code elimination.
-       Leo     113 statements after dead code elimination.
+       Leo     121 statements before dead code elimination.
+       Leo     115 statements after dead code elimination.
        Leo     The program checksum is: '[226u8, 104u8, 115u8, 137u8, 3u8, 83u8, 131u8, 89u8, 56u8, 167u8, 125u8, 100u8, 155u8, 220u8, 210u8, 53u8, 15u8, 25u8, 15u8, 152u8, 34u8, 88u8, 82u8, 31u8, 208u8, 157u8, 23u8, 145u8, 128u8, 36u8, 118u8, 40u8]'.
        Leo     Program size: 5.43 KB / 500.00 KB
        Leo ✅ Compiled 'storage_demo.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'storage_demo.aleo'.
 
        Leo 🔨 Compiling 'test_storage_demo.aleo'
-       Leo     900 statements before dead code elimination.
-       Leo     808 statements after dead code elimination.
+       Leo     902 statements before dead code elimination.
+       Leo     810 statements after dead code elimination.
        Leo     The program checksum is: '[218u8, 54u8, 178u8, 205u8, 225u8, 177u8, 179u8, 66u8, 11u8, 152u8, 142u8, 198u8, 190u8, 231u8, 167u8, 122u8, 210u8, 173u8, 88u8, 199u8, 221u8, 138u8, 248u8, 107u8, 188u8, 165u8, 151u8, 55u8, 17u8, 168u8, 73u8, 134u8]'.
        Leo     Program size: 20.35 KB / 500.00 KB
        Leo ✅ Compiled 'test_storage_demo.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_with_record/STDOUT
+++ b/tests/expectations/cli/test_with_record/STDOUT
@@ -3,16 +3,16 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
        Leo 🔨 Compiling 'my_program.aleo'
-       Leo     5 statements before dead code elimination.
-       Leo     5 statements after dead code elimination.
+       Leo     7 statements before dead code elimination.
+       Leo     7 statements after dead code elimination.
        Leo     The program checksum is: '[32u8, 215u8, 139u8, 153u8, 2u8, 205u8, 164u8, 76u8, 101u8, 152u8, 142u8, 209u8, 119u8, 54u8, 128u8, 25u8, 178u8, 241u8, 182u8, 203u8, 99u8, 32u8, 39u8, 38u8, 132u8, 175u8, 47u8, 148u8, 127u8, 233u8, 200u8, 184u8]'.
        Leo     Program size: 0.39 KB / 500.00 KB
        Leo ✅ Compiled 'my_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_program.aleo'.
 
        Leo 🔨 Compiling 'test_my_program.aleo'
-       Leo     12 statements before dead code elimination.
-       Leo     12 statements after dead code elimination.
+       Leo     14 statements before dead code elimination.
+       Leo     14 statements after dead code elimination.
        Leo     The program checksum is: '[131u8, 107u8, 31u8, 81u8, 117u8, 189u8, 35u8, 79u8, 214u8, 164u8, 229u8, 255u8, 189u8, 116u8, 103u8, 214u8, 55u8, 203u8, 16u8, 66u8, 226u8, 110u8, 236u8, 233u8, 8u8, 29u8, 75u8, 62u8, 141u8, 152u8, 212u8, 48u8]'.
        Leo     Program size: 0.27 KB / 500.00 KB
        Leo ✅ Compiled 'test_my_program.aleo' into Aleo instructions.

--- a/tests/expectations/cli/test_workspace_deploy/STDOUT
+++ b/tests/expectations/cli/test_workspace_deploy/STDOUT
@@ -2,8 +2,8 @@
 --- building workspace member 'token' ---
 
        Leo 🔨 Compiling 'token.aleo'
-       Leo     1 statements before dead code elimination.
-       Leo     1 statements after dead code elimination.
+       Leo     3 statements before dead code elimination.
+       Leo     3 statements after dead code elimination.
        Leo     The program checksum is: '[3u8, 95u8, 196u8, 87u8, 201u8, 25u8, 21u8, 148u8, 199u8, 65u8, 183u8, 183u8, 245u8, 253u8, 162u8, 121u8, 112u8, 233u8, 65u8, 132u8, 7u8, 239u8, 243u8, 9u8, 88u8, 169u8, 25u8, 111u8, 5u8, 98u8, 6u8, 94u8]'.
        Leo     Program size: 0.17 KB / 500.00 KB
        Leo ✅ Compiled 'token.aleo' into Aleo instructions.
@@ -12,8 +12,8 @@
 --- building workspace member 'swap' ---
 
        Leo 🔨 Compiling 'swap.aleo'
-       Leo     3 statements before dead code elimination.
-       Leo     3 statements after dead code elimination.
+       Leo     5 statements before dead code elimination.
+       Leo     5 statements after dead code elimination.
        Leo     The program checksum is: '[51u8, 201u8, 4u8, 184u8, 225u8, 223u8, 52u8, 188u8, 32u8, 75u8, 0u8, 3u8, 102u8, 156u8, 180u8, 24u8, 102u8, 252u8, 38u8, 187u8, 224u8, 235u8, 84u8, 129u8, 15u8, 90u8, 153u8, 63u8, 56u8, 50u8, 177u8, 210u8]'.
        Leo     Program size: 0.23 KB / 500.00 KB
        Leo ✅ Compiled 'swap.aleo' into Aleo instructions.

--- a/tests/expectations/compiler/std/calls_std_dummy_module.out
+++ b/tests/expectations/compiler/std/calls_std_dummy_module.out
@@ -1,0 +1,8 @@
+program main.aleo;
+
+function pass_through:
+    input r0 as u32.private;
+    output r0 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/std/calls_std_identity.out
+++ b/tests/expectations/compiler/std/calls_std_identity.out
@@ -1,0 +1,8 @@
+program main.aleo;
+
+function pass_through:
+    input r0 as u32.private;
+    output r0 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/std/calls_std_dummy_module.leo
+++ b/tests/tests/compiler/std/calls_std_dummy_module.leo
@@ -1,0 +1,8 @@
+program main.aleo {
+    fn pass_through(x: u32) -> u32 {
+        return std::dummy::dummy_u32(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/std/calls_std_identity.leo
+++ b/tests/tests/compiler/std/calls_std_identity.leo
@@ -1,0 +1,8 @@
+program main.aleo {
+    fn pass_through(x: u32) -> u32 {
+        return std::identity_u32(x);
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
This change introduces a built-in standard library that the compiler injects into every Leo program without requiring users to declare it in `program.json`. Programs can call std members directly through typical `std::foo()` syntax.

A new `leo-std` crate holds the std Leo source, currently consisting of a single `identity_u32` placeholder, and exposes it to the compiler. The source is embedded with `include_str!` so the compiler has no runtime filesystem dependency on std.

Injection runs from `Compiler::add_import_stubs`. `inject_std_library` compiles std with a no-std sub-compiler, converts the resulting library AST into a stub and registers it with the current unit as a parent. The library participates in name resolution and type checking like any other stub.

Per-build caching avoids re-parsing and re-type-checking std for every unit. `leo build` compiles N+1 units through
fresh `Compiler` instances.

A new `no_std` manifest field allowt user to disable the injection if they don't want or need the standard library for their program/library.

The package validator and manifest loader will now reject any program, library, or dependency named `std`.
