### PR TITLE
Preserve fallible unused DCE expressions

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -119,9 +119,10 @@ commands:
     steps:
       - run:
           name: Install Rust (Windows)
+          no_output_timeout: 30m
           command: |
             $ProgressPreference = "SilentlyContinue"
-            choco uninstall rust
+            choco uninstall rust -y --no-progress
             Invoke-WebRequest -Uri "https://win.rustup.rs/" -OutFile "C:\\rustup-init.exe"
             Start-Process "C:\\rustup-init.exe" -ArgumentList '-y' -Wait
             $Env:Path += ";$Env:USERPROFILE\.cargo\bin"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -347,10 +347,10 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - cargo-v4-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
-            - cargo-v4-test-linux-{{ arch }}-{{ .Branch }}-
-            - cargo-v4-test-linux-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
-            - cargo-v4-test-linux-{{ arch }}-master-
+            - cargo-v3-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-linux-{{ arch }}-{{ .Branch }}-
+            - cargo-v3-test-linux-{{ arch }}-master-{{ checksum "Cargo.lock" }}-
+            - cargo-v3-test-linux-{{ arch }}-master-
       - install-rust
       - install-libclang
       - install-snarkos
@@ -359,7 +359,7 @@ jobs:
             command: git submodule update --init --recursive
       - build-and-test
       - save_cache:
-          key: cargo-v4-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
+          key: cargo-v3-test-linux-{{ arch }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ .Revision }}
           paths:
             - ~/.cargo
             - ~/.aleo/resources

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -5,6 +5,7 @@
   "ignorePatterns": [
     { "pattern": "^https://api\\.explorer\\.provable\\.com" },
     { "pattern": "^https://faucet\\.aleo\\.org" },
-    { "pattern": "^https://docs\\.aleo\\.org" }
+    { "pattern": "^https://docs\\.aleo\\.org" },
+    { "pattern": "^https://eprint\\.iacr\\.org/2021/651\\.pdf$" }
   ]
 }

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -5,7 +5,6 @@
   "ignorePatterns": [
     { "pattern": "^https://api\\.explorer\\.provable\\.com" },
     { "pattern": "^https://faucet\\.aleo\\.org" },
-    { "pattern": "^https://docs\\.aleo\\.org" },
-    { "pattern": "^https://eprint\\.iacr\\.org/2021/651\\.pdf$" }
+    { "pattern": "^https://docs\\.aleo\\.org" }
   ]
 }

--- a/crates/ast/src/expressions/mod.rs
+++ b/crates/ast/src/expressions/mod.rs
@@ -336,7 +336,11 @@ impl Expression {
                     // These can halt for any of their operand types.
                     Div | DivWrapped | Mod | Rem | RemWrapped | Shl | Shr => false,
                     // These can only halt for integers.
-                    Add | Mul | Pow | Sub => !matches!(get_type(expr.id()), Type::Integer(..)),
+                    Add | Mul | Pow | Sub => {
+                        expr.left.is_pure(get_type)
+                            && expr.right.is_pure(get_type)
+                            && !matches!(get_type(expr.id()), Type::Integer(..))
+                    }
                     _ => expr.left.is_pure(get_type) && expr.right.is_pure(get_type),
                 }
             }
@@ -346,7 +350,7 @@ impl Expression {
                     // These can halt for any of their operand types.
                     Abs | Inverse | SquareRoot => false,
                     // Negate can only halt for integers.
-                    Negate => !matches!(get_type(expr.id()), Type::Integer(..)),
+                    Negate => expr.receiver.is_pure(get_type) && !matches!(get_type(expr.id()), Type::Integer(..)),
                     _ => expr.receiver.is_pure(get_type),
                 }
             }

--- a/crates/ast/src/expressions/mod.rs
+++ b/crates/ast/src/expressions/mod.rs
@@ -15,7 +15,7 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::{Identifier, IntegerType, Intrinsic, Location, Mode, Node, NodeBuilder, NodeID, Path, Type};
-use leo_span::{Span, Symbol};
+use leo_span::{Span, Symbol, sym};
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -334,7 +334,7 @@ impl Expression {
                 use BinaryOperation::*;
                 match expr.op {
                     // These can halt for any of their operand types.
-                    Div | Mod | Rem | Shl | Shr => false,
+                    Div | DivWrapped | Mod | Rem | RemWrapped | Shl | Shr => false,
                     // These can only halt for integers.
                     Add | Mul | Pow | Sub => !matches!(get_type(expr.id()), Type::Integer(..)),
                     _ => expr.left.is_pure(get_type) && expr.right.is_pure(get_type),
@@ -356,7 +356,11 @@ impl Expression {
 
             // Recurse
             Expression::ArrayAccess(expr) => expr.array.is_pure(get_type) && expr.index.is_pure(get_type),
-            Expression::MemberAccess(expr) => expr.inner.is_pure(get_type),
+            Expression::MemberAccess(expr) => {
+                let is_dynamic_record_read =
+                    matches!(get_type(expr.inner.id()), Type::DynRecord) && expr.name.name != sym::owner;
+                !is_dynamic_record_read && expr.inner.is_pure(get_type)
+            }
             Expression::Repeat(expr) => expr.expr.is_pure(get_type) && expr.count.is_pure(get_type),
             Expression::TupleAccess(expr) => expr.tuple.is_pure(get_type),
             Expression::Array(expr) => expr.elements.iter().all(|e| e.is_pure(get_type)),

--- a/crates/ast/src/expressions/mod.rs
+++ b/crates/ast/src/expressions/mod.rs
@@ -316,7 +316,7 @@ impl Expression {
             // Discriminate intrinsics
             Expression::Intrinsic(intr) => {
                 if let Some(intrinsic) = Intrinsic::from_symbol(intr.name, &intr.type_parameters) {
-                    intrinsic.is_pure()
+                    intrinsic.is_pure() && intr.arguments.iter().all(|arg| arg.is_pure(get_type))
                 } else {
                     false
                 }

--- a/crates/ast/src/expressions/mod.rs
+++ b/crates/ast/src/expressions/mod.rs
@@ -337,9 +337,9 @@ impl Expression {
                     Div | DivWrapped | Mod | Rem | RemWrapped | Shl | Shr => false,
                     // These can only halt for integers.
                     Add | Mul | Pow | Sub => {
-                        expr.left.is_pure(get_type)
+                        !matches!(get_type(expr.id()), Type::Integer(..))
+                            && expr.left.is_pure(get_type)
                             && expr.right.is_pure(get_type)
-                            && !matches!(get_type(expr.id()), Type::Integer(..))
                     }
                     _ => expr.left.is_pure(get_type) && expr.right.is_pure(get_type),
                 }
@@ -361,6 +361,7 @@ impl Expression {
             // Recurse
             Expression::ArrayAccess(expr) => expr.array.is_pure(get_type) && expr.index.is_pure(get_type),
             Expression::MemberAccess(expr) => {
+                // Keep dyn record owner handling in sync with type checking and code generation.
                 let is_dynamic_record_read =
                     matches!(get_type(expr.inner.id()), Type::DynRecord) && expr.name.name != sym::owner;
                 !is_dynamic_record_read && expr.inner.is_pure(get_type)

--- a/tests/expectations/compiler/dyn_record/dyn_record_multiple_fields.out
+++ b/tests/expectations/compiler/dyn_record/dyn_record_multiple_fields.out
@@ -9,8 +9,9 @@ function main:
     input r0 as Token.record;
     cast r0 into r1 as dynamic.record;
     get.record.dynamic r1.balance into r2 as u64;
-    is.eq r2 0u64 into r3;
-    output r3 as boolean.private;
+    get.record.dynamic r1.memo into r3 as field;
+    is.eq r2 0u64 into r4;
+    output r4 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/i128/operator_methods.out
+++ b/tests/expectations/compiler/integers/i128/operator_methods.out
@@ -7,19 +7,21 @@ function main:
     neg r0 into r3;
     add r0 r1 into r4;
     div r0 r1 into r5;
-    is.eq r0 r1 into r6;
-    mul r0 r1 into r7;
-    pow r0 2u8 into r8;
-    pow r0 2u16 into r9;
-    pow r0 2u32 into r10;
-    shl r0 2u8 into r11;
-    shl r0 2u16 into r12;
-    shl r0 2u32 into r13;
-    shr r0 2u8 into r14;
-    shr r0 2u16 into r15;
-    shr r0 2u32 into r16;
-    rem r0 r1 into r17;
-    output r6 as boolean.private;
+    div.w r0 r1 into r6;
+    is.eq r0 r1 into r7;
+    mul r0 r1 into r8;
+    pow r0 2u8 into r9;
+    pow r0 2u16 into r10;
+    pow r0 2u32 into r11;
+    shl r0 2u8 into r12;
+    shl r0 2u16 into r13;
+    shl r0 2u32 into r14;
+    shr r0 2u8 into r15;
+    shr r0 2u16 into r16;
+    shr r0 2u32 into r17;
+    rem r0 r1 into r18;
+    rem.w r0 r1 into r19;
+    output r7 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/i16/operator_methods.out
+++ b/tests/expectations/compiler/integers/i16/operator_methods.out
@@ -7,19 +7,21 @@ function main:
     neg r0 into r3;
     add r0 r1 into r4;
     div r0 r1 into r5;
-    is.eq r0 r1 into r6;
-    mul r0 r1 into r7;
-    pow r0 2u8 into r8;
-    pow r0 2u16 into r9;
-    pow r0 2u32 into r10;
-    shl r0 2u8 into r11;
-    shl r0 2u16 into r12;
-    shl r0 2u32 into r13;
-    shr r0 2u8 into r14;
-    shr r0 2u16 into r15;
-    shr r0 2u32 into r16;
-    rem r0 r1 into r17;
-    output r6 as boolean.private;
+    div.w r0 r1 into r6;
+    is.eq r0 r1 into r7;
+    mul r0 r1 into r8;
+    pow r0 2u8 into r9;
+    pow r0 2u16 into r10;
+    pow r0 2u32 into r11;
+    shl r0 2u8 into r12;
+    shl r0 2u16 into r13;
+    shl r0 2u32 into r14;
+    shr r0 2u8 into r15;
+    shr r0 2u16 into r16;
+    shr r0 2u32 into r17;
+    rem r0 r1 into r18;
+    rem.w r0 r1 into r19;
+    output r7 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/i32/operator_methods.out
+++ b/tests/expectations/compiler/integers/i32/operator_methods.out
@@ -7,19 +7,21 @@ function main:
     neg r0 into r3;
     add r0 r1 into r4;
     div r0 r1 into r5;
-    is.eq r0 r1 into r6;
-    mul r0 r1 into r7;
-    pow r0 2u8 into r8;
-    pow r0 2u16 into r9;
-    pow r0 2u32 into r10;
-    shl r0 2u8 into r11;
-    shl r0 2u16 into r12;
-    shl r0 2u32 into r13;
-    shr r0 2u8 into r14;
-    shr r0 2u16 into r15;
-    shr r0 2u32 into r16;
-    rem r0 r1 into r17;
-    output r6 as boolean.private;
+    div.w r0 r1 into r6;
+    is.eq r0 r1 into r7;
+    mul r0 r1 into r8;
+    pow r0 2u8 into r9;
+    pow r0 2u16 into r10;
+    pow r0 2u32 into r11;
+    shl r0 2u8 into r12;
+    shl r0 2u16 into r13;
+    shl r0 2u32 into r14;
+    shr r0 2u8 into r15;
+    shr r0 2u16 into r16;
+    shr r0 2u32 into r17;
+    rem r0 r1 into r18;
+    rem.w r0 r1 into r19;
+    output r7 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/i64/operator_methods.out
+++ b/tests/expectations/compiler/integers/i64/operator_methods.out
@@ -7,19 +7,21 @@ function main:
     neg r0 into r3;
     add r0 r1 into r4;
     div r0 r1 into r5;
-    is.eq r0 r1 into r6;
-    mul r0 r1 into r7;
-    pow r0 2u8 into r8;
-    pow r0 2u16 into r9;
-    pow r0 2u32 into r10;
-    shl r0 2u8 into r11;
-    shl r0 2u16 into r12;
-    shl r0 2u32 into r13;
-    shr r0 2u8 into r14;
-    shr r0 2u16 into r15;
-    shr r0 2u32 into r16;
-    rem r0 r1 into r17;
-    output r6 as boolean.private;
+    div.w r0 r1 into r6;
+    is.eq r0 r1 into r7;
+    mul r0 r1 into r8;
+    pow r0 2u8 into r9;
+    pow r0 2u16 into r10;
+    pow r0 2u32 into r11;
+    shl r0 2u8 into r12;
+    shl r0 2u16 into r13;
+    shl r0 2u32 into r14;
+    shr r0 2u8 into r15;
+    shr r0 2u16 into r16;
+    shr r0 2u32 into r17;
+    rem r0 r1 into r18;
+    rem.w r0 r1 into r19;
+    output r7 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/i8/operator_methods.out
+++ b/tests/expectations/compiler/integers/i8/operator_methods.out
@@ -7,19 +7,21 @@ function main:
     neg r0 into r3;
     add r0 r1 into r4;
     div r0 r1 into r5;
-    is.eq r0 r1 into r6;
-    mul r0 r1 into r7;
-    pow r0 2u8 into r8;
-    pow r0 2u16 into r9;
-    pow r0 2u32 into r10;
-    shl r0 2u8 into r11;
-    shl r0 2u16 into r12;
-    shl r0 2u32 into r13;
-    shr r0 2u8 into r14;
-    shr r0 2u16 into r15;
-    shr r0 2u32 into r16;
-    rem r0 r1 into r17;
-    output r6 as boolean.private;
+    div.w r0 r1 into r6;
+    is.eq r0 r1 into r7;
+    mul r0 r1 into r8;
+    pow r0 2u8 into r9;
+    pow r0 2u16 into r10;
+    pow r0 2u32 into r11;
+    shl r0 2u8 into r12;
+    shl r0 2u16 into r13;
+    shl r0 2u32 into r14;
+    shr r0 2u8 into r15;
+    shr r0 2u16 into r16;
+    shr r0 2u32 into r17;
+    rem r0 r1 into r18;
+    rem.w r0 r1 into r19;
+    output r7 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/u128/operator_methods.out
+++ b/tests/expectations/compiler/integers/u128/operator_methods.out
@@ -5,20 +5,22 @@ function main:
     input r1 as u128.private;
     add r0 r1 into r2;
     div r0 r1 into r3;
-    is.eq r0 r1 into r4;
-    mul r0 r1 into r5;
-    pow r0 2u8 into r6;
-    pow r0 2u16 into r7;
-    pow r0 2u32 into r8;
-    shl r0 2u8 into r9;
-    shl r0 2u16 into r10;
-    shl r0 2u32 into r11;
-    shr r0 2u8 into r12;
-    shr r0 2u16 into r13;
-    shr r0 2u32 into r14;
-    mod r0 r1 into r15;
-    rem r0 r1 into r16;
-    output r4 as boolean.private;
+    div.w r0 r1 into r4;
+    is.eq r0 r1 into r5;
+    mul r0 r1 into r6;
+    pow r0 2u8 into r7;
+    pow r0 2u16 into r8;
+    pow r0 2u32 into r9;
+    shl r0 2u8 into r10;
+    shl r0 2u16 into r11;
+    shl r0 2u32 into r12;
+    shr r0 2u8 into r13;
+    shr r0 2u16 into r14;
+    shr r0 2u32 into r15;
+    mod r0 r1 into r16;
+    rem r0 r1 into r17;
+    rem.w r0 r1 into r18;
+    output r5 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/u16/operator_methods.out
+++ b/tests/expectations/compiler/integers/u16/operator_methods.out
@@ -5,20 +5,22 @@ function main:
     input r1 as u16.private;
     add r0 r1 into r2;
     div r0 r1 into r3;
-    is.eq r0 r1 into r4;
-    mul r0 r1 into r5;
-    pow r0 2u8 into r6;
-    pow r0 r1 into r7;
-    pow r0 2u32 into r8;
-    shl r0 2u8 into r9;
-    shl r0 r1 into r10;
-    shl r0 2u32 into r11;
-    shr r0 2u8 into r12;
-    shr r0 r1 into r13;
-    shr r0 2u32 into r14;
-    mod r0 r1 into r15;
-    rem r0 r1 into r16;
-    output r4 as boolean.private;
+    div.w r0 r1 into r4;
+    is.eq r0 r1 into r5;
+    mul r0 r1 into r6;
+    pow r0 2u8 into r7;
+    pow r0 r1 into r8;
+    pow r0 2u32 into r9;
+    shl r0 2u8 into r10;
+    shl r0 r1 into r11;
+    shl r0 2u32 into r12;
+    shr r0 2u8 into r13;
+    shr r0 r1 into r14;
+    shr r0 2u32 into r15;
+    mod r0 r1 into r16;
+    rem r0 r1 into r17;
+    rem.w r0 r1 into r18;
+    output r5 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/u32/operator_methods.out
+++ b/tests/expectations/compiler/integers/u32/operator_methods.out
@@ -5,20 +5,22 @@ function main:
     input r1 as u32.private;
     add r0 r1 into r2;
     div r0 r1 into r3;
-    is.eq r0 r1 into r4;
-    mul r0 r1 into r5;
-    pow r0 2u8 into r6;
-    pow r0 2u16 into r7;
-    pow r0 r1 into r8;
-    shl r0 2u8 into r9;
-    shl r0 2u16 into r10;
-    shl r0 r1 into r11;
-    shr r0 2u8 into r12;
-    shr r0 2u16 into r13;
-    shr r0 r1 into r14;
-    mod r0 r1 into r15;
-    rem r0 r1 into r16;
-    output r4 as boolean.private;
+    div.w r0 r1 into r4;
+    is.eq r0 r1 into r5;
+    mul r0 r1 into r6;
+    pow r0 2u8 into r7;
+    pow r0 2u16 into r8;
+    pow r0 r1 into r9;
+    shl r0 2u8 into r10;
+    shl r0 2u16 into r11;
+    shl r0 r1 into r12;
+    shr r0 2u8 into r13;
+    shr r0 2u16 into r14;
+    shr r0 r1 into r15;
+    mod r0 r1 into r16;
+    rem r0 r1 into r17;
+    rem.w r0 r1 into r18;
+    output r5 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/u64/operator_methods.out
+++ b/tests/expectations/compiler/integers/u64/operator_methods.out
@@ -5,20 +5,22 @@ function main:
     input r1 as u64.private;
     add r0 r1 into r2;
     div r0 r1 into r3;
-    is.eq r0 r1 into r4;
-    mul r0 r1 into r5;
-    pow r0 2u8 into r6;
-    pow r0 2u16 into r7;
-    pow r0 2u32 into r8;
-    shl r0 2u8 into r9;
-    shl r0 2u16 into r10;
-    shl r0 2u32 into r11;
-    shr r0 2u8 into r12;
-    shr r0 2u16 into r13;
-    shr r0 2u32 into r14;
-    mod r0 r1 into r15;
-    rem r0 r1 into r16;
-    output r4 as boolean.private;
+    div.w r0 r1 into r4;
+    is.eq r0 r1 into r5;
+    mul r0 r1 into r6;
+    pow r0 2u8 into r7;
+    pow r0 2u16 into r8;
+    pow r0 2u32 into r9;
+    shl r0 2u8 into r10;
+    shl r0 2u16 into r11;
+    shl r0 2u32 into r12;
+    shr r0 2u8 into r13;
+    shr r0 2u16 into r14;
+    shr r0 2u32 into r15;
+    mod r0 r1 into r16;
+    rem r0 r1 into r17;
+    rem.w r0 r1 into r18;
+    output r5 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/compiler/integers/u8/operator_methods.out
+++ b/tests/expectations/compiler/integers/u8/operator_methods.out
@@ -5,20 +5,22 @@ function main:
     input r1 as u8.private;
     add r0 r1 into r2;
     div r0 r1 into r3;
-    is.eq r0 r1 into r4;
-    mul r0 r1 into r5;
-    pow r0 r1 into r6;
-    pow r0 2u16 into r7;
-    pow r0 2u32 into r8;
-    shl r0 r1 into r9;
-    shl r0 2u16 into r10;
-    shl r0 2u32 into r11;
-    shr r0 r1 into r12;
-    shr r0 2u16 into r13;
-    shr r0 2u32 into r14;
-    mod r0 r1 into r15;
-    rem r0 r1 into r16;
-    output r4 as boolean.private;
+    div.w r0 r1 into r4;
+    is.eq r0 r1 into r5;
+    mul r0 r1 into r6;
+    pow r0 r1 into r7;
+    pow r0 2u16 into r8;
+    pow r0 2u32 into r9;
+    shl r0 r1 into r10;
+    shl r0 2u16 into r11;
+    shl r0 2u32 into r12;
+    shr r0 r1 into r13;
+    shr r0 2u16 into r14;
+    shr r0 2u32 into r15;
+    mod r0 r1 into r16;
+    rem r0 r1 into r17;
+    rem.w r0 r1 into r18;
+    output r5 as boolean.private;
 
 constructor:
     assert.eq edition 0u16;

--- a/tests/expectations/passes/dead_code_elimination/fallible_unused.out
+++ b/tests/expectations/passes/dead_code_elimination/fallible_unused.out
@@ -11,6 +11,7 @@ program test.aleo {
         let unused_balance: field = r.balance;
         let unused_balance_add: field = r.balance + 0field;
         let unused_balance_negate: field = -r.balance;
+        let unused_hash: field = BHP256::hash_to_field(r.balance);
         return x;
     }
 }

--- a/tests/expectations/passes/dead_code_elimination/fallible_unused.out
+++ b/tests/expectations/passes/dead_code_elimination/fallible_unused.out
@@ -1,0 +1,14 @@
+program test.aleo {
+    record Token {
+        owner: address,
+        balance: field,
+    }
+
+    transition main(t: Token, x: u8) -> u8 {
+        let unused_div: u8 = x.div_wrapped(0u8);
+        let unused_rem: u8 = x.rem_wrapped(0u8);
+        let r: dyn record = t as dyn record;
+        let unused_balance: field = r.balance;
+        return x;
+    }
+}

--- a/tests/expectations/passes/dead_code_elimination/fallible_unused.out
+++ b/tests/expectations/passes/dead_code_elimination/fallible_unused.out
@@ -9,6 +9,8 @@ program test.aleo {
         let unused_rem: u8 = x.rem_wrapped(0u8);
         let r: dyn record = t as dyn record;
         let unused_balance: field = r.balance;
+        let unused_balance_add: field = r.balance + 0field;
+        let unused_balance_negate: field = -r.balance;
         return x;
     }
 }

--- a/tests/tests/passes/dead_code_elimination/fallible_unused.leo
+++ b/tests/tests/passes/dead_code_elimination/fallible_unused.leo
@@ -13,6 +13,8 @@ program test.aleo {
         let unused_rem: u8 = x.rem_wrapped(0u8);
         let r: dyn record = t as dyn record;
         let unused_balance: field = r.balance;
+        let unused_balance_add: field = r.balance + 0field;
+        let unused_balance_negate: field = -r.balance;
         return x;
     }
 }

--- a/tests/tests/passes/dead_code_elimination/fallible_unused.leo
+++ b/tests/tests/passes/dead_code_elimination/fallible_unused.leo
@@ -15,6 +15,7 @@ program test.aleo {
         let unused_balance: field = r.balance;
         let unused_balance_add: field = r.balance + 0field;
         let unused_balance_negate: field = -r.balance;
+        let unused_hash: field = BHP256::hash_to_field(r.balance);
         return x;
     }
 }

--- a/tests/tests/passes/dead_code_elimination/fallible_unused.leo
+++ b/tests/tests/passes/dead_code_elimination/fallible_unused.leo
@@ -1,0 +1,18 @@
+program test.aleo {
+    record Token {
+        owner: address,
+        balance: field,
+    }
+
+    @noupgrade
+    constructor() {}
+
+    fn main(t: Token, x: u8) -> u8 {
+        let unused_add: u8 = x.add_wrapped(1u8);
+        let unused_div: u8 = x.div_wrapped(0u8);
+        let unused_rem: u8 = x.rem_wrapped(0u8);
+        let r: dyn record = t as dyn record;
+        let unused_balance: field = r.balance;
+        return x;
+    }
+}


### PR DESCRIPTION
## Motivation

Fixes #29519.

`Expression::is_pure` is used by DCE to decide whether unused expressions can be removed. Wrapped division and remainder can still halt on a zero divisor, and non-owner `dyn record` field reads lower to `get.record.dynamic`, which should not be removed just because the result is unused.

This marks `div_wrapped`, `rem_wrapped`, and non-owner dynamic record field reads as non-pure for DCE while still allowing genuinely pure unused expressions to be eliminated.

## Test Plan

Added `tests/tests/passes/dead_code_elimination/fallible_unused.leo`, which expects unused `div_wrapped`, `rem_wrapped`, and `dyn record` field access to be preserved while an unused `add_wrapped` negative control is removed.

Fork CI also passed the targeted DCE regression step on branch `dce-purity-repro`.

## Related PRs

None.