### PR TITLE
docs: contrast leo run and leo execute in the Executing guide

### DIFF
--- a/documentation/guides/executing.md
+++ b/documentation/guides/executing.md
@@ -8,6 +8,24 @@ sidebar_label: Executing
 
 The `leo execute` command executes the Leo program and outputs a transaction object
 
+## `leo run` vs `leo execute`
+
+Leo offers two commands for running an entry function, and they serve different
+purposes:
+
+- `leo run` evaluates the function and prints its outputs locally. It does not
+  generate a zero-knowledge proof, does not produce a transaction, and nothing
+  touches the network. This makes it fast and ideal for iterating on your logic.
+- `leo execute` compiles the program, synthesizes the circuit, generates an
+  execution proof, and produces a broadcastable [`Transaction`](https://docs.aleo.org/learn/core-concepts/transactions/index.html).
+  Pass `--broadcast` to send that transaction to the network.
+
+A typical development loop is to iterate with `leo run` until the function
+behaves as expected, then switch to `leo execute` to produce the proof and
+transaction.
+
+## Running `leo execute`
+
 ```bash
 leo execute <FUNCTION_NAME> <INPUT_1> <INPUT_2> ...
 ```

--- a/documentation/guides/executing.md
+++ b/documentation/guides/executing.md
@@ -13,16 +13,50 @@ The `leo execute` command executes the Leo program and outputs a transaction obj
 Leo offers two commands for running an entry function, and they serve different
 purposes:
 
-- `leo run` evaluates the function and prints its outputs locally. It does not
-  generate a zero-knowledge proof, does not produce a transaction, and nothing
-  touches the network. This makes it fast and ideal for iterating on your logic.
+- `leo run` evaluates the off-chain (circuit) part of the function and prints
+  its outputs locally. It does not generate a zero-knowledge proof, does not
+  produce a transaction, and nothing touches the network. Crucially, it does
+  **not** run the on-chain `final` block, so it cannot exercise any logic that
+  reads or writes program state. This makes it fast and ideal for iterating on
+  the circuit logic.
 - `leo execute` compiles the program, synthesizes the circuit, generates an
   execution proof, and produces a broadcastable [`Transaction`](https://docs.aleo.org/learn/core-concepts/transactions/index.html).
   Pass `--broadcast` to send that transaction to the network.
 
-A typical development loop is to iterate with `leo run` until the function
-behaves as expected, then switch to `leo execute` to produce the proof and
-transaction.
+For a function without a `final` block, a typical development loop is to iterate
+with `leo run` until it behaves as expected, then switch to `leo execute` to
+produce the proof and transaction. If the function has a `final` block, keep in
+mind that `leo run` only covers the off-chain circuit portion. The `final` block
+runs on-chain only once a transaction is broadcast and confirmed, so to exercise
+that logic you need to broadcast (for example, `leo execute --broadcast` against
+a local [`leo devnode`](../cli/devnode.md)).
+
+## Running `leo run`
+
+To evaluate a function locally and see its outputs without producing a proof or
+transaction, use `leo run`:
+
+```bash
+leo run <FUNCTION_NAME> <INPUT_1> <INPUT_2> ...
+```
+
+It compiles the program, evaluates the function, and prints its outputs. Because
+it only evaluates the circuit (no proof is synthesized), there is no cost summary
+or transaction:
+
+```bash title="console output:"
+       Leo     ... statements before dead code elimination.
+       Leo     ... statements after dead code elimination.
+       Leo ✅ Compiled 'hello.aleo' into Aleo instructions.
+
+➡️  Outputs
+
+ • <OUTPUT_1>
+ • <OUTPUT_2>
+ ...
+```
+
+See the [`leo run`](../cli/run.md) reference for the full list of flags.
 
 ## Running `leo execute`
 
@@ -75,11 +109,11 @@ It will then print out the summary of the execution plan with
 Finally, an execution cost breakdown will be printed alongside any outputs from the function itself.
 
 ```bash
-📊 Execution Summary for <PROGRAM_NAME>
+📊 Execution Cost Summary for <PROGRAM_NAME>
 ──────────────────────────────────────────────
 💰 Cost Breakdown (credits)
   Transaction Storage:  0.001316
-  On‑chain Execution:   0.000000
+  On-chain Execution:   0.000000
   Priority Fee:         0.000000
   Total Fee:            0.001316
 ──────────────────────────────────────────────


### PR DESCRIPTION
## Motivation

The Executing guide (`documentation/guides/executing.md`) walks through `leo execute` but never mentions `leo run`, so new developers are not told how the two commands differ or when to use each. This adds a short "`leo run` vs `leo execute`" section near the top of the guide that contrasts the two: `leo run` evaluates the function and prints outputs locally with no proof and no transaction, while `leo execute` compiles, synthesizes the circuit, generates a proof, and produces a broadcastable `Transaction`. It also notes the typical dev loop of iterating with `leo run` first, then switching to `leo execute` once the function behaves.

The contrast matches the existing `documentation/cli/run.md` and `documentation/cli/execute.md` descriptions of each command.

Fixes #29379

## Test Plan

Documentation-only change. Verified `markdownlint --config .markdownlint.yaml documentation/guides/executing.md` passes (exit 0) and that the new headings render with balanced fenced code blocks.

## Related PRs

None.

AI was used for assistance.
