### PR TITLE
Handle equal inclusive loop bounds when unrolling

### DIFF
--- a/crates/passes/src/loop_unrolling/ast.rs
+++ b/crates/passes/src/loop_unrolling/ast.rs
@@ -107,9 +107,15 @@ impl AstReconstructor for UnrollingVisitor<'_> {
 
         self.loop_unrolled = true;
 
+        let empty_range = if input.inclusive {
+            start_value.gt(&stop_value).expect("Type checking guarantees these are the same type")
+        } else {
+            start_value.gte(&stop_value).expect("Type checking guarantees these are the same type")
+        };
+
         // Actually unroll.
         (
-            if start_value.gte(&stop_value).expect("Type checking guarantees these are the same type") {
+            if empty_range {
                 let new_block_id = self.state.node_builder.next_id();
                 self.in_scope(new_block_id, |_| {
                     Statement::from(Block { span: input.span, statements: vec![], id: new_block_id })

--- a/tests/expectations/execution/loop_inclusive_bounds.out
+++ b/tests/expectations/execution/loop_inclusive_bounds.out
@@ -21,5 +21,5 @@ status: success
 output: 0u32
 status: success
 output: 0u32
-status: failed: Stack evaluation failed: Instruction (assert.eq false true;) at index 0 failed: 'assert.eq' failed: 'false' is not equal to 'true' (should be equal)
+status: failed: Process authorization failed: Stack authorization failed: Stack execution failed: Instruction (assert.eq false true;) at index 0 failed: Failed to execute: Constraint unsatisfied: (0 * 1) != 1
 output: ()

--- a/tests/expectations/execution/loop_inclusive_bounds.out
+++ b/tests/expectations/execution/loop_inclusive_bounds.out
@@ -1,0 +1,25 @@
+program test.aleo;
+
+function inclusive_equal:
+    output 1u32 as u32.private;
+
+function exclusive_equal:
+    output 0u32 as u32.private;
+
+function inclusive_decreasing:
+    output 0u32 as u32.private;
+
+function inclusive_equal_assert:
+    assert.eq false true;
+    output 0u32 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 1u32
+status: success
+output: 0u32
+status: success
+output: 0u32
+status: failed: Stack evaluation failed: Instruction (assert.eq false true;) at index 0 failed: 'assert.eq' failed: 'false' is not equal to 'true' (should be equal)
+output: ()

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/loop_unrolling.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/loop_unrolling.out
@@ -46,3 +46,4 @@ program test.aleo {
         return sum;
     }
 }
+

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/loop_unrolling.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/loop_unrolling.out
@@ -33,7 +33,16 @@ program test.aleo {
         }
         sum = sum + 1u32;
         sum = sum + 1u32;
+        sum = sum + 1u32;
+        {
+            {
+                {
+                    sum = sum + 1u32;
+                }
+            }
+        }
+        sum = sum + 1u32;
+        sum = sum + 1u32;
         return sum;
     }
 }
-

--- a/tests/tests/execution/loop_inclusive_bounds.leo
+++ b/tests/tests/execution/loop_inclusive_bounds.leo
@@ -1,0 +1,56 @@
+/*
+seed = 123456789
+
+[case]
+program = "test.aleo"
+function = "inclusive_equal"
+input = []
+[case]
+program = "test.aleo"
+function = "exclusive_equal"
+input = []
+[case]
+program = "test.aleo"
+function = "inclusive_decreasing"
+input = []
+[case]
+program = "test.aleo"
+function = "inclusive_equal_assert"
+input = []
+*/
+
+program test.aleo {
+    fn inclusive_equal() -> u32 {
+        let count = 0u32;
+        for i in 5u32..=5u32 {
+            count += 1u32;
+        }
+        return count;
+    }
+
+    fn exclusive_equal() -> u32 {
+        let count = 0u32;
+        for i in 5u32..5u32 {
+            count += 1u32;
+        }
+        return count;
+    }
+
+    fn inclusive_decreasing() -> u32 {
+        let count = 0u32;
+        for i in 6u32..=5u32 {
+            count += 1u32;
+        }
+        return count;
+    }
+
+    fn inclusive_equal_assert() -> u32 {
+        for i in 5u32..=5u32 {
+            assert(false);
+        }
+        return 0u32;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/passes/const_prop_unroll_and_morphing/loop_unrolling.leo
+++ b/tests/tests/passes/const_prop_unroll_and_morphing/loop_unrolling.leo
@@ -15,6 +15,18 @@ program test.aleo {
         for i in 5u32..0u32 {
             sum += i;
         }
+        sum += 1;
+        for i in 5u32..=5u32 {
+            sum += 1;
+        }
+        sum += 1;
+        for i in 5u32..5u32 {
+            sum += 1;
+        }
+        sum += 1;
+        for i in 6u32..=5u32 {
+            sum += 1;
+        }
         return sum;
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #29536.

Loop unrolling treated both exclusive and inclusive ranges as empty when `start >= stop`. That is correct for `start..stop`, but `start..=stop` with equal bounds should execute exactly once.

This changes the empty-range check so inclusive ranges are empty only when `start > stop`, while exclusive ranges keep the existing `start >= stop` behavior.

## Test Plan

- Extended `tests/tests/passes/const_prop_unroll_and_morphing/loop_unrolling.leo`.
- Added `tests/tests/execution/loop_inclusive_bounds.leo`.
- Added expectations covering:
  - `5u32..=5u32` executes once.
  - `5u32..5u32` remains empty.
  - `6u32..=5u32` remains empty.
  - an assertion inside `5u32..=5u32` is preserved and fails.
- Ran `git diff --check`.
- Ran `rustfmt --check crates/passes/src/option_lowering/ast.rs crates/passes/src/loop_unrolling/ast.rs`.

Cargo tests were not run locally on Termux; this should be covered by CI.

## Related PRs

None.
