### PR TITLE
Reject Leo keywords as package names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2555,6 +2555,7 @@ dependencies = [
  "indexmap",
  "leo-ast",
  "leo-errors",
+ "leo-parser-rowan",
  "leo-span",
  "serde",
  "serde_json",

--- a/crates/package/Cargo.toml
+++ b/crates/package/Cargo.toml
@@ -21,6 +21,7 @@ edition = "2024"
 # leo dependencies
 leo-ast     = { workspace = true }
 leo-errors  = { workspace = true }
+leo-parser-rowan = { workspace = true }
 leo-span    = { workspace = true }
 # third party dependencies
 glob        = { workspace = true }

--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -202,17 +202,15 @@ fn is_valid_package_name(name: &str) -> bool {
         return false;
     }
 
-    // Check Leo keywords.
     if is_leo_keyword(name) {
         tracing::error!("Aleo names cannot be a Leo keyword.");
         return false;
     }
 
-    // Check reserved keywords.
-    if reserved_keywords().any(|kw| kw == name) {
+    if is_aleo_keyword(name) {
         tracing::error!(
             "Aleo names cannot be a SnarkVM reserved keyword. Reserved keywords are: {}.",
-            reserved_keywords().collect::<Vec<_>>().join(", ")
+            aleo_reserved_keywords().collect::<Vec<_>>().join(", ")
         );
         return false;
     }
@@ -229,7 +227,7 @@ fn is_valid_package_name(name: &str) -> bool {
 /// Get the list of all reserved and restricted keywords from snarkVM.
 /// These keywords cannot be used as program names.
 /// See: https://github.com/ProvableHQ/snarkVM/blob/046a2964f75576b2c4afbab9aa9eabc43ceb6dc3/synthesizer/program/src/lib.rs#L192
-pub fn reserved_keywords() -> impl Iterator<Item = &'static str> {
+pub fn aleo_reserved_keywords() -> impl Iterator<Item = &'static str> {
     use snarkvm::prelude::{Program, TestnetV0};
 
     // Flatten RESTRICTED_KEYWORDS by ignoring ConsensusVersion
@@ -239,15 +237,11 @@ pub fn reserved_keywords() -> impl Iterator<Item = &'static str> {
 }
 
 fn is_leo_keyword(name: &str) -> bool {
-    let (tokens, errors) = leo_parser_rowan::lex(name);
-    if !errors.is_empty() {
-        return false;
-    }
-    let payload: Vec<_> = tokens
-        .into_iter()
-        .filter(|token| !token.kind.is_trivia() && token.kind != leo_parser_rowan::SyntaxKind::EOF)
-        .collect();
-    matches!(payload.as_slice(), [token] if token.kind.is_keyword())
+    leo_parser_rowan::is_keyword(name)
+}
+
+fn is_aleo_keyword(name: &str) -> bool {
+    aleo_reserved_keywords().any(|kw| kw == name)
 }
 
 /// Creates a configured ureq agent for Leo network requests.

--- a/crates/package/src/lib.rs
+++ b/crates/package/src/lib.rs
@@ -202,6 +202,12 @@ fn is_valid_package_name(name: &str) -> bool {
         return false;
     }
 
+    // Check Leo keywords.
+    if is_leo_keyword(name) {
+        tracing::error!("Aleo names cannot be a Leo keyword.");
+        return false;
+    }
+
     // Check reserved keywords.
     if reserved_keywords().any(|kw| kw == name) {
         tracing::error!(
@@ -230,6 +236,18 @@ pub fn reserved_keywords() -> impl Iterator<Item = &'static str> {
     let restricted = Program::<TestnetV0>::RESTRICTED_KEYWORDS.iter().flat_map(|(_, kws)| kws.iter().copied());
 
     Program::<TestnetV0>::KEYWORDS.iter().copied().chain(restricted)
+}
+
+fn is_leo_keyword(name: &str) -> bool {
+    let (tokens, errors) = leo_parser_rowan::lex(name);
+    if !errors.is_empty() {
+        return false;
+    }
+    let payload: Vec<_> = tokens
+        .into_iter()
+        .filter(|token| !token.kind.is_trivia() && token.kind != leo_parser_rowan::SyntaxKind::EOF)
+        .collect();
+    matches!(payload.as_slice(), [token] if token.kind.is_keyword())
 }
 
 /// Creates a configured ureq agent for Leo network requests.
@@ -350,4 +368,32 @@ pub fn filename_no_aleo_extension(path: &Path) -> Option<&str> {
 
 fn filename_no_extension<'a>(path: &'a Path, extension: &'static str) -> Option<&'a str> {
     path.file_name().and_then(|os_str| os_str.to_str()).and_then(|s| s.strip_suffix(extension))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Package, is_valid_library_name, is_valid_program_name};
+
+    #[test]
+    fn package_names_reject_leo_keywords() {
+        assert!(!is_valid_program_name("in.aleo"));
+        assert!(!is_valid_library_name("in"));
+    }
+
+    #[test]
+    fn package_names_accept_keyword_prefixes() {
+        assert!(is_valid_program_name("inside.aleo"));
+        assert!(is_valid_library_name("inside"));
+    }
+
+    #[test]
+    fn package_initialize_rejects_leo_keyword_program_names() {
+        let dir = std::env::temp_dir().join(format!("leo_keyword_program_name_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        assert!(Package::initialize("in", &dir, false).is_err());
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/crates/parser-rowan/src/lexer.rs
+++ b/crates/parser-rowan/src/lexer.rs
@@ -344,6 +344,10 @@ fn ident_to_kind(s: &str) -> SyntaxKind {
     }
 }
 
+pub(crate) fn is_keyword(s: &str) -> bool {
+    ident_to_kind(s).is_keyword()
+}
+
 /// Strip integer type suffix from a string, returning the numeric part.
 fn strip_int_suffix(s: &str) -> Option<&str> {
     // Check for integer type suffixes (longest first to match correctly)
@@ -722,6 +726,14 @@ mod tests {
             KW_IDENTIFIER "identifier"
             EOF ""
         "#]]);
+    }
+
+    #[test]
+    fn keyword_predicate_matches_identifier_keywords() {
+        assert!(super::is_keyword("view"));
+        assert!(super::is_keyword("dyn"));
+        assert!(super::is_keyword("in"));
+        assert!(!super::is_keyword("inside"));
     }
 
     #[test]

--- a/crates/parser-rowan/src/lib.rs
+++ b/crates/parser-rowan/src/lib.rs
@@ -37,6 +37,11 @@ pub use parser::{
 pub use rowan::TextRange;
 pub use syntax_kind::{SyntaxKind, syntax_kind_from_raw};
 
+/// Returns whether `s` is a Leo keyword recognized by the lexer.
+pub fn is_keyword(s: &str) -> bool {
+    lexer::is_keyword(s)
+}
+
 /// The Leo language type for rowan.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum LeoLanguage {}

--- a/crates/parser/src/rowan.rs
+++ b/crates/parser/src/rowan.rs
@@ -259,7 +259,7 @@ impl<'a> ConversionContext<'a> {
         if text.starts_with('_') {
             self.handler.emit_err(crate::errors::identifier_cannot_start_with_underscore(ident.span));
         }
-        if symbol_is_keyword(ident.name) {
+        if leo_parser_rowan::is_keyword(&text) {
             self.emit_unexpected_str("an identifier", &text, ident.span);
         }
     }
@@ -3052,7 +3052,7 @@ pub fn parse_program(
 
         if let Some(key) = compute_module_key(&module.name, root_dir.as_deref()) {
             for segment in &key {
-                if symbol_is_keyword(*segment) {
+                if leo_parser_rowan::is_keyword(&segment.to_string()) {
                     return Err(crate::errors::keyword_used_as_module_name(key.iter().format("::"), segment).into());
                 }
             }
@@ -3106,7 +3106,7 @@ pub fn parse_library(
 
         if let Some(key) = compute_module_key(&module_sf.name, root_dir.as_deref()) {
             for segment in &key {
-                if symbol_is_keyword(*segment) {
+                if leo_parser_rowan::is_keyword(&segment.to_string()) {
                     return Err(crate::errors::keyword_used_as_module_name(key.iter().format("::"), segment).into());
                 }
             }
@@ -3264,62 +3264,6 @@ fn token_to_binary_op(kind: SyntaxKind) -> leo_ast::BinaryOperation {
         CARET => leo_ast::BinaryOperation::Xor,
         _ => panic!("unexpected binary operator: {:?}", kind),
     }
-}
-
-fn symbol_is_keyword(symbol: Symbol) -> bool {
-    matches!(
-        symbol,
-        sym::address
-            | sym::aleo
-            | sym::As
-            | sym::assert
-            | sym::assert_eq
-            | sym::assert_neq
-            | sym::block
-            | sym::bool
-            | sym::Const
-            | sym::constant
-            | sym::constructor
-            | sym::Else
-            | sym::False
-            | sym::field
-            | sym::FnUpper
-            | sym::Fn
-            | sym::For
-            | sym::Final
-            | sym::group
-            | sym::i8
-            | sym::i16
-            | sym::i32
-            | sym::i64
-            | sym::i128
-            | sym::If
-            | sym::import
-            | sym::In
-            | sym::inline
-            | sym::Let
-            | sym::leo
-            | sym::mapping
-            | sym::storage
-            | sym::network
-            | sym::private
-            | sym::program
-            | sym::public
-            | sym::record
-            | sym::Return
-            | sym::scalar
-            | sym::script
-            | sym::SelfLower
-            | sym::signature
-            | sym::string
-            | sym::Struct
-            | sym::True
-            | sym::u8
-            | sym::u16
-            | sym::u32
-            | sym::u64
-            | sym::u128
-    )
 }
 
 /// Computes a module key from a `FileName`, optionally relative to a root directory.

--- a/crates/parser/src/test.rs
+++ b/crates/parser/src/test.rs
@@ -188,3 +188,34 @@ fn runner_parser_test(test: &str) -> String {
 fn parser_tests() {
     leo_test_framework::run_tests("parser", runner_parser_test);
 }
+
+#[test]
+#[serial]
+fn parser_rejects_keyword_module_names_from_rowan_lexer() {
+    create_session_if_not_set_then(|_| {
+        for keyword in ["view", "dyn"] {
+            let buf = BufferEmitter::new();
+            let handler = Handler::new(buf.clone());
+            let source_file = with_session_globals(|s| {
+                s.source_map.new_source("program test.aleo {}", FileName::Custom("test.leo".into()))
+            });
+            let module =
+                with_session_globals(|s| s.source_map.new_source("", FileName::Custom(format!("{keyword}.leo"))));
+
+            let result = crate::parse_program(
+                handler.clone(),
+                &Default::default(),
+                &source_file,
+                &[module],
+                NetworkName::TestnetV0,
+            );
+
+            assert!(handler.extend_if_error(result).is_err(), "expected `{keyword}` module name to be rejected");
+            let errors = format!("{}", buf.extract_errs());
+            assert!(
+                errors.contains(&format!("reserved keyword `{keyword}`")),
+                "expected keyword module error for `{keyword}`"
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Motivation

Fixes #29071.

`leo new` currently accepts package names that are Leo keywords. Those names later conflict with Leo syntax, so this rejects keyword names during package name validation.

## Test Plan

- `cargo test -p leo-package -- --nocapture`

## Related PRs

None
