### PR TITLE
Spill external-struct cast operands in finalize

### DIFF
--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -383,6 +383,14 @@ impl CodeGeneratingVisitor<'_> {
         // Initialize instruction builder strings.
         let mut instructions = vec![];
 
+        // Workaround for snarkVM bug ProvableHQ/snarkVM#3330 (surfaced by #29586): in a finalize
+        // it validates an external-struct cast against that struct's own program stack and
+        // resolves the operand member accesses there too, rejecting them. Spill member/array-access
+        // operands to plain registers so the cast carries no external member access. The transition
+        // path is unaffected, hence the finalize gate.
+        let spill_operands =
+            matches!(composite_type, AleoType::Location { .. }) && matches!(self.variant, Some(Variant::Finalize));
+
         // Visit each composite member and accumulate instructions from expressions.
         let operands: Vec<AleoExpr> = input
             .members
@@ -393,7 +401,15 @@ impl CodeGeneratingVisitor<'_> {
                     let (variable_operand, variable_instructions) = self.visit_expression(expr);
                     instructions.extend(variable_instructions);
 
-                    variable_operand
+                    let operand = variable_operand?;
+                    if spill_operands {
+                        let type_ = self.state.type_table.get(&expr.id()).expect("member type should be known");
+                        let (spilled, spill_instructions) = self.spill_finalize_operand(operand, &type_);
+                        instructions.extend(spill_instructions);
+                        Some(spilled)
+                    } else {
+                        Some(operand)
+                    }
                 } else {
                     Some(self.visit_path(&Path::from(member.identifier).to_local()))
                 }
@@ -407,6 +423,56 @@ impl CodeGeneratingVisitor<'_> {
 
         instructions.push(composite_init_instruction);
 
+        (AleoExpr::Reg(dest_reg), instructions)
+    }
+
+    /// Workaround for snarkVM bug ProvableHQ/snarkVM#3330: materializes a member/array-access
+    /// `operand` into a fresh register so a cast to an external struct in a finalize carries no
+    /// external member access. Plain registers/literals are returned as-is; a struct is rebuilt
+    /// recursively (a struct field is itself an external access), while an array is rebuilt from
+    /// its elements without recursing (array casts validate locally).
+    fn spill_finalize_operand(&mut self, operand: AleoExpr, type_: &Type) -> (AleoExpr, Vec<AleoStmt>) {
+        if !matches!(operand, AleoExpr::MemberAccess(..) | AleoExpr::ArrayAccess(..)) {
+            return (operand, vec![]);
+        }
+
+        let mut instructions = vec![];
+        let aleo_type = self.visit_type(type_);
+        let dest_reg = self.next_register();
+        match type_ {
+            Type::Composite(composite) => {
+                let location = composite.path.expect_global_location();
+                let fields: Vec<(String, Type)> = self
+                    .state
+                    .symbol_table
+                    .lookup_struct(location.program, location)
+                    .expect("struct definition should exist")
+                    .members
+                    .iter()
+                    .map(|member| (member.identifier.to_string(), member.type_.clone()))
+                    .collect();
+                let field_operands = fields
+                    .into_iter()
+                    .map(|(name, field_type)| {
+                        let field_operand = AleoExpr::MemberAccess(Box::new(operand.clone()), name);
+                        let (spilled, spill_instructions) = self.spill_finalize_operand(field_operand, &field_type);
+                        instructions.extend(spill_instructions);
+                        spilled
+                    })
+                    .collect();
+                instructions.push(AleoStmt::Cast(AleoExpr::Tuple(field_operands), dest_reg.clone(), aleo_type));
+            }
+            Type::Array(array_type) => {
+                let length = array_type.length.as_u32().expect("array length should be known");
+                let element_operands = (0..length)
+                    .map(|i| AleoExpr::ArrayAccess(Box::new(operand.clone()), Box::new(AleoExpr::U32(i))))
+                    .collect();
+                instructions.push(AleoStmt::Cast(AleoExpr::Tuple(element_operands), dest_reg.clone(), aleo_type));
+            }
+            _ => {
+                instructions.push(AleoStmt::Cast(operand, dest_reg.clone(), aleo_type));
+            }
+        }
         (AleoExpr::Reg(dest_reg), instructions)
     }
 

--- a/tests/expectations/execution/external_submodule_struct_finalize_rebuild.out
+++ b/tests/expectations/execution/external_submodule_struct_finalize_rebuild.out
@@ -1,0 +1,58 @@
+program child.aleo;
+
+struct S__Eqkz1pp1Ejj:
+    hi as u128;
+    lo as u128;
+
+function noop:
+
+constructor:
+    assert.eq edition 0u16;
+// --- Next Program --- //
+import child.aleo;
+program parent.aleo;
+
+function run:
+    input r0 as child.aleo/S__Eqkz1pp1Ejj.private;
+    async run r0 into r1;
+    output r1 as parent.aleo/run.future;
+
+finalize run:
+    input r0 as child.aleo/S__Eqkz1pp1Ejj.public;
+    cast r0.hi into r1 as u128;
+    cast r0.lo into r2 as u128;
+    cast r1 r2 into r3 as child.aleo/S__Eqkz1pp1Ejj;
+    assert.eq r3.lo r0.lo;
+
+constructor:
+    assert.eq edition 0u16;
+verified: true
+status: accepted
+{
+  "transitions": [
+    {
+      "id": "au16leaeyyz2zqkparz0v98ggccjftaz5lvrau6dv9k3cgvwna2jypsdxwyd5",
+      "program": "parent.aleo",
+      "function": "run",
+      "inputs": [
+        {
+          "type": "private",
+          "id": "1502051417082292853619788205127209961533893136745199223406097239817117813912field",
+          "value": "ciphertext1qgqva0g8gw2ej76v30ms7h6l68v53vm9p24rh8fn85gzxrja4l22srnygpn7wsj5gjl68554ncys9hdl7kky0ntej37ltxxkv7a2t5gqq5fvpd98"
+        }
+      ],
+      "outputs": [
+        {
+          "type": "future",
+          "id": "7429033492878210775409452479115106334599749928046577624853422349221959643598field",
+          "value": "{\n  program_id: parent.aleo,\n  function_name: run,\n  arguments: [\n    {\n  hi: 0u128,\n  lo: 7u128\n}\n  ]\n}"
+        }
+      ],
+      "tpk": "59517101639069244690218806718172759817774084448733030979634609300207556343group",
+      "tcm": "3439287105411081472002244584104526469221102650797619533190690523741340896533field",
+      "scm": "1816974850713937437026517823493448391070390307098007095178907976258948759676field"
+    }
+  ],
+  "global_state_root": "sr1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq6gk0xu"
+}
+

--- a/tests/tests/execution/external_submodule_struct_finalize_rebuild.leo
+++ b/tests/tests/execution/external_submodule_struct_finalize_rebuild.leo
@@ -1,0 +1,48 @@
+/*
+[case]
+program = "parent.aleo"
+function = "run"
+input = ["{ hi: 0u128, lo: 7u128 }"]
+*/
+
+// Regression test for #29586. In a finalize, a struct from a cross-program
+// submodule is rebuilt from the members of an existing external-struct register
+// (`cast x.hi x.lo into r as child.aleo/S`). snarkVM validates a cast to an
+// external struct against the external program's stack and then resolves the
+// operand member accesses there too, hitting "main program as external". Codegen
+// must not emit a struct that merely reconstructs an external struct from its own
+// members; the reconstruction is an identity and is elided.
+
+program child.aleo {
+    @noupgrade
+    constructor() {}
+    fn noop() {}
+}
+
+// --- Next Module: m.leo --- //
+
+export struct S {
+    hi: u128,
+    lo: u128,
+}
+
+// Inlined into the caller's finalize; rebuilds `x` from its own members.
+export fn rebuild(x: S) -> S {
+    return S { hi: x.hi, lo: x.lo };
+}
+
+// --- Next Program --- //
+
+import child.aleo;
+
+program parent.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn run(x: child.aleo::m::S) -> Final {
+        return final {
+            let r: child.aleo::m::S = child.aleo::m::rebuild(x);
+            assert_eq(r.lo, x.lo);
+        };
+    }
+}


### PR DESCRIPTION
Fixes #29586 by working around snarkVM bug ProvableHQ/snarkVM#3330.

In a finalize, a cast to an external struct with member-access operands (`cast x.hi x.lo into r as other.aleo/S`) is rejected by snarkVM with "main program as external": its `FinalizeTypes::matches_struct` validates the cast against the external struct's own program stack and resolves the operand member accesses there too (the transition path passes a separate operand stack and is unaffected). The trigger here was a const-folded struct ternary leaving a struct rebuilt from another external struct's own members.

Code generation now materializes such member/array-access operands into plain registers before the external-struct cast (scalar via identity cast, struct rebuilt field-by-field, array from its elements), confined to finalize context. This keeps valid-bytecode generation independent of the peephole optimizer. The proper fix belongs in snarkVM (ProvableHQ/snarkVM#3330); this can be reverted once that lands.
