### PR TITLE
Test referencing generated __ names from Aleo dependencies

### DIFF
--- a/tests/expectations/compiler/mappings/modify_external_underscore_mapping_fail.out
+++ b/tests/expectations/compiler/mappings/modify_external_underscore_mapping_fail.out
@@ -1,0 +1,14 @@
+[ETYC0372108] Error: cannot use operation `set` on external mappings
+    ╭─[ compiler-test:11:13 ]
+    │
+ 11 │             optprod.aleo::maybe__.set(false, 7u32); // ❌ illegal external mutation
+    │ 
+    │ Help: The only valid operations on external mappings are `contains`, `get`, and `get_or_use`.
+────╯
+[ETYC0372108] Error: cannot use operation `remove` on external mappings
+    ╭─[ compiler-test:12:13 ]
+    │
+ 12 │             optprod.aleo::maybe__.remove(true); // ❌ illegal external mutation
+    │ 
+    │ Help: The only valid operations on external mappings are `contains`, `get`, and `get_or_use`.
+────╯

--- a/tests/expectations/compiler/mappings/read_external_underscore_mapping.out
+++ b/tests/expectations/compiler/mappings/read_external_underscore_mapping.out
@@ -1,0 +1,17 @@
+import optprod.aleo;
+program optconsumer.aleo;
+
+function peek:
+    async peek into r0;
+    output r0 as optconsumer.aleo/peek.future;
+
+finalize peek:
+    contains optprod.aleo/maybe__[true] into r0;
+    get optprod.aleo/maybe__[true] into r1;
+    get.or_use optprod.aleo/maybe__[false] 0u32 into r2;
+    assert.eq r0 r0;
+    assert.eq r1 r1;
+    assert.eq r2 r2;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/structs/aleo_dep_generated_struct_name.out
+++ b/tests/expectations/compiler/structs/aleo_dep_generated_struct_name.out
@@ -1,0 +1,18 @@
+import producer.aleo;
+program consumer.aleo;
+
+function build:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    add r0 r1 into r2;
+    output r2 as u32.private;
+
+function via_call:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    call producer.aleo/origin r0 r1 into r2;
+    add r2.x r2.y into r3;
+    output r3 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/structs/aleo_dep_generic_struct_name.out
+++ b/tests/expectations/compiler/structs/aleo_dep_generic_struct_name.out
@@ -1,0 +1,15 @@
+import genprod.aleo;
+program genconsumer.aleo;
+
+function build:
+    input r0 as u32.private;
+    output r0 as u32.private;
+
+function via_call:
+    input r0 as u32.private;
+    cast r0 into r1 as genprod.aleo/Slot__LbJovpLEwVd;
+    call genprod.aleo/store r1 into r2;
+    output r2 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/structs/aleo_dep_optional_struct_name.out
+++ b/tests/expectations/compiler/structs/aleo_dep_optional_struct_name.out
@@ -1,0 +1,9 @@
+import optprod.aleo;
+program optconsumer.aleo;
+
+function build:
+    input r0 as u32.private;
+    output r0 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/mappings/modify_external_underscore_mapping_fail.leo
+++ b/tests/tests/compiler/mappings/modify_external_underscore_mapping_fail.leo
@@ -1,0 +1,41 @@
+// #28996: external mapping writes are rejected even when the dependency's
+// mapping name contains `__` (here `maybe__`). The `__` in the name does not
+// grant any extra cross-program access — only `contains`, `get`, and
+// `get_or_use` are allowed on external mappings; see
+// `read_external_underscore_mapping.leo`.
+
+// --- aleo stub --- //
+program optprod.aleo;
+
+mapping maybe__:
+    key as boolean.public;
+    value as u32.public;
+
+function seed:
+    async seed into r0;
+    output r0 as optprod.aleo/seed.future;
+
+finalize seed:
+    set 1u32 into maybe__[true];
+
+constructor:
+    assert.eq edition 0u16;
+
+// --- Next Program --- //
+
+import optprod.aleo;
+
+program optconsumer.aleo {
+    fn poke() -> Final {
+        return final {
+            //
+            // Both writes must be rejected — external mapping mutation is illegal.
+            //
+            optprod.aleo::maybe__.set(false, 7u32); // ❌ illegal external mutation
+            optprod.aleo::maybe__.remove(true); // ❌ illegal external mutation
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/mappings/read_external_underscore_mapping.leo
+++ b/tests/tests/compiler/mappings/read_external_underscore_mapping.leo
@@ -1,0 +1,45 @@
+// #28996: a dependency's bytecode can expose a compiler-generated mapping whose
+// name contains `__` (here `maybe__`, as emitted for an internal `Option` store).
+// A consumer importing only the Aleo bytecode can read from that mapping by
+// spelling out the full name — the permitted external operations `contains`,
+// `get`, and `get_or_use` all work regardless of the `__` in the name. External
+// writes remain illegal; see `modify_external_underscore_mapping_fail.leo`.
+
+// --- aleo stub --- //
+program optprod.aleo;
+
+mapping maybe__:
+    key as boolean.public;
+    value as u32.public;
+
+function seed:
+    async seed into r0;
+    output r0 as optprod.aleo/seed.future;
+
+finalize seed:
+    set 1u32 into maybe__[true];
+
+constructor:
+    assert.eq edition 0u16;
+
+// --- Next Program --- //
+
+import optprod.aleo;
+
+program optconsumer.aleo {
+    fn peek() -> Final {
+        return final { finalize_peek(); };
+    }
+
+    @noupgrade
+    constructor() {}
+}
+
+final fn finalize_peek() {
+    let present: bool = Mapping::contains(optprod.aleo::maybe__, true);
+    let v: u32 = Mapping::get(optprod.aleo::maybe__, true);
+    let w: u32 = Mapping::get_or_use(optprod.aleo::maybe__, false, 0u32);
+    assert_eq(present, present);
+    assert_eq(v, v);
+    assert_eq(w, w);
+}

--- a/tests/tests/compiler/structs/aleo_dep_generated_struct_name.leo
+++ b/tests/tests/compiler/structs/aleo_dep_generated_struct_name.leo
@@ -1,0 +1,42 @@
+// #28996: a dependency can expose a compiler-generated struct name containing
+// `__` (here a library composite `geo::Point` lowered to `Point__<hash>` in
+// `producer.aleo`'s transition signature). When only the Aleo bytecode is
+// available, a consumer can still use that type by spelling out the full
+// mangled name — no source and no disassembly desugaring required.
+
+// --- aleo stub --- //
+program producer.aleo;
+
+struct Point__IHPtDcGjLAc:
+    x as u32;
+    y as u32;
+
+function origin:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    cast r0 r1 into r2 as Point__IHPtDcGjLAc;
+    output r2 as Point__IHPtDcGjLAc.private;
+
+constructor:
+    assert.eq edition 0u16;
+
+// --- Next Program --- //
+
+import producer.aleo;
+
+program consumer.aleo {
+    // Construct the dependency's `__` struct and read its fields.
+    fn build(x: u32, y: u32) -> u32 {
+        let p: producer.aleo::Point__IHPtDcGjLAc = producer.aleo::Point__IHPtDcGjLAc { x: x, y: y };
+        return p.x + p.y;
+    }
+
+    // Receive the `__` struct as the output of an external call.
+    fn via_call(x: u32, y: u32) -> u32 {
+        let p: producer.aleo::Point__IHPtDcGjLAc = producer.aleo::origin(x, y);
+        return p.x + p.y;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/structs/aleo_dep_generic_struct_name.leo
+++ b/tests/tests/compiler/structs/aleo_dep_generic_struct_name.leo
@@ -1,0 +1,38 @@
+// #28996: a dependency exposes a monomorphized const-generic struct, whose name
+// is the compiler-generated `Slot__<hash>` (from `Slot::[8u32]`), in its
+// transition signature. A consumer importing only the Aleo bytecode references
+// that type by spelling out the full mangled name.
+
+// --- aleo stub --- //
+program genprod.aleo;
+
+struct Slot__LbJovpLEwVd:
+    val as u32;
+
+function store:
+    input r0 as Slot__LbJovpLEwVd.private;
+    output r0.val as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+
+// --- Next Program --- //
+
+import genprod.aleo;
+
+program genconsumer.aleo {
+    // Construct the dependency's generic `__` struct directly.
+    fn build(v: u32) -> u32 {
+        let s: genprod.aleo::Slot__LbJovpLEwVd = genprod.aleo::Slot__LbJovpLEwVd { val: v };
+        return s.val;
+    }
+
+    // Pass it into the dependency's external call.
+    fn via_call(v: u32) -> u32 {
+        let s: genprod.aleo::Slot__LbJovpLEwVd = genprod.aleo::Slot__LbJovpLEwVd { val: v };
+        return genprod.aleo::store(s);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/structs/aleo_dep_optional_struct_name.leo
+++ b/tests/tests/compiler/structs/aleo_dep_optional_struct_name.leo
@@ -1,0 +1,51 @@
+// #28996, the literal case: a dependency uses `Option` internally (here a
+// storage value), so its bytecode defines the compiler-generated wrapper
+// `Optional__<hash>` (for `u32?`). A consumer importing only the Aleo bytecode
+// can construct and inspect that struct by spelling out the full mangled name.
+//
+// Note: this test only exercises the generated struct name. Reading the
+// dependency's `maybe__` mapping across programs (and the rejection of external
+// writes) is covered by `mappings/read_external_underscore_mapping.leo` and
+// `mappings/modify_external_underscore_mapping_fail.leo`.
+
+// --- aleo stub --- //
+program optprod.aleo;
+
+struct Optional__JzunLORyB8U:
+    is_some as boolean;
+    val as u32;
+
+mapping maybe__:
+    key as boolean.public;
+    value as u32.public;
+
+function peek:
+    async peek into r0;
+    output r0 as optprod.aleo/peek.future;
+
+finalize peek:
+    contains maybe__[false] into r0;
+    get.or_use maybe__[false] 0u32 into r1;
+    ternary r0 r1 0u32 into r2;
+    cast r0 r2 into r3 as Optional__JzunLORyB8U;
+    ternary r3.is_some r3.val 0u32 into r4;
+    assert.eq r4 r4;
+
+constructor:
+    assert.eq edition 0u16;
+
+// --- Next Program --- //
+
+import optprod.aleo;
+
+program optconsumer.aleo {
+    // Construct the dependency's generated `Optional__<hash>` and read its fields.
+    fn build(v: u32) -> u32 {
+        let o: optprod.aleo::Optional__JzunLORyB8U =
+            optprod.aleo::Optional__JzunLORyB8U { is_some: true, val: v };
+        return o.is_some ? o.val : 0u32;
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
Adds tests verifying a consumer can reference compiler-generated `__` struct names (library composites, const-generic structs, internal `Optional__` wrappers) from an Aleo bytecode dependency by spelling out the full name. No compiler change needed.

Closes #28996