### PR TITLE
Display program size for each import during leo build

### DIFF
--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -652,6 +652,16 @@ fn compile_leo_source_directory(
         }
     }
 
+    // Import sizes track the primary program size rather than the checksums:
+    // both answer "will this fit on chain", so they print together.
+    if !is_test {
+        for import in &compiled.imports {
+            let import_size = import.bytecode.len();
+            let (size_kb, max_kb, _warning) = format_program_size(import_size, MAX_PROGRAM_SIZE);
+            tracing::info!("    Import '{}': program size: {size_kb:.2} KB / {max_kb:.2} KB", import.name);
+        }
+    }
+
     Ok(compiled)
 }
 

--- a/tests/expectations/cli/multiple_leo_deps/STDOUT
+++ b/tests/expectations/cli/multiple_leo_deps/STDOUT
@@ -4,4 +4,7 @@
        Leo 🔨 Compiling 'parent.aleo'
        Leo     Program size: 0.29 KB / 2000.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.
+       Leo     Import 'grandchild.aleo': program size: 0.18 KB / 2000.00 KB
+       Leo     Import 'child1.aleo': program size: 0.26 KB / 2000.00 KB
+       Leo     Import 'child2.aleo': program size: 0.26 KB / 2000.00 KB
        Leo ✅ Generated ABI for program 'parent.aleo'.

--- a/tests/expectations/cli/test_external_program_submodule/STDOUT
+++ b/tests/expectations/cli/test_external_program_submodule/STDOUT
@@ -13,4 +13,5 @@
        Leo     Program size: 1.69 KB / 2000.00 KB
        Leo ✅ Compiled 'consumer.aleo' into Aleo instructions.
        Leo     Import 'provider.aleo': checksum = '[65u8, 143u8, 101u8, 10u8, 122u8, 113u8, 65u8, 0u8, 200u8, 13u8, 10u8, 147u8, 182u8, 18u8, 16u8, 101u8, 135u8, 136u8, 47u8, 202u8, 209u8, 17u8, 150u8, 249u8, 134u8, 116u8, 3u8, 5u8, 53u8, 167u8, 16u8, 6u8]'
+       Leo     Import 'provider.aleo': program size: 0.48 KB / 2000.00 KB
        Leo ✅ Generated ABI for program 'consumer.aleo'.

--- a/tests/expectations/cli/test_external_toplevel_closure/STDOUT
+++ b/tests/expectations/cli/test_external_toplevel_closure/STDOUT
@@ -5,4 +5,5 @@
        Leo 🔨 Compiling 'parent.aleo'
        Leo     Program size: 0.13 KB / 2000.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.
+       Leo     Import 'child.aleo': program size: 0.18 KB / 2000.00 KB
        Leo ✅ Generated ABI for program 'parent.aleo'.

--- a/tests/expectations/cli/test_workspace_deploy/STDOUT
+++ b/tests/expectations/cli/test_workspace_deploy/STDOUT
@@ -11,6 +11,7 @@
        Leo 🔨 Compiling 'swap.aleo'
        Leo     Program size: 0.23 KB / 2000.00 KB
        Leo ✅ Compiled 'swap.aleo' into Aleo instructions.
+       Leo     Import 'token.aleo': program size: 0.17 KB / 2000.00 KB
        Leo ✅ Generated ABI for program 'swap.aleo'.
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16


### PR DESCRIPTION
## Motivation

The program-sizes report only listed the primary program, so a developer reviewing a program that pulls in several imports had no per-import size breakdown and could not tell which dependency dominated the on-chain footprint. This adds an import-size line per imported program, formatted consistently with the existing primary-program size output. Closes #29174.

## Test Plan

Updated the affected CLI expectation snapshots so they include the new import-size lines, and confirmed the formatting matches the existing primary-size rendering. Run the CLI test suite to verify the snapshots match.

## Related PRs

None.

AI was used for assistance.
