### PR TITLE
ci: bump CircleCI Xcode image to 26.5.0

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -29,7 +29,7 @@ parameters:
 executors:
   macos-executor:
     macos:
-      xcode: "26.0.1"  # Use appropriate Xcode version
+      xcode: "26.5.0"
     resource_class: m4pro.large
 
   linux-executor:


### PR DESCRIPTION
CircleCI now flags the `xcode:26.0.1` macOS image as deprecated