### PR TITLE
Install libclang in musl release builder for rocksdb/bindgen

### DIFF
--- a/.github/workflows/release-crate.yml
+++ b/.github/workflows/release-crate.yml
@@ -239,6 +239,9 @@ jobs:
             --rm \
             -t docker.io/blackdex/rust-musl:x86_64-musl-stable \
             bash -lc "
+              apt-get update &&
+              apt-get install -y clang libclang-dev &&
+              export LIBCLANG_PATH=\$(dirname \$(find /usr/lib -name 'libclang.so*' | head -1)) &&
               rustup target add x86_64-unknown-linux-musl &&
               cd /home/rust/src &&
               cargo build \


### PR DESCRIPTION
Install `clang`/`libclang-dev` inside the musl Docker step and export `LIBCLANG_PATH` so bindgen can find libclang.