### PR TITLE
Bump to v4.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9ebd144c81671193ed85aa2db9bb5e183421843e0485de8fffc07e5cf50e18a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 1.0.109",
 ]
 
@@ -81,7 +81,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f6ff9e4c36858fa2c29e5284b77527b5a7466743976e1ba1f5824e16683545"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 1.0.109",
 ]
 
@@ -173,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -222,9 +222,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -233,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -413,7 +413,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "regex",
  "rustc-hash 2.1.2",
  "shlex 1.3.0",
@@ -490,13 +490,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -513,9 +513,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bytesize"
@@ -541,9 +541,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -574,9 +574,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -664,7 +664,7 @@ checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -1013,9 +1013,9 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97bb4a855e3b10f84c4e7e895a7de01db7f9a7b7eb7f73ed9773fd52ac686451"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -1090,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -1106,6 +1106,38 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote 1.0.46",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1142,7 +1174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 1.0.109",
 ]
 
@@ -1153,7 +1185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -1174,7 +1206,7 @@ checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "rustc_version",
  "syn 2.0.118",
 ]
@@ -1253,7 +1285,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -1286,9 +1318,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ecdsa"
-version = "0.17.0-rc.19"
+version = "0.17.0-rc.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcddae1289a08e614a83d155a070f54c1803196e92089b8299e2738eb74d3e4"
+checksum = "b7c72d1455753a703ad4b90ed2a759f2bc4562024a303176439cf6e593b5ade4"
 dependencies = [
  "der 0.8.0",
  "digest 0.11.3",
@@ -1331,9 +1363,9 @@ checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.14.0-rc.34"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a44d097c9f3e494ddc19f77af5aab89f0b3b2652cde370ec8c6064faca5bd2"
+checksum = "3273f1195b6f6253ebda493d6742c8baa9b26a291674cd96d92a0f09e90e9b46"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -1443,7 +1475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -1729,17 +1761,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1838,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "gix-attributes"
-version = "0.33.1"
+version = "0.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
+checksum = "39b40888d0ed415c0744a6cdc61eebf0304c9d26ab726725b718443c322e5ba4"
 dependencies = [
  "bstr",
  "gix-glob",
@@ -1969,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
+checksum = "3d63f9e28b59ddeb1a1eb9e5cf986a9222b5d484947445edbc20473939cc7fd0"
 dependencies = [
  "bstr",
  "gix-error",
@@ -2130,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
+checksum = "7e261d54091f0d1c729bc83f54548c071bdec60a697de1e58e88bdfd7a99d24e"
 dependencies = [
  "gix-hash",
  "hashbrown 0.17.1",
@@ -2154,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "gix-imara-diff"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19753d40da53d0ec41604750eeb969097a90fb2d7f7992730d904541c04e2c19"
+checksum = "b305d85504de270ad3525d726a6b69cc59ee7b2269b014387651107ab9f0755b"
 dependencies = [
  "bstr",
  "hashbrown 0.17.1",
@@ -2514,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "23.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
+checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
 dependencies = [
  "dashmap",
  "gix-fs",
@@ -2535,9 +2565,9 @@ checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
 
 [[package]]
 name = "gix-transport"
-version = "0.57.1"
+version = "0.57.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
+checksum = "186874f7ad1fb2f9a2f2aa9c2dabc7f9dd087bef74c1a0eee2b4a9cf0248fcb3"
 dependencies = [
  "base64",
  "bstr",
@@ -3094,12 +3124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3214,10 +3238,11 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
@@ -3229,12 +3254,12 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.28"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -3277,7 +3302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.118",
@@ -3298,7 +3323,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -3314,9 +3339,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3325,14 +3350,16 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.14.0-rc.11"
+version = "0.14.0-rc.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eb95d01f9d0270fc40dcb217cb25de1494383597d27b4fe832a42f5d907824a"
+checksum = "905d38bdbb43bb506efa0a428b3e969ff244549832a86b18591492f503adfe37"
 dependencies = [
  "cpubits",
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.11.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -3351,14 +3378,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "leo-abi"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "indexmap",
  "itertools 0.14.0",
@@ -3371,16 +3392,16 @@ dependencies = [
 
 [[package]]
 name = "leo-abi-types"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "leo-aleo-abi-wasm"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "leo-abi",
  "leo-ast",
  "serde_json",
@@ -3389,10 +3410,10 @@ dependencies = [
 
 [[package]]
 name = "leo-ast"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "indexmap",
  "itertools 0.14.0",
  "leo-errors",
@@ -3406,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "leo-benchmarks"
-version = "0.1.0"
+version = "4.3.1"
 dependencies = [
  "aleo-std",
  "codspeed-criterion-compat",
@@ -3425,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "leo-compiler"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "aleo-std",
  "aleo-std-storage",
@@ -3454,9 +3475,9 @@ dependencies = [
 
 [[package]]
 name = "leo-disassembler"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "leo-ast",
  "leo-errors",
  "leo-span",
@@ -3467,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "leo-errors"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -3483,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "leo-fmt"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "clap",
  "colored 3.1.1",
@@ -3499,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "leo-lang"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "aleo-std",
  "aleo-std-storage",
@@ -3564,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "leo-lsp"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3589,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "leo-package"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "gix",
  "glob",
@@ -3607,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "leo-parser"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "indexmap",
  "itertools 0.14.0",
@@ -3622,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "leo-parser-rowan"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "expect-test",
  "leo-errors",
@@ -3633,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "leo-passes"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "anyhow",
  "base62",
@@ -3658,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "leo-span"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "ariadne",
  "fxhash",
@@ -3669,11 +3690,11 @@ dependencies = [
 
 [[package]]
 name = "leo-std"
-version = "4.3.0"
+version = "4.3.1"
 
 [[package]]
 name = "leo-test-framework"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "rayon",
  "similar",
@@ -3769,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -3790,7 +3811,7 @@ checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
 dependencies = [
  "fnv",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "regex-automata",
  "regex-syntax",
  "syn 2.0.118",
@@ -3878,7 +3899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -3890,9 +3911,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4026,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -4131,7 +4152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -4213,7 +4234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -4307,12 +4328,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0-rc.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e56e6d67fdf5744e9e245ae571450fe584b91f5af261d0e40163b618e53a1f6"
+dependencies = [
+ "elliptic-curve",
+ "primefield",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
+ "quote 1.0.46",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -4362,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4382,9 +4439,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4424,9 +4481,9 @@ checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4460,7 +4517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4749,9 +4806,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4975,7 +5032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -5011,7 +5068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -5048,7 +5105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6111,7 +6168,7 @@ version = "4.7.3"
 source = "git+https://github.com/ProvableHQ/snarkVM?tag=testnet-v4.8.0#357899f8e85d6340bda5db8373b1cdffdf88a6d7"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6203,7 +6260,7 @@ checksum = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 dependencies = [
  "quote 0.3.15",
  "synom",
- "unicode-xid 0.0.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -6213,7 +6270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "unicode-ident",
 ]
 
@@ -6224,7 +6281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "unicode-ident",
 ]
 
@@ -6243,7 +6300,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 dependencies = [
- "unicode-xid 0.0.4",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -6253,7 +6310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6295,7 +6352,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6341,7 +6398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6352,7 +6409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6367,9 +6424,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -6387,9 +6444,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6463,7 +6520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6626,7 +6683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -6691,7 +6748,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-leo"
-version = "4.3.0"
+version = "4.3.1"
 dependencies = [
  "cc",
  "leo-parser-rowan",
@@ -6768,12 +6825,6 @@ name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -6909,23 +6960,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6936,9 +6978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6946,75 +6988,41 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
- "quote 1.0.45",
+ "quote 1.0.46",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7032,18 +7040,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7108,7 +7116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -7119,7 +7127,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -7325,96 +7333,19 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
+name = "wnaf"
+version = "0.14.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+checksum = "f86421f2a70c9e6cab8d84c99fb62d8761d355bd1285443a7e7ccad15aa515f2"
 dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.118",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.118",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid 0.2.6",
- "wasmparser",
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -7453,7 +7384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
  "synstructure",
 ]
@@ -7474,7 +7405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -7494,7 +7425,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
  "synstructure",
 ]
@@ -7515,7 +7446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -7548,7 +7479,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
- "quote 1.0.45",
+ "quote 1.0.46",
  "syn 2.0.118",
 ]
 
@@ -7579,9 +7510,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,20 @@ resolver = "3"
 
 [workspace.dependencies]
 # leo dependencies
-leo-abi             = { path = "./crates/abi",              version = "=4.3.0" }
-leo-abi-types       = { path = "./crates/abi-types",        version = "=4.3.0" }
-leo-ast             = { path = "./crates/ast",              version = "=4.3.0" }
-leo-compiler        = { path = "./crates/compiler",         version = "=4.3.0" }
-leo-disassembler    = { path = "./crates/disassembler",     version = "=4.3.0" }
-leo-errors          = { path = "./crates/errors",           version = "=4.3.0" }
-leo-fmt             = { path = "./crates/fmt",              version = "=4.3.0" }
-leo-lsp             = { path = "./crates/lsp",              version = "=4.3.0" }
-leo-package         = { path = "./crates/package",          version = "=4.3.0" }
-leo-parser          = { path = "./crates/parser",           version = "=4.3.0" }
-leo-parser-rowan    = { path = "./crates/parser-rowan",     version = "=4.3.0" }
-leo-passes          = { path = "./crates/passes",           version = "=4.3.0" }
-leo-span            = { path = "./crates/span",             version = "=4.3.0" }
-leo-std             = { path = "./crates/leo-std",          version = "=4.3.0" }
+leo-abi             = { path = "./crates/abi", version = "=4.3.1" }
+leo-abi-types       = { path = "./crates/abi-types", version = "=4.3.1" }
+leo-ast             = { path = "./crates/ast", version = "=4.3.1" }
+leo-compiler        = { path = "./crates/compiler", version = "=4.3.1" }
+leo-disassembler    = { path = "./crates/disassembler", version = "=4.3.1" }
+leo-errors          = { path = "./crates/errors", version = "=4.3.1" }
+leo-fmt             = { path = "./crates/fmt", version = "=4.3.1" }
+leo-lsp             = { path = "./crates/lsp", version = "=4.3.1" }
+leo-package         = { path = "./crates/package", version = "=4.3.1" }
+leo-parser          = { path = "./crates/parser", version = "=4.3.1" }
+leo-parser-rowan    = { path = "./crates/parser-rowan", version = "=4.3.1" }
+leo-passes          = { path = "./crates/passes", version = "=4.3.1" }
+leo-span            = { path = "./crates/span", version = "=4.3.1" }
+leo-std             = { path = "./crates/leo-std", version = "=4.3.1" }
 leo-test-framework  = { path = "./crates/test-framework" }
 # third party dependencies
 aleo-std           = { version = "1.0.3"}

--- a/crates/abi-types/Cargo.toml
+++ b/crates/abi-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-abi-types"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "ABI type definitions for Leo programs"
 homepage = "https://leo-lang.org"

--- a/crates/abi/Cargo.toml
+++ b/crates/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-abi"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "ABI generation for Leo programs"
 homepage = "https://leo-lang.org"

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-ast"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Abstract syntax tree (AST) for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-compiler"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Compiler for Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/compiler/benchmarks/Cargo.toml
+++ b/crates/compiler/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-benchmarks"
-version = "0.1.0"
+version = "4.3.1"
 edition = "2024"
 publish = false
 

--- a/crates/disassembler/Cargo.toml
+++ b/crates/disassembler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-disassembler"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "A disassembler for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-errors"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Errors for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/fmt/Cargo.toml
+++ b/crates/fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-fmt"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Source code formatter for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/leo-aleo-abi-wasm/Cargo.toml
+++ b/crates/leo-aleo-abi-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-aleo-abi-wasm"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "WASM bindings for ABI generation from Aleo bytecode"
 homepage = "https://leo-lang.org"

--- a/crates/leo-std/Cargo.toml
+++ b/crates/leo-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-std"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Embedded Leo standard library source"
 homepage = "https://leo-lang.org"

--- a/crates/leo/Cargo.toml
+++ b/crates/leo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-lang"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "The Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-lsp"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Language Server Protocol implementation for Leo"
 homepage = "https://leo-lang.org"

--- a/crates/package/Cargo.toml
+++ b/crates/package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-package"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Package parser for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/parser-rowan/Cargo.toml
+++ b/crates/parser-rowan/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "leo-parser-rowan"
-version = "4.3.0"
+version = "4.3.1"
 authors = ["The Leo Team <leo@provable.com>"]
 description = "Rowan-based lossless parser for Leo"
 homepage = "https://leo-lang.org"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-parser"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Translating from the lossless syntax tree to the AST for the Leo language language"
 homepage = "https://leo-lang.org"

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-passes"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Compiler passes for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-span"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Span handling for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-test-framework"
-version = "4.3.0"
+version = "4.3.1"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "The testing framework for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/tree-sitter-leo/Cargo.toml
+++ b/crates/tree-sitter-leo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-leo"
 description = "Rust bindings and tests for the Leo tree-sitter grammar"
-version = "4.3.0"
+version = "4.3.1"
 authors = ["Provable"]
 license = "GPL-3.0-only"
 readme = "README.md"

--- a/documentation/cli/devnode.md
+++ b/documentation/cli/devnode.md
@@ -120,6 +120,42 @@ leo execute <TRANSITION> <INPUTS> --skip-execute-proof --endpoint http://localho
 leo upgrade --skip-deploy-certificate --endpoint http://localhost:3030
 ```
 
+## Evaluating View Functions
+
+A devnode exposes two REST endpoints for evaluating a program's [`view fn`](../language/programs_in_practice/functions.md) against the current ledger state. View functions are read-only: they compute a result from on-chain state without producing a transaction, so no key, signature, or proof is required.
+
+Both endpoints are mounted under the network prefix (e.g. `testnet`) and are also available behind the `v1` and `v2` API version prefixes:
+
+| Method | Path                                               | Description                                          |
+| ------ | -------------------------------------------------- | ---------------------------------------------------- |
+| `POST` | `/{network}/program/{id}/view/{function}`          | Evaluate a view function at the latest block height. |
+| `POST` | `/{network}/program/{id}/view/{function}/{height}` | Evaluate a view function at a specific block height. |
+
+The request body is a JSON array of the view function's inputs, each encoded as an Aleo value string. Pass `[]` when the function takes no inputs. The response is a JSON array of the function's outputs.
+
+The latest-height endpoint accepts an optional `?metadata=true` query parameter; when set, the response is wrapped as `{ "data": [...], "height": <block_height> }` instead of a bare output array.
+
+### **Examples**
+
+```bash
+# Evaluate `my_view` on `my_program.aleo` at the latest height
+curl -X POST http://localhost:3030/testnet/program/my_program.aleo/view/my_view \
+  -H 'Content-Type: application/json' \
+  -d '["1u32", "2u32"]'
+
+# Include the block height the result was evaluated at
+curl -X POST 'http://localhost:3030/testnet/program/my_program.aleo/view/my_view?metadata=true' \
+  -H 'Content-Type: application/json' \
+  -d '[]'
+
+# Evaluate against historical state at block height 10
+curl -X POST http://localhost:3030/testnet/program/my_program.aleo/view/my_view/10 \
+  -H 'Content-Type: application/json' \
+  -d '[]'
+```
+
+Under the `v2` prefix the endpoints return `422 Unprocessable Entity` for malformed inputs and `400 Bad Request` for an unknown view function or a height before the program was deployed.
+
 ## Typical Workflow
 
 ```bash

--- a/tests/expectations/cli/aleo_dep_imports_local_dep/contents/program.json
+++ b/tests/expectations/cli/aleo_dep_imports_local_dep/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "helper.aleo",

--- a/tests/expectations/cli/aleo_dep_reversed_order/contents/program.json
+++ b/tests/expectations/cli/aleo_dep_reversed_order/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "lib.aleo",

--- a/tests/expectations/cli/local_aleo_dependency/contents/program.json
+++ b/tests/expectations/cli/local_aleo_dependency/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "simple.aleo",

--- a/tests/expectations/cli/multiple_leo_deps/contents/child1/program.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/child1/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/expectations/cli/multiple_leo_deps/contents/child2/program.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/child2/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/program.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "child1.aleo",

--- a/tests/expectations/cli/test_add/contents/program.json
+++ b/tests/expectations/cli/test_add/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",

--- a/tests/expectations/cli/test_add_dependency/STDOUT
+++ b/tests/expectations/cli/test_add_dependency/STDOUT
@@ -25,7 +25,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -42,7 +42,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -60,7 +60,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -83,7 +83,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -107,7 +107,7 @@ missing network dep exit code: 213
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -132,7 +132,7 @@ network dev dep exit code: 0
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -162,7 +162,7 @@ network dev dep exit code: 0
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -186,7 +186,7 @@ network dev dep exit code: 0
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",

--- a/tests/expectations/cli/test_add_dependency/contents/my_program/program.json
+++ b/tests/expectations/cli/test_add_dependency/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "credits.aleo",

--- a/tests/expectations/cli/test_add_library_to_program/contents/my_program/program.json
+++ b/tests/expectations/cli/test_add_library_to_program/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "actual_lib",

--- a/tests/expectations/cli/test_add_workspace/STDOUT
+++ b/tests/expectations/cli/test_add_workspace/STDOUT
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "token.aleo",
@@ -23,7 +23,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "token.aleo",

--- a/tests/expectations/cli/test_add_workspace/contents/swap/program.json
+++ b/tests/expectations/cli/test_add_workspace/contents/swap/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "token.aleo",

--- a/tests/expectations/cli/test_deploy_rename_conflict/contents/child/program.json
+++ b/tests/expectations/cli/test_deploy_rename_conflict/contents/child/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/expectations/cli/test_deploy_rename_conflict/contents/grandchild/program.json
+++ b/tests/expectations/cli/test_deploy_rename_conflict/contents/grandchild/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/expectations/cli/test_deploy_rename_conflict/contents/parent/program.json
+++ b/tests/expectations/cli/test_deploy_rename_conflict/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "child.aleo",

--- a/tests/expectations/cli/test_deploy_rename_rejected/contents/solo/program.json
+++ b/tests/expectations/cli/test_deploy_rename_rejected/contents/solo/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/expectations/cli/test_interface_abi_from_library/contents/my_program/program.json
+++ b/tests/expectations/cli/test_interface_abi_from_library/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "my_lib",

--- a/tests/expectations/cli/test_library/contents/base_lib/program.json
+++ b/tests/expectations/cli/test_library/contents/base_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/expectations/cli/test_library/contents/program_using_lib/program.json
+++ b/tests/expectations/cli/test_library/contents/program_using_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/expectations/cli/test_library/contents/top_lib/program.json
+++ b/tests/expectations/cli/test_library/contents/top_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/expectations/cli/test_library_build/contents/my_program/program.json
+++ b/tests/expectations/cli/test_library_build/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "my_lib",

--- a/tests/expectations/cli/test_library_build_with_dep_lib/contents/top_lib/program.json
+++ b/tests/expectations/cli/test_library_build_with_dep_lib/contents/top_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/expectations/cli/test_library_circular/contents/lib_a/program.json
+++ b/tests/expectations/cli/test_library_circular/contents/lib_a/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "lib_b",

--- a/tests/expectations/cli/test_library_circular/contents/lib_b/program.json
+++ b/tests/expectations/cli/test_library_circular/contents/lib_b/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "lib_a",

--- a/tests/expectations/cli/test_library_parse_error/contents/my_program/program.json
+++ b/tests/expectations/cli/test_library_parse_error/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "bad_lib",

--- a/tests/expectations/cli/test_library_submodule_access/contents/my_app/program.json
+++ b/tests/expectations/cli/test_library_submodule_access/contents/my_app/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Program that uses structs, consts, and functions from shapes_lib submodules.",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "shapes_lib",

--- a/tests/expectations/cli/test_version/STDOUT
+++ b/tests/expectations/cli/test_version/STDOUT
@@ -1,1 +1,1 @@
-leo 4.3.0 (HASH BRANCH) features=[FEATURES]
+leo 4.3.1 (HASH BRANCH) features=[FEATURES]

--- a/tests/tests/cli/aleo_dep_imports_local_dep/contents/program.json
+++ b/tests/tests/cli/aleo_dep_imports_local_dep/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "helper.aleo",

--- a/tests/tests/cli/aleo_dep_reversed_order/contents/program.json
+++ b/tests/tests/cli/aleo_dep_reversed_order/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "lib.aleo",

--- a/tests/tests/cli/local_aleo_dependency/contents/program.json
+++ b/tests/tests/cli/local_aleo_dependency/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "simple.aleo",

--- a/tests/tests/cli/multiple_leo_deps/contents/child1/program.json
+++ b/tests/tests/cli/multiple_leo_deps/contents/child1/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/tests/cli/multiple_leo_deps/contents/child2/program.json
+++ b/tests/tests/cli/multiple_leo_deps/contents/child2/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/tests/cli/multiple_leo_deps/contents/parent/program.json
+++ b/tests/tests/cli/multiple_leo_deps/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "child1.aleo",

--- a/tests/tests/cli/test_deploy_rename_conflict/contents/child/program.json
+++ b/tests/tests/cli/test_deploy_rename_conflict/contents/child/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/tests/cli/test_deploy_rename_conflict/contents/grandchild/program.json
+++ b/tests/tests/cli/test_deploy_rename_conflict/contents/grandchild/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/tests/cli/test_deploy_rename_conflict/contents/parent/program.json
+++ b/tests/tests/cli/test_deploy_rename_conflict/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "child.aleo",

--- a/tests/tests/cli/test_deploy_rename_rejected/contents/solo/program.json
+++ b/tests/tests/cli/test_deploy_rename_rejected/contents/solo/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/tests/cli/test_library/contents/base_lib/program.json
+++ b/tests/tests/cli/test_library/contents/base_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/tests/cli/test_library/contents/program_using_lib/program.json
+++ b/tests/tests/cli/test_library/contents/program_using_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/tests/cli/test_library/contents/top_lib/program.json
+++ b/tests/tests/cli/test_library/contents/top_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.0",
+  "leo": "4.3.1",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tree-sitter/package.json
+++ b/tree-sitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-leo",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Leo grammar for tree-sitter",
   "repository": "https://github.com/ProvableHQ/leo/tree/master/tree-sitter",
   "license": "GPL-3.0-only",

--- a/tree-sitter/tree-sitter.json
+++ b/tree-sitter/tree-sitter.json
@@ -18,7 +18,7 @@
     }
   ],
   "metadata": {
-    "version": "4.3.0",
+    "version": "4.3.1",
     "license": "GPL-3.0-only",
     "description": "Leo grammar for tree-sitter",
     "authors": [


### PR DESCRIPTION
Release v4.3.1: bump workspace crates and `cargo update`, and document the devnode view evaluation endpoints.
