### PR TITLE
Bump to v4.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3379,7 +3379,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leo-abi"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "indexmap",
  "itertools 0.14.0",
@@ -3392,14 +3392,14 @@ dependencies = [
 
 [[package]]
 name = "leo-abi-types"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "leo-aleo-abi-wasm"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "getrandom 0.4.3",
  "leo-abi",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "leo-ast"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "anyhow",
  "getrandom 0.4.3",
@@ -3427,7 +3427,7 @@ dependencies = [
 
 [[package]]
 name = "leo-benchmarks"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "aleo-std",
  "codspeed-criterion-compat",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "leo-compiler"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "aleo-std",
  "aleo-std-storage",
@@ -3475,7 +3475,7 @@ dependencies = [
 
 [[package]]
 name = "leo-disassembler"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "getrandom 0.4.3",
  "leo-ast",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "leo-errors"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "anyhow",
  "ariadne",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "leo-fmt"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "clap",
  "colored 3.1.1",
@@ -3520,7 +3520,7 @@ dependencies = [
 
 [[package]]
 name = "leo-lang"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "aleo-std",
  "aleo-std-storage",
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "leo-lsp"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3610,7 +3610,7 @@ dependencies = [
 
 [[package]]
 name = "leo-package"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "gix",
  "glob",
@@ -3628,7 +3628,7 @@ dependencies = [
 
 [[package]]
 name = "leo-parser"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "indexmap",
  "itertools 0.14.0",
@@ -3643,7 +3643,7 @@ dependencies = [
 
 [[package]]
 name = "leo-parser-rowan"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "expect-test",
  "leo-errors",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "leo-passes"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "anyhow",
  "base62",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "leo-span"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "ariadne",
  "fxhash",
@@ -3690,11 +3690,11 @@ dependencies = [
 
 [[package]]
 name = "leo-std"
-version = "4.3.2"
+version = "4.3.3"
 
 [[package]]
 name = "leo-test-framework"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "rayon",
  "similar",
@@ -6748,7 +6748,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-leo"
-version = "4.3.2"
+version = "4.3.3"
 dependencies = [
  "cc",
  "leo-parser-rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,20 +4,20 @@ resolver = "3"
 
 [workspace.dependencies]
 # leo dependencies
-leo-abi             = { path = "./crates/abi", version = "=4.3.2" }
-leo-abi-types       = { path = "./crates/abi-types", version = "=4.3.2" }
-leo-ast             = { path = "./crates/ast", version = "=4.3.2" }
-leo-compiler        = { path = "./crates/compiler", version = "=4.3.2" }
-leo-disassembler    = { path = "./crates/disassembler", version = "=4.3.2" }
-leo-errors          = { path = "./crates/errors", version = "=4.3.2" }
-leo-fmt             = { path = "./crates/fmt", version = "=4.3.2" }
-leo-lsp             = { path = "./crates/lsp", version = "=4.3.2" }
-leo-package         = { path = "./crates/package", version = "=4.3.2" }
-leo-parser          = { path = "./crates/parser", version = "=4.3.2" }
-leo-parser-rowan    = { path = "./crates/parser-rowan", version = "=4.3.2" }
-leo-passes          = { path = "./crates/passes", version = "=4.3.2" }
-leo-span            = { path = "./crates/span", version = "=4.3.2" }
-leo-std             = { path = "./crates/leo-std", version = "=4.3.2" }
+leo-abi             = { path = "./crates/abi", version = "=4.3.3" }
+leo-abi-types       = { path = "./crates/abi-types", version = "=4.3.3" }
+leo-ast             = { path = "./crates/ast", version = "=4.3.3" }
+leo-compiler        = { path = "./crates/compiler", version = "=4.3.3" }
+leo-disassembler    = { path = "./crates/disassembler", version = "=4.3.3" }
+leo-errors          = { path = "./crates/errors", version = "=4.3.3" }
+leo-fmt             = { path = "./crates/fmt", version = "=4.3.3" }
+leo-lsp             = { path = "./crates/lsp", version = "=4.3.3" }
+leo-package         = { path = "./crates/package", version = "=4.3.3" }
+leo-parser          = { path = "./crates/parser", version = "=4.3.3" }
+leo-parser-rowan    = { path = "./crates/parser-rowan", version = "=4.3.3" }
+leo-passes          = { path = "./crates/passes", version = "=4.3.3" }
+leo-span            = { path = "./crates/span", version = "=4.3.3" }
+leo-std             = { path = "./crates/leo-std", version = "=4.3.3" }
 leo-test-framework  = { path = "./crates/test-framework" }
 # third party dependencies
 aleo-std           = { version = "1.0.3"}

--- a/crates/abi-types/Cargo.toml
+++ b/crates/abi-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-abi-types"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "ABI type definitions for Leo programs"
 homepage = "https://leo-lang.org"

--- a/crates/abi/Cargo.toml
+++ b/crates/abi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-abi"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "ABI generation for Leo programs"
 homepage = "https://leo-lang.org"

--- a/crates/ast/Cargo.toml
+++ b/crates/ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-ast"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Abstract syntax tree (AST) for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/compiler/Cargo.toml
+++ b/crates/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-compiler"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Compiler for Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/compiler/benchmarks/Cargo.toml
+++ b/crates/compiler/benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-benchmarks"
-version = "4.3.2"
+version = "4.3.3"
 edition = "2024"
 publish = false
 

--- a/crates/disassembler/Cargo.toml
+++ b/crates/disassembler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-disassembler"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "A disassembler for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/errors/Cargo.toml
+++ b/crates/errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-errors"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Errors for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/fmt/Cargo.toml
+++ b/crates/fmt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-fmt"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Source code formatter for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/leo-aleo-abi-wasm/Cargo.toml
+++ b/crates/leo-aleo-abi-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-aleo-abi-wasm"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "WASM bindings for ABI generation from Aleo bytecode"
 homepage = "https://leo-lang.org"

--- a/crates/leo-std/Cargo.toml
+++ b/crates/leo-std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-std"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Embedded Leo standard library source"
 homepage = "https://leo-lang.org"

--- a/crates/leo/Cargo.toml
+++ b/crates/leo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-lang"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "The Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-lsp"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Language Server Protocol implementation for Leo"
 homepage = "https://leo-lang.org"

--- a/crates/package/Cargo.toml
+++ b/crates/package/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-package"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Package parser for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/parser-rowan/Cargo.toml
+++ b/crates/parser-rowan/Cargo.toml
@@ -16,7 +16,7 @@
 
 [package]
 name = "leo-parser-rowan"
-version = "4.3.2"
+version = "4.3.3"
 authors = ["The Leo Team <leo@provable.com>"]
 description = "Rowan-based lossless parser for Leo"
 homepage = "https://leo-lang.org"

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-parser"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Translating from the lossless syntax tree to the AST for the Leo language language"
 homepage = "https://leo-lang.org"

--- a/crates/passes/Cargo.toml
+++ b/crates/passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-passes"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Compiler passes for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/span/Cargo.toml
+++ b/crates/span/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-span"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "Span handling for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/test-framework/Cargo.toml
+++ b/crates/test-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leo-test-framework"
-version = "4.3.2"
+version = "4.3.3"
 authors = [ "The Leo Team <leo@provable.com>" ]
 description = "The testing framework for the Leo programming language"
 homepage = "https://leo-lang.org"

--- a/crates/tree-sitter-leo/Cargo.toml
+++ b/crates/tree-sitter-leo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-leo"
 description = "Rust bindings and tests for the Leo tree-sitter grammar"
-version = "4.3.2"
+version = "4.3.3"
 authors = ["Provable"]
 license = "GPL-3.0-only"
 readme = "README.md"

--- a/tests/expectations/cli/aleo_dep_imports_local_dep/contents/program.json
+++ b/tests/expectations/cli/aleo_dep_imports_local_dep/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "helper.aleo",

--- a/tests/expectations/cli/aleo_dep_reversed_order/contents/program.json
+++ b/tests/expectations/cli/aleo_dep_reversed_order/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "lib.aleo",

--- a/tests/expectations/cli/local_aleo_dependency/contents/program.json
+++ b/tests/expectations/cli/local_aleo_dependency/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "simple.aleo",

--- a/tests/expectations/cli/multiple_leo_deps/contents/child1/program.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/child1/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/expectations/cli/multiple_leo_deps/contents/child2/program.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/child2/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/expectations/cli/multiple_leo_deps/contents/parent/program.json
+++ b/tests/expectations/cli/multiple_leo_deps/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "child1.aleo",

--- a/tests/expectations/cli/test_add/contents/program.json
+++ b/tests/expectations/cli/test_add/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",

--- a/tests/expectations/cli/test_add_dependency/STDOUT
+++ b/tests/expectations/cli/test_add_dependency/STDOUT
@@ -25,7 +25,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -42,7 +42,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -60,7 +60,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -83,7 +83,7 @@ multiple flags exit code: 2
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -107,7 +107,7 @@ missing network dep exit code: 213
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -132,7 +132,7 @@ network dev dep exit code: 0
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -162,7 +162,7 @@ network dev dep exit code: 0
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",
@@ -186,7 +186,7 @@ network dev dep exit code: 0
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",

--- a/tests/expectations/cli/test_add_dependency/contents/my_program/program.json
+++ b/tests/expectations/cli/test_add_dependency/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "credits.aleo",

--- a/tests/expectations/cli/test_add_library_to_program/contents/my_program/program.json
+++ b/tests/expectations/cli/test_add_library_to_program/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "actual_lib",

--- a/tests/expectations/cli/test_add_workspace/STDOUT
+++ b/tests/expectations/cli/test_add_workspace/STDOUT
@@ -5,7 +5,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "token.aleo",
@@ -23,7 +23,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "token.aleo",

--- a/tests/expectations/cli/test_add_workspace/contents/swap/program.json
+++ b/tests/expectations/cli/test_add_workspace/contents/swap/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "token.aleo",

--- a/tests/expectations/cli/test_deploy_rename_conflict/contents/child/program.json
+++ b/tests/expectations/cli/test_deploy_rename_conflict/contents/child/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/expectations/cli/test_deploy_rename_conflict/contents/grandchild/program.json
+++ b/tests/expectations/cli/test_deploy_rename_conflict/contents/grandchild/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/expectations/cli/test_deploy_rename_conflict/contents/parent/program.json
+++ b/tests/expectations/cli/test_deploy_rename_conflict/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "child.aleo",

--- a/tests/expectations/cli/test_deploy_rename_rejected/contents/solo/program.json
+++ b/tests/expectations/cli/test_deploy_rename_rejected/contents/solo/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/expectations/cli/test_interface_abi_from_library/contents/my_program/program.json
+++ b/tests/expectations/cli/test_interface_abi_from_library/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "my_lib",

--- a/tests/expectations/cli/test_library/contents/base_lib/program.json
+++ b/tests/expectations/cli/test_library/contents/base_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/expectations/cli/test_library/contents/program_using_lib/program.json
+++ b/tests/expectations/cli/test_library/contents/program_using_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/expectations/cli/test_library/contents/top_lib/program.json
+++ b/tests/expectations/cli/test_library/contents/top_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/expectations/cli/test_library_build/contents/my_program/program.json
+++ b/tests/expectations/cli/test_library_build/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "my_lib",

--- a/tests/expectations/cli/test_library_build_with_dep_lib/contents/top_lib/program.json
+++ b/tests/expectations/cli/test_library_build_with_dep_lib/contents/top_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/expectations/cli/test_library_circular/contents/lib_a/program.json
+++ b/tests/expectations/cli/test_library_circular/contents/lib_a/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "lib_b",

--- a/tests/expectations/cli/test_library_circular/contents/lib_b/program.json
+++ b/tests/expectations/cli/test_library_circular/contents/lib_b/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "lib_a",

--- a/tests/expectations/cli/test_library_parse_error/contents/my_program/program.json
+++ b/tests/expectations/cli/test_library_parse_error/contents/my_program/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "bad_lib",

--- a/tests/expectations/cli/test_library_submodule_access/contents/my_app/program.json
+++ b/tests/expectations/cli/test_library_submodule_access/contents/my_app/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Program that uses structs, consts, and functions from shapes_lib submodules.",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "shapes_lib",

--- a/tests/expectations/cli/test_version/STDOUT
+++ b/tests/expectations/cli/test_version/STDOUT
@@ -1,1 +1,1 @@
-leo 4.3.2 (HASH BRANCH) features=[FEATURES]
+leo 4.3.3 (HASH BRANCH) features=[FEATURES]

--- a/tests/tests/cli/aleo_dep_imports_local_dep/contents/program.json
+++ b/tests/tests/cli/aleo_dep_imports_local_dep/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "helper.aleo",

--- a/tests/tests/cli/aleo_dep_reversed_order/contents/program.json
+++ b/tests/tests/cli/aleo_dep_reversed_order/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "lib.aleo",

--- a/tests/tests/cli/local_aleo_dependency/contents/program.json
+++ b/tests/tests/cli/local_aleo_dependency/contents/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "simple.aleo",

--- a/tests/tests/cli/multiple_leo_deps/contents/child1/program.json
+++ b/tests/tests/cli/multiple_leo_deps/contents/child1/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/tests/cli/multiple_leo_deps/contents/child2/program.json
+++ b/tests/tests/cli/multiple_leo_deps/contents/child2/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/tests/cli/multiple_leo_deps/contents/parent/program.json
+++ b/tests/tests/cli/multiple_leo_deps/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "child1.aleo",

--- a/tests/tests/cli/test_deploy_rename_conflict/contents/child/program.json
+++ b/tests/tests/cli/test_deploy_rename_conflict/contents/child/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "grandchild.aleo",

--- a/tests/tests/cli/test_deploy_rename_conflict/contents/grandchild/program.json
+++ b/tests/tests/cli/test_deploy_rename_conflict/contents/grandchild/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/tests/cli/test_deploy_rename_conflict/contents/parent/program.json
+++ b/tests/tests/cli/test_deploy_rename_conflict/contents/parent/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "child.aleo",

--- a/tests/tests/cli/test_deploy_rename_rejected/contents/solo/program.json
+++ b/tests/tests/cli/test_deploy_rename_rejected/contents/solo/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/tests/cli/test_library/contents/base_lib/program.json
+++ b/tests/tests/cli/test_library/contents/base_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tests/tests/cli/test_library/contents/program_using_lib/program.json
+++ b/tests/tests/cli/test_library/contents/program_using_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": [
     {
       "name": "base_lib",

--- a/tests/tests/cli/test_library/contents/top_lib/program.json
+++ b/tests/tests/cli/test_library/contents/top_lib/program.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "",
   "license": "MIT",
-  "leo": "4.3.2",
+  "leo": "4.3.3",
   "dependencies": null,
   "dev_dependencies": null
 }

--- a/tree-sitter/package.json
+++ b/tree-sitter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-leo",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "description": "Leo grammar for tree-sitter",
   "repository": "https://github.com/ProvableHQ/leo/tree/master/tree-sitter",
   "license": "GPL-3.0-only",

--- a/tree-sitter/tree-sitter.json
+++ b/tree-sitter/tree-sitter.json
@@ -18,7 +18,7 @@
     }
   ],
   "metadata": {
-    "version": "4.3.2",
+    "version": "4.3.3",
     "license": "GPL-3.0-only",
     "description": "Leo grammar for tree-sitter",
     "authors": [


### PR DESCRIPTION
Bump to v4.3.3 on the release branch. Version-string bumps only (Cargo manifests/lockfile and CLI expectation fixtures); no dependency or feature changes.
