### PR TITLE
perf(build): optimize deps but not workspace crates in dev/test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,17 +107,26 @@ incremental = true
 debug-assertions = false
 
 [profile.dev]
-opt-level = 2
+opt-level = 1     # Low opt-level keeps incremental rebuilds of workspace crates fast.
 lto = "off"
 incremental = true
 debug-assertions = false
 
+# Build all dependencies (notably the large snarkVM tree) with full optimizations.
+# They are compiled once and cached, so this does not affect incremental rebuild
+# times, but it keeps runtime fast even though our own crates are barely optimized.
+[profile.dev.package."*"]
+opt-level = 3
+
 [profile.test]
-opt-level = 2
+opt-level = 1     # See `profile.dev`; low opt-level for fast workspace rebuilds.
 lto = "off"
 incremental = true
-debug = true
+debug = "line-tables-only" # Enough for file/line in backtraces; far cheaper to emit and link than full debuginfo.
 debug-assertions = true
+
+[profile.test.package."*"]
+opt-level = 3
 
 [profile.ci]
 inherits = "test"
@@ -127,3 +136,9 @@ incremental = false
 debug = false
 debug-assertions = false
 codegen-units = 32 # HIGH codegen parallelism speeds compile (default is usually 16)
+
+# CI does near-clean builds, so optimizing dependencies would only slow compilation.
+# Override the `profile.test` dependency setting inherited above to keep every crate
+# at the low opt-level for the fastest possible CI builds.
+[profile.ci.package."*"]
+opt-level = 1


### PR DESCRIPTION
## What

Speeds up local build iteration by splitting optimization between Leo's own crates and its dependencies:

- `dev`/`test` profiles: workspace crates drop from `opt-level = 2` → `1` (fast incremental rebuilds), while **all dependencies** build at `opt-level = 3` via `[profile.<p>.package."*"]`. snarkVM and friends are compiled once and cached, so runtime — including snarkVM proving in the test suite — stays fast even though our own crates are barely optimized.
- `test` profile now emits `debug = "line-tables-only"` instead of full debuginfo — keeps file/line in backtraces, much cheaper to generate and link.
- `ci` profile pins `package."*"` back to `opt-level = 1`, so the new dependency optimization does **not** leak in through `inherits = "test"` and slow CI's near-clean builds.

## Why

The runtime hot path is inside snarkVM, not Leo's passes, so optimizing the workspace at `-O2` on every edit cost compile time without buying meaningful runtime. This is the standard "optimize deps, not your code" dev-profile split.

## Verification

`cargo build -v` confirms the resolved flags:
- **dev**: `leo_span` → `opt-level=1`, `fxhash`/`indexmap` → `opt-level=3`
- **ci**: every crate → `opt-level=1` (CI compile time unchanged)

## Deliberately *not* in this PR (need benchmarking / sign-off)

- **Gating snarkVM's `rocks` feature** off the default/test builds — would remove the RocksDB C++ + bindgen compile (and the CI libclang install) from builds that don't need persistent storage. Biggest cold-build win, but a behavior change.
- **Shrinking the full-`snarkvm` reach** in `parser`/`ast` (they pull the umbrella crate but mostly need the lighter `snarkvm-console` subset they already depend on) — improves build-graph parallelism, but needs an import refactor + verification.
- **Faster linker** (`lld`/`mold`) via `.cargo/config.toml` — left as a per-developer opt-in rather than forced repo-wide, since not every machine/CI image ships it.
- The existing `.cargo/config.toml` has a malformed `cfg(... not(feature = "noconfig)))` (unterminated string) that silently disables its `target-cpu=native` rule — flagging separately since fixing it changes runtime codegen, not build speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)