### PR TITLE
Keep option unwrap prologues inside else-if branches

### DIFF
--- a/crates/passes/src/option_lowering/ast.rs
+++ b/crates/passes/src/option_lowering/ast.rs
@@ -615,18 +615,23 @@ impl leo_ast::AstReconstructor for OptionLoweringVisitor<'_> {
     fn reconstruct_conditional(&mut self, mut input: ConditionalStatement) -> (Statement, Self::AdditionalOutput) {
         let (condition, mut stmts_condition) = self.reconstruct_expression(input.condition, &None);
         let (then_block, mut stmts_then) = self.reconstruct_block(input.then);
+        stmts_condition.append(&mut stmts_then);
 
         let otherwise = match input.otherwise {
             Some(otherwise_stmt) => {
                 let (stmt, mut stmts_otherwise) = self.reconstruct_statement(*otherwise_stmt);
-                stmts_condition.append(&mut stmts_then);
-                stmts_condition.append(&mut stmts_otherwise);
-                Some(Box::new(stmt))
+                if stmts_otherwise.is_empty() {
+                    Some(Box::new(stmt))
+                } else {
+                    // Else-if condition prologues must not run unless the outer else branch is taken.
+                    let span = stmt.span();
+                    stmts_otherwise.push(stmt);
+                    Some(Box::new(
+                        Block { statements: stmts_otherwise, span, id: self.state.node_builder.next_id() }.into(),
+                    ))
+                }
             }
-            None => {
-                stmts_condition.append(&mut stmts_then);
-                None
-            }
+            None => None,
         };
 
         input.condition = condition;

--- a/crates/passes/src/option_lowering/ast.rs
+++ b/crates/passes/src/option_lowering/ast.rs
@@ -624,7 +624,7 @@ impl leo_ast::AstReconstructor for OptionLoweringVisitor<'_> {
                     Some(Box::new(stmt))
                 } else {
                     // Else-if condition prologues must not run unless the outer else branch is taken.
-                    let span = stmt.span();
+                    let span = stmts_otherwise[0].span() + stmt.span();
                     stmts_otherwise.push(stmt);
                     Some(Box::new(
                         Block { statements: stmts_otherwise, span, id: self.state.node_builder.next_id() }.into(),

--- a/tests/expectations/passes/option_lowering/else_if_unwrap_condition.out
+++ b/tests/expectations/passes/option_lowering/else_if_unwrap_condition.out
@@ -21,4 +21,3 @@ program test.aleo {
         }
     }
 }
-

--- a/tests/expectations/passes/option_lowering/else_if_unwrap_condition.out
+++ b/tests/expectations/passes/option_lowering/else_if_unwrap_condition.out
@@ -21,3 +21,4 @@ program test.aleo {
         }
     }
 }
+

--- a/tests/expectations/passes/option_lowering/else_if_unwrap_condition.out
+++ b/tests/expectations/passes/option_lowering/else_if_unwrap_condition.out
@@ -1,0 +1,24 @@
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    struct u8? {
+        is_some: bool,
+        val: u8,
+    }
+    fn main(first: bool, check: u8) -> u8 {
+        let missing: test.aleo::u8? = test.aleo::u8? { is_some: false, val: 0u8 };
+        if first {
+            return 1u8;
+        } else {
+            let $opt$0 = missing;
+            assert($opt$0.is_some);
+            if $opt$0.val == check {
+                return 2u8;
+            } else {
+                return 3u8;
+            }
+        }
+    }
+}
+

--- a/tests/tests/passes/option_lowering/else_if_unwrap_condition.leo
+++ b/tests/tests/passes/option_lowering/else_if_unwrap_condition.leo
@@ -1,0 +1,16 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn main(first: bool, check: u8) -> u8 {
+        let missing: u8? = none;
+
+        if first {
+            return 1u8;
+        } else if missing.unwrap() == check {
+            return 2u8;
+        } else {
+            return 3u8;
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Fixes #29534.

Option lowering can produce prologue statements for expressions such as `unwrap()`. When an `else if` condition produced those statements, the outer conditional previously hoisted them before the outer `if`, so they could execute even when the outer `then` branch was taken.

This keeps prologue statements from an `else if` condition inside the outer `else` branch, preserving the original control-flow dominance.

## Test Plan

- Added `tests/tests/passes/option_lowering/else_if_unwrap_condition.leo`.
- Added the corresponding option-lowering expectation showing the unwrap binding and assertion inside the outer `else`.
- Ran `git diff --check`.
- Ran `rustfmt --check crates/passes/src/option_lowering/ast.rs crates/passes/src/loop_unrolling/ast.rs`.

Cargo tests were not run locally on Termux; this should be covered by CI.

## Related PRs

None.
