### PR TITLE
Make `leo test` output nicer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5295,7 +5295,8 @@ dependencies = [
 [[package]]
 name = "snarkvm"
 version = "4.8.1"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e35ef2036e93bbfa2342f8c53c134f84d00f4e6cf008c577c88c88f95acdeb9"
 dependencies = [
  "anyhow",
  "dotenvy",
@@ -5314,8 +5315,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9324633a2ca8e6c1796d7d8d5a65f21aa03545acc7552db05d5b54ae6895093d"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5341,8 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3100c3d4a0950ccbfdee58640e3da7e6ea421883f26d89e684ce2acd0a8a8b"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5355,8 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-account"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ece1b5d533eb975a4971b1cd113583db4b1503f706f5c000dd4aa29d6adb07"
 dependencies = [
  "snarkvm-circuit-network",
  "snarkvm-circuit-types",
@@ -5365,8 +5369,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9ffedabd1d2a20ef1c776174235a460ba5eb92a38ee2ece59b565045371829"
 dependencies = [
  "snarkvm-circuit-types",
  "snarkvm-console-algorithms",
@@ -5375,8 +5380,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-collections"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3060cfc0d863fd1d3244b2c722864b5b54b36c1b252c27f285d6e20bdb6147"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-types",
@@ -5385,8 +5391,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4c7ab151b346df065a7e7eed58ae88f34d81bcd2443957140056a83215d41b"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -5405,13 +5412,15 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-environment-witness"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58e027011380f20228c56366d578f0a1a768dd93a4199c54676f55b4486101a"
 
 [[package]]
 name = "snarkvm-circuit-network"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8f8b926e687ad79726fc5f100fd94296eb409473aed122d3defae3ff8d4d31"
 dependencies = [
  "snarkvm-circuit-algorithms",
  "snarkvm-circuit-collections",
@@ -5421,8 +5430,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89218041e04e1fbca9b0dc26cb1124cc03d3c3fe02b83fe578ff9effb3fb59fb"
 dependencies = [
  "snarkvm-circuit-account",
  "snarkvm-circuit-algorithms",
@@ -5435,8 +5445,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e31ebf0f2725c9e04a279ae9093858aa2b20eb6c287d3b653d584b638f5540"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-address",
@@ -5450,8 +5461,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-address"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee5cbebc2b4eb00b690699167cf70ef0dc74da8509c9c0b93368b26d03bcba5"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5463,8 +5475,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-boolean"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf2299aafd7df0695a8a9816d689bbae134227bc5a4d30f9f2f33234d706427"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-console-types-boolean",
@@ -5472,8 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-field"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2122f8eaa4eff3dd62d9fffebcb2f455e157d264b45dca12c4be537acb7d5b7c"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5482,8 +5496,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-group"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a5e1863624072d61d6a3cc3c1bae47839ff819439f132e574b866a5de9d98"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5494,8 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-integers"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1fc42313949a3895a5ab91b4ebb5ff02b11bceb41235f82b37c84f8c0ad763"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5506,8 +5522,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-scalar"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fb89773ab0afed9ef9042c10c52d6f0b7589bb57e11444135d12d53026617"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5517,8 +5534,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-circuit-types-string"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3f0b44d842e53af04afceff1629b5945be0e281c92ddb5e72c7ae0c49c3b14"
 dependencies = [
  "snarkvm-circuit-environment",
  "snarkvm-circuit-types-boolean",
@@ -5529,8 +5547,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34c436414e7c2de53f18704a841af7c818101cd87337fd25a4c8bf69b13e741"
 dependencies = [
  "snarkvm-console-account",
  "snarkvm-console-algorithms",
@@ -5542,8 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-account"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15550d188aa870e051b6a40d6868eb01d9367546fbc1c7878c195b4ab8a680e"
 dependencies = [
  "bs58",
  "snarkvm-console-network",
@@ -5553,8 +5573,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-algorithms"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25f8b9b2b39d0a9a94afb2e711cb7540f7b58483ebea10a42610582604bad44"
 dependencies = [
  "blake2s_simd",
  "hex",
@@ -5569,8 +5590,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-collections"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa3af2a6ea79048d641561b8fa1522ea2658f7f2e8c0cf2c94a7f126529b786"
 dependencies = [
  "aleo-std",
  "parking_lot",
@@ -5582,8 +5604,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c4ae1a3511bd3fc8eda645c4090f48b4242bc40f5accc67cf1da5c26393fef"
 dependencies = [
  "anyhow",
  "enum-iterator",
@@ -5602,8 +5625,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-network-environment"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9abb04b58b02f1ae1fe308bc89cf8521023bc5836bf00de43dcf927672dc29d5"
 dependencies = [
  "anyhow",
  "bech32",
@@ -5620,8 +5644,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7a3b00538fd345023f76216b95a40e09521ac30c23eab5e10fccc8bffdbc6c"
 dependencies = [
  "enum-iterator",
  "enum_index",
@@ -5641,8 +5666,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffef5883feaf28a35cc3576952b13553e4b32817067c44ca458459650929d09d"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-address",
@@ -5656,8 +5682,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-address"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc8bb7d753d9cb569ee0c451793d1aa3150055fd04b19d2f1afd2ed0d9eb025"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5667,16 +5694,18 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-boolean"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fb594e3b6260d237b41b160d5522a5d7e8faf845066db906c7340779c4d850"
 dependencies = [
  "snarkvm-console-network-environment",
 ]
 
 [[package]]
 name = "snarkvm-console-types-field"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3e36c42202308bbf81a605670e3417f4c04817954026c6f3de273e091cebac"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5685,8 +5714,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-group"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d042f829548154d28bef6af8dd00bbb731cc350c72a133db52ab7e0365687f3"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5696,8 +5726,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-integers"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bfc35c8b39c6688edcbeed60172e43a6a07e6676b06343901b5e306e7579e07"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5707,8 +5738,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-scalar"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704c2654e977afdc9682e2a4967f6cd7ee24019cb80744cc80c0e6df70508265"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5718,8 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-console-types-string"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c846bbc6076b0ce20e8fb1198a04743ef342a7d57e1845d142627abef396702b"
 dependencies = [
  "snarkvm-console-network-environment",
  "snarkvm-console-types-boolean",
@@ -5729,8 +5762,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-curves"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884289cd786abe0e31e97fcf9c4dbc6cc988cd47da8ec3854e4f061af1f1e325"
 dependencies = [
  "rand 0.10.1",
  "rustc_version",
@@ -5742,8 +5776,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-fields"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0c322a2c9b7222e7d0fed1559a5a5104b272b364eebec31499b1b3aba00c95c"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5759,8 +5794,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b77772aded094332fab5fe488bc0280f2f94e78aeea2b87fcf2be0cb49444ed"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5789,8 +5825,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-authority"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb5d31f0e2a414aa8c2f40e4d80ebacde351adda4171b7dcd68b0cbe8ca10b0"
 dependencies = [
  "anyhow",
  "rand 0.10.1",
@@ -5801,8 +5838,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-block"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108da50438afee00396cb2c48419662ec2da8e771ec3a9f1a5b1ae794be98725"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -5825,8 +5863,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-committee"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b77dbf03fcfd0fa38bed6bc0cb9816fbb51d343db23346e56462c6c43c3e0083"
 dependencies = [
  "indexmap",
  "rayon",
@@ -5837,8 +5876,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f82a9d27b7bad806115fa1dddaf043c1e168d8d4bc54fead73f98a472b4419"
 dependencies = [
  "snarkvm-ledger-narwhal-batch-certificate",
  "snarkvm-ledger-narwhal-batch-header",
@@ -5850,8 +5890,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-certificate"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da425de42fdf84271ac1268d68ddd8d4f6bfc46b2804d754d8aee7fea46938cf"
 dependencies = [
  "indexmap",
  "rayon",
@@ -5863,8 +5904,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-batch-header"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f15ab0b561a2a882c95cd961f7fdaf4370cbf8d0590a726a9e6cf8c4ba8b4f5"
 dependencies = [
  "indexmap",
  "rayon",
@@ -5875,8 +5917,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-data"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c15656c4a89d7ab71d1883ad16e62148c82b30f335af8a25146ad3a6db4d5703"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5886,8 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-subdag"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4200e2f5f7a4312673123650a508148977e3d3695e49df84cc7a8420c428f5be"
 dependencies = [
  "indexmap",
  "rayon",
@@ -5901,8 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133fa30f6a0c37cb027361b7630216f501bee08fd7a616b5a431afebaa52f798"
 dependencies = [
  "bytes",
  "serde_json",
@@ -5914,8 +5959,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-narwhal-transmission-id"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721fe467857f3f85aed85958a72fd3ddf333c1aa60bc8fca2c0770e1915682c6"
 dependencies = [
  "snarkvm-console",
  "snarkvm-ledger-puzzle",
@@ -5923,8 +5969,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0df3fdd09d494e649609f066155792e81ce57c218af0d250c3af963e878bdf2e"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5943,8 +5990,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-puzzle-epoch"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75d413a7b9eeecd59bfbfe088fa9177cdc0aea2004e66be4acd7d66314d3af91"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -5965,8 +6013,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-query"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83e392b4439236341c4a376246fa4cf5fb8ca368f69f09aceab04dfa515f7f8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5982,8 +6031,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-ledger-store"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f780376da38c5efbdcf137a05d96d3cf492b87d30f3d8a5c7eecf8c48273273b"
 dependencies = [
  "aleo-std-storage",
  "anyhow",
@@ -6009,8 +6059,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-parameters"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6560dfd95e2963b86baae31222609cb7e5fcc734dbfbf5993559c56a6c6fa51"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6034,8 +6085,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "800fd59b4942e3ad2d06982f8f531a80706ca0fdd72f92a1e255cf47747dac20"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6069,8 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-error"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "052014a8b414daaf1c4ba5582e9ddf8505b2c28ea8c09affd7c4b75a3bbfdcda"
 dependencies = [
  "anyhow",
  "snarkvm-circuit-environment",
@@ -6081,8 +6134,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-process"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26e0212359bcc226fa24019d24be728e414b00d5846218129adcb8d4ff74ae78"
 dependencies = [
  "aleo-std",
  "colored 3.1.1",
@@ -6107,8 +6161,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-program"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14344567bdaac5d8aaa82e1e1fc458e448ec53f59b62d7c6808bfe60e39981c0"
 dependencies = [
  "enum-iterator",
  "indexmap",
@@ -6128,8 +6183,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-synthesizer-snark"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71052ce457f0ec7fefae8d3fb07b21a0cc3007c0956f6cd2a3b247113c393dc3"
 dependencies = [
  "bincode",
  "serde_json",
@@ -6141,8 +6197,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee1c9ddbc365e6575e3991bf191d8c0c42d9e55ba3963e7819ef047d77462e25"
 dependencies = [
  "aleo-std",
  "anyhow",
@@ -6164,8 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "snarkvm-utilities-derives"
-version = "4.7.3"
-source = "git+https://github.com/ProvableHQ/snarkVM?tag=v4.8.1#b7f0859592c75dd251430377240c7697a37ab899"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a757dd7c952d69e6385cd0621c5c8ee7d4ab874f3ddc34b62a8d6bbfc56ae9ce"
 dependencies = [
  "proc-macro2",
  "quote 1.0.46",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,16 +80,12 @@ serial_test        = "3.5"
 sha2               = "0.11"
 signal-hook        = { version = "0.4", features = [ "iterator" ] }
 similar            = "3.1"
-# We enable "test_consensus_heights" to give developers freedom to set custom consensus version upgrade heights and "test_targets" because the devnode's genesis block was created with the same feature flag.
-# Pinned to the snarkVM `v4.8.1` tag, which ships consensus V17 (the latest) on top of V16's
-# `ComponentChecksum` operand and 2048 kB program size limit. Not yet published to crates.io, so all three crates track the same tag.
-# `history` is required to compile `Process::evaluate_view_with_history`, the public-facing view entry point.
-snarkvm            = { git = "https://github.com/ProvableHQ/snarkVM", tag = "v4.8.1", features = [ "test_consensus_heights", "dev_skip_checks", "test_targets", "history" ] }
-# Wasm-friendly snarkVM subsets pinned at the same tag as the umbrella crate; used by
-# `leo-ast` and `leo-disassembler` on `wasm32-unknown-unknown` where the full `snarkvm`
-# crate pulls in native-only ledger/package code.
-snarkvm-console = { git = "https://github.com/ProvableHQ/snarkVM", tag = "v4.8.1", default-features = false, features = [ "account", "program", "types", "dev_skip_checks", "test_consensus_heights", "test_targets", "wasm" ] }
-snarkvm-synthesizer-program = { git = "https://github.com/ProvableHQ/snarkVM", tag = "v4.8.1", features = [ "wasm" ] }
+# Custom consensus heights support local devnets, and `test_targets` matches the devnode genesis block.
+# `history` exposes the public view-evaluation entry point.
+snarkvm            = { version = "4.8.1", features = [ "test_consensus_heights", "dev_skip_checks", "test_targets", "history" ] }
+# Wasm builds use smaller snarkVM subsets to avoid native-only ledger and package code.
+snarkvm-console = { version = "4.8.1", default-features = false, features = [ "account", "program", "types", "dev_skip_checks", "test_consensus_heights", "test_targets", "wasm" ] }
+snarkvm-synthesizer-program = { version = "4.8.1", features = [ "wasm" ] }
 sys-info           = "0.9"
 tempfile           = "3.27"
 thiserror          = "2.0"

--- a/crates/compiler/src/run.rs
+++ b/crates/compiler/src/run.rs
@@ -63,12 +63,22 @@ use snarkvm::{
     synthesizer::program::{FinalizeStoreTrait, ProgramCore, StackTrait},
 };
 use std::{
+    cell::Cell,
     fmt,
     panic::{AssertUnwindSafe, catch_unwind},
     str::FromStr as _,
 };
 
 type CurrentNetwork = TestnetV0;
+
+thread_local! {
+    static HALT_EXPECTED: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Returns whether a caught program halt is expected on this thread.
+pub fn halt_expected() -> bool {
+    HALT_EXPECTED.with(Cell::get)
+}
 
 /// Programs and configuration to run.
 #[derive(Debug)]
@@ -526,8 +536,12 @@ fn failed_evaluation_outcome(case: &Case, e: String) -> EvaluationOutcome {
     }
 }
 
-/// Run the functions indicated by `cases` from the programs in `config`.
-pub fn run_with_ledger(config: &Config, case_sets: &[Vec<Case>]) -> Result<Vec<Vec<ExecutionOutcome>>> {
+/// Runs each case set on its own ledger and reports each set's outcomes in input order.
+pub fn run_with_ledger(
+    config: &Config,
+    case_sets: &[Vec<Case>],
+    mut on_case_set_done: impl FnMut(usize, &[ExecutionOutcome]),
+) -> Result<Vec<Vec<ExecutionOutcome>>> {
     if case_sets.is_empty() {
         return Ok(Vec::new());
     }
@@ -617,34 +631,29 @@ pub fn run_with_ledger(config: &Config, case_sets: &[Vec<Case>]) -> Result<Vec<V
         }
     }
 
-    // Initialize ledger instances for each case set.
-    let mut indexed_ledgers = vec![(0, ledger)];
-    indexed_ledgers.extend(
-        (1..case_sets.len())
-            .map(|i| {
-                // Initialize a `Ledger`. This should always succeed.
-                // Use `new_test` to avoid spurious block-tree persistence errors on drop.
-                let l = Ledger::<CurrentNetwork, ConsensusMemory<CurrentNetwork>>::load(
+    // Build each pristine post-deploy ledger only when its case set is ready to run.
+    let mut original_ledger = Some(ledger);
+    case_sets
+        .iter()
+        .enumerate()
+        .map(|(index, cases)| {
+            // Ledger 0 is the original (it already holds the deploys); later sets get a fresh
+            // copy with the setup blocks replayed in.
+            // Use `new_test` to avoid spurious block-tree persistence errors on drop.
+            let ledger = if index == 0 {
+                original_ledger.take().expect("ledger 0 is built exactly once")
+            } else {
+                let ledger = Ledger::<CurrentNetwork, ConsensusMemory<CurrentNetwork>>::load(
                     genesis_block.clone(),
                     StorageMode::new_test(None),
                 )
                 .expect("Failed to load copy of ledger");
-                // Add the setup blocks.
-                for block in blocks.iter() {
-                    l.advance_to_next_block(block).expect("Failed to add setup block to ledger");
+                for block in &blocks {
+                    ledger.advance_to_next_block(block).expect("Failed to add setup block to ledger");
                 }
+                ledger
+            };
 
-                (i, l)
-            })
-            .collect::<Vec<_>>(),
-    );
-
-    // For each of the case sets, run the cases sequentially.
-    let results = indexed_ledgers
-        .into_iter()
-        .map(|(index, ledger)| {
-            // Get the cases for this ledger.
-            let cases = &case_sets[index];
             // Clone the RNG.
             let mut rng = rng.clone();
 
@@ -729,34 +738,37 @@ pub fn run_with_ledger(config: &Config, case_sets: &[Vec<Case>]) -> Result<Vec<V
                 let mut abort_reason: Option<String> = None;
 
                 // Halts are handled by panics, so we need to catch them.
-                // I'm not thrilled about this usage of `AssertUnwindSafe`, but it seems to be
-                // used frequently in SnarkVM anyway.
-                let execute_output = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    if skip_proving {
-                        execute_without_proof(
-                            ledger.vm(),
-                            &private_key,
-                            &case.program_name,
-                            &case.function,
-                            case.input.iter(),
-                            latest_consensus_version,
-                            &mut rng,
-                        )
-                    } else {
-                        ledger
-                            .vm()
-                            .execute_with_response(
+                let execute_output = HALT_EXPECTED.with(|expected| {
+                    let previous = expected.replace(true);
+                    let result = catch_unwind(AssertUnwindSafe(|| {
+                        if skip_proving {
+                            execute_without_proof(
+                                ledger.vm(),
                                 &private_key,
-                                (&case.program_name, &case.function),
+                                &case.program_name,
+                                &case.function,
                                 case.input.iter(),
-                                None,
-                                0,
-                                None,
+                                latest_consensus_version,
                                 &mut rng,
                             )
-                            .map_err(anyhow::Error::from)
-                    }
-                }));
+                        } else {
+                            ledger
+                                .vm()
+                                .execute_with_response(
+                                    &private_key,
+                                    (&case.program_name, &case.function),
+                                    case.input.iter(),
+                                    None,
+                                    0,
+                                    None,
+                                    &mut rng,
+                                )
+                                .map_err(anyhow::Error::from)
+                        }
+                    }));
+                    expected.set(previous);
+                    result
+                });
 
                 if let Err(payload) = execute_output {
                     let s1 = payload.downcast_ref::<&str>().map(|s| s.to_string());
@@ -835,15 +847,9 @@ pub fn run_with_ledger(config: &Config, case_sets: &[Vec<Case>]) -> Result<Vec<V
                 });
             }
 
-            Ok((index, case_outcomes))
+            on_case_set_done(index, &case_outcomes);
+
+            Ok(case_outcomes)
         })
-        .collect::<Result<Vec<_>>>()?;
-
-    // Reorder results to match input order.
-    let mut ordered_results: Vec<Vec<ExecutionOutcome>> = vec![Default::default(); case_sets.len()];
-    for (index, outcomes) in results.into_iter() {
-        ordered_results[index] = outcomes;
-    }
-
-    Ok(ordered_results)
+        .collect()
 }

--- a/crates/compiler/src/test_execution.rs
+++ b/crates/compiler/src/test_execution.rs
@@ -112,8 +112,10 @@ fn execution_run_test(
 
     if requires_ledger {
         // Note: We wrap cases in a slice to run them all in one ledger instance.
-        let outcomes =
-            run::run_with_ledger(&ledger_config, &[cases.to_vec()])?.into_iter().flatten().collect::<Vec<_>>();
+        let outcomes = run::run_with_ledger(&ledger_config, &[cases.to_vec()], |_, _| {})?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
 
         assert_eq!(outcomes.len(), cases.len());
 

--- a/crates/leo/src/cli/commands/build.rs
+++ b/crates/leo/src/cli/commands/build.rs
@@ -577,8 +577,9 @@ fn compile_leo_source_directory(
     network: NetworkName,
     rename: Option<String>,
 ) -> Result<Compiled> {
-    // Print a newline for better formatting.
-    println!();
+    if !is_test {
+        println!();
+    }
     tracing::info!("🔨 Compiling '{program_name}'");
     // Capture before `options` is consumed by the conversion below.
     let print_checksums = options.checksums;
@@ -622,29 +623,33 @@ fn compile_leo_source_directory(
     }
 
     let (size_kb, max_kb, warning) = format_program_size(program_size, MAX_PROGRAM_SIZE);
-    tracing::info!("    Program size: {size_kb:.2} KB / {max_kb:.2} KB");
     if let Some(msg) = warning {
         tracing::warn!("⚠️  Program '{program_name}' is {msg}.");
     }
 
-    tracing::info!("✅ Compiled '{program_name}' into Aleo instructions.");
+    if !is_test {
+        tracing::info!("    Program size: {size_kb:.2} KB / {max_kb:.2} KB");
+        tracing::info!("✅ Compiled '{program_name}' into Aleo instructions.");
+    }
 
-    // Print checksums for all additional bytecodes (imports).
-    for import in &compiled.imports {
-        // Compute checksum depending on network.
-        let dep_checksum: String = match network {
-            NetworkName::MainnetV0 => {
-                SvmProgram::<MainnetV0>::from_str(&import.bytecode)?.to_checksum().iter().join(", ")
-            }
-            NetworkName::TestnetV0 => {
-                SvmProgram::<TestnetV0>::from_str(&import.bytecode)?.to_checksum().iter().join(", ")
-            }
-            NetworkName::CanaryV0 => {
-                SvmProgram::<CanaryV0>::from_str(&import.bytecode)?.to_checksum().iter().join(", ")
-            }
-        };
+    // Print import checksums only when explicitly requested.
+    if print_checksums {
+        for import in &compiled.imports {
+            // Compute checksum depending on network.
+            let dep_checksum: String = match network {
+                NetworkName::MainnetV0 => {
+                    SvmProgram::<MainnetV0>::from_str(&import.bytecode)?.to_checksum().iter().join(", ")
+                }
+                NetworkName::TestnetV0 => {
+                    SvmProgram::<TestnetV0>::from_str(&import.bytecode)?.to_checksum().iter().join(", ")
+                }
+                NetworkName::CanaryV0 => {
+                    SvmProgram::<CanaryV0>::from_str(&import.bytecode)?.to_checksum().iter().join(", ")
+                }
+            };
 
-        tracing::info!("    Import '{}': checksum = '[{dep_checksum}]'", import.name);
+            tracing::info!("    Import '{}': checksum = '[{dep_checksum}]'", import.name);
+        }
     }
 
     Ok(compiled)

--- a/crates/leo/src/cli/commands/test.rs
+++ b/crates/leo/src/cli/commands/test.rs
@@ -110,6 +110,7 @@ impl Command for LeoTest {
 }
 
 struct TestFunction {
+    file: String,
     program: String,
     function: String,
     should_fail: bool,
@@ -134,6 +135,8 @@ fn discover_test_functions(package: &Package, match_str: &str, network: NetworkN
         let ProgramData::SourcePath { directory, source } = &unit.data else {
             continue;
         };
+
+        let file = source.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or_default();
 
         let handler = Handler::default();
         let node_builder = Rc::new(NodeBuilder::default());
@@ -166,9 +169,12 @@ fn discover_test_functions(package: &Package, match_str: &str, network: NetworkN
                     continue;
                 }
 
-                let qualified = format!("{program_name}/{}", function.identifier);
-                if !match_str.is_empty() && !qualified.contains(match_str) {
-                    continue;
+                if !match_str.is_empty() {
+                    let program_qualified = format!("{program_name}/{}", function.identifier);
+                    let file_qualified = format!("{file}::{}", function.identifier);
+                    if !program_qualified.contains(match_str) && !file_qualified.contains(match_str) {
+                        continue;
+                    }
                 }
 
                 let should_fail = function.annotations.iter().any(|a| a.identifier.name == sym::should_fail);
@@ -180,6 +186,7 @@ fn discover_test_functions(package: &Package, match_str: &str, network: NetworkN
                     .and_then(|a| a.map.get(&private_key_symbol).cloned());
 
                 test_functions.push(TestFunction {
+                    file: file.clone(),
                     program: program_name.clone(),
                     function: function.identifier.to_string(),
                     should_fail,
@@ -231,7 +238,13 @@ fn handle_test(command: LeoTest, package: Package) -> Result<TestOutput> {
         })
         .collect();
 
-    let should_fails: Vec<bool> = test_functions.iter().map(|tf| tf.should_fail).collect();
+    let test_metadata: Vec<_> = test_functions
+        .iter()
+        .map(|tf| {
+            (tf.should_fail, format!("{}::{}", tf.file, tf.function), format!("{}.aleo/{}", tf.program, tf.function))
+        })
+        .collect();
+
     let cases: Vec<Vec<run::Case>> = test_functions
         .into_iter()
         .map(|tf| {
@@ -245,55 +258,64 @@ fn handle_test(command: LeoTest, package: Package) -> Result<TestOutput> {
         })
         .collect();
 
-    let outcomes = run::run_with_ledger(
-        &run::Config { seed: 0, start_height: None, programs, skip_proving: !command.prove },
-        &cases,
-    )?
-    .into_iter()
-    .flatten()
-    .collect::<Vec<_>>();
-
-    let results: Vec<_> = outcomes
-        .into_iter()
-        .zip(should_fails)
-        .map(|(outcome, should_fail)| {
-            let run::ExecutionOutcome { outcome: inner, status, .. } = outcome;
-
-            let message = match (&status, should_fail) {
-                (run::ExecutionStatus::Accepted, false) => None,
-                (run::ExecutionStatus::Accepted, true) => Some("Test succeeded when failure was expected.".to_string()),
-                (_, true) => None,
-                (_, false) => Some(format!("{} -- {}", status, inner.output)),
-            };
-
-            (inner.program_name, inner.function, message)
-        })
-        .collect::<Vec<_>>();
-
-    // Report results.
-    let total = results.len();
-    let total_passed = results.iter().filter(|(_, _, x)| x.is_none()).count();
-
-    let mut tests = Vec::new();
-
+    let total = cases.len();
     if total == 0 {
         println!("No tests run.");
-    } else {
-        println!("{total_passed} / {total} tests passed.");
-        let failed = "FAILED".bold().red();
-        let passed = "PASSED".bold().green();
-
-        for (program, function, case_result) in &results {
-            let str_id = format!("{program}/{function}");
-            if let Some(err_str) = case_result {
-                println!("{failed}: {str_id:<30} | {err_str}");
-                tests.push(TestResult { name: str_id, passed: false, error: Some(err_str.clone()) });
-            } else {
-                println!("{passed}: {str_id}");
-                tests.push(TestResult { name: str_id, passed: true, error: None });
-            }
-        }
+        return Ok(TestOutput::default());
     }
 
-    Ok(TestOutput { passed: total_passed, failed: total - total_passed, tests })
+    let plural = if total == 1 { "" } else { "s" };
+    println!();
+    println!("{} {total} test{plural}", gutter("Running").green().bold());
+
+    let mut tests = Vec::with_capacity(total);
+    let mut passed = 0usize;
+    let mut failures: Vec<(usize, String)> = Vec::new();
+
+    // Debug logs make an in-place `RUNNING` status unreliable, so print each result after completion.
+    run::run_with_ledger(
+        &run::Config { seed: 0, start_height: None, programs, skip_proving: !command.prove },
+        &cases,
+        |index, outcomes| {
+            let outcome = &outcomes[0];
+            let (should_fail, display, qualified_name) = &test_metadata[index];
+
+            let message = match (&outcome.status, *should_fail) {
+                (run::ExecutionStatus::Accepted, false) => None,
+                (run::ExecutionStatus::Accepted, true) => Some("test succeeded when failure was expected".to_string()),
+                (_, true) => None,
+                (_, false) => Some(format!("{} -- {}", outcome.status, outcome.outcome.output)),
+            };
+
+            match message {
+                Some(err) => {
+                    println!("{} {display}", gutter("FAIL").red().bold());
+                    failures.push((index, err.clone()));
+                    tests.push(TestResult { name: qualified_name.clone(), passed: false, error: Some(err) });
+                }
+                None => {
+                    passed += 1;
+                    println!("{} {display}", gutter("PASS").green().bold());
+                    tests.push(TestResult { name: qualified_name.clone(), passed: true, error: None });
+                }
+            }
+        },
+    )?;
+
+    let failed = total - passed;
+    println!("{}", "─".repeat(24).dimmed());
+    let summary = gutter("Summary");
+    let summary = if failed == 0 { summary.green().bold() } else { summary.red().bold() };
+    println!("{summary} {total} test{plural} run: {passed} passed, {failed} failed");
+    for (index, err) in &failures {
+        let (_, display, _) = &test_metadata[*index];
+        println!("{} {display}\n{:>14}{}", gutter("FAIL").red().bold(), "", err.dimmed());
+    }
+
+    Ok(TestOutput { passed, failed, tests })
+}
+
+/// Right-align a status verb before adding ANSI color.
+fn gutter(word: &str) -> String {
+    format!("{word:>12}")
 }

--- a/crates/leo/src/cli/helpers/logger.rs
+++ b/crates/leo/src/cli/helpers/logger.rs
@@ -20,6 +20,7 @@ use colored::Colorize;
 use std::{fmt, sync::Once};
 use tracing::{event::Event, subscriber::Subscriber};
 use tracing_subscriber::{
+    EnvFilter,
     FmtSubscriber,
     fmt::{FmtContext, FormattedFields, format::*, time::*},
     registry::LookupSpan,
@@ -181,15 +182,18 @@ pub fn init_logger(_app_name: &'static str, verbosity: usize) -> Result<()> {
     let stderr = std::io::stderr.with_max_level(tracing::Level::WARN);
     let mk_writer = stderr.or_else(std::io::stdout);
 
+    let base = match verbosity {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    // Hide snarkVM ledger chatter at normal verbosity; `-d` restores it.
+    let filter =
+        if verbosity >= 2 { EnvFilter::new(base) } else { EnvFilter::new(format!("{base},snarkvm_ledger=warn")) };
+
     let subscriber = FmtSubscriber::builder()
-        // all spans/events with a level higher than TRACE (e.g, debug, info, warn, etc.)
-        // will be written to stdout.
-        .with_max_level(match verbosity {
-            0 => tracing::Level::WARN,
-            1 => tracing::Level::INFO,
-            2 => tracing::Level::DEBUG,
-            _ => tracing::Level::TRACE
-        })
+        .with_env_filter(filter)
         .with_writer(mk_writer)
         .without_time()
         .with_target(false)

--- a/crates/leo/src/cli/main.rs
+++ b/crates/leo/src/cli/main.rs
@@ -22,6 +22,10 @@ use clap::Parser;
 fn set_panic_hook() {
     std::panic::set_hook({
         Box::new(move |e| {
+            // Caught test halts are reported by their caller, not as compiler errors.
+            if leo_compiler::run::halt_expected() {
+                return;
+            }
             eprintln!("thread `{}` {}", std::thread::current().name().unwrap_or("<unnamed>"), e);
             eprintln!("stack backtrace: \n{:?}", backtrace::Backtrace::new());
             eprintln!("error: internal compiler error: unexpected panic\n");

--- a/crates/leo/src/errors.rs
+++ b/crates/leo/src/errors.rs
@@ -156,7 +156,6 @@ pub(crate) fn custom(msg: impl Display) -> Backtraced {
 
 pub(crate) fn tests_failed(failed: impl Display, total: impl Display) -> Backtraced {
     Backtraced::error(CODE_PREFIX, CODE_MASK + 46, format!("{failed} out of {total} tests failed"))
-        .with_help("Re-run with `leo test -- --nocapture` to see per-test output.")
 }
 
 pub(crate) fn generated_invalid_bytecode(

--- a/tests/expectations/cli/multiple_leo_deps/STDOUT
+++ b/tests/expectations/cli/multiple_leo_deps/STDOUT
@@ -4,7 +4,4 @@
        Leo 🔨 Compiling 'parent.aleo'
        Leo     Program size: 0.29 KB / 2000.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.
-       Leo     Import 'grandchild.aleo': checksum = '[174u8, 187u8, 41u8, 199u8, 29u8, 93u8, 47u8, 173u8, 98u8, 32u8, 73u8, 250u8, 151u8, 53u8, 73u8, 94u8, 242u8, 95u8, 71u8, 74u8, 121u8, 121u8, 133u8, 66u8, 113u8, 125u8, 133u8, 149u8, 137u8, 234u8, 137u8, 134u8]'
-       Leo     Import 'child1.aleo': checksum = '[138u8, 68u8, 23u8, 17u8, 147u8, 202u8, 54u8, 131u8, 68u8, 191u8, 115u8, 122u8, 104u8, 93u8, 82u8, 133u8, 237u8, 116u8, 228u8, 7u8, 183u8, 28u8, 164u8, 4u8, 200u8, 189u8, 94u8, 146u8, 227u8, 27u8, 196u8, 215u8]'
-       Leo     Import 'child2.aleo': checksum = '[23u8, 157u8, 69u8, 176u8, 63u8, 187u8, 23u8, 101u8, 134u8, 214u8, 248u8, 221u8, 72u8, 152u8, 104u8, 120u8, 22u8, 40u8, 157u8, 249u8, 73u8, 22u8, 38u8, 208u8, 53u8, 79u8, 137u8, 191u8, 121u8, 50u8, 88u8, 15u8]'
        Leo ✅ Generated ABI for program 'parent.aleo'.

--- a/tests/expectations/cli/test_dependency_visible_to_tests/STDOUT
+++ b/tests/expectations/cli/test_dependency_visible_to_tests/STDOUT
@@ -6,11 +6,9 @@
        Leo     Program size: 0.24 KB / 2000.00 KB
        Leo ✅ Compiled 'my_app.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_app.aleo'.
-
        Leo 🔨 Compiling 'test_my_app.aleo'
-       Leo     Program size: 0.23 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_my_app.aleo' into Aleo instructions.
-       Leo     Import 'my_app.aleo': checksum = '[254u8, 98u8, 107u8, 69u8, 193u8, 121u8, 99u8, 187u8, 182u8, 80u8, 195u8, 16u8, 168u8, 141u8, 26u8, 111u8, 236u8, 121u8, 3u8, 83u8, 163u8, 213u8, 217u8, 160u8, 105u8, 125u8, 141u8, 184u8, 3u8, 143u8, 103u8, 204u8]'
-       Leo Loading the ledger from storage...
-1 / 1 tests passed.
-PASSED: test_my_app.aleo/test_combine
+
+     Running 1 test
+        PASS test_my_app.leo::test_combine
+────────────────────────
+     Summary 1 test run: 1 passed, 0 failed

--- a/tests/expectations/cli/test_external_toplevel_closure/STDOUT
+++ b/tests/expectations/cli/test_external_toplevel_closure/STDOUT
@@ -5,5 +5,4 @@
        Leo 🔨 Compiling 'parent.aleo'
        Leo     Program size: 0.13 KB / 2000.00 KB
        Leo ✅ Compiled 'parent.aleo' into Aleo instructions.
-       Leo     Import 'child.aleo': checksum = '[13u8, 159u8, 189u8, 165u8, 153u8, 228u8, 68u8, 149u8, 32u8, 212u8, 198u8, 89u8, 84u8, 99u8, 168u8, 177u8, 75u8, 40u8, 177u8, 103u8, 64u8, 157u8, 149u8, 3u8, 244u8, 170u8, 16u8, 188u8, 1u8, 23u8, 203u8, 193u8]'
        Leo ✅ Generated ABI for program 'parent.aleo'.

--- a/tests/expectations/cli/test_failure_exit_code/STDERR
+++ b/tests/expectations/cli/test_failure_exit_code/STDERR
@@ -1,3 +1,2 @@
 Error [ECLI0377046]: 1 out of 1 tests failed
-     |
-     = Re-run with `leo test -- --nocapture` to see per-test output.
+

--- a/tests/expectations/cli/test_failure_exit_code/STDOUT
+++ b/tests/expectations/cli/test_failure_exit_code/STDOUT
@@ -5,11 +5,11 @@
        Leo     Program size: 0.20 KB / 2000.00 KB
        Leo ✅ Compiled 'test_failure_exit_code.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'test_failure_exit_code.aleo'.
-
        Leo 🔨 Compiling 'test_test_failure_exit_code.aleo'
-       Leo     Program size: 0.17 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_test_failure_exit_code.aleo' into Aleo instructions.
-       Leo     Import 'test_failure_exit_code.aleo': checksum = '[221u8, 98u8, 184u8, 91u8, 106u8, 23u8, 100u8, 225u8, 172u8, 241u8, 136u8, 60u8, 210u8, 232u8, 121u8, 251u8, 30u8, 86u8, 109u8, 166u8, 1u8, 21u8, 133u8, 255u8, 216u8, 171u8, 227u8, 187u8, 160u8, 103u8, 226u8, 24u8]'
-       Leo Loading the ledger from storage...
-0 / 1 tests passed.
-FAILED: test_test_failure_exit_code.aleo/test_deliberate_failure | none -- "Failed to extract output: Process authorization failed: Stack authorization failed: Stack execution failed: Instruction (assert.eq 1u8 2u8;) at index 0 failed: Failed to execute: Constraint unsatisfied: (0 * 1) != 1"
+
+     Running 1 test
+        FAIL test_test_failure_exit_code.leo::test_deliberate_failure
+────────────────────────
+     Summary 1 test run: 0 passed, 1 failed
+        FAIL test_test_failure_exit_code.leo::test_deliberate_failure
+              none -- "Failed to extract output: Process authorization failed: Stack authorization failed: Stack execution failed: Instruction (assert.eq 1u8 2u8;) at index 0 failed: Failed to execute: Constraint unsatisfied: (0 * 1) != 1"

--- a/tests/expectations/cli/test_json/STDOUT
+++ b/tests/expectations/cli/test_json/STDOUT
@@ -14,8 +14,10 @@
 ⚠️ No endpoint specified, defaulting to 'https://api.explorer.provable.com/v1'.
 
 
-1 / 1 tests passed.
-PASSED: test_main.aleo/test_addition
+     Running 1 test
+        PASS test_main.leo::test_addition
+────────────────────────
+     Summary 1 test run: 1 passed, 0 failed
 
 
 ➕ Adding programs to the VM in the following order:

--- a/tests/expectations/cli/test_lib_program_test/STDOUT
+++ b/tests/expectations/cli/test_lib_program_test/STDOUT
@@ -6,17 +6,12 @@
        Leo     Program size: 0.50 KB / 2000.00 KB
        Leo ✅ Compiled 'my_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_program.aleo'.
-
        Leo 🔨 Compiling 'test_my_program.aleo'
-       Leo     Program size: 0.48 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_my_program.aleo' into Aleo instructions.
-       Leo     Import 'my_program.aleo': checksum = '[106u8, 110u8, 195u8, 22u8, 179u8, 122u8, 162u8, 160u8, 221u8, 236u8, 9u8, 111u8, 202u8, 246u8, 155u8, 195u8, 105u8, 115u8, 23u8, 190u8, 127u8, 125u8, 146u8, 111u8, 253u8, 158u8, 178u8, 185u8, 206u8, 163u8, 205u8, 126u8]'
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-4 / 4 tests passed.
-PASSED: test_my_program.aleo/test_via_calc
-PASSED: test_my_program.aleo/test_via_base
-PASSED: test_my_program.aleo/test_via_triple
-PASSED: test_my_program.aleo/test_via_fivefold
+
+     Running 4 tests
+        PASS test_my_program.leo::test_via_calc
+        PASS test_my_program.leo::test_via_base
+        PASS test_my_program.leo::test_via_triple
+        PASS test_my_program.leo::test_via_fivefold
+────────────────────────
+     Summary 4 tests run: 4 passed, 0 failed

--- a/tests/expectations/cli/test_lib_submodule_with_tests/STDOUT
+++ b/tests/expectations/cli/test_lib_submodule_with_tests/STDOUT
@@ -4,16 +4,12 @@
 
        Leo 🔨 Building library 'my_lib'
        Leo ✅ Validated 'my_lib'.
-
        Leo 🔨 Compiling 'test_my_lib.aleo'
-       Leo     Program size: 0.27 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_my_lib.aleo' into Aleo instructions.
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-4 / 4 tests passed.
-PASSED: test_my_lib.aleo/test_double
-PASSED: test_my_lib.aleo/test_double_zero
-PASSED: test_my_lib.aleo/test_triple
-PASSED: test_my_lib.aleo/test_triple_zero
+
+     Running 4 tests
+        PASS test_my_lib.leo::test_double
+        PASS test_my_lib.leo::test_double_zero
+        PASS test_my_lib.leo::test_triple
+        PASS test_my_lib.leo::test_triple_zero
+────────────────────────
+     Summary 4 tests run: 4 passed, 0 failed

--- a/tests/expectations/cli/test_lib_with_tests/STDOUT
+++ b/tests/expectations/cli/test_lib_with_tests/STDOUT
@@ -4,14 +4,11 @@
 
        Leo 🔨 Building library 'my_lib'
        Leo ✅ Validated 'my_lib'.
-
        Leo 🔨 Compiling 'test_my_lib.aleo'
-       Leo     Program size: 0.22 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_my_lib.aleo' into Aleo instructions.
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-3 / 3 tests passed.
-PASSED: test_my_lib.aleo/test_double
-PASSED: test_my_lib.aleo/test_square
-PASSED: test_my_lib.aleo/test_square_zero
+
+     Running 3 tests
+        PASS test_my_lib.leo::test_double
+        PASS test_my_lib.leo::test_square
+        PASS test_my_lib.leo::test_square_zero
+────────────────────────
+     Summary 3 tests run: 3 passed, 0 failed

--- a/tests/expectations/cli/test_library_submodule_access/STDOUT
+++ b/tests/expectations/cli/test_library_submodule_access/STDOUT
@@ -8,15 +8,11 @@
        Leo     Program size: 1.05 KB / 2000.00 KB
        Leo ✅ Compiled 'my_app.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_app.aleo'.
-
        Leo 🔨 Compiling 'test_my_app.aleo'
-       Leo     Program size: 0.64 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_my_app.aleo' into Aleo instructions.
-       Leo     Import 'my_app.aleo': checksum = '[93u8, 245u8, 51u8, 127u8, 99u8, 181u8, 136u8, 128u8, 74u8, 171u8, 76u8, 239u8, 117u8, 174u8, 196u8, 73u8, 60u8, 16u8, 72u8, 68u8, 36u8, 48u8, 229u8, 148u8, 64u8, 232u8, 195u8, 46u8, 166u8, 177u8, 77u8, 7u8]'
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-3 / 3 tests passed.
-PASSED: test_my_app.aleo/test_rect_area
-PASSED: test_my_app.aleo/test_unit_side
-PASSED: test_my_app.aleo/test_scaled_area
+
+     Running 3 tests
+        PASS test_my_app.leo::test_rect_area
+        PASS test_my_app.leo::test_unit_side
+        PASS test_my_app.leo::test_scaled_area
+────────────────────────
+     Summary 3 tests run: 3 passed, 0 failed

--- a/tests/expectations/cli/test_multiple_test_files/STDOUT
+++ b/tests/expectations/cli/test_multiple_test_files/STDOUT
@@ -5,20 +5,12 @@
        Leo     Program size: 0.19 KB / 2000.00 KB
        Leo ✅ Compiled 'multi_test_prog.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'multi_test_prog.aleo'.
-
        Leo 🔨 Compiling 'test_addition.aleo'
-       Leo     Program size: 0.20 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_addition.aleo' into Aleo instructions.
-       Leo     Import 'multi_test_prog.aleo': checksum = '[236u8, 16u8, 16u8, 113u8, 241u8, 197u8, 161u8, 246u8, 83u8, 175u8, 133u8, 88u8, 194u8, 17u8, 181u8, 70u8, 202u8, 247u8, 217u8, 250u8, 12u8, 18u8, 78u8, 33u8, 54u8, 150u8, 81u8, 227u8, 218u8, 70u8, 176u8, 7u8]'
-
        Leo 🔨 Compiling 'test_larger.aleo'
-       Leo     Program size: 0.31 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_larger.aleo' into Aleo instructions.
-       Leo     Import 'multi_test_prog.aleo': checksum = '[236u8, 16u8, 16u8, 113u8, 241u8, 197u8, 161u8, 246u8, 83u8, 175u8, 133u8, 88u8, 194u8, 17u8, 181u8, 70u8, 202u8, 247u8, 217u8, 250u8, 12u8, 18u8, 78u8, 33u8, 54u8, 150u8, 81u8, 227u8, 218u8, 70u8, 176u8, 7u8]'
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-3 / 3 tests passed.
-PASSED: test_addition.aleo/adds_small_numbers
-PASSED: test_larger.aleo/adds_larger_numbers
-PASSED: test_larger.aleo/wrong_expectation
+
+     Running 3 tests
+        PASS test_addition.leo::adds_small_numbers
+        PASS test_larger.leo::adds_larger_numbers
+        PASS test_larger.leo::wrong_expectation
+────────────────────────
+     Summary 3 tests run: 3 passed, 0 failed

--- a/tests/expectations/cli/test_simple_test/STDOUT
+++ b/tests/expectations/cli/test_simple_test/STDOUT
@@ -5,13 +5,10 @@
        Leo     Program size: 0.20 KB / 2000.00 KB
        Leo ✅ Compiled 'some_sample_leo_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'some_sample_leo_program.aleo'.
-
        Leo 🔨 Compiling 'test_some_sample_leo_program.aleo'
-       Leo     Program size: 0.33 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_some_sample_leo_program.aleo' into Aleo instructions.
-       Leo     Import 'some_sample_leo_program.aleo': checksum = '[95u8, 99u8, 136u8, 243u8, 82u8, 169u8, 200u8, 72u8, 133u8, 227u8, 122u8, 161u8, 195u8, 178u8, 69u8, 37u8, 167u8, 114u8, 104u8, 192u8, 161u8, 175u8, 195u8, 180u8, 120u8, 4u8, 192u8, 16u8, 86u8, 199u8, 76u8, 235u8]'
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-2 / 2 tests passed.
-PASSED: test_some_sample_leo_program.aleo/do_nothing
-PASSED: test_some_sample_leo_program.aleo/test_it
+
+     Running 2 tests
+        PASS test_some_sample_leo_program.leo::do_nothing
+        PASS test_some_sample_leo_program.leo::test_it
+────────────────────────
+     Summary 2 tests run: 2 passed, 0 failed

--- a/tests/expectations/cli/test_storage_from_unit_test/STDOUT
+++ b/tests/expectations/cli/test_storage_from_unit_test/STDOUT
@@ -5,51 +5,29 @@
        Leo     Program size: 5.43 KB / 2000.00 KB
        Leo ✅ Compiled 'storage_demo.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'storage_demo.aleo'.
-
        Leo 🔨 Compiling 'test_storage_demo.aleo'
-       Leo     Program size: 20.35 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_storage_demo.aleo' into Aleo instructions.
-       Leo     Import 'storage_demo.aleo': checksum = '[226u8, 104u8, 115u8, 137u8, 3u8, 83u8, 131u8, 89u8, 56u8, 167u8, 125u8, 100u8, 155u8, 220u8, 210u8, 53u8, 15u8, 25u8, 15u8, 152u8, 34u8, 88u8, 82u8, 31u8, 208u8, 157u8, 23u8, 145u8, 128u8, 36u8, 118u8, 40u8]'
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-       Leo Loading the ledger from storage...
-21 / 21 tests passed.
-PASSED: test_storage_demo.aleo/unset_singletons_default
-PASSED: test_storage_demo.aleo/set_and_read_flag
-PASSED: test_storage_demo.aleo/set_and_read_counter
-PASSED: test_storage_demo.aleo/bump_counter_from_unset
-PASSED: test_storage_demo.aleo/bump_counter_twice
-PASSED: test_storage_demo.aleo/clear_counter_resets_default
-PASSED: test_storage_demo.aleo/set_and_read_tiny
-PASSED: test_storage_demo.aleo/set_and_read_signed
-PASSED: test_storage_demo.aleo/set_and_read_tag
-PASSED: test_storage_demo.aleo/set_and_read_marker
-PASSED: test_storage_demo.aleo/set_and_read_pivot
-PASSED: test_storage_demo.aleo/set_and_read_point
-PASSED: test_storage_demo.aleo/set_and_read_quad
-PASSED: test_storage_demo.aleo/vector_starts_empty
-PASSED: test_storage_demo.aleo/push_then_len_and_get
-PASSED: test_storage_demo.aleo/pop_drops_last_element
-PASSED: test_storage_demo.aleo/set_replaces_slot
-PASSED: test_storage_demo.aleo/swap_remove_pulls_last
-PASSED: test_storage_demo.aleo/clear_resets_length
-PASSED: test_storage_demo.aleo/unwrap_unset_singleton_halts
-PASSED: test_storage_demo.aleo/unwrap_oob_get_halts
+
+     Running 21 tests
+        PASS test_storage_demo.leo::unset_singletons_default
+        PASS test_storage_demo.leo::set_and_read_flag
+        PASS test_storage_demo.leo::set_and_read_counter
+        PASS test_storage_demo.leo::bump_counter_from_unset
+        PASS test_storage_demo.leo::bump_counter_twice
+        PASS test_storage_demo.leo::clear_counter_resets_default
+        PASS test_storage_demo.leo::set_and_read_tiny
+        PASS test_storage_demo.leo::set_and_read_signed
+        PASS test_storage_demo.leo::set_and_read_tag
+        PASS test_storage_demo.leo::set_and_read_marker
+        PASS test_storage_demo.leo::set_and_read_pivot
+        PASS test_storage_demo.leo::set_and_read_point
+        PASS test_storage_demo.leo::set_and_read_quad
+        PASS test_storage_demo.leo::vector_starts_empty
+        PASS test_storage_demo.leo::push_then_len_and_get
+        PASS test_storage_demo.leo::pop_drops_last_element
+        PASS test_storage_demo.leo::set_replaces_slot
+        PASS test_storage_demo.leo::swap_remove_pulls_last
+        PASS test_storage_demo.leo::clear_resets_length
+        PASS test_storage_demo.leo::unwrap_unset_singleton_halts
+        PASS test_storage_demo.leo::unwrap_oob_get_halts
+────────────────────────
+     Summary 21 tests run: 21 passed, 0 failed

--- a/tests/expectations/cli/test_with_record/STDOUT
+++ b/tests/expectations/cli/test_with_record/STDOUT
@@ -6,11 +6,9 @@
        Leo     Program size: 0.39 KB / 2000.00 KB
        Leo ✅ Compiled 'my_program.aleo' into Aleo instructions.
        Leo ✅ Generated ABI for program 'my_program.aleo'.
-
        Leo 🔨 Compiling 'test_my_program.aleo'
-       Leo     Program size: 0.27 KB / 2000.00 KB
-       Leo ✅ Compiled 'test_my_program.aleo' into Aleo instructions.
-       Leo     Import 'my_program.aleo': checksum = '[248u8, 185u8, 83u8, 218u8, 45u8, 99u8, 133u8, 143u8, 142u8, 20u8, 130u8, 182u8, 223u8, 58u8, 198u8, 216u8, 21u8, 134u8, 26u8, 61u8, 1u8, 68u8, 18u8, 235u8, 248u8, 3u8, 169u8, 211u8, 40u8, 8u8, 225u8, 98u8]'
-       Leo Loading the ledger from storage...
-1 / 1 tests passed.
-PASSED: test_my_program.aleo/test_double_amount
+
+     Running 1 test
+        PASS test_my_program.leo::test_double_amount
+────────────────────────
+     Summary 1 test run: 1 passed, 0 failed

--- a/tests/expectations/cli/test_workspace_deploy/STDOUT
+++ b/tests/expectations/cli/test_workspace_deploy/STDOUT
@@ -11,7 +11,6 @@
        Leo 🔨 Compiling 'swap.aleo'
        Leo     Program size: 0.23 KB / 2000.00 KB
        Leo ✅ Compiled 'swap.aleo' into Aleo instructions.
-       Leo     Import 'token.aleo': checksum = '[3u8, 95u8, 196u8, 87u8, 201u8, 25u8, 21u8, 148u8, 199u8, 65u8, 183u8, 183u8, 245u8, 253u8, 162u8, 121u8, 112u8, 233u8, 65u8, 132u8, 7u8, 239u8, 243u8, 9u8, 88u8, 169u8, 25u8, 111u8, 5u8, 98u8, 6u8, 94u8]'
        Leo ✅ Generated ABI for program 'swap.aleo'.
 
 📢 Using the following consensus heights: 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16


### PR DESCRIPTION
Makes `leo test` stream file-qualified `PASS`/`FAIL` results with a concise summary. It also removes compile and ledger noise, builds per-test ledgers lazily, and uses crates.io snarkVM 4.8.1.

### Output

Successful run:

![Successful leo test output](https://gist.githubusercontent.com/mohammadfawaz/63184caa207601e0152cc4983cbdebde/raw/db2ab61563713d7cc094504622cc8b44c81e64c5/leo-test-success.svg)

Failing run:

![Failing leo test output](https://gist.githubusercontent.com/mohammadfawaz/63184caa207601e0152cc4983cbdebde/raw/c131dbabaf4d3acc23d1fb6c5222f5cc484f6c56/leo-test-failure.svg)