### PR TITLE
Verify network dependency exists on `leo add`

### DIFF
--- a/crates/leo/src/cli/cli.rs
+++ b/crates/leo/src/cli/cli.rs
@@ -310,7 +310,11 @@ pub fn run_with_args(cli: CLI) -> Result<()> {
 mod tests {
     use crate::cli::{
         CLI,
+        DependencySource,
+        GitRef,
+        LeoAdd,
         cli::{Commands, test_helpers},
+        commands::LeoNew,
         run_with_args,
     };
     use clap::Parser;
@@ -318,6 +322,63 @@ mod tests {
     use leo_span::create_session_if_not_set_then;
     use serial_test::serial;
     use std::env::temp_dir;
+
+    // An unreachable endpoint with no retries stands in for a program that isn't on the network.
+    #[test]
+    #[serial]
+    fn add_network_dependency_rejects_missing_program() {
+        let temp_dir = temp_dir();
+        let project_directory = temp_dir.join("add_missing_network_dep");
+        if project_directory.exists() {
+            std::fs::remove_dir_all(&project_directory).unwrap();
+        }
+
+        let new = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::New {
+                command: LeoNew { name: "add_missing_network_dep".to_string(), library: false, workspace: false },
+            },
+            path: Some(project_directory.clone()),
+            home: None,
+            package: None,
+        };
+
+        let add = CLI {
+            debug: false,
+            quiet: false,
+            json_output: None,
+            disable_update_check: false,
+            command: Commands::Add {
+                command: LeoAdd {
+                    name: "nonexistent_program".to_string(),
+                    source: DependencySource { local: None, network: true, edition: None, workspace: false, git: None },
+                    git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: Some("http://localhost:1".to_string()),
+                    network_retries: 0,
+                    dev: false,
+                },
+            },
+            path: Some(project_directory.clone()),
+            home: Some(temp_dir.join(".aleo_add_missing")),
+            package: None,
+        };
+
+        create_session_if_not_set_then(|_| {
+            run_with_args(new).expect("Failed to execute `leo new`");
+
+            assert!(run_with_args(add).is_err(), "`leo add` should reject an unverifiable network dependency");
+
+            let manifest_path = project_directory.join(leo_package::MANIFEST_FILENAME);
+            let manifest = leo_package::Manifest::read_from_file(&manifest_path).unwrap();
+            assert!(
+                manifest.dependencies.is_none(),
+                "manifest should not record a dependency that failed verification"
+            );
+        });
+    }
 
     #[test]
     #[serial]
@@ -1814,6 +1875,23 @@ function external_nested_function:
         // Overwrite `src/main.leo` file
         std::fs::write(project_directory.join("src").join("main.leo"), program_str).unwrap();
 
+        // Cache the program before the add: `leo add --network` verifies existence by fetching,
+        // and a cached copy satisfies that check offline.
+        let registry = temp_dir.join(".aleo").join("registry").join("testnet");
+        std::fs::create_dir_all(&registry).unwrap();
+
+        let dir = registry.join("nested_example_layer_0").join("0");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("nested_example_layer_0.aleo"), nested_example_layer_0).unwrap();
+
+        let dir = registry.join("nested_example_layer_1").join("0");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("nested_example_layer_1.aleo"), nested_example_layer_1).unwrap();
+
+        let dir = registry.join("nested_example_layer_2").join("0");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("nested_example_layer_2.aleo"), nested_example_layer_2).unwrap();
+
         // Add dependencies
         let add = CLI {
             debug: false,
@@ -1831,33 +1909,19 @@ function external_nested_function:
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
             path: Some(project_directory.clone()),
-            home: None,
+            home: Some(temp_dir.join(".aleo")),
             package: None,
         };
 
         create_session_if_not_set_then(|_| {
             run_with_args(add).expect("Failed to execute `leo add`");
         });
-
-        // Add custom `.aleo` directory with the appropriate cache entries.
-        let registry = temp_dir.join(".aleo").join("registry").join("testnet");
-        std::fs::create_dir_all(&registry).unwrap();
-
-        let dir = registry.join("nested_example_layer_0").join("0");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("nested_example_layer_0.aleo"), nested_example_layer_0).unwrap();
-
-        let dir = registry.join("nested_example_layer_1").join("0");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("nested_example_layer_1.aleo"), nested_example_layer_1).unwrap();
-
-        let dir = registry.join("nested_example_layer_2").join("0");
-        std::fs::create_dir_all(&dir).unwrap();
-        std::fs::write(dir.join("nested_example_layer_2.aleo"), nested_example_layer_2).unwrap();
     }
 
     pub(crate) fn sample_grandparent_package(temp_dir: &Path) {
@@ -1963,6 +2027,8 @@ program child.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
@@ -1987,6 +2053,8 @@ program child.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
@@ -2011,6 +2079,8 @@ program child.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
@@ -2166,6 +2236,8 @@ program inner_2.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
@@ -2190,6 +2262,8 @@ program inner_2.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
@@ -2380,6 +2454,8 @@ program inner_2.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },
@@ -2404,6 +2480,8 @@ program inner_2.aleo {
                         git: None,
                     },
                     git_ref: GitRef { branch: None, tag: None, rev: None },
+                    endpoint: None,
+                    network_retries: 2,
                     dev: false,
                 },
             },

--- a/crates/leo/src/cli/commands/add.rs
+++ b/crates/leo/src/cli/commands/add.rs
@@ -15,7 +15,9 @@
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
 use super::*;
-use leo_package::{Dependency, GitReference, GitSource, Location, Lock, Manifest, Workspace};
+use leo_ast::NetworkName;
+use leo_package::{CompilationUnit, Dependency, GitReference, GitSource, Location, Lock, Manifest, Workspace};
+use leo_span::Symbol;
 use std::path::{Path, PathBuf};
 
 /// Add a new on-chain, local, or git dependency to the current package.
@@ -30,6 +32,20 @@ pub struct LeoAdd {
 
     #[clap(flatten)]
     pub(crate) git_ref: GitRef,
+
+    #[clap(
+        long,
+        help = "Endpoint used to verify a network dependency exists. Overrides the `ENDPOINT` environment variable."
+    )]
+    pub(crate) endpoint: Option<String>,
+
+    #[clap(
+        long,
+        env = "NETWORK_RETRIES",
+        help = "Number of times to retry a failed network request when verifying a network dependency.",
+        default_value = "2"
+    )]
+    pub(crate) network_retries: u32,
 
     #[clap(long, help = "This is a development dependency.", default_value = "false")]
     pub(crate) dev: bool,
@@ -219,7 +235,36 @@ impl Command for LeoAdd {
                 )
                 .into());
             }
-            (normalize_program_name(&self.name)?, Location::Network, None)
+            let name = normalize_program_name(&self.name)?;
+
+            // Verify the program exists before recording it, reusing the build's fetch path.
+            // Network/endpoint default like `build`; the name comes from the env because
+            // `--network` here selects the source rather than a network name.
+            let network = get_network(&None).unwrap_or_else(|_| {
+                tracing::warn!("⚠️ No network specified, defaulting to 'testnet'.");
+                NetworkName::TestnetV0
+            });
+            let endpoint = get_endpoint(&self.endpoint).unwrap_or_else(|_| {
+                tracing::warn!("⚠️ No endpoint specified, defaulting to '{DEFAULT_ENDPOINT}'.");
+                DEFAULT_ENDPOINT.to_string()
+            });
+            let home = context.home()?;
+            CompilationUnit::fetch(
+                Symbol::intern(&name),
+                self.source.edition,
+                &home,
+                network,
+                &endpoint,
+                false,
+                self.network_retries,
+            )
+            .map_err(|err| {
+                crate::errors::custom(format!(
+                    "Could not find program `{name}` on network `{network}` at `{endpoint}`: {err}",
+                ))
+            })?;
+
+            (name, Location::Network, None)
         };
 
         let new_dependency = Dependency {

--- a/tests/expectations/cli/test_add/COMMANDS
+++ b/tests/expectations/cli/test_add/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} --disable-update-check add --network credits.aleo
+${LEO_BIN} --disable-update-check add --network credits.aleo --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
 
 ${LEO_BIN} --disable-update-check build
 

--- a/tests/expectations/cli/test_add/STDERR
+++ b/tests/expectations/cli/test_add/STDERR
@@ -1,0 +1,1 @@
+       Leo ⚠️ No network specified, defaulting to 'testnet'.

--- a/tests/expectations/cli/test_add_dependency/COMMANDS
+++ b/tests/expectations/cli/test_add_dependency/COMMANDS
@@ -15,7 +15,7 @@ echo "multiple flags exit code: $?"
 cat program.json
 
 echo "--- 3. leo add --network (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --network credits
+${LEO_BIN} --disable-update-check add --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
 cat program.json
 
 echo "--- 4. leo add --local (should succeed) ---" | tee /dev/stderr
@@ -30,17 +30,23 @@ echo "--- 6. leo add overwrite existing dep (should succeed) ---" | tee /dev/std
 ${LEO_BIN} --disable-update-check add credits --local ../credits
 cat program.json
 
-echo "--- 7. leo add --dev (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --dev --network dev_dep
+echo "--- 7. leo add --dev for a program not on the network (should fail) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add --dev --network dev_dep --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+echo "missing network dep exit code: $?"
 cat program.json
 
-echo "--- 8. leo remove library dep by bare name (should succeed) ---" | tee /dev/stderr
+echo "--- 8. leo add --dev for a program on the network (should succeed) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add --dev --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+echo "network dev dep exit code: $?"
+cat program.json
+
+echo "--- 9. leo remove library dep by bare name (should succeed) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check remove my_lib
 cat program.json
 
-echo "--- 9. leo remove program dep by bare name (should succeed) ---" | tee /dev/stderr
+echo "--- 10. leo remove program dep by bare name (should succeed) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check remove some_local
 cat program.json
 
-echo "--- 10. leo remove non-existent dep (should fail) ---" | tee /dev/stderr
+echo "--- 11. leo remove non-existent dep (should fail) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check remove nonexistent || true

--- a/tests/expectations/cli/test_add_dependency/STDERR
+++ b/tests/expectations/cli/test_add_dependency/STDERR
@@ -12,6 +12,7 @@ Usage: leo add <--local <LOCAL>|--network|--edition <EDITION>|--workspace|--git 
 
 For more information, try '--help'.
 --- 3. leo add --network (should succeed) ---
+       Leo ⚠️ No network specified, defaulting to 'testnet'.
 --- 4. leo add --local (should succeed) ---
 Error [ECLI0377045]: Could not read `../some_local/program.json` — is `../some_local` a valid Leo package?
 
@@ -19,14 +20,21 @@ Error [ECLI0377045]: Could not read `../some_local/program.json` — is `../some
 --- 6. leo add overwrite existing dep (should succeed) ---
 Error [ECLI0377045]: Could not read `../credits/program.json` — is `../credits` a valid Leo package?
 
---- 7. leo add --dev (should succeed) ---
---- 8. leo remove library dep by bare name (should succeed) ---
+--- 7. leo add --dev for a program not on the network (should fail) ---
+       Leo ⚠️ No network specified, defaulting to 'testnet'.
+Error [ECLI0377045]: Could not find program `dev_dep.aleo` on network `testnet` at `http://localhost:3030`: Error [EPAK0375067]: network request to `http://localhost:3030/testnet/program/dev_dep.aleo/latest_edition` failed with status `500 Internal Server Error`
+     |
+     = Verify that `--network` and `--endpoint` point to a running node and that you have connectivity.
+
+--- 8. leo add --dev for a program on the network (should succeed) ---
+       Leo ⚠️ No network specified, defaulting to 'testnet'.
+--- 9. leo remove library dep by bare name (should succeed) ---
        Leo ✅ Successfully removed the local dependency my_lib with path ../my_lib.
---- 9. leo remove program dep by bare name (should succeed) ---
+--- 10. leo remove program dep by bare name (should succeed) ---
 Error [ECLI0377050]: dependency program `some_local.aleo` was not found among the manifest's dependencies
      |
      = Add `some_local.aleo` to `program.json` (e.g. with `leo add some_local.aleo`), then retry.
---- 10. leo remove non-existent dep (should fail) ---
+--- 11. leo remove non-existent dep (should fail) ---
 Error [ECLI0377050]: dependency program `nonexistent.aleo` was not found among the manifest's dependencies
      |
      = Add `nonexistent.aleo` to `program.json` (e.g. with `leo add nonexistent.aleo`), then retry.

--- a/tests/expectations/cli/test_add_dependency/STDOUT
+++ b/tests/expectations/cli/test_add_dependency/STDOUT
@@ -100,8 +100,33 @@ multiple flags exit code: 2
   ],
   "dev_dependencies": null
 }
---- 7. leo add --dev (should succeed) ---
-       Leo ✅ Added network dependency `dev_dep.aleo`.
+--- 7. leo add --dev for a program not on the network (should fail) ---
+missing network dep exit code: 213
+{
+  "program": "my_program.aleo",
+  "version": "0.1.0",
+  "description": "",
+  "license": "MIT",
+  "leo": "4.3.0",
+  "dependencies": [
+    {
+      "name": "credits.aleo",
+      "location": "network",
+      "path": null,
+      "edition": null
+    },
+    {
+      "name": "my_lib",
+      "location": "local",
+      "path": "../my_lib",
+      "edition": null
+    }
+  ],
+  "dev_dependencies": null
+}
+--- 8. leo add --dev for a program on the network (should succeed) ---
+       Leo ✅ Added network dependency `credits.aleo`.
+network dev dep exit code: 0
 {
   "program": "my_program.aleo",
   "version": "0.1.0",
@@ -124,14 +149,14 @@ multiple flags exit code: 2
   ],
   "dev_dependencies": [
     {
-      "name": "dev_dep.aleo",
+      "name": "credits.aleo",
       "location": "network",
       "path": null,
       "edition": null
     }
   ]
 }
---- 8. leo remove library dep by bare name (should succeed) ---
+--- 9. leo remove library dep by bare name (should succeed) ---
 {
   "program": "my_program.aleo",
   "version": "0.1.0",
@@ -148,14 +173,14 @@ multiple flags exit code: 2
   ],
   "dev_dependencies": [
     {
-      "name": "dev_dep.aleo",
+      "name": "credits.aleo",
       "location": "network",
       "path": null,
       "edition": null
     }
   ]
 }
---- 9. leo remove program dep by bare name (should succeed) ---
+--- 10. leo remove program dep by bare name (should succeed) ---
 {
   "program": "my_program.aleo",
   "version": "0.1.0",
@@ -172,11 +197,11 @@ multiple flags exit code: 2
   ],
   "dev_dependencies": [
     {
-      "name": "dev_dep.aleo",
+      "name": "credits.aleo",
       "location": "network",
       "path": null,
       "edition": null
     }
   ]
 }
---- 10. leo remove non-existent dep (should fail) ---
+--- 11. leo remove non-existent dep (should fail) ---

--- a/tests/expectations/cli/test_add_dependency/contents/my_program/program.json
+++ b/tests/expectations/cli/test_add_dependency/contents/my_program/program.json
@@ -14,7 +14,7 @@
   ],
   "dev_dependencies": [
     {
-      "name": "dev_dep.aleo",
+      "name": "credits.aleo",
       "location": "network",
       "path": null,
       "edition": null

--- a/tests/tests/cli/test_add/COMMANDS
+++ b/tests/tests/cli/test_add/COMMANDS
@@ -2,7 +2,7 @@
 
 LEO_BIN=${1}
 
-${LEO_BIN} --disable-update-check add --network credits.aleo
+${LEO_BIN} --disable-update-check add --network credits.aleo --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
 
 ${LEO_BIN} --disable-update-check build
 

--- a/tests/tests/cli/test_add_dependency/COMMANDS
+++ b/tests/tests/cli/test_add_dependency/COMMANDS
@@ -15,7 +15,7 @@ echo "multiple flags exit code: $?"
 cat program.json
 
 echo "--- 3. leo add --network (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --network credits
+${LEO_BIN} --disable-update-check add --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
 cat program.json
 
 echo "--- 4. leo add --local (should succeed) ---" | tee /dev/stderr
@@ -30,17 +30,23 @@ echo "--- 6. leo add overwrite existing dep (should succeed) ---" | tee /dev/std
 ${LEO_BIN} --disable-update-check add credits --local ../credits
 cat program.json
 
-echo "--- 7. leo add --dev (should succeed) ---" | tee /dev/stderr
-${LEO_BIN} --disable-update-check add --dev --network dev_dep
+echo "--- 7. leo add --dev for a program not on the network (should fail) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add --dev --network dev_dep --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+echo "missing network dep exit code: $?"
 cat program.json
 
-echo "--- 8. leo remove library dep by bare name (should succeed) ---" | tee /dev/stderr
+echo "--- 8. leo add --dev for a program on the network (should succeed) ---" | tee /dev/stderr
+${LEO_BIN} --disable-update-check add --dev --network credits --endpoint http://localhost:${LEO_DEVNODE_PORT:-3030}
+echo "network dev dep exit code: $?"
+cat program.json
+
+echo "--- 9. leo remove library dep by bare name (should succeed) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check remove my_lib
 cat program.json
 
-echo "--- 9. leo remove program dep by bare name (should succeed) ---" | tee /dev/stderr
+echo "--- 10. leo remove program dep by bare name (should succeed) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check remove some_local
 cat program.json
 
-echo "--- 10. leo remove non-existent dep (should fail) ---" | tee /dev/stderr
+echo "--- 11. leo remove non-existent dep (should fail) ---" | tee /dev/stderr
 ${LEO_BIN} --disable-update-check remove nonexistent || true


### PR DESCRIPTION
`leo add` now checks that a network/edition dependency actually exists before writing it to `program.json`, closing the last gap (git/local/workspace deps were already validated). Closes #28514.

- Reuses the build's `CompilationUnit::fetch` path so `leo add` and the build agree; a cached copy counts as "exists" (no network call).
- Adds an optional `--endpoint` (+ `--network-retries`); network name resolves from the env, defaulting to testnet like `build`. The endpoint is only consulted for network deps.
- On failure the manifest is left untouched.