### PR TITLE
Preserve fallible ternary arms during constant folding

### DIFF
--- a/crates/passes/src/common/mod.rs
+++ b/crates/passes/src/common/mod.rs
@@ -47,8 +47,8 @@ pub use type_table::*;
 /// Returns true if `expr` can be removed without changing eager evaluation.
 ///
 /// This is stricter than [`Expression::is_pure`]: source-level operations that
-/// lower to assertions, storage reads, or non-removable instructions must still
-/// be evaluated even when their result is unused.
+/// can lower to assertions or storage reads must still be evaluated even when
+/// their result is unused.
 pub(crate) fn expression_can_be_discarded(expr: &Expression, state: &CompilerState) -> bool {
     expr.is_pure(&|id| state.type_table.get(&id).expect("Types should be assigned."))
         && !contains_non_discardable_operation(expr, state)
@@ -121,11 +121,5 @@ fn intrinsic_can_be_discarded(intrinsic: &Intrinsic) -> bool {
             // Lower to storage reads before code generation.
             | Intrinsic::VectorGet
             | Intrinsic::VectorLen
-            // Code generation emits instructions that later DCE treats as non-removable.
-            | Intrinsic::Hash(_, _)
-            | Intrinsic::GroupToXCoordinate
-            | Intrinsic::GroupToYCoordinate
-            | Intrinsic::SignatureVerify
-            | Intrinsic::Serialize(_)
     ) && intrinsic.is_pure()
 }

--- a/crates/passes/src/common/mod.rs
+++ b/crates/passes/src/common/mod.rs
@@ -109,7 +109,7 @@ fn path_is_storage_read(path: &leo_ast::Path, state: &CompilerState) -> bool {
         .and_then(|location| state.symbol_table.lookup_global(location.program, location))
         .is_some_and(|var| {
             var.declaration == symbol_table::VariableType::Storage
-                && var.type_.as_ref().is_none_or(|type_| !type_.is_mapping())
+                && var.type_.as_ref().is_none_or(|type_| !type_.is_mapping() && !type_.is_vector())
         })
 }
 

--- a/crates/passes/src/common/mod.rs
+++ b/crates/passes/src/common/mod.rs
@@ -14,6 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::CompilerState;
+use leo_ast::{Expression, Intrinsic};
+
 mod assigner;
 pub use assigner::*;
 
@@ -40,3 +43,89 @@ pub use tree_node::ConditionalTreeNode;
 
 mod type_table;
 pub use type_table::*;
+
+/// Returns true if `expr` can be removed without changing eager evaluation.
+///
+/// This is stricter than [`Expression::is_pure`]: source-level operations that
+/// lower to assertions, storage reads, or non-removable instructions must still
+/// be evaluated even when their result is unused.
+pub(crate) fn expression_can_be_discarded(expr: &Expression, state: &CompilerState) -> bool {
+    expr.is_pure(&|id| state.type_table.get(&id).expect("Types should be assigned."))
+        && !contains_non_discardable_operation(expr, state)
+}
+
+fn contains_non_discardable_operation(expr: &Expression, state: &CompilerState) -> bool {
+    match expr {
+        Expression::Intrinsic(intr) => {
+            let intrinsic = Intrinsic::from_symbol(intr.name, &intr.type_parameters);
+            intrinsic.is_some_and(|intrinsic| !intrinsic_can_be_discarded(&intrinsic))
+                || intr.arguments.iter().any(|arg| contains_non_discardable_operation(arg, state))
+        }
+        Expression::Array(expr) => expr.elements.iter().any(|elem| contains_non_discardable_operation(elem, state)),
+        Expression::ArrayAccess(expr) => {
+            contains_non_discardable_operation(&expr.array, state)
+                || contains_non_discardable_operation(&expr.index, state)
+        }
+        Expression::Binary(expr) => {
+            contains_non_discardable_operation(&expr.left, state)
+                || contains_non_discardable_operation(&expr.right, state)
+        }
+        Expression::Composite(expr) => {
+            expr.const_arguments.iter().any(|arg| contains_non_discardable_operation(arg, state))
+                || expr
+                    .members
+                    .iter()
+                    // Const propagation and SSA make shorthand members explicit before
+                    // this check is used.
+                    .filter_map(|init| init.expression.as_ref())
+                    .any(|member| contains_non_discardable_operation(member, state))
+        }
+        Expression::MemberAccess(expr) => contains_non_discardable_operation(&expr.inner, state),
+        Expression::Repeat(expr) => {
+            contains_non_discardable_operation(&expr.expr, state)
+                || contains_non_discardable_operation(&expr.count, state)
+        }
+        Expression::Ternary(expr) => {
+            contains_non_discardable_operation(&expr.condition, state)
+                || contains_non_discardable_operation(&expr.if_true, state)
+                || contains_non_discardable_operation(&expr.if_false, state)
+        }
+        Expression::Tuple(expr) => expr.elements.iter().any(|elem| contains_non_discardable_operation(elem, state)),
+        Expression::TupleAccess(expr) => contains_non_discardable_operation(&expr.tuple, state),
+        Expression::Unary(expr) => contains_non_discardable_operation(&expr.receiver, state),
+        Expression::Path(path) => path_is_storage_read(path, state),
+        Expression::Async(_)
+        | Expression::Call(_)
+        | Expression::Cast(_)
+        | Expression::DynamicOp(_)
+        | Expression::Err(_)
+        | Expression::Literal(_)
+        | Expression::Unit(_) => false,
+    }
+}
+
+fn path_is_storage_read(path: &leo_ast::Path, state: &CompilerState) -> bool {
+    path.try_global_location()
+        .and_then(|location| state.symbol_table.lookup_global(location.program, location))
+        .is_some_and(|var| {
+            var.declaration == symbol_table::VariableType::Storage
+                && var.type_.as_ref().is_none_or(|type_| !type_.is_mapping())
+        })
+}
+
+fn intrinsic_can_be_discarded(intrinsic: &Intrinsic) -> bool {
+    !matches!(
+        intrinsic,
+        // Lowers to an assertion on the option tag.
+        Intrinsic::OptionalUnwrap
+            // Lower to storage reads before code generation.
+            | Intrinsic::VectorGet
+            | Intrinsic::VectorLen
+            // Code generation emits instructions that later DCE treats as non-removable.
+            | Intrinsic::Hash(_, _)
+            | Intrinsic::GroupToXCoordinate
+            | Intrinsic::GroupToYCoordinate
+            | Intrinsic::SignatureVerify
+            | Intrinsic::Serialize(_)
+    ) && intrinsic.is_pure()
+}

--- a/crates/passes/src/const_propagation/ast.rs
+++ b/crates/passes/src/const_propagation/ast.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::errors::static_analyzer;
+use crate::{errors::static_analyzer, expression_can_be_discarded};
 use leo_ast::{
     const_eval::{self, Value},
     *,
@@ -115,20 +115,13 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
         _additional: &(),
     ) -> (Expression, Self::AdditionalOutput) {
         let (cond, cond_value) = self.reconstruct_expression(input.condition, &());
+        let (if_true, if_true_value) = self.reconstruct_expression(input.if_true, &());
+        let (if_false, if_false_value) = self.reconstruct_expression(input.if_false, &());
 
         match cond_value.and_then(|v| v.try_into().ok()) {
-            Some(true) => self.reconstruct_expression(input.if_true, &()),
-            Some(false) => self.reconstruct_expression(input.if_false, &()),
-            _ => (
-                TernaryExpression {
-                    condition: cond,
-                    if_true: self.reconstruct_expression(input.if_true, &()).0,
-                    if_false: self.reconstruct_expression(input.if_false, &()).0,
-                    ..input
-                }
-                .into(),
-                None,
-            ),
+            Some(true) if expression_can_be_discarded(&if_false, self.state) => (if_true, if_true_value),
+            Some(false) if expression_can_be_discarded(&if_true, self.state) => (if_false, if_false_value),
+            _ => (TernaryExpression { condition: cond, if_true, if_false, ..input }.into(), None),
         }
     }
 

--- a/crates/passes/src/const_propagation/ast.rs
+++ b/crates/passes/src/const_propagation/ast.rs
@@ -115,10 +115,20 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
         _additional: &(),
     ) -> (Expression, Self::AdditionalOutput) {
         let (cond, cond_value) = self.reconstruct_expression(input.condition, &());
+        let cond_bool = cond_value.and_then(|v| v.try_into().ok());
+
+        if self.fold_const_initializer_ternaries {
+            match cond_bool {
+                Some(true) => return self.reconstruct_expression(input.if_true, &()),
+                Some(false) => return self.reconstruct_expression(input.if_false, &()),
+                _ => {}
+            }
+        }
+
         let (if_true, if_true_value) = self.reconstruct_expression(input.if_true, &());
         let (if_false, if_false_value) = self.reconstruct_expression(input.if_false, &());
 
-        match cond_value.and_then(|v| v.try_into().ok()) {
+        match cond_bool {
             Some(true) if expression_can_be_discarded(&if_false, self.state) => (if_true, if_true_value),
             Some(false) if expression_can_be_discarded(&if_true, self.state) => (if_false, if_false_value),
             _ => (TernaryExpression { condition: cond, if_true, if_false, ..input }.into(), None),
@@ -547,7 +557,7 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
         let span = input.span();
 
         let type_ = self.reconstruct_type(input.type_).0;
-        let (expr, opt_value) = self.reconstruct_expression(input.value, &());
+        let (expr, opt_value) = self.in_const_initializer(|slf| slf.reconstruct_expression(input.value, &()));
 
         if opt_value.is_some() {
             if self.state.symbol_table.global_scope() {

--- a/crates/passes/src/const_propagation/mod.rs
+++ b/crates/passes/src/const_propagation/mod.rs
@@ -52,7 +52,7 @@ pub struct ConstPropagationOutput {
 ///
 /// whose arguments are consts or literals will be subject to constant folding.
 /// The ternary conditional operator will also be folded if its condition is
-/// a constant or literal.
+/// a constant or literal and the discarded arm is safe to remove.
 ///
 /// This includes the LHS of assignment statements which include array indices.
 pub struct ConstPropagation;

--- a/crates/passes/src/const_propagation/mod.rs
+++ b/crates/passes/src/const_propagation/mod.rs
@@ -75,6 +75,7 @@ impl Pass for ConstPropagation {
             array_index_not_evaluated: None,
             array_length_not_evaluated: None,
             repeat_count_not_evaluated: None,
+            fold_const_initializer_ternaries: false,
         };
 
         let ast = ast.map(
@@ -106,6 +107,7 @@ impl<'a> ConstPropagationVisitor<'a> {
             array_index_not_evaluated: None,
             array_length_not_evaluated: None,
             repeat_count_not_evaluated: None,
+            fold_const_initializer_ternaries: false,
         }
     }
 }

--- a/crates/passes/src/const_propagation/visitor.rs
+++ b/crates/passes/src/const_propagation/visitor.rs
@@ -36,6 +36,8 @@ pub struct ConstPropagationVisitor<'a> {
     pub array_length_not_evaluated: Option<Span>,
     /// A repeat expression count which was not able to be evaluated.
     pub repeat_count_not_evaluated: Option<Span>,
+    /// Whether const initializers may fold a constant-condition ternary before inspecting the unselected arm.
+    pub fold_const_initializer_ternaries: bool,
 }
 
 impl ConstPropagationVisitor<'_> {
@@ -53,6 +55,15 @@ impl ConstPropagationVisitor<'_> {
         self.module = module.to_vec();
         let result = func(self);
         self.module = parent_module;
+        result
+    }
+
+    /// Reconstruct a const initializer with compile-time ternary selection enabled.
+    pub fn in_const_initializer<T>(&mut self, func: impl FnOnce(&mut Self) -> T) -> T {
+        let previous = self.fold_const_initializer_ternaries;
+        self.fold_const_initializer_ternaries = true;
+        let result = func(self);
+        self.fold_const_initializer_ternaries = previous;
         result
     }
 

--- a/crates/passes/src/dead_code_elimination/ast.rs
+++ b/crates/passes/src/dead_code_elimination/ast.rs
@@ -80,7 +80,7 @@ impl AstReconstructor for DeadCodeEliminatingVisitor<'_> {
             }
         };
 
-        if !lhs_is_used && self.is_pure(&input.value) {
+        if !lhs_is_used && self.can_discard(&input.value) {
             // We can eliminate this statement.
             (Statement::dummy(), Default::default())
         } else {
@@ -96,7 +96,7 @@ impl AstReconstructor for DeadCodeEliminatingVisitor<'_> {
     }
 
     fn reconstruct_expression_statement(&mut self, input: ExpressionStatement) -> (Statement, Self::AdditionalOutput) {
-        if self.is_pure(&input.expression) {
+        if self.can_discard(&input.expression) {
             (Statement::dummy(), Default::default())
         } else {
             (

--- a/crates/passes/src/dead_code_elimination/visitor.rs
+++ b/crates/passes/src/dead_code_elimination/visitor.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::CompilerState;
+use crate::{CompilerState, expression_can_be_discarded};
 
 use leo_ast::Expression;
 use leo_span::Symbol;
@@ -32,7 +32,7 @@ pub struct DeadCodeEliminatingVisitor<'a> {
 }
 
 impl DeadCodeEliminatingVisitor<'_> {
-    pub fn is_pure(&self, expr: &Expression) -> bool {
-        expr.is_pure(&|id| self.state.type_table.get(&id).expect("Types should be assigned."))
+    pub fn can_discard(&self, expr: &Expression) -> bool {
+        expression_can_be_discarded(expr, self.state)
     }
 }

--- a/crates/passes/src/ssa_const_propagation/ast.rs
+++ b/crates/passes/src/ssa_const_propagation/ast.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
+use crate::expression_can_be_discarded;
+
 use super::{
     SsaConstPropagationVisitor,
     visitor::{is_atom, is_one_literal, is_zero_literal, same_ssa_atom},
@@ -373,7 +375,7 @@ impl AstReconstructor for SsaConstPropagationVisitor<'_> {
         (UnaryExpression { receiver, ..input }.into(), None)
     }
 
-    /// Reconstruct a ternary expression and fold it if the condition is a constant.
+    /// Reconstruct a ternary expression and fold a constant condition only after both arms are reconstructed.
     fn reconstruct_ternary(
         &mut self,
         input: TernaryExpression,
@@ -381,20 +383,19 @@ impl AstReconstructor for SsaConstPropagationVisitor<'_> {
     ) -> (Expression, Self::AdditionalOutput) {
         let ternary_span = input.span();
         let (cond, cond_value) = self.reconstruct_expression(input.condition, &());
+        let (if_true, if_true_value) = self.reconstruct_expression(input.if_true, &());
+        let (if_false, if_false_value) = self.reconstruct_expression(input.if_false, &());
 
         match cond_value.and_then(|v| v.try_into().ok()) {
-            Some(true) => {
+            Some(true) if expression_can_be_discarded(&if_false, self.state) => {
                 self.changed = true;
-                self.reconstruct_expression(input.if_true, &())
+                (if_true, if_true_value)
             }
-            Some(false) => {
+            Some(false) if expression_can_be_discarded(&if_true, self.state) => {
                 self.changed = true;
-                self.reconstruct_expression(input.if_false, &())
+                (if_false, if_false_value)
             }
             _ => {
-                let (if_true, if_true_value) = self.reconstruct_expression(input.if_true, &());
-                let (if_false, if_false_value) = self.reconstruct_expression(input.if_false, &());
-
                 // Boolean branch folding: collapse a bool-literal-branched ternary.
                 // Commonly arises after composite forwarding erases an `is_some`-style
                 // flag that was selected across a ternary.

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
@@ -20,3 +20,4 @@ program test.aleo {
         return y;
     }
 }
+

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
@@ -1,0 +1,22 @@
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    fn preserve_false_arm(x: u8) -> u8 {
+        let y: u8 = true ? x : x.div_wrapped(0u8);
+        return y;
+    }
+    fn preserve_true_arm(x: u8) -> u8 {
+        let y: u8 = false ? x.div_wrapped(0u8) : x;
+        return y;
+    }
+    fn preserve_unwrap_arm(x: u8) -> u8 {
+        let maybe: u8? = none;
+        let y: u8 = true ? x : maybe.unwrap();
+        return y;
+    }
+    fn fold_pure_arm(x: u8) -> u8 {
+        let y: u8 = x;
+        return y;
+    }
+}

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
@@ -20,4 +20,3 @@ program test.aleo {
         return y;
     }
 }
-

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
@@ -19,5 +19,9 @@ program test.aleo {
         let y: u8 = x;
         return y;
     }
+    fn fold_const_initializer(x: u8) -> u8 {
+        const N: u8 = 5u8;
+        return 5u8;
+    }
 }
 

--- a/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
+++ b/tests/expectations/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.out
@@ -12,7 +12,7 @@ program test.aleo {
     }
     fn preserve_unwrap_arm(x: u8) -> u8 {
         let maybe: u8? = none;
-        let y: u8 = true ? x : maybe.unwrap();
+        let y: u8 = true ? x : _optional_unwrap(maybe);
         return y;
     }
     fn fold_pure_arm(x: u8) -> u8 {

--- a/tests/expectations/passes/dead_code_elimination/fallible_unused.out
+++ b/tests/expectations/passes/dead_code_elimination/fallible_unused.out
@@ -7,6 +7,8 @@ program test.aleo {
     transition main(t: Token, x: u8) -> u8 {
         let unused_div: u8 = x.div_wrapped(0u8);
         let unused_rem: u8 = x.rem_wrapped(0u8);
+        let missing: u8? = none;
+        let unused_unwrap: u8 = _optional_unwrap(missing);
         let r: dyn record = t as dyn record;
         let unused_balance: field = r.balance;
         let unused_balance_add: field = r.balance + 0field;

--- a/tests/expectations/passes/ssa_const_propagation/ternary_fallible_arm.out
+++ b/tests/expectations/passes/ssa_const_propagation/ternary_fallible_arm.out
@@ -17,3 +17,4 @@ program test.aleo {
         return $var$9;
     }
 }
+

--- a/tests/expectations/passes/ssa_const_propagation/ternary_fallible_arm.out
+++ b/tests/expectations/passes/ssa_const_propagation/ternary_fallible_arm.out
@@ -17,4 +17,3 @@ program test.aleo {
         return $var$9;
     }
 }
-

--- a/tests/expectations/passes/ssa_const_propagation/ternary_fallible_arm.out
+++ b/tests/expectations/passes/ssa_const_propagation/ternary_fallible_arm.out
@@ -1,0 +1,19 @@
+program test.aleo {
+    @noupgrade
+    async constructor() {
+    }
+    fn preserve_false_arm(x$$0: u8) -> u8 {
+        let $var$1 = true;
+        let $var$2 = 0u8;
+        let $var$3 = x$$0.div_wrapped(0u8);
+        let $var$4 = x$$0;
+        return $var$4;
+    }
+    fn preserve_true_arm(x$$5: u8) -> u8 {
+        let $var$6 = false;
+        let $var$7 = 0u8;
+        let $var$8 = x$$5.div_wrapped(0u8);
+        let $var$9 = x$$5;
+        return $var$9;
+    }
+}

--- a/tests/tests/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.leo
+++ b/tests/tests/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.leo
@@ -1,0 +1,25 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn preserve_false_arm(x: u8) -> u8 {
+        let y: u8 = true ? x : x.div_wrapped(0u8);
+        return y;
+    }
+
+    fn preserve_true_arm(x: u8) -> u8 {
+        let y: u8 = false ? x.div_wrapped(0u8) : x;
+        return y;
+    }
+
+    fn preserve_unwrap_arm(x: u8) -> u8 {
+        let maybe: u8? = none;
+        let y: u8 = true ? x : maybe.unwrap();
+        return y;
+    }
+
+    fn fold_pure_arm(x: u8) -> u8 {
+        let y: u8 = true ? x : x.add_wrapped(1u8);
+        return y;
+    }
+}

--- a/tests/tests/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.leo
+++ b/tests/tests/passes/const_prop_unroll_and_morphing/ternary_fallible_arm.leo
@@ -22,4 +22,9 @@ program test.aleo {
         let y: u8 = true ? x : x.add_wrapped(1u8);
         return y;
     }
+
+    fn fold_const_initializer(x: u8) -> u8 {
+        const N: u8 = true ? 5u8 : x.div_wrapped(1u8);
+        return N;
+    }
 }

--- a/tests/tests/passes/dead_code_elimination/fallible_unused.leo
+++ b/tests/tests/passes/dead_code_elimination/fallible_unused.leo
@@ -11,6 +11,8 @@ program test.aleo {
         let unused_add: u8 = x.add_wrapped(1u8);
         let unused_div: u8 = x.div_wrapped(0u8);
         let unused_rem: u8 = x.rem_wrapped(0u8);
+        let missing: u8? = none;
+        let unused_unwrap: u8 = missing.unwrap();
         let r: dyn record = t as dyn record;
         let unused_balance: field = r.balance;
         let unused_balance_add: field = r.balance + 0field;

--- a/tests/tests/passes/ssa_const_propagation/ternary_fallible_arm.leo
+++ b/tests/tests/passes/ssa_const_propagation/ternary_fallible_arm.leo
@@ -1,0 +1,12 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn preserve_false_arm(x: u8) -> u8 {
+        return true ? x : x.div_wrapped(0u8);
+    }
+
+    fn preserve_true_arm(x: u8) -> u8 {
+        return false ? x.div_wrapped(0u8) : x;
+    }
+}


### PR DESCRIPTION
## Motivation

Closes #29535.

Constant-condition ternary folding reconstructed only the selected arm, which could drop a discarded arm that still has to be evaluated under the current ternary lowering semantics. This could change a program from halting to succeeding when the discarded arm contains a fallible operation.

This change reconstructs both ternary arms before folding and only drops the unselected arm when it is safe to remove. The discard-safety check is shared with dead-code elimination so unused expressions and folded ternary arms use the same preservation rule for fallible or observable operations.

## Test Plan

Added pass expectation tests covering:
- source-level constant ternaries with fallible discarded arms
- source-level `Optional::unwrap` in a discarded arm
- a pure discarded arm that still folds
- SSA const propagation preserving hoisted fallible arm work

Ran:
- `git diff --check`
- targeted `rustfmt --check` on changed Rust files

## Related PRs

N/A
