### PR TITLE
Merge eq_user and eq_flat_relaxed into Type::types_equivalent

### DIFF
--- a/crates/ast/src/types/type_.rs
+++ b/crates/ast/src/types/type_.rs
@@ -101,7 +101,7 @@ impl Type {
     /// Composite types are considered equal if their names and resolved program names match. If either side still has
     /// const generic arguments, they are treated as equal unconditionally since monomorphization and other passes of
     /// type-checking will handle mismatches later.
-    pub fn eq_user(&self, other: &Type) -> bool {
+    pub fn types_equivalent(&self, other: &Type) -> bool {
         match (self, other) {
             (Type::Err, _)
             | (_, Type::Err)
@@ -123,20 +123,20 @@ impl Type {
                         // equal to other arrays because their lengths _may_ eventually be proven equal.
                         true
                     }
-                }) && left.element_type().eq_user(right.element_type())
+                }) && left.element_type().types_equivalent(right.element_type())
             }
             (Type::Ident(left), Type::Ident(right)) => left.name == right.name,
             (Type::Integer(left), Type::Integer(right)) => left == right,
             (Type::Mapping(left), Type::Mapping(right)) => {
-                left.key.eq_user(&right.key) && left.value.eq_user(&right.value)
+                left.key.types_equivalent(&right.key) && left.value.types_equivalent(&right.value)
             }
-            (Type::Optional(left), Type::Optional(right)) => left.inner.eq_user(&right.inner),
+            (Type::Optional(left), Type::Optional(right)) => left.inner.types_equivalent(&right.inner),
             (Type::Tuple(left), Type::Tuple(right)) if left.length() == right.length() => left
                 .elements()
                 .iter()
                 .zip_eq(right.elements().iter())
-                .all(|(left_type, right_type)| left_type.eq_user(right_type)),
-            (Type::Vector(left), Type::Vector(right)) => left.element_type.eq_user(&right.element_type),
+                .all(|(left_type, right_type)| left_type.types_equivalent(right_type)),
+            (Type::Vector(left), Type::Vector(right)) => left.element_type.types_equivalent(&right.element_type),
             (Type::Composite(left), Type::Composite(right)) => {
                 // If either composite still has const generic arguments, treat them as equal;
                 // monomorphization and a subsequent type-checking pass will handle mismatches.
@@ -156,78 +156,7 @@ impl Type {
                 .inputs()
                 .iter()
                 .zip_eq(right.inputs().iter())
-                .all(|(left_type, right_type)| left_type.eq_user(right_type)),
-            _ => false,
-        }
-    }
-
-    /// Returns `true` if the self `Type` is equal to the other `Type` in all aspects besides composite program of origin.
-    ///
-    /// In the case of futures, it also makes sure that if both are not explicit, they are equal.
-    ///
-    /// Flattens array syntax: `[[u8; 1]; 2] == [u8; (2, 1)] == true`
-    ///
-    /// Composite types are considered equal if their names match. If either side still has const generic arguments,
-    /// they are treated as equal unconditionally since monomorphization and other passes of type-checking will handle
-    /// mismatches later.
-    pub fn eq_flat_relaxed(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Type::Address, Type::Address)
-            | (Type::Boolean, Type::Boolean)
-            | (Type::Field, Type::Field)
-            | (Type::Group, Type::Group)
-            | (Type::Scalar, Type::Scalar)
-            | (Type::Signature, Type::Signature)
-            | (Type::String, Type::String)
-            | (Type::Identifier, Type::Identifier)
-            | (Type::DynRecord, Type::DynRecord)
-            | (Type::Unit, Type::Unit) => true,
-            (Type::Array(left), Type::Array(right)) => {
-                // Two arrays are equal if their element types are the same and if their lengths
-                // are the same, assuming the lengths can be extracted as `u32`.
-                (match (left.length.as_u32(), right.length.as_u32()) {
-                    (Some(l1), Some(l2)) => l1 == l2,
-                    _ => {
-                        // An array with an undetermined length (e.g., one that depends on a `const`) is considered
-                        // equal to other arrays because their lengths _may_ eventually be proven equal.
-                        true
-                    }
-                }) && left.element_type().eq_flat_relaxed(right.element_type())
-            }
-            (Type::Ident(left), Type::Ident(right)) => left.matches(right),
-            (Type::Integer(left), Type::Integer(right)) => left.eq(right),
-            (Type::Mapping(left), Type::Mapping(right)) => {
-                left.key.eq_flat_relaxed(&right.key) && left.value.eq_flat_relaxed(&right.value)
-            }
-            (Type::Optional(left), Type::Optional(right)) => left.inner.eq_flat_relaxed(&right.inner),
-            (Type::Tuple(left), Type::Tuple(right)) if left.length() == right.length() => left
-                .elements()
-                .iter()
-                .zip_eq(right.elements().iter())
-                .all(|(left_type, right_type)| left_type.eq_flat_relaxed(right_type)),
-            (Type::Vector(left), Type::Vector(right)) => left.element_type.eq_flat_relaxed(&right.element_type),
-            (Type::Composite(left), Type::Composite(right)) => {
-                // If either composite still has const generic arguments, treat them as equal.
-                // Type checking will run again after monomorphization.
-                if !left.const_arguments.is_empty() || !right.const_arguments.is_empty() {
-                    return true;
-                }
-
-                // Two composite types are the same if their global paths match.
-                // If the absolute paths are not available, then we really can't compare the two
-                // types and we just return `false` to be conservative.
-                match (&left.path.try_global_location(), &right.path.try_global_location()) {
-                    (Some(l), Some(r)) => l.path == r.path,
-                    _ => false,
-                }
-            }
-            // Don't type check when type hasn't been explicitly defined.
-            (Type::Future(left), Type::Future(right)) if !left.is_explicit || !right.is_explicit => true,
-            (Type::Future(left), Type::Future(right)) if left.inputs.len() == right.inputs.len() => left
-                .inputs()
-                .iter()
-                .zip_eq(right.inputs().iter())
-                .all(|(left_type, right_type)| left_type.eq_flat_relaxed(right_type)),
+                .all(|(left_type, right_type)| left_type.types_equivalent(right_type)),
             _ => false,
         }
     }
@@ -335,7 +264,7 @@ impl Type {
             }
 
             // Fallback: check for exact match
-            _ => self.eq_user(expected),
+            _ => self.types_equivalent(expected),
         }
     }
 

--- a/crates/passes/src/check_interfaces/visitor.rs
+++ b/crates/passes/src/check_interfaces/visitor.rs
@@ -211,7 +211,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
                                     return None;
                                 }
                                 Some(cm)
-                                    if !cm.type_.eq_user(&parent_member.type_)
+                                    if !cm.type_.types_equivalent(&parent_member.type_)
                                         || !cm.mode.eq_user(&parent_member.mode) =>
                                 {
                                     self.state.handler.emit_err(
@@ -254,8 +254,8 @@ impl<'a> CheckInterfacesVisitor<'a> {
                     flattened.mappings.iter().find(|m| m.identifier.name == parent_mapping.identifier.name)
                 {
                     // Same name exists - check if types are compatible.
-                    if !existing_mapping.key_type.eq_user(&parent_mapping.key_type)
-                        || !existing_mapping.value_type.eq_user(&parent_mapping.value_type)
+                    if !existing_mapping.key_type.types_equivalent(&parent_mapping.key_type)
+                        || !existing_mapping.value_type.types_equivalent(&parent_mapping.value_type)
                     {
                         self.state.handler.emit_err(crate::errors::check_interfaces::conflicting_interface_member(
                             parent_mapping.identifier.name,
@@ -278,7 +278,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
                     flattened.storages.iter().find(|s| s.identifier.name == parent_storage.identifier.name)
                 {
                     // Same name exists - check if types are compatible.
-                    if !existing_storage.type_.eq_user(&parent_storage.type_) {
+                    if !existing_storage.type_.types_equivalent(&parent_storage.type_) {
                         self.state.handler.emit_err(crate::errors::check_interfaces::conflicting_interface_member(
                             parent_storage.identifier.name,
                             interface_name,
@@ -428,8 +428,8 @@ impl<'a> CheckInterfacesVisitor<'a> {
             match program_scope.mappings.iter().find(|(name, _)| *name == mapping_name) {
                 Some((_, program_mapping)) => {
                     // Mapping exists - check types match.
-                    if !program_mapping.key_type.eq_user(&required_mapping.key_type)
-                        || !program_mapping.value_type.eq_user(&required_mapping.value_type)
+                    if !program_mapping.key_type.types_equivalent(&required_mapping.key_type)
+                        || !program_mapping.value_type.types_equivalent(&required_mapping.value_type)
                     {
                         self.state.handler.emit_err(crate::errors::check_interfaces::mapping_type_mismatch(
                             mapping_name,
@@ -459,7 +459,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
             match program_scope.storage_variables.iter().find(|(name, _)| *name == storage_name) {
                 Some((_, program_storage)) => {
                     // Storage exists - check type matches.
-                    if !program_storage.type_.eq_user(&required_storage.type_) {
+                    if !program_storage.type_.types_equivalent(&required_storage.type_) {
                         self.state.handler.emit_err(crate::errors::check_interfaces::storage_type_mismatch(
                             storage_name,
                             interface_location,
@@ -503,7 +503,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
 
         // Const parameters must match.
         a.const_parameters.len() == b.const_parameters.len() &&
-        a.const_parameters.iter().zip(b.const_parameters.iter()).all(|(const_a, const_b)| const_a.type_.eq_user(&const_b.type_)) &&
+        a.const_parameters.iter().zip(b.const_parameters.iter()).all(|(const_a, const_b)| const_a.type_.types_equivalent(&const_b.type_)) &&
 
         //TODO: we may want to check certain annotations, but they are not significant yet
         // // Annotations must match.
@@ -570,7 +570,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
                         None => name_match && prototype_record_locations.contains(lhs_loc),
                     };
                 }
-                lhs.eq_user(rhs)
+                lhs.types_equivalent(rhs)
             }
             (Type::Tuple(lt), Type::Tuple(rt)) => {
                 lt.elements.len() == rt.elements.len()
@@ -580,7 +580,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
                         .zip(rt.elements.iter())
                         .all(|(le, re)| Self::record_type_eq(le, re, prototype_record_locations, concrete_program))
             }
-            _ => lhs.eq_user(rhs),
+            _ => lhs.types_equivalent(rhs),
         }
     }
 
@@ -612,7 +612,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
 
         // Const parameters must match.
         func.const_parameters.len() == proto.const_parameters.len() &&
-        func.const_parameters.iter().zip(proto.const_parameters.iter()).all(|(func_const, proto_const)| func_const.type_.eq_user(&proto_const.type_)) &&
+        func.const_parameters.iter().zip(proto.const_parameters.iter()).all(|(func_const, proto_const)| func_const.type_.types_equivalent(&proto_const.type_)) &&
 
         //TODO: we may want to check certain annotations, but they are not significant yet
         // // Annotations must match.
@@ -656,7 +656,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
         parent.members.iter().all(|parent_member| {
             child.members.iter().any(|child_member| {
                 child_member.identifier.name == parent_member.identifier.name
-                    && child_member.type_.eq_user(&parent_member.type_)
+                    && child_member.type_.types_equivalent(&parent_member.type_)
                     && child_member.mode.eq_user(&parent_member.mode)
             })
         })
@@ -677,7 +677,7 @@ impl<'a> CheckInterfacesVisitor<'a> {
             match found {
                 None => return Some((required_member.identifier.name, required_member, None)),
                 Some(actual_member) => {
-                    if !actual_member.type_.eq_user(&required_member.type_)
+                    if !actual_member.type_.types_equivalent(&required_member.type_)
                         || !actual_member.mode.eq_user(&required_member.mode)
                     {
                         return Some((required_member.identifier.name, required_member, Some(actual_member)));

--- a/crates/passes/src/flattening/ast.rs
+++ b/crates/passes/src/flattening/ast.rs
@@ -84,7 +84,7 @@ impl AstReconstructor for FlatteningVisitor<'_> {
             .expect("Type checking guarantees that all expressions are typed.");
 
         // Note that type checking guarantees that both expressions have the same same type. This is a sanity check.
-        assert!(if_true_type.eq_flat_relaxed(&if_false_type));
+        assert!(if_true_type.types_equivalent(&if_false_type));
 
         fn as_identifier(path_expr: Expression) -> Identifier {
             let Expression::Path(path) = path_expr else {

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -667,7 +667,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         let assert_same_type = |slf: &Self, t1: &Type, t2: &Type| -> Type {
             if t1 == &Type::Err || t2 == &Type::Err {
                 Type::Err
-            } else if !t1.eq_user(t2) {
+            } else if !t1.types_equivalent(t2) {
                 slf.emit_err(crate::errors::type_checker::operation_types_mismatch(input.op, t1, t2, input.span()));
                 Type::Err
             } else {
@@ -2068,7 +2068,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
                 let t1 = self.visit_expression_reject_numeric(left, &None);
                 let t2 = self.visit_expression_reject_numeric(right, &None);
 
-                if t1 != Type::Err && t2 != Type::Err && !t1.eq_user(&t2) {
+                if t1 != Type::Err && t2 != Type::Err && !t1.types_equivalent(&t2) {
                     let op =
                         if matches!(input.variant, AssertVariant::AssertEq(..)) { "assert_eq" } else { "assert_neq" };
                     self.emit_err(crate::errors::type_checker::operation_types_mismatch(op, &t1, &t2, input.span()));

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -338,7 +338,7 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
                 .iter()
                 .find_map(|Member { identifier, type_, .. }| (identifier.name == need).then_some((identifier, type_)))
             {
-                Some((_, actual_ty)) if expected_ty.eq_flat_relaxed(actual_ty) => {} // All good, found + right type!
+                Some((_, actual_ty)) if expected_ty.types_equivalent(actual_ty) => {} // All good, found + right type!
                 Some((field, _)) => {
                     self.emit_err(crate::errors::type_checker::record_var_wrong_type(field, expected_ty, input.span()));
                 }

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -121,7 +121,7 @@ impl TypeCheckingVisitor<'_> {
     /// Emits an error if the two given types are not equal.
     pub fn check_eq_types(&self, t1: &Option<Type>, t2: &Option<Type>, span: Span) {
         match (t1, t2) {
-            (Some(t1), Some(t2)) if !t1.eq_user(t2) => {
+            (Some(t1), Some(t2)) if !t1.types_equivalent(t2) => {
                 self.emit_err(crate::errors::type_checker::type_should_be(t1, t2, span))
             }
             (Some(type_), None) | (None, Some(type_)) => {
@@ -1577,7 +1577,7 @@ impl TypeCheckingVisitor<'_> {
 
                     // Check that the input type is an array of the correct size.
                     let expected_type = Type::Array(ArrayType::bit_array(size_in_bits));
-                    if !input_type.eq_flat_relaxed(&expected_type) {
+                    if !input_type.types_equivalent(&expected_type) {
                         self.emit_err(crate::errors::type_checker::type_should_be2(
                             input_type,
                             format!("an array of {size_in_bits} bits"),
@@ -2520,7 +2520,7 @@ impl TypeCheckingVisitor<'_> {
             } else {
                 *lhs = Type::Err;
             }
-        } else if !lhs.eq_user(rhs) {
+        } else if !lhs.types_equivalent(rhs) {
             *lhs = Type::Err;
         }
     }


### PR DESCRIPTION
Closes #28898.

`eq_user` and `eq_flat_relaxed` were identical except for the composite case: `eq_flat_relaxed` compared composites by path only, ignoring the program of origin.

- That relaxation is unnecessary — a composite's program *is* its definition program, so the same struct always carries the same program — and a latent bug, since two distinct same-named structs from different programs compared equal.
- None of `eq_flat_relaxed`'s three call sites actually compared composites (two compared against `Address` / a bit-array, one was a ternary sanity `assert!`).

Changes:
- Remove `eq_flat_relaxed`; keep a single program-aware method.
- Rename `eq_user` → `types_equivalent` to avoid confusion with the derived `PartialEq::eq` (structural `==`).
- Migrate the three call sites to the unified method.
- `Mode::eq_user` is unrelated (visibility, not types) and left unchanged.

Tests: `cargo test -p leo-compiler` (130) and `-p leo-passes` (15) pass; no expectation files changed.