### PR TITLE
Reject orphan final functions that access storage

### DIFF
--- a/crates/fmt/tests/source/expr_call.leo
+++ b/crates/fmt/tests/source/expr_call.leo
@@ -33,5 +33,10 @@ let x
                 x  ;
     }
 
+    fn finalize_map(
+            public  addr  :  address  )  ->  Final   {
+        return final { do_map(addr); };
+    }
+
 	mapping balances  :  address  =>  u64  ;
 }

--- a/crates/fmt/tests/source/stmt_expression.leo
+++ b/crates/fmt/tests/source/stmt_expression.leo
@@ -17,8 +17,11 @@ program test.aleo
     mapping  balances  :  address  =>  u64  ;
 
 	fn main(
+            public addr
+                :  address  ,
             public item
                 :  u64
-    )  {
+    )  ->  Final  {
+        return final { do_mapping(addr, item); };
     }
 }

--- a/crates/fmt/tests/target/expr_call.leo
+++ b/crates/fmt/tests/target/expr_call.leo
@@ -14,5 +14,9 @@ program test.aleo {
         return x;
     }
 
+    fn finalize_map(public addr: address) -> Final {
+        return final { do_map(addr); };
+    }
+
     mapping balances: address => u64;
 }

--- a/crates/fmt/tests/target/stmt_expression.leo
+++ b/crates/fmt/tests/target/stmt_expression.leo
@@ -6,5 +6,7 @@ final fn do_mapping(addr: address, item: u64) {
 program test.aleo {
     mapping balances: address => u64;
 
-    fn main(public item: u64) {}
+    fn main(public addr: address, public item: u64) -> Final {
+        return final { do_mapping(addr, item); };
+    }
 }

--- a/crates/passes/src/errors/type_checker.rs
+++ b/crates/passes/src/errors/type_checker.rs
@@ -1086,6 +1086,11 @@ pub(crate) fn cannot_have_mode(kind: impl Display, span: Span) -> Formatted {
         )
 }
 
+pub(crate) fn orphan_final_fn(name: impl Display, span: Span) -> Formatted {
+    Formatted::error(CODE_PREFIX, CODE_MASK + 193, format!("`final fn {name}` is never called"), span)
+        .with_help("Remove this `final fn`, or call it from a `final` block or another `final fn`.")
+}
+
 // TypeCheckerWarning builder functions
 
 pub(crate) fn caller_as_record_owner(record_name: impl Display, span: Span) -> Formatted {

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -21,6 +21,7 @@ use leo_ast::{DiGraphError, Type, *};
 use leo_errors::Label;
 use leo_span::{Symbol, sym};
 
+use indexmap::{IndexMap, IndexSet};
 use itertools::Itertools;
 use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 use std::collections::{BTreeMap, HashMap};
@@ -77,8 +78,7 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
 
         if self.state.handler.err_count() == 0 {
-            input.program_scopes.values().for_each(|scope| self.check_orphan_storage_final_fns_in_scope(scope));
-            input.modules.values().for_each(|module| self.check_orphan_storage_final_fns_in_module(module));
+            self.check_orphan_storage_final_fns(input);
         }
     }
 
@@ -760,41 +760,102 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
 }
 
 impl TypeCheckingVisitor<'_> {
-    fn check_orphan_storage_final_fns_in_scope(&mut self, input: &ProgramScope) {
+    fn collect_final_fns_in_scope<'a>(final_fns: &mut IndexMap<Location, &'a Function>, input: &'a ProgramScope) {
         let unit_name = input.program_id.as_symbol();
         for (_, function) in input.functions.iter().filter(|(_, function)| function.variant == Variant::FinalFn) {
-            self.check_orphan_storage_final_fn(unit_name, &[], function);
+            final_fns.insert(Location::new(unit_name, vec![function.name()]), function);
         }
     }
 
-    fn check_orphan_storage_final_fns_in_module(&mut self, input: &Module) {
+    fn collect_final_fns_in_module<'a>(final_fns: &mut IndexMap<Location, &'a Function>, input: &'a Module) {
         for (_, function) in input.functions.iter().filter(|(_, function)| function.variant == Variant::FinalFn) {
-            self.check_orphan_storage_final_fn(input.unit_name, &input.path, function);
+            let path = input.path.iter().cloned().chain(std::iter::once(function.name())).collect();
+            final_fns.insert(Location::new(input.unit_name, path), function);
         }
     }
 
-    fn check_orphan_storage_final_fn(&mut self, unit_name: Symbol, module_path: &[Symbol], function: &Function) {
-        let location =
-            Location::new(unit_name, module_path.iter().cloned().chain(std::iter::once(function.name())).collect());
-        if self.state.call_count.get(&location).copied().unwrap_or_default() != 0 {
-            return;
+    fn check_orphan_storage_final_fns(&mut self, input: &Program) {
+        let mut final_fns = IndexMap::new();
+        input.program_scopes.values().for_each(|scope| Self::collect_final_fns_in_scope(&mut final_fns, scope));
+        input.modules.values().for_each(|module| Self::collect_final_fns_in_module(&mut final_fns, module));
+
+        let mut reaches_storage = HashMap::new();
+        for (location, function) in final_fns.iter() {
+            if self.state.call_count.get(location).copied().unwrap_or_default() != 0 {
+                continue;
+            }
+
+            if self.final_fn_reaches_storage(location, &final_fns, &mut reaches_storage, &mut IndexSet::new()) {
+                self.emit_err(crate::errors::type_checker::orphan_final_fn(
+                    function.name(),
+                    function.identifier.span(),
+                ));
+            }
+        }
+    }
+
+    fn final_fn_reaches_storage<'a>(
+        &mut self,
+        location: &Location,
+        final_fns: &IndexMap<Location, &'a Function>,
+        reaches_storage: &mut HashMap<Location, bool>,
+        visiting: &mut IndexSet<Location>,
+    ) -> bool {
+        if let Some(reaches_storage) = reaches_storage.get(location) {
+            return *reaches_storage;
         }
 
+        if !visiting.insert(location.clone()) {
+            return false;
+        }
+
+        let function =
+            final_fns.get(location).expect("final function reachability is only queried for collected final functions");
         let symbol_accesses = {
             let mut collector = SymbolAccessCollector::new(self.state);
             collector.visit_block(&function.block);
             collector.symbol_accesses
         };
 
-        let touches_storage = symbol_accesses.into_iter().any(|(path, _)| {
+        let reaches = symbol_accesses.into_iter().any(|(path, _)| {
             self.state
                 .symbol_table
-                .lookup_path(unit_name, &path)
+                .lookup_path(location.program, &path)
                 .is_some_and(|var| var.declaration == VariableType::Storage)
-        });
+        }) || {
+            let mut collector = FunctionCallCollector::default();
+            collector.visit_block(&function.block);
+            collector.calls.iter().any(|callee| {
+                final_fns.contains_key(callee)
+                    && self.final_fn_reaches_storage(callee, final_fns, reaches_storage, visiting)
+            })
+        };
 
-        if touches_storage {
-            self.emit_err(crate::errors::type_checker::orphan_final_fn(function.name(), function.identifier.span()));
+        visiting.shift_remove(location);
+        reaches_storage.insert(location.clone(), reaches);
+        reaches
+    }
+}
+
+#[derive(Default)]
+struct FunctionCallCollector {
+    calls: IndexSet<Location>,
+}
+
+impl AstVisitor for FunctionCallCollector {
+    type AdditionalInput = ();
+    type Output = ();
+
+    fn visit_call(&mut self, input: &CallExpression, _: &Self::AdditionalInput) -> Self::Output {
+        if let Some(location) = input.function.try_global_location() {
+            self.calls.insert(location.clone());
         }
+
+        input.const_arguments.iter().for_each(|expr| {
+            self.visit_expression(expr, &());
+        });
+        input.arguments.iter().for_each(|expr| {
+            self.visit_expression(expr, &());
+        });
     }
 }

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::TypeCheckingVisitor;
-use crate::VariableSymbol;
+use crate::{SymbolAccessCollector, VariableSymbol, VariableType};
 
 use leo_ast::{DiGraphError, Type, *};
 use leo_errors::Label;
@@ -75,6 +75,11 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
 
         // Typecheck the program scopes.
         input.program_scopes.values().for_each(|scope| self.visit_program_scope(scope));
+
+        if self.state.handler.err_count() == 0 {
+            input.program_scopes.values().for_each(|scope| self.check_orphan_storage_final_fns_in_scope(scope));
+            input.modules.values().for_each(|module| self.check_orphan_storage_final_fns_in_module(module));
+        }
     }
 
     fn visit_program_scope(&mut self, input: &ProgramScope) {
@@ -751,5 +756,45 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
 
     fn visit_composite_stub(&mut self, input: &Composite) {
         self.visit_composite(input);
+    }
+}
+
+impl TypeCheckingVisitor<'_> {
+    fn check_orphan_storage_final_fns_in_scope(&mut self, input: &ProgramScope) {
+        let unit_name = input.program_id.as_symbol();
+        for (_, function) in input.functions.iter().filter(|(_, function)| function.variant == Variant::FinalFn) {
+            self.check_orphan_storage_final_fn(unit_name, &[], function);
+        }
+    }
+
+    fn check_orphan_storage_final_fns_in_module(&mut self, input: &Module) {
+        for (_, function) in input.functions.iter().filter(|(_, function)| function.variant == Variant::FinalFn) {
+            self.check_orphan_storage_final_fn(input.unit_name, &input.path, function);
+        }
+    }
+
+    fn check_orphan_storage_final_fn(&mut self, unit_name: Symbol, module_path: &[Symbol], function: &Function) {
+        let location =
+            Location::new(unit_name, module_path.iter().cloned().chain(std::iter::once(function.name())).collect());
+        if self.state.call_count.get(&location).copied().unwrap_or_default() != 0 {
+            return;
+        }
+
+        let symbol_accesses = {
+            let mut collector = SymbolAccessCollector::new(self.state);
+            collector.visit_block(&function.block);
+            collector.symbol_accesses
+        };
+
+        let touches_storage = symbol_accesses.into_iter().any(|(path, _)| {
+            self.state
+                .symbol_table
+                .lookup_path(unit_name, &path)
+                .is_some_and(|var| var.declaration == VariableType::Storage)
+        });
+
+        if touches_storage {
+            self.emit_err(crate::errors::type_checker::orphan_final_fn(function.name(), function.identifier.span()));
+        }
     }
 }

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -794,10 +794,10 @@ impl TypeCheckingVisitor<'_> {
         }
     }
 
-    fn final_fn_reaches_storage<'a>(
+    fn final_fn_reaches_storage(
         &mut self,
         location: &Location,
-        final_fns: &IndexMap<Location, &'a Function>,
+        final_fns: &IndexMap<Location, &Function>,
         reaches_storage: &mut HashMap<Location, bool>,
         visiting: &mut IndexSet<Location>,
     ) -> bool {

--- a/documentation/code_snippets/cheatsheet/main/src/main.leo
+++ b/documentation/code_snippets/cheatsheet/main/src/main.leo
@@ -260,6 +260,7 @@ program cheatsheet.aleo {
 
             // Modifying
             balances.set(receiver, 100u64);
+            update_balance(receiver, 1u64);
             balances.remove(receiver);
 
             // External mappings (read-only)

--- a/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
@@ -2,6 +2,6 @@
    ╭─[ compiler-test:1:10 ]
    │
  1 │ final fn orphan() {
-   │ 
+   │
    │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.
 ───╯

--- a/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
@@ -1,0 +1,7 @@
+[ETYC0372193] Error: `final fn orphan` is never called
+   ╭─[ compiler-test:1:10 ]
+   │
+ 1 │ final fn orphan() {
+   │ 
+   │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.
+───╯

--- a/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
@@ -1,7 +1,7 @@
 [ETYC0372193] Error: `final fn orphan` is never called
    ╭─[ compiler-test:1:10 ]
-   │ 
- 1 │ final fn orphan() {
    │
+ 1 │ final fn orphan() {
+   │ 
    │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.
 ───╯

--- a/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_final_fn_storage_fail.out
@@ -1,6 +1,6 @@
 [ETYC0372193] Error: `final fn orphan` is never called
    ╭─[ compiler-test:1:10 ]
-   │
+   │ 
  1 │ final fn orphan() {
    │
    │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.

--- a/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
@@ -2,6 +2,6 @@
    ╭─[ compiler-test:1:10 ]
    │
  1 │ final fn orphan() {
-   │ 
+   │
    │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.
 ───╯

--- a/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
@@ -1,0 +1,7 @@
+[ETYC0372193] Error: `final fn orphan` is never called
+   ╭─[ compiler-test:1:10 ]
+   │
+ 1 │ final fn orphan() {
+   │ 
+   │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.
+───╯

--- a/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
@@ -1,7 +1,7 @@
 [ETYC0372193] Error: `final fn orphan` is never called
    ╭─[ compiler-test:1:10 ]
-   │ 
- 1 │ final fn orphan() {
    │
+ 1 │ final fn orphan() {
+   │ 
    │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.
 ───╯

--- a/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
+++ b/tests/expectations/compiler/storage/orphan_transitive_final_fn_storage_fail.out
@@ -1,6 +1,6 @@
 [ETYC0372193] Error: `final fn orphan` is never called
    ╭─[ compiler-test:1:10 ]
-   │
+   │ 
  1 │ final fn orphan() {
    │
    │ Help: Remove this `final fn`, or call it from a `final` block or another `final fn`.

--- a/tests/expectations/compiler/storage/reachable_final_fn_storage.out
+++ b/tests/expectations/compiler/storage/reachable_final_fn_storage.out
@@ -1,0 +1,17 @@
+program reachable_final_fn_storage.aleo;
+
+mapping flag__:
+    key as boolean.public;
+    value as u8.public;
+
+function main:
+    input r0 as u8.private;
+    async main r0 into r1;
+    output r1 as reachable_final_fn_storage.aleo/main.future;
+
+finalize main:
+    input r0 as u8.public;
+    set r0 into flag__[false];
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/storage/orphan_final_fn_storage_fail.leo
+++ b/tests/tests/compiler/storage/orphan_final_fn_storage_fail.leo
@@ -1,0 +1,14 @@
+final fn orphan() {
+    let value = flag.unwrap_or(0u8);
+}
+
+program orphan_final_fn_storage.aleo {
+    @noupgrade
+    constructor() {}
+
+    storage flag: u8;
+
+    fn main() -> u8 {
+        return 0u8;
+    }
+}

--- a/tests/tests/compiler/storage/orphan_transitive_final_fn_storage_fail.leo
+++ b/tests/tests/compiler/storage/orphan_transitive_final_fn_storage_fail.leo
@@ -1,0 +1,18 @@
+final fn orphan() {
+    update(1u8);
+}
+
+final fn update(value: u8) {
+    flag = value;
+}
+
+program orphan_transitive_final_fn_storage.aleo {
+    @noupgrade
+    constructor() {}
+
+    storage flag: u8;
+
+    fn main() -> u8 {
+        return 0u8;
+    }
+}

--- a/tests/tests/compiler/storage/reachable_final_fn_storage.leo
+++ b/tests/tests/compiler/storage/reachable_final_fn_storage.leo
@@ -1,0 +1,14 @@
+final fn update(value: u8) {
+    flag = value;
+}
+
+program reachable_final_fn_storage.aleo {
+    @noupgrade
+    constructor() {}
+
+    storage flag: u8;
+
+    fn main(value: u8) -> Final {
+        return final { update(value); };
+    }
+}


### PR DESCRIPTION
## Motivation

Reject orphan `final fn`s that access storage, fixing #29421.

## Test Plan

- `TEST_FILTER=orphan_final_fn_storage_fail cargo test -p leo-compiler test_compiler -- --nocapture`
- `TEST_FILTER=reachable_final_fn_storage cargo test -p leo-compiler test_compiler -- --nocapture`
- `TEST_FILTER=dynamic_future_multiple cargo test -p leo-compiler test_compiler -- --nocapture`
- `rustfmt --check crates/passes/src/type_checking/program.rs crates/passes/src/errors/type_checker.rs`
- `cargo test -p leo-compiler test_compiler -- --nocapture`

## Related PRs

N/A
