### PR TITLE
Emit deterministic Aleo import declarations

### DIFF
--- a/crates/passes/src/code_generation/program.rs
+++ b/crates/passes/src/code_generation/program.rs
@@ -39,12 +39,12 @@ use snarkvm::prelude::{CanaryV0, MainnetV0, TestnetV0};
 
 impl<'a> CodeGeneratingVisitor<'a> {
     pub fn visit_program(&mut self, input: &'a Program) -> AleoProgram {
-        // Dependencies of the program. Already arranged in post order by Retriever module.
-        // Ignore library stubs since they are compile-time only entities.
+        // Emit import declarations deterministically; library stubs are compile-time only.
         let imports = input
             .stubs
             .iter()
             .filter_map(|(program_name, stub)| if stub.is_library() { None } else { Some(program_name.to_string()) })
+            .sorted()
             .collect();
 
         // Retrieve the program scope.

--- a/crates/passes/src/code_generation/visitor.rs
+++ b/crates/passes/src/code_generation/visitor.rs
@@ -90,6 +90,7 @@ impl CodeGeneratingVisitor<'_> {
                                 .get_transitive_imports(program_name)
                                 .into_iter()
                                 .map(|sym| sym.to_string())
+                                .sorted()
                                 .collect::<Vec<_>>();
 
                             let mut generated = self.visit_program(program);

--- a/tests/expectations/cli/multiple_leo_deps/STDOUT
+++ b/tests/expectations/cli/multiple_leo_deps/STDOUT
@@ -4,7 +4,7 @@
        Leo 🔨 Compiling 'parent.aleo'
        Leo     9 statements before dead code elimination.
        Leo     9 statements after dead code elimination.
-       Leo     The program checksum is: '[215u8, 203u8, 66u8, 86u8, 222u8, 65u8, 57u8, 252u8, 117u8, 231u8, 155u8, 25u8, 45u8, 60u8, 202u8, 131u8, 149u8, 90u8, 30u8, 208u8, 156u8, 22u8, 227u8, 204u8, 30u8, 127u8, 166u8, 190u8, 70u8, 12u8, 210u8, 133u8]'.
+       Leo     The program checksum is: '[36u8, 42u8, 7u8, 48u8, 36u8, 141u8, 90u8, 111u8, 93u8, 3u8, 27u8, 112u8, 152u8, 129u8, 88u8, 13u8, 223u8, 75u8, 216u8, 223u8, 25u8, 10u8, 48u8, 182u8, 189u8, 54u8, 128u8, 147u8, 96u8, 174u8, 215u8, 57u8]'.
        Leo     Program size: 0.29 KB / 500.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.
        Leo     Import 'grandchild.aleo': checksum = '[174u8, 187u8, 41u8, 199u8, 29u8, 93u8, 47u8, 173u8, 98u8, 32u8, 73u8, 250u8, 151u8, 53u8, 73u8, 94u8, 242u8, 95u8, 71u8, 74u8, 121u8, 121u8, 133u8, 66u8, 113u8, 125u8, 133u8, 149u8, 137u8, 234u8, 137u8, 134u8]'

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/build/parent/parent.aleo
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/build/parent/parent.aleo
@@ -1,6 +1,6 @@
-import grandchild.aleo;
 import child1.aleo;
 import child2.aleo;
+import grandchild.aleo;
 program parent.aleo;
 
 function main:

--- a/tests/expectations/compiler/async_blocks/nested.out
+++ b/tests/expectations/compiler/async_blocks/nested.out
@@ -85,8 +85,8 @@ finalize main:
     position end_otherwise_0_3;
     set r3 into ayo[1u32];
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 program wrapper.aleo;
 
 function main:
@@ -107,8 +107,8 @@ finalize main:
     await r1;
     await r2;
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 import wrapper.aleo;
 program big_wrapper.aleo;
 

--- a/tests/expectations/compiler/async_blocks/partial_type_specification.out
+++ b/tests/expectations/compiler/async_blocks/partial_type_specification.out
@@ -95,8 +95,8 @@ finalize main:
     position end_otherwise_0_3;
     set r3 into ayo[1u32];
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 program wrapper.aleo;
 
 function main:
@@ -117,8 +117,8 @@ finalize main:
     await r1;
     await r2;
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 import wrapper.aleo;
 program big_wrapper.aleo;
 

--- a/tests/expectations/compiler/bugs/sorted_import_bytecode.out
+++ b/tests/expectations/compiler/bugs/sorted_import_bytecode.out
@@ -1,0 +1,19 @@
+program a_dep.aleo;
+
+function one:
+    output 1u8 as u8.private;
+// --- Next Program --- //
+program z_dep.aleo;
+
+function two:
+    output 2u8 as u8.private;
+// --- Next Program --- //
+import a_dep.aleo;
+import z_dep.aleo;
+program sorted_import_bytecode.aleo;
+
+function main:
+    call a_dep.aleo/one into r0;
+    call z_dep.aleo/two into r1;
+    add r0 r1 into r2;
+    output r2 as u8.private;

--- a/tests/expectations/compiler/cei/bypass_taint_via_dynamic_call_arg.out
+++ b/tests/expectations/compiler/cei/bypass_taint_via_dynamic_call_arg.out
@@ -52,8 +52,8 @@ finalize execute_trade:
     input r1 as u64.public;
     set r1 into trades[r0];
 // --- Next Program --- //
-import oracle.aleo;
 import exchange.aleo;
+import oracle.aleo;
 program trader.aleo;
 
 function trade:

--- a/tests/expectations/compiler/cei/bypass_taint_via_external_call_arg.out
+++ b/tests/expectations/compiler/cei/bypass_taint_via_external_call_arg.out
@@ -52,8 +52,8 @@ finalize execute_trade:
     input r1 as u64.public;
     set r1 into trades[r0];
 // --- Next Program --- //
-import oracle.aleo;
 import exchange.aleo;
+import oracle.aleo;
 program trader.aleo;
 
 function trade:

--- a/tests/expectations/compiler/futures/nested.out
+++ b/tests/expectations/compiler/futures/nested.out
@@ -80,8 +80,8 @@ finalize main:
     position end_otherwise_0_3;
     set 1u32 into ayo[1u32];
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 program wrapper.aleo;
 
 function main:
@@ -102,8 +102,8 @@ finalize main:
     await r1;
     await r2;
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 import wrapper.aleo;
 program big_wrapper.aleo;
 

--- a/tests/expectations/compiler/futures/partial_type_specification.out
+++ b/tests/expectations/compiler/futures/partial_type_specification.out
@@ -90,8 +90,8 @@ finalize main:
     position end_otherwise_0_3;
     set 1u32 into ayo[1u32];
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 program wrapper.aleo;
 
 function main:
@@ -112,8 +112,8 @@ finalize main:
     await r1;
     await r2;
 // --- Next Program --- //
-import test_dep.aleo;
 import test.aleo;
+import test_dep.aleo;
 import wrapper.aleo;
 program big_wrapper.aleo;
 

--- a/tests/expectations/compiler/interfaces/abstract_and_external_same_name_valid.out
+++ b/tests/expectations/compiler/interfaces/abstract_and_external_same_name_valid.out
@@ -21,8 +21,8 @@ program lib.aleo;
 
 function dummy:
 // --- Next Program --- //
-import other.aleo;
 import lib.aleo;
+import other.aleo;
 program test.aleo;
 
 record Token:

--- a/tests/expectations/execution/complex_async_blocks.out
+++ b/tests/expectations/execution/complex_async_blocks.out
@@ -36,8 +36,8 @@ finalize d:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
+import zero_program.aleo;
 program two_program.aleo;
 
 mapping counts:
@@ -63,9 +63,9 @@ finalize b:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
 import two_program.aleo;
+import zero_program.aleo;
 program three_program.aleo;
 
 mapping counts:
@@ -94,10 +94,10 @@ finalize e:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
-import two_program.aleo;
 import three_program.aleo;
+import two_program.aleo;
+import zero_program.aleo;
 program four_program.aleo;
 
 mapping counts:

--- a/tests/expectations/execution/complex_finalization.out
+++ b/tests/expectations/execution/complex_finalization.out
@@ -36,8 +36,8 @@ finalize d:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
+import zero_program.aleo;
 program two_program.aleo;
 
 mapping counts:
@@ -63,9 +63,9 @@ finalize b:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
 import two_program.aleo;
+import zero_program.aleo;
 program three_program.aleo;
 
 mapping counts:
@@ -94,10 +94,10 @@ finalize e:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
-import two_program.aleo;
 import three_program.aleo;
+import two_program.aleo;
+import zero_program.aleo;
 program four_program.aleo;
 
 mapping counts:

--- a/tests/expectations/execution/external_storage.out
+++ b/tests/expectations/execution/external_storage.out
@@ -50,8 +50,8 @@ finalize d:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import zero_program.aleo;
 import one_program.aleo;
+import zero_program.aleo;
 program two_program.aleo;
 
 struct Optional__DmN5CQ9hzeK:

--- a/tests/expectations/execution/external_submodule_fn_deep_chain.out
+++ b/tests/expectations/execution/external_submodule_fn_deep_chain.out
@@ -17,8 +17,8 @@ function entry:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import grandchild.aleo;
 import child.aleo;
+import grandchild.aleo;
 program top.aleo;
 
 function pipeline:

--- a/tests/expectations/execution/external_submodule_transitive.out
+++ b/tests/expectations/execution/external_submodule_transitive.out
@@ -39,8 +39,8 @@ function scale_pixel:
 constructor:
     assert.eq edition 0u16;
 // --- Next Program --- //
-import grandchild.aleo;
 import child.aleo;
+import grandchild.aleo;
 program parent.aleo;
 
 function sum_pixel:

--- a/tests/tests/compiler/bugs/sorted_import_bytecode.leo
+++ b/tests/tests/compiler/bugs/sorted_import_bytecode.leo
@@ -1,0 +1,22 @@
+program a_dep.aleo {
+    fn one() -> u8 {
+        return 1u8;
+    }
+}
+
+// --- Next Program --- //
+program z_dep.aleo {
+    fn two() -> u8 {
+        return 2u8;
+    }
+}
+
+// --- Next Program --- //
+import z_dep.aleo;
+import a_dep.aleo;
+
+program sorted_import_bytecode.aleo {
+    fn main() -> u8 {
+        return a_dep.aleo::one() + z_dep.aleo::two();
+    }
+}


### PR DESCRIPTION
## Motivation

Fixes #29058.

Generated Aleo bytecode can emit import declarations in source/stub insertion order. This normalizes emitted import declarations to alphanumeric order so equivalent builds produce stable bytecode.

## Test Plan

- `TEST_FILTER=sorted_import_bytecode cargo test -p leo-compiler test_compiler -- --nocapture`
- `cargo test -p leo-compiler test_compiler -- --nocapture`

## Related PRs

None
