### PR TITLE
Document the constructor in the language reference

### DIFF
--- a/documentation/guides/10_program_upgradability.md
+++ b/documentation/guides/10_program_upgradability.md
@@ -61,6 +61,7 @@ Within a `constructor`, you can access on-chain metadata about the program using
 
 | Operand              | Leo Type   | Description                                                                                                                                  |
 | -------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `self.address`       | `address`  | The program's own account address.                                                                                                           |
 | `self.edition`       | `u16`      | The program's version number. Starts at `0` and is incremented by `1` for each upgrade. The edition is tracked automatically on the network. |
 | `self.program_owner` | `address`  | The address that submitted the deployment transaction.                                                                                       |
 | `self.checksum`      | `[u8, 32]` | The program's checksum, which is a unique identifier for the program's code.                                                                 |

--- a/documentation/language/01_layout.md
+++ b/documentation/language/01_layout.md
@@ -34,6 +34,7 @@ The body of the program is delimited by curly braces `{}`.
 
 The following must be declared inside the scope of a program in a Leo file:
 
+- A single, mandatory [`constructor`](./02_structure.md#constructor)
 - [Mappings](./02_structure.md#mappings) and [Storage](./02_structure.md#storage)
 - [Records](./02_structure.md#record)
 - [Entry point `fn` declarations](./programs_in_practice/functions.md#entry-functions)

--- a/documentation/language/02_structure.md
+++ b/documentation/language/02_structure.md
@@ -8,7 +8,7 @@ sidebar_label: Program Structure
 
 ## Layout of a Leo Program
 
-A Leo program contains declarations of a [Program](#program), [Constants](#constant), [Imports](#import)
+A Leo program contains declarations of a [Program](#program), a [Constructor](#constructor), [Constants](#constant), [Imports](#import)
 , [Structs](#struct), [Records](#record), [Mappings](#mappings), [Interfaces](./programs_in_practice/interfaces.md), and functions.
 Declarations are locally accessible within a program file.
 If you need a declaration from another Leo file, you must import it.
@@ -21,6 +21,25 @@ For the canonical list of which declarations belong inside vs. outside the `prog
 
 ```leo file=../code_snippets/layout/main_example/src/main.leo#file
 ```
+
+### Constructor
+
+A `constructor` is a special, mandatory function declared inside the `program { ... }` block as `constructor() { ... }`. Every program must declare exactly one. It takes no parameters and returns no value, and it is not a regular `fn`: you never call it directly. Instead, the network runs it on-chain during the program's initial deployment and on every subsequent upgrade, where it acts as the gatekeeper for the program's upgrade policy.
+
+Two properties set a `constructor` apart from an ordinary function:
+
+- **Immutable.** The logic set at first deployment can never be changed, modified, or deleted by a future upgrade.
+- **Policy-bearing.** It carries exactly one upgrade annotation — `@noupgrade`, `@admin`, `@checksum`, or `@custom` — that selects how the program may be upgraded. The managed modes (`@noupgrade`, `@admin`, `@checksum`) require an **empty** body, since the compiler generates their logic; `@custom` requires a **non-empty** body that you write yourself. A constructor with no annotation, or with more than one, is a compile error.
+
+```leo file=../code_snippets/upgradability/noupgrade/src/main.leo#file
+```
+
+Inside a `constructor`, you can read on-chain program metadata through `self` — namely `self.address`, `self.edition`, `self.program_owner`, and `self.checksum`. A `@custom` constructor typically branches on `self.edition` to apply different rules at first deployment (`edition == 0`) versus later upgrades:
+
+```leo file=../code_snippets/upgradability/timelock/src/main.leo#file
+```
+
+For the annotation argument grammar, the type and meaning of each `self.*` operand, and worked patterns for every upgrade mode, see the [Upgrading Programs guide](../guides/10_program_upgradability.md).
 
 ### Constant
 

--- a/documentation/language/programs_in_practice/functions.md
+++ b/documentation/language/programs_in_practice/functions.md
@@ -80,6 +80,10 @@ The same rule applies across programs — a `final {}` block can call a `view fn
 ```leo file=../../code_snippets/functions/view_cross_program_caller/src/main.leo#file showLineNumbers
 ```
 
+## The Constructor
+
+The `constructor` is the one other function-like declaration inside a `program {}` block. Unlike the entry, `final`, and `view` functions above, it is never called directly: the network runs it on-chain at deployment and on every upgrade to enforce the program's upgrade policy. It is documented alongside the other program-level declarations under [Constructor](../02_structure.md#constructor), with the full upgrade-policy semantics in the [Upgrading Programs guide](../../guides/10_program_upgradability.md).
+
 ## Helper Function
 
 A helper function is declared as `fn {name}({arguments}) {}` **outside** the `program {}` block.


### PR DESCRIPTION
Adds `constructor` documentation to the Language section.

- New `Constructor` section in the program structure page (syntax, placement, immutability, the upgrade annotations, and the `self.*` metadata it can read).
- Listed as a mandatory program-level declaration in the project layout.
- A short pointer from the functions page.
- Added `self.address` to the upgradability guide's metadata table.

Detailed upgrade-policy semantics stay in the upgradability guide to avoid duplication.

Closes #29385