### PR TITLE
Check for duplicate items in interfaces

### DIFF
--- a/crates/passes/src/check_interfaces/visitor.rs
+++ b/crates/passes/src/check_interfaces/visitor.rs
@@ -688,6 +688,54 @@ impl<'a> CheckInterfacesVisitor<'a> {
         None
     }
 
+    /// Emit an error for every duplicated member name within a single interface body.
+    ///
+    /// A single map catches both within-kind duplicates (two `fn foo`) and cross-kind
+    /// clashes (`fn foo` + `mapping foo`); the error names each side's kind so users
+    /// can tell which two declarations collide. Walks kinds in a fixed order so the
+    /// "first seen" report is deterministic across runs.
+    fn check_intra_interface_duplicates<'b>(&mut self, interfaces: impl IntoIterator<Item = &'b Interface>) {
+        for interface in interfaces {
+            let interface_name = interface.identifier.name;
+            let mut seen: IndexMap<Symbol, (&'static str, Span)> = IndexMap::new();
+
+            let entries = interface
+                .functions
+                .iter()
+                .map(|(name, proto)| ("function", *name, proto.identifier.span))
+                .chain(interface.records.iter().map(|(name, proto)| ("record", *name, proto.identifier.span)))
+                .chain(interface.mappings.iter().map(|proto| ("mapping", proto.identifier.name, proto.identifier.span)))
+                .chain(
+                    interface
+                        .storages
+                        .iter()
+                        .map(|proto| ("storage variable", proto.identifier.name, proto.identifier.span)),
+                );
+
+            for (kind, name, span) in entries {
+                if let Some((first_kind, first_span)) = seen.get(&name).copied() {
+                    self.state.handler.emit_err(
+                        crate::errors::check_interfaces::duplicate_interface_member(
+                            kind,
+                            first_kind,
+                            name,
+                            interface_name,
+                            span,
+                        )
+                        .with_labels(vec![
+                            Label::new(first_span)
+                                .with_message(format!("`{name}` first declared here as a {first_kind}"))
+                                .with_color(Color::Blue),
+                            Label::new(span).with_message(format!("`{name}` redeclared here as a {kind}")),
+                        ]),
+                    );
+                } else {
+                    seen.insert(name, (kind, span));
+                }
+            }
+        }
+    }
+
     /// Validate that record prototypes don't specify `owner` with a type other than `address`.
     fn validate_record_prototypes<'b>(&mut self, interfaces: impl IntoIterator<Item = &'b Interface>) {
         for interface in interfaces {
@@ -805,6 +853,10 @@ impl UnitVisitor for CheckInterfacesVisitor<'_> {
             return;
         }
 
+        // Reject duplicate member names within a single interface before flattening,
+        // so inheritance errors aren't cascaded from an already-malformed interface.
+        self.check_intra_interface_duplicates(prefixed.iter().map(|(_, i)| i));
+
         // Validate record prototypes (e.g. owner must be address).
         self.validate_record_prototypes(prefixed.iter().map(|(_, i)| i));
 
@@ -849,6 +901,10 @@ impl UnitVisitor for CheckInterfacesVisitor<'_> {
             ));
             return;
         }
+
+        // Reject duplicate member names within a single interface before flattening,
+        // so inheritance errors aren't cascaded from an already-malformed interface.
+        self.check_intra_interface_duplicates(input.interfaces.iter().map(|(_, i)| i));
 
         // Validate record prototypes (e.g. owner must be address).
         self.validate_record_prototypes(input.interfaces.iter().map(|(_, i)| i));

--- a/crates/passes/src/errors/check_interfaces.rs
+++ b/crates/passes/src/errors/check_interfaces.rs
@@ -256,3 +256,19 @@ pub(crate) fn record_prototype_owner_wrong_type(
     )
     .with_help("Change the field's type to `address`. The `owner` field of every record is always `address`.")
 }
+
+pub(crate) fn duplicate_interface_member(
+    kind: &str,
+    first_kind: &str,
+    member_name: impl Display,
+    interface_name: impl Display,
+    span: Span,
+) -> Formatted {
+    let message = if kind == first_kind {
+        format!("interface `{interface_name}` declares {kind} `{member_name}` more than once")
+    } else {
+        format!("interface `{interface_name}` declares `{member_name}` as both a {first_kind} and a {kind}")
+    };
+    Formatted::error(CODE_PREFIX, CODE_MASK + 15, message, span)
+        .with_help("Rename or remove one of the declarations. Member names must be unique within an interface.")
+}

--- a/tests/expectations/passes/check_interfaces/duplicate_cross_kind_fail.out
+++ b/tests/expectations/passes/check_interfaces/duplicate_cross_kind_fail.out
@@ -1,0 +1,16 @@
+[ECHI03712015] Error: interface `Clash` declares `bucket` as both a mapping and a storage variable
+   ╭─[ test:6:13 ]
+   │
+ 6 │     storage bucket: u64;
+   │
+   ├─[ test:6:13 ]
+   │
+ 5 │     mapping bucket: address => u64;
+   │             ───┬──  
+   │                ╰──── `bucket` first declared here as a mapping
+ 6 │     storage bucket: u64;
+   │             ───┬──  
+   │                ╰──── `bucket` redeclared here as a storage variable
+   │ 
+   │ Help: Rename or remove one of the declarations. Member names must be unique within an interface.
+───╯

--- a/tests/expectations/passes/check_interfaces/duplicate_function_fail.out
+++ b/tests/expectations/passes/check_interfaces/duplicate_function_fail.out
@@ -1,0 +1,16 @@
+[ECHI03712015] Error: interface `Foo` declares function `main` more than once
+   ╭─[ test:6:8 ]
+   │
+ 6 │     fn main(public a: u32, b: u32) -> u32;
+   │
+   ├─[ test:6:8 ]
+   │
+ 5 │     fn main(public a: u32, b: u32);
+   │        ──┬─  
+   │          ╰─── `main` first declared here as a function
+ 6 │     fn main(public a: u32, b: u32) -> u32;
+   │        ──┬─  
+   │          ╰─── `main` redeclared here as a function
+   │ 
+   │ Help: Rename or remove one of the declarations. Member names must be unique within an interface.
+───╯

--- a/tests/expectations/passes/check_interfaces/duplicate_members_fail.out
+++ b/tests/expectations/passes/check_interfaces/duplicate_members_fail.out
@@ -1,0 +1,87 @@
+[ECHI03712015] Error: interface `Bag` declares function `ping` more than once
+   ╭─[ test:7:8 ]
+   │
+ 7 │     fn ping() -> u32;
+   │
+   ├─[ test:7:8 ]
+   │
+ 6 │     fn ping();
+   │        ──┬─  
+   │          ╰─── `ping` first declared here as a function
+ 7 │     fn ping() -> u32;
+   │        ──┬─  
+   │          ╰─── `ping` redeclared here as a function
+   │ 
+   │ Help: Rename or remove one of the declarations. Member names must be unique within an interface.
+───╯
+[ECHI03712015] Error: interface `Bag` declares record `Token` more than once
+    ╭─[ test:13:12 ]
+    │
+ 13 │     record Token {
+    │
+    ├─[ test:13:12 ]
+    │
+  9 │     record Token {
+    │            ──┬──  
+    │              ╰──── `Token` first declared here as a record
+    │ 
+ 13 │     record Token {
+    │            ──┬──  
+    │              ╰──── `Token` redeclared here as a record
+    │ 
+    │ Help: Rename or remove one of the declarations. Member names must be unique within an interface.
+────╯
+[ECHI03712015] Error: interface `Bag` declares mapping `counts` more than once
+    ╭─[ test:19:13 ]
+    │
+ 19 │     mapping counts: address => u64;
+    │
+    ├─[ test:19:13 ]
+    │
+ 18 │     mapping counts: address => u64;
+    │             ───┬──  
+    │                ╰──── `counts` first declared here as a mapping
+ 19 │     mapping counts: address => u64;
+    │             ───┬──  
+    │                ╰──── `counts` redeclared here as a mapping
+    │ 
+    │ Help: Rename or remove one of the declarations. Member names must be unique within an interface.
+────╯
+[ECHI03712015] Error: interface `Bag` declares storage variable `total` more than once
+    ╭─[ test:22:13 ]
+    │
+ 22 │     storage total: u64;
+    │
+    ├─[ test:22:13 ]
+    │
+ 21 │     storage total: u64;
+    │             ──┬──  
+    │               ╰──── `total` first declared here as a storage variable
+ 22 │     storage total: u64;
+    │             ──┬──  
+    │               ╰──── `total` redeclared here as a storage variable
+    │ 
+    │ Help: Rename or remove one of the declarations. Member names must be unique within an interface.
+────╯
+[WPAR0370002] Warning: record prototype `Token` does not constrain any fields beyond the implicit `owner: address`
+    ╭─[ test:7:22 ]
+    │
+  7 │ ╭─▶     fn ping() -> u32;
+    ┆ ┆   
+ 12 │ ├─▶     }
+    │ │           
+    │ ╰─────────── here
+    │     
+    │     Help: Simplify the declaration to `record Token;`.
+────╯
+[WPAR0370002] Warning: record prototype `Token` does not constrain any fields beyond the implicit `owner: address`
+    ╭─[ test:12:6 ]
+    │
+ 12 │ ╭─▶     }
+    ┆ ┆   
+ 16 │ ├─▶     }
+    │ │           
+    │ ╰─────────── here
+    │     
+    │     Help: Simplify the declaration to `record Token;`.
+────╯

--- a/tests/tests/passes/check_interfaces/duplicate_cross_kind_fail.leo
+++ b/tests/tests/passes/check_interfaces/duplicate_cross_kind_fail.leo
@@ -1,0 +1,16 @@
+// Test: an interface must reject a name being used for two different member kinds
+// (e.g. a mapping and a storage variable both called `bucket`).
+
+interface Clash {
+    mapping bucket: address => u64;
+    storage bucket: u64;
+}
+
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn main(a: u32) -> u32 {
+        return a;
+    }
+}

--- a/tests/tests/passes/check_interfaces/duplicate_function_fail.leo
+++ b/tests/tests/passes/check_interfaces/duplicate_function_fail.leo
@@ -1,0 +1,16 @@
+// Test: an interface declaring the same function name twice must be rejected.
+// Regression for ProvableHQ/leo#29560.
+
+interface Foo {
+    fn main(public a: u32, b: u32);
+    fn main(public a: u32, b: u32) -> u32;
+}
+
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn main(a: u32, b: u32) -> u32 {
+        return a;
+    }
+}

--- a/tests/tests/passes/check_interfaces/duplicate_members_fail.leo
+++ b/tests/tests/passes/check_interfaces/duplicate_members_fail.leo
@@ -1,0 +1,32 @@
+// Test: an interface must reject duplicates across every member kind
+// (functions, records, mappings, storages) — the reporter of #29560 asked
+// that we cover more than just `fn`.
+
+interface Bag {
+    fn ping();
+    fn ping() -> u32;
+
+    record Token {
+        owner: address,
+        ..
+    }
+    record Token {
+        owner: address,
+        ..
+    }
+
+    mapping counts: address => u64;
+    mapping counts: address => u64;
+
+    storage total: u64;
+    storage total: u64;
+}
+
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn main(a: u32) -> u32 {
+        return a;
+    }
+}


### PR DESCRIPTION
Fixes #29560

Adds logic to `check_interfaces` that validates there aren't any items with the same name in an interface.