### PR TITLE
Reject cross-program final fn state writes

### DIFF
--- a/crates/passes/src/cei_analysis/ordering.rs
+++ b/crates/passes/src/cei_analysis/ordering.rs
@@ -40,331 +40,17 @@
 //! interaction. The [`classify_intrinsic`] match is the single source of
 //! truth for this categorization and is exhaustive over `Intrinsic`.
 
-use crate::{CompilerState, SymbolTable, VariableType, errors::cei_analyzer};
+use crate::{
+    CompilerState,
+    common::function_effects::{Op, Summarizer, Summary, classify_intrinsic, is_storage_var, peel_assign_root},
+    errors::cei_analyzer,
+};
 
 use leo_ast::*;
 use leo_errors::Formatted;
 use leo_span::{Span, Symbol};
 
 use indexmap::{IndexMap, IndexSet};
-
-// ---------------------------------------------------------------------------
-// Classifier — the single VM-facing surface of this analysis.
-
-/// The CEI category of an operation.
-///
-/// `Read` and `Write` refer specifically to *mutable persistent state*
-/// (mappings, vectors, storage variables, dynamic external storage) that a
-/// rival program's finalize could observe or alter. Immutable environment
-/// queries and pure computations are `None`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Op {
-    /// A read of mutable persistent state.
-    Read,
-    /// A write to mutable persistent state.
-    Write,
-    /// Yields control to another program's finalize.
-    Interaction,
-}
-
-/// Classify an intrinsic. Exhaustive `match` — a new `Intrinsic` variant is a
-/// compile error until it is categorized here.
-fn classify_intrinsic(i: &Intrinsic) -> Option<Op> {
-    use Intrinsic::*;
-    match i {
-        // Mutable-state reads
-        MappingGet | MappingGetOrUse | MappingContains | VectorGet | VectorLen | DynamicContains | DynamicGet
-        | DynamicGetOrUse => Some(Op::Read),
-
-        // Mutable-state writes
-        MappingSet | MappingRemove | VectorSet | VectorPush | VectorPop | VectorClear | VectorSwapRemove => {
-            Some(Op::Write)
-        }
-
-        // Interactions
-        FinalRun => Some(Op::Interaction),
-
-        // Immutable-within-a-transaction environment queries: a rival
-        // finalize cannot change these, so a late read carries no
-        // reentrancy risk.
-        BlockHeight | BlockTimestamp | NetworkId | SelfProgramOwner | SelfAddress | SelfCaller | SelfChecksum
-        | SelfEdition | SelfId | SelfSigner | ProgramOwner | ProgramChecksum | ProgramEdition | FunctionChecksum => {
-            None
-        }
-
-        // SNARK verifications compute a boolean from arguments. If a
-        // verifying key comes from a mapping, that mapping read fires
-        // on its own.
-        SnarkVerify | SnarkVerifyBatch => None,
-
-        // Pure computations.
-        ChaChaRand(_)
-        | Commit(_, _)
-        | ECDSAVerify(_)
-        | Hash(_, _)
-        | OptionalUnwrap
-        | OptionalUnwrapOr
-        | GroupToXCoordinate
-        | GroupToYCoordinate
-        | GroupGen
-        | AleoGenerator
-        | AleoGeneratorPowers
-        | SignatureVerify
-        | Serialize(_)
-        | Deserialize(_, _) => None,
-
-        // Transition-only. Unreachable in a finalize context; earlier
-        // passes reject it there.
-        DynamicCall => None,
-    }
-}
-
-/// A plain storage variable — not a mapping and not a vector, which are
-/// only ever accessed through intrinsics.
-fn is_storage_var(sym: &SymbolTable, prog: Symbol, p: &Path) -> bool {
-    if let Some(loc) = p.try_global_location()
-        && let Some(var) = sym.lookup_global(prog, loc)
-        && var.declaration == VariableType::Storage
-    {
-        if let Some(ty) = &var.type_ {
-            return !ty.is_mapping() && !ty.is_vector();
-        }
-        return true;
-    }
-    false
-}
-
-/// Peel wrappers on an assignment LHS to find the root `Path` (the write
-/// target). Returns `None` if the root is not a `Path`.
-fn peel_assign_root(expr: &Expression) -> Option<&Path> {
-    match expr {
-        Expression::Path(p) => Some(p),
-        Expression::MemberAccess(a) => peel_assign_root(&a.inner),
-        Expression::TupleAccess(a) => peel_assign_root(&a.tuple),
-        Expression::ArrayAccess(a) => peel_assign_root(&a.array),
-        _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Effect summaries
-
-/// What CEI operations a callee transitively performs.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-struct Summary {
-    reads: bool,
-    writes: bool,
-    interacts: bool,
-}
-
-impl Summary {
-    fn merge(&mut self, other: Summary) {
-        self.reads |= other.reads;
-        self.writes |= other.writes;
-        self.interacts |= other.interacts;
-    }
-}
-
-/// Computes callee [`Summary`]s with an order-insensitive walk. It borrows only
-/// the symbol table (read) and the memo map (write) — disjoint from the rest of
-/// the [`Scanner`] — and reborrows the symbol table through its own `&'a` field,
-/// so callee bodies are summarized in place rather than cloned out.
-struct Summarizer<'a> {
-    sym: &'a SymbolTable,
-    summaries: &'a mut IndexMap<Location, Summary>,
-}
-
-impl Summarizer<'_> {
-    /// Get or compute a callee's summary. Off-chain callees (regular `fn`)
-    /// and unresolved paths return the empty summary.
-    fn summary_of(&mut self, callee: &Path) -> Summary {
-        // Copy of the shared symbol-table ref, lifetime-independent of the
-        // `&mut self` borrows below, so `func`/`block` outlive `summarize_block`.
-        let sym = self.sym;
-        let Some(loc) = callee.try_global_location() else { return Summary::default() };
-        if let Some(s) = self.summaries.get(loc) {
-            return *s;
-        }
-        let loc = loc.clone();
-        // Seed with default so any self-reference terminates. Recursion is
-        // rejected by earlier passes; this is defensive.
-        self.summaries.insert(loc.clone(), Summary::default());
-        let Some(func) = sym.lookup_function(loc.program, &loc) else {
-            return Summary::default();
-        };
-        if !func.function.variant.is_onchain() {
-            // Regular helper `fn`s can't touch state or interact.
-            return Summary::default();
-        }
-        let variant = func.function.variant;
-        let s = if func.is_stub {
-            // Callee is an external stub. Its body isn't visible as Leo AST, so
-            // we can't summarize it. Fall back to a conservative summary based
-            // on the variant, so callee-has-effects warnings still fire against
-            // externals. (A local function with a genuinely empty body is not a
-            // stub and correctly summarizes to no effects.)
-            match variant {
-                Variant::View => Summary { reads: true, writes: false, interacts: false },
-                Variant::FinalFn | Variant::Finalize => Summary { reads: true, writes: true, interacts: true },
-                Variant::Fn | Variant::EntryPoint => Summary::default(),
-            }
-        } else {
-            self.summarize_block(&func.function.block, loc.program)
-        };
-        self.summaries.insert(loc, s);
-        s
-    }
-
-    fn summarize_block(&mut self, b: &Block, prog: Symbol) -> Summary {
-        let mut s = Summary::default();
-        for stmt in &b.statements {
-            self.summarize_stmt(stmt, prog, &mut s);
-        }
-        s
-    }
-
-    fn summarize_stmt(&mut self, stmt: &Statement, prog: Symbol, s: &mut Summary) {
-        match stmt {
-            Statement::Assert(a) => match &a.variant {
-                AssertVariant::Assert(e) => self.summarize_expr(e, prog, s),
-                AssertVariant::AssertEq(l, r) | AssertVariant::AssertNeq(l, r) => {
-                    self.summarize_expr(l, prog, s);
-                    self.summarize_expr(r, prog, s);
-                }
-            },
-            Statement::Assign(a) => {
-                if let Some(root) = peel_assign_root(&a.place)
-                    && is_storage_var(self.sym, prog, root)
-                {
-                    s.writes = true;
-                }
-                self.summarize_lhs_indices(&a.place, prog, s);
-                self.summarize_expr(&a.value, prog, s);
-            }
-            Statement::Block(b) => s.merge(self.summarize_block(b, prog)),
-            Statement::Conditional(c) => {
-                self.summarize_expr(&c.condition, prog, s);
-                s.merge(self.summarize_block(&c.then, prog));
-                if let Some(o) = &c.otherwise {
-                    self.summarize_stmt(o, prog, s);
-                }
-            }
-            Statement::Const(d) => self.summarize_expr(&d.value, prog, s),
-            Statement::Definition(d) => self.summarize_expr(&d.value, prog, s),
-            Statement::Expression(e) => self.summarize_expr(&e.expression, prog, s),
-            Statement::Iteration(it) => {
-                self.summarize_expr(&it.start, prog, s);
-                self.summarize_expr(&it.stop, prog, s);
-                s.merge(self.summarize_block(&it.block, prog));
-            }
-            Statement::Return(r) => self.summarize_expr(&r.expression, prog, s),
-        }
-    }
-
-    fn summarize_lhs_indices(&mut self, expr: &Expression, prog: Symbol, s: &mut Summary) {
-        match expr {
-            Expression::Path(_) => {}
-            Expression::MemberAccess(a) => self.summarize_lhs_indices(&a.inner, prog, s),
-            Expression::TupleAccess(a) => self.summarize_lhs_indices(&a.tuple, prog, s),
-            Expression::ArrayAccess(a) => {
-                self.summarize_lhs_indices(&a.array, prog, s);
-                self.summarize_expr(&a.index, prog, s);
-            }
-            _ => {}
-        }
-    }
-
-    fn summarize_expr(&mut self, e: &Expression, prog: Symbol, s: &mut Summary) {
-        match e {
-            Expression::Intrinsic(i) => {
-                for arg in &i.arguments {
-                    self.summarize_expr(arg, prog, s);
-                }
-                if let Some(intr) = Intrinsic::from_symbol(i.name, &i.type_parameters)
-                    && let Some(op) = classify_intrinsic(&intr)
-                {
-                    match op {
-                        Op::Read => s.reads = true,
-                        Op::Write => s.writes = true,
-                        Op::Interaction => s.interacts = true,
-                    }
-                }
-            }
-            Expression::Call(c) => {
-                for arg in &c.arguments {
-                    self.summarize_expr(arg, prog, s);
-                }
-                let cs = self.summary_of(&c.function);
-                s.merge(cs);
-            }
-            Expression::DynamicOp(d) => {
-                self.summarize_expr(&d.target_program, prog, s);
-                if let Some(n) = &d.network {
-                    self.summarize_expr(n, prog, s);
-                }
-                match &d.kind {
-                    DynamicOpKind::Call { arguments, .. } => {
-                        for arg in arguments {
-                            self.summarize_expr(arg, prog, s);
-                        }
-                    }
-                    DynamicOpKind::Read { .. } => s.reads = true,
-                    DynamicOpKind::Op { arguments, .. } => {
-                        s.reads = true;
-                        for arg in arguments {
-                            self.summarize_expr(arg, prog, s);
-                        }
-                    }
-                }
-            }
-            Expression::Path(p) => {
-                if is_storage_var(self.sym, prog, p) {
-                    s.reads = true;
-                }
-            }
-            Expression::Binary(b) => {
-                self.summarize_expr(&b.left, prog, s);
-                self.summarize_expr(&b.right, prog, s);
-            }
-            Expression::Unary(u) => self.summarize_expr(&u.receiver, prog, s),
-            Expression::Ternary(t) => {
-                self.summarize_expr(&t.condition, prog, s);
-                self.summarize_expr(&t.if_true, prog, s);
-                self.summarize_expr(&t.if_false, prog, s);
-            }
-            Expression::Cast(c) => self.summarize_expr(&c.expression, prog, s),
-            Expression::Tuple(t) => {
-                for e in &t.elements {
-                    self.summarize_expr(e, prog, s);
-                }
-            }
-            Expression::Array(a) => {
-                for e in &a.elements {
-                    self.summarize_expr(e, prog, s);
-                }
-            }
-            Expression::ArrayAccess(a) => {
-                self.summarize_expr(&a.array, prog, s);
-                self.summarize_expr(&a.index, prog, s);
-            }
-            Expression::MemberAccess(a) => self.summarize_expr(&a.inner, prog, s),
-            Expression::TupleAccess(a) => self.summarize_expr(&a.tuple, prog, s),
-            Expression::Composite(c) => {
-                for m in &c.members {
-                    if let Some(e) = &m.expression {
-                        self.summarize_expr(e, prog, s);
-                    }
-                }
-            }
-            Expression::Repeat(r) => {
-                self.summarize_expr(&r.expr, prog, s);
-                self.summarize_expr(&r.count, prog, s);
-            }
-            Expression::Async(a) => s.merge(self.summarize_block(&a.block, prog)),
-            Expression::Literal(_) | Expression::Unit(_) | Expression::Err(_) => {}
-        }
-    }
-}
 
 // ---------------------------------------------------------------------------
 // Scanner
@@ -450,7 +136,7 @@ impl<'a> Scanner<'a> {
     // from the rest of the scanner so callee bodies need not be cloned.
 
     fn summarizer(&mut self) -> Summarizer<'_> {
-        Summarizer { sym: &self.state.symbol_table, summaries: &mut self.summaries }
+        Summarizer::new(&self.state.symbol_table, &mut self.summaries)
     }
 
     // -----------------------------------------------------------------
@@ -524,15 +210,8 @@ impl<'a> Scanner<'a> {
 
         // Iteration i's non-interactions come after iteration i-1's
         // interaction, so a body containing both violates CEI.
-        let body_summary = {
-            let mut s = Summary::default();
-            let prog = self.program;
-            let mut summarizer = self.summarizer();
-            for st in &it.block.statements {
-                summarizer.summarize_stmt(st, prog, &mut s);
-            }
-            s
-        };
+        let prog = self.program;
+        let body_summary = self.summarizer().summarize_block(&it.block, prog);
         if body_summary.interacts && (body_summary.reads || body_summary.writes) {
             let span = it.variable.span();
             self.emit(span, Warning::Loop, cei_analyzer::cei_violation_in_loop(span));
@@ -593,6 +272,9 @@ impl<'a> Scanner<'a> {
                     if let Some(e) = &m.expression {
                         post = self.scan_expr(e, post);
                     }
+                }
+                if let Some(base) = &c.base {
+                    post = self.scan_expr(base, post);
                 }
                 post
             }

--- a/crates/passes/src/common/function_effects.rs
+++ b/crates/passes/src/common/function_effects.rs
@@ -124,8 +124,12 @@ impl Summary {
     }
 }
 
-pub(crate) fn function_writes_state(symbol_table: &SymbolTable, function: &Path) -> bool {
-    Summarizer::new(symbol_table, &mut IndexMap::new()).summary_of(function).writes
+pub(crate) fn function_writes_state(
+    symbol_table: &SymbolTable,
+    summaries: &mut IndexMap<Location, Summary>,
+    function: &Path,
+) -> bool {
+    Summarizer::new(symbol_table, summaries).summary_of(function).writes
 }
 
 /// Computes function summaries with an order-insensitive walk, borrowing

--- a/crates/passes/src/common/function_effects.rs
+++ b/crates/passes/src/common/function_effects.rs
@@ -1,0 +1,329 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use super::{SymbolTable, VariableType};
+
+use leo_ast::*;
+use leo_span::Symbol;
+
+use indexmap::IndexMap;
+
+/// The effect of an operation relevant to on-chain execution.
+///
+/// Reads and writes refer specifically to mutable persistent state that
+/// another program's finalizer could observe or alter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Op {
+    /// A read of mutable persistent state.
+    Read,
+    /// A write to mutable persistent state.
+    Write,
+    /// Yields control to another program's finalizer.
+    Interaction,
+}
+
+/// Classify an intrinsic. Exhaustive `match` — a new `Intrinsic` variant is a
+/// compile error until it is categorized here.
+pub(crate) fn classify_intrinsic(i: &Intrinsic) -> Option<Op> {
+    use Intrinsic::*;
+    match i {
+        // Mutable-state reads.
+        MappingGet | MappingGetOrUse | MappingContains | VectorGet | VectorLen | DynamicContains | DynamicGet
+        | DynamicGetOrUse => Some(Op::Read),
+
+        // Mutable-state writes.
+        MappingSet | MappingRemove | VectorSet | VectorPush | VectorPop | VectorClear | VectorSwapRemove => {
+            Some(Op::Write)
+        }
+
+        // Interactions.
+        FinalRun => Some(Op::Interaction),
+
+        // Immutable-within-a-transaction environment queries.
+        BlockHeight | BlockTimestamp | NetworkId | SelfProgramOwner | SelfAddress | SelfCaller | SelfChecksum
+        | SelfEdition | SelfId | SelfSigner | ProgramOwner | ProgramChecksum | ProgramEdition | FunctionChecksum => {
+            None
+        }
+
+        // Pure verification operations.
+        SnarkVerify | SnarkVerifyBatch => None,
+
+        // Pure computations.
+        ChaChaRand(_)
+        | Commit(_, _)
+        | ECDSAVerify(_)
+        | Hash(_, _)
+        | OptionalUnwrap
+        | OptionalUnwrapOr
+        | GroupToXCoordinate
+        | GroupToYCoordinate
+        | GroupGen
+        | AleoGenerator
+        | AleoGeneratorPowers
+        | SignatureVerify
+        | Serialize(_)
+        | Deserialize(_, _) => None,
+
+        // Transition-only.
+        DynamicCall => None,
+    }
+}
+
+/// A plain storage variable — not a mapping and not a vector, which are
+/// only ever accessed through intrinsics.
+pub(crate) fn is_storage_var(sym: &SymbolTable, prog: Symbol, p: &Path) -> bool {
+    if let Some(loc) = p.try_global_location()
+        && let Some(var) = sym.lookup_global(prog, loc)
+        && var.declaration == VariableType::Storage
+    {
+        if let Some(ty) = &var.type_ {
+            return !ty.is_mapping() && !ty.is_vector();
+        }
+        return true;
+    }
+    false
+}
+
+/// Peel wrappers on an assignment LHS to find the root `Path`, if any.
+pub(crate) fn peel_assign_root(expr: &Expression) -> Option<&Path> {
+    match expr {
+        Expression::Path(p) => Some(p),
+        Expression::MemberAccess(a) => peel_assign_root(&a.inner),
+        Expression::TupleAccess(a) => peel_assign_root(&a.tuple),
+        Expression::ArrayAccess(a) => peel_assign_root(&a.array),
+        _ => None,
+    }
+}
+
+/// The effects a function transitively performs.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct Summary {
+    pub(crate) reads: bool,
+    pub(crate) writes: bool,
+    pub(crate) interacts: bool,
+}
+
+impl Summary {
+    pub(crate) fn merge(&mut self, other: Summary) {
+        self.reads |= other.reads;
+        self.writes |= other.writes;
+        self.interacts |= other.interacts;
+    }
+}
+
+pub(crate) fn function_writes_state(symbol_table: &SymbolTable, function: &Path) -> bool {
+    Summarizer::new(symbol_table, &mut IndexMap::new()).summary_of(function).writes
+}
+
+/// Computes function summaries with an order-insensitive walk, borrowing
+/// function bodies directly from the symbol table.
+pub(crate) struct Summarizer<'a> {
+    sym: &'a SymbolTable,
+    summaries: &'a mut IndexMap<Location, Summary>,
+}
+
+impl<'a> Summarizer<'a> {
+    pub(crate) fn new(sym: &'a SymbolTable, summaries: &'a mut IndexMap<Location, Summary>) -> Self {
+        Self { sym, summaries }
+    }
+
+    /// Get or compute a callee's summary. Off-chain callees (regular `fn`)
+    /// and unresolved paths return the empty summary.
+    pub(crate) fn summary_of(&mut self, callee: &Path) -> Summary {
+        let sym = self.sym;
+        let Some(loc) = callee.try_global_location() else { return Summary::default() };
+        if let Some(s) = self.summaries.get(loc) {
+            return *s;
+        }
+        let loc = loc.clone();
+        // Seed the cache so self-references terminate. Recursion is rejected
+        // by an earlier pass.
+        self.summaries.insert(loc.clone(), Summary::default());
+        let Some(func) = sym.lookup_function(loc.program, &loc) else {
+            return Summary::default();
+        };
+        if !func.function.variant.is_onchain() {
+            return Summary::default();
+        }
+        let variant = func.function.variant;
+        let s = if func.is_stub {
+            // The Leo body of an external stub may be unavailable, so use a
+            // conservative summary based on its variant.
+            match variant {
+                Variant::View => Summary { reads: true, writes: false, interacts: false },
+                Variant::FinalFn | Variant::Finalize => Summary { reads: true, writes: true, interacts: true },
+                Variant::Fn | Variant::EntryPoint => Summary::default(),
+            }
+        } else {
+            self.summarize_block(&func.function.block, loc.program)
+        };
+        self.summaries.insert(loc, s);
+        s
+    }
+
+    pub(crate) fn summarize_block(&mut self, b: &Block, prog: Symbol) -> Summary {
+        let mut s = Summary::default();
+        for stmt in &b.statements {
+            self.summarize_stmt(stmt, prog, &mut s);
+        }
+        s
+    }
+
+    fn summarize_stmt(&mut self, stmt: &Statement, prog: Symbol, s: &mut Summary) {
+        match stmt {
+            Statement::Assert(a) => match &a.variant {
+                AssertVariant::Assert(e) => self.summarize_expr(e, prog, s),
+                AssertVariant::AssertEq(l, r) | AssertVariant::AssertNeq(l, r) => {
+                    self.summarize_expr(l, prog, s);
+                    self.summarize_expr(r, prog, s);
+                }
+            },
+            Statement::Assign(a) => {
+                if let Some(root) = peel_assign_root(&a.place)
+                    && is_storage_var(self.sym, prog, root)
+                {
+                    s.writes = true;
+                }
+                self.summarize_lhs_indices(&a.place, prog, s);
+                self.summarize_expr(&a.value, prog, s);
+            }
+            Statement::Block(b) => s.merge(self.summarize_block(b, prog)),
+            Statement::Conditional(c) => {
+                self.summarize_expr(&c.condition, prog, s);
+                s.merge(self.summarize_block(&c.then, prog));
+                if let Some(o) = &c.otherwise {
+                    self.summarize_stmt(o, prog, s);
+                }
+            }
+            Statement::Const(d) => self.summarize_expr(&d.value, prog, s),
+            Statement::Definition(d) => self.summarize_expr(&d.value, prog, s),
+            Statement::Expression(e) => self.summarize_expr(&e.expression, prog, s),
+            Statement::Iteration(it) => {
+                self.summarize_expr(&it.start, prog, s);
+                self.summarize_expr(&it.stop, prog, s);
+                s.merge(self.summarize_block(&it.block, prog));
+            }
+            Statement::Return(r) => self.summarize_expr(&r.expression, prog, s),
+        }
+    }
+
+    fn summarize_lhs_indices(&mut self, expr: &Expression, prog: Symbol, s: &mut Summary) {
+        match expr {
+            Expression::Path(_) => {}
+            Expression::MemberAccess(a) => self.summarize_lhs_indices(&a.inner, prog, s),
+            Expression::TupleAccess(a) => self.summarize_lhs_indices(&a.tuple, prog, s),
+            Expression::ArrayAccess(a) => {
+                self.summarize_lhs_indices(&a.array, prog, s);
+                self.summarize_expr(&a.index, prog, s);
+            }
+            _ => {}
+        }
+    }
+
+    fn summarize_expr(&mut self, e: &Expression, prog: Symbol, s: &mut Summary) {
+        match e {
+            Expression::Intrinsic(i) => {
+                for arg in &i.arguments {
+                    self.summarize_expr(arg, prog, s);
+                }
+                if let Some(intr) = Intrinsic::from_symbol(i.name, &i.type_parameters)
+                    && let Some(op) = classify_intrinsic(&intr)
+                {
+                    match op {
+                        Op::Read => s.reads = true,
+                        Op::Write => s.writes = true,
+                        Op::Interaction => s.interacts = true,
+                    }
+                }
+            }
+            Expression::Call(c) => {
+                for arg in &c.arguments {
+                    self.summarize_expr(arg, prog, s);
+                }
+                let cs = self.summary_of(&c.function);
+                s.merge(cs);
+            }
+            Expression::DynamicOp(d) => {
+                self.summarize_expr(&d.target_program, prog, s);
+                if let Some(n) = &d.network {
+                    self.summarize_expr(n, prog, s);
+                }
+                match &d.kind {
+                    DynamicOpKind::Call { arguments, .. } => {
+                        for arg in arguments {
+                            self.summarize_expr(arg, prog, s);
+                        }
+                    }
+                    DynamicOpKind::Read { .. } => s.reads = true,
+                    DynamicOpKind::Op { arguments, .. } => {
+                        s.reads = true;
+                        for arg in arguments {
+                            self.summarize_expr(arg, prog, s);
+                        }
+                    }
+                }
+            }
+            Expression::Path(p) => {
+                if is_storage_var(self.sym, prog, p) {
+                    s.reads = true;
+                }
+            }
+            Expression::Binary(b) => {
+                self.summarize_expr(&b.left, prog, s);
+                self.summarize_expr(&b.right, prog, s);
+            }
+            Expression::Unary(u) => self.summarize_expr(&u.receiver, prog, s),
+            Expression::Ternary(t) => {
+                self.summarize_expr(&t.condition, prog, s);
+                self.summarize_expr(&t.if_true, prog, s);
+                self.summarize_expr(&t.if_false, prog, s);
+            }
+            Expression::Cast(c) => self.summarize_expr(&c.expression, prog, s),
+            Expression::Tuple(t) => {
+                for e in &t.elements {
+                    self.summarize_expr(e, prog, s);
+                }
+            }
+            Expression::Array(a) => {
+                for e in &a.elements {
+                    self.summarize_expr(e, prog, s);
+                }
+            }
+            Expression::ArrayAccess(a) => {
+                self.summarize_expr(&a.array, prog, s);
+                self.summarize_expr(&a.index, prog, s);
+            }
+            Expression::MemberAccess(a) => self.summarize_expr(&a.inner, prog, s),
+            Expression::TupleAccess(a) => self.summarize_expr(&a.tuple, prog, s),
+            Expression::Composite(c) => {
+                for m in &c.members {
+                    if let Some(e) = &m.expression {
+                        self.summarize_expr(e, prog, s);
+                    }
+                }
+                if let Some(base) = &c.base {
+                    self.summarize_expr(base, prog, s);
+                }
+            }
+            Expression::Repeat(r) => {
+                self.summarize_expr(&r.expr, prog, s);
+                self.summarize_expr(&r.count, prog, s);
+            }
+            Expression::Async(a) => s.merge(self.summarize_block(&a.block, prog)),
+            Expression::Literal(_) | Expression::Unit(_) | Expression::Err(_) => {}
+        }
+    }
+}

--- a/crates/passes/src/common/mod.rs
+++ b/crates/passes/src/common/mod.rs
@@ -23,6 +23,9 @@ pub use assigner::*;
 mod block_to_function_rewriter;
 pub use block_to_function_rewriter::*;
 
+pub(crate) mod function_effects;
+pub(crate) use function_effects::function_writes_state;
+
 mod rename_table;
 pub use rename_table::*;
 

--- a/crates/passes/src/errors/type_checker.rs
+++ b/crates/passes/src/errors/type_checker.rs
@@ -1138,6 +1138,16 @@ pub(crate) fn offchain_op_in_view(operation: impl Display, span: Span) -> Format
         .with_help("Read the value in an off-chain scope and pass it in.")
 }
 
+pub(crate) fn external_final_fn_writes_state(function: impl Display, span: Span) -> Formatted {
+    Formatted::error(
+        CODE_PREFIX,
+        CODE_MASK + 197,
+        format!("`{function}` cannot be called from another program because it may write on-chain state"),
+        span,
+    )
+    .with_help("Call a transition in that program instead, or make the `final fn` read-only.")
+}
+
 // TypeCheckerWarning builder functions
 
 pub(crate) fn caller_as_record_owner(record_name: impl Display, span: Span) -> Formatted {

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1255,7 +1255,11 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
         // Check the declared body so const specialization cannot erase state writes.
         if matches!(func.variant, Variant::FinalFn)
             && callee_program != current_program
-            && crate::common::function_writes_state(&self.state.symbol_table, &input.function)
+            && crate::common::function_writes_state(
+                &self.state.symbol_table,
+                &mut self.function_effect_summaries,
+                &input.function,
+            )
         {
             self.emit_err(crate::errors::type_checker::external_final_fn_writes_state(&input.function, input.span));
         }

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -1252,6 +1252,14 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
             return TypeKind::Err;
         }
 
+        // Check the declared body so const specialization cannot erase state writes.
+        if matches!(func.variant, Variant::FinalFn)
+            && callee_program != current_program
+            && crate::common::function_writes_state(&self.state.symbol_table, &input.function)
+        {
+            self.emit_err(crate::errors::type_checker::external_final_fn_writes_state(&input.function, input.span));
+        }
+
         // Regular `fn`s are inlined into the caller's scope; if any transitively-called function
         // reaches an off-chain-only intrinsic (`_self_caller` / `_self_signer`), the inlined body
         // would emit e.g. `self.caller` in the caller's context. Record this callsite so a

--- a/crates/passes/src/type_checking/mod.rs
+++ b/crates/passes/src/type_checking/mod.rs
@@ -109,6 +109,7 @@ impl Pass for TypeChecking {
             async_function_input_types: IndexMap::new(),
             async_function_callers: IndexMap::new(),
             used_composites: IndexSet::new(),
+            function_effect_summaries: IndexMap::new(),
             conditional_scopes: Vec::new(),
             limits: input,
             async_block_id: None,

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{CompilerState, type_checking::scope_state::ScopeState};
+use crate::{CompilerState, common::function_effects::Summary, type_checking::scope_state::ScopeState};
 
 use super::*;
 
@@ -66,6 +66,8 @@ pub struct TypeCheckingVisitor<'a> {
     pub async_function_callers: IndexMap<Location, IndexSet<Location>>,
     /// The set of used composites.
     pub used_composites: IndexSet<Location>,
+    /// Function-effect summaries cached for this type-checking run.
+    pub function_effect_summaries: IndexMap<Location, Summary>,
     /// So we can check if we exceed limits on array size, number of mappings, or number of functions.
     pub limits: TypeCheckingInput,
     /// For detecting the error `crate::errors::type_checker::async_cannot_assign_outside_conditional`.

--- a/tests/expectations/compiler/finalize/cross_program_final_fn_write_fail.out
+++ b/tests/expectations/compiler/finalize/cross_program_final_fn_write_fail.out
@@ -1,0 +1,54 @@
+[ETYC0372197] Error: `registry.aleo::maybe_register` cannot be called from another program because it may write on-chain state
+   ╭─[ compiler-test:8:13 ]
+   │
+ 8 │             registry.aleo::maybe_register::[false](addr);
+   │ 
+   │ Help: Call a transition in that program instead, or make the `final fn` read-only.
+───╯
+[ETYC0372197] Error: `registry.aleo::maybe_register` cannot be called from another program because it may write on-chain state
+   ╭─[ compiler-test:9:13 ]
+   │
+ 9 │             registry.aleo::maybe_register::[true](addr);
+   │ 
+   │ Help: Call a transition in that program instead, or make the `final fn` read-only.
+───╯
+[ETYC0372197] Error: `registry.aleo::finalize_register_wrapper` cannot be called from another program because it may write on-chain state
+    ╭─[ compiler-test:10:13 ]
+    │
+ 10 │             registry.aleo::finalize_register_wrapper(addr);
+    │ 
+    │ Help: Call a transition in that program instead, or make the `final fn` read-only.
+────╯
+
+
+---
+Note: Treating dependencies as Aleo produces different results:
+
+[ETYC0372005] Error: unknown function `registry.aleo::is_registered`
+   ╭─[ compiler-test:7:23 ]
+   │
+ 7 │             assert_eq(registry.aleo::is_registered(addr), true);
+   │ 
+   │ Help: Check `registry.aleo::is_registered` for typos and confirm it is declared in this scope. If it lives in another program, import it with the program-qualified name (e.g. `credits.aleo::credits`).
+───╯
+[ETYC0372005] Error: unknown function `registry.aleo::maybe_register`
+   ╭─[ compiler-test:8:13 ]
+   │
+ 8 │             registry.aleo::maybe_register::[false](addr);
+   │ 
+   │ Help: Check `registry.aleo::maybe_register` for typos and confirm it is declared in this scope. If it lives in another program, import it with the program-qualified name (e.g. `credits.aleo::credits`).
+───╯
+[ETYC0372005] Error: unknown function `registry.aleo::maybe_register`
+   ╭─[ compiler-test:9:13 ]
+   │
+ 9 │             registry.aleo::maybe_register::[true](addr);
+   │ 
+   │ Help: Check `registry.aleo::maybe_register` for typos and confirm it is declared in this scope. If it lives in another program, import it with the program-qualified name (e.g. `credits.aleo::credits`).
+───╯
+[ETYC0372005] Error: unknown function `registry.aleo::finalize_register_wrapper`
+    ╭─[ compiler-test:10:13 ]
+    │
+ 10 │             registry.aleo::finalize_register_wrapper(addr);
+    │ 
+    │ Help: Check `registry.aleo::finalize_register_wrapper` for typos and confirm it is declared in this scope. If it lives in another program, import it with the program-qualified name (e.g. `credits.aleo::credits`).
+────╯

--- a/tests/tests/compiler/finalize/cross_program_final_fn_write_fail.leo
+++ b/tests/tests/compiler/finalize/cross_program_final_fn_write_fail.leo
@@ -1,0 +1,52 @@
+export struct Registration {
+    registered: bool,
+    count: u32,
+}
+
+program registry.aleo {
+    mapping users: address => bool;
+
+    fn register(addr: address) -> Final {
+        return final { finalize_register(addr); };
+    }
+
+    @noupgrade
+    constructor() {}
+}
+
+export final fn finalize_register(addr: address) -> Registration {
+    Mapping::set(users, addr, true);
+    return Registration { registered: true, count: 1u32 };
+}
+
+export final fn finalize_register_wrapper(addr: address) -> Registration {
+    return Registration { registered: false, ..finalize_register(addr) };
+}
+
+export final fn is_registered(addr: address) -> bool {
+    return Mapping::get_or_use(users, addr, false);
+}
+
+export final fn maybe_register::[WRITE: bool](addr: address) -> bool {
+    if WRITE {
+        Mapping::set(users, addr, true);
+    }
+    return is_registered(addr);
+}
+
+// --- Next Program --- //
+import registry.aleo;
+
+program relay.aleo {
+    fn relay(addr: address) -> Final {
+        return final {
+            assert_eq(registry.aleo::is_registered(addr), true);
+            registry.aleo::maybe_register::[false](addr);
+            registry.aleo::maybe_register::[true](addr);
+            registry.aleo::finalize_register_wrapper(addr);
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
Closes #29572.

Rejects cross-program `final fn` calls whose bodies may directly or transitively write on-chain state. Read-only calls remain allowed. State effects are summarized once in a common utility shared with CEI.