### PR TITLE
Fix five leo-fmt bugs

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -1657,11 +1657,24 @@ fn format_type_locator(node: &SyntaxNode, out: &mut Output) {
 }
 
 fn format_type_path(node: &SyntaxNode, out: &mut Output) {
-    for elem in node.children_with_tokens() {
+    // Index of the last non-trivia child. Trivia after it are trailing comments,
+    // which are re-emitted by `emit_node_trailing_comments`; trivia before it are
+    // interior comments that must be preserved here.
+    let children: Vec<_> = node.children_with_tokens().collect();
+    let last_real = children.iter().rposition(|elem| match elem {
+        SyntaxElement::Token(tok) => !is_trivia(tok.kind()),
+        SyntaxElement::Node(_) => true,
+    });
+    for (i, elem) in children.into_iter().enumerate() {
         match elem {
             SyntaxElement::Token(tok) => {
                 let k = tok.kind();
-                if k != WHITESPACE && k != LINEBREAK {
+                if k == COMMENT_LINE || k == COMMENT_BLOCK {
+                    // Emit interior comments; skip trailing ones.
+                    if last_real.is_some_and(|last| i < last) {
+                        out.write(tok.text());
+                    }
+                } else if !is_trivia(k) {
                     out.write(tok.text());
                 }
             }
@@ -2835,6 +2848,11 @@ fn try_format_postfix_chain(node: &SyntaxNode, out: &mut Output) -> bool {
         return false;
     }
 
+    // Only break a chain with a method call; a bare `receiver.field` reads worse split.
+    if !segments.iter().any(|segment| is_method_call_segment(segment)) {
+        return false;
+    }
+
     out.write(&base_string);
     out.indented(|out| {
         let mut on_continuation_line = false;
@@ -2857,6 +2875,11 @@ fn try_format_postfix_chain(node: &SyntaxNode, out: &mut Output) -> bool {
     });
 
     true
+}
+
+/// Whether a postfix-chain segment is a method call (`.name(args)`).
+fn is_method_call_segment(segment: &str) -> bool {
+    segment.starts_with('.') && segment.contains('(')
 }
 
 fn is_postfix_chain_root(node: &SyntaxNode) -> bool {
@@ -2903,6 +2926,10 @@ fn format_postfix_suffix(node: &SyntaxNode, receiver: &SyntaxNode) -> Option<Str
             SyntaxElement::Token(tok) => {
                 if !is_trivia(tok.kind()) {
                     suffix.push_str(tok.text());
+                    // Normalize argument separators to `, ` just like the non-wrapped path.
+                    if tok.kind() == COMMA {
+                        suffix.push(' ');
+                    }
                 }
             }
             SyntaxElement::Node(n) if n.kind().is_expression() => {

--- a/crates/fmt/src/lib.rs
+++ b/crates/fmt/src/lib.rs
@@ -34,7 +34,7 @@ mod output;
 
 use clap::{Args, Parser};
 use colored::Colorize;
-use leo_parser_rowan::parse_main;
+use leo_parser_rowan::{LexError, LexErrorKind, ParseError, SyntaxNode, parse_file};
 use leo_span::file_source::{DiskFileSource, FileSource};
 use similar::{ChangeTag, TextDiff};
 use std::{
@@ -97,13 +97,22 @@ pub fn run_format_with_file_source(
 ) -> io::Result<bool> {
     let paths = resolve_paths(&args.paths, base_dir);
     let leo_files = collect_leo_files(&paths)?;
-    let mut has_unformatted = false;
+    let mut needs_attention = false;
 
     for file_path in leo_files {
         let source = file_source.read_file(&file_path).map_err(|error| {
             io::Error::new(error.kind(), format!("failed to read {}: {error}", file_path.display()))
         })?;
-        let formatted = format_source(&source);
+
+        // Fail closed on parse errors: never write output that could drop source.
+        let formatted = match try_format_source(&source) {
+            Ok(formatted) => formatted,
+            Err(errors) => {
+                report_parse_errors(&file_path, &source, &errors);
+                needs_attention = true;
+                continue;
+            }
+        };
 
         if source == formatted {
             continue;
@@ -111,7 +120,7 @@ pub fn run_format_with_file_source(
 
         if args.check {
             print_diff(&file_path, &source, &formatted);
-            has_unformatted = true;
+            needs_attention = true;
         } else {
             fs::write(&file_path, formatted).map_err(|error| {
                 io::Error::new(error.kind(), format!("failed to write {}: {error}", file_path.display()))
@@ -119,7 +128,28 @@ pub fn run_format_with_file_source(
         }
     }
 
-    Ok(has_unformatted)
+    Ok(needs_attention)
+}
+
+fn report_parse_errors(path: &Path, source: &str, errors: &[ParseError]) {
+    eprintln!("{}: cannot format {} (leaving it untouched)", "error".red().bold(), path.display());
+    for error in errors {
+        let offset = usize::from(error.range.start());
+        let (line, col) = line_col(source, offset);
+        eprintln!("  {}:{line}:{col}: {}", path.display(), error.message);
+    }
+}
+
+/// Convert a byte offset into a 1-based `(line, column)` pair.
+///
+/// The column counts characters, not bytes, so multibyte characters earlier on
+/// the line do not push the reported column past the error.
+fn line_col(source: &str, offset: usize) -> (usize, usize) {
+    let offset = offset.min(source.len());
+    let line = source[..offset].bytes().filter(|&b| b == b'\n').count() + 1;
+    let line_start = source[..offset].rfind('\n').map_or(0, |i| i + 1);
+    let col = source[line_start..offset].chars().count() + 1;
+    (line, col)
 }
 
 /// Standalone `leo-fmt` entrypoint logic.
@@ -134,7 +164,7 @@ pub fn run_standalone() -> ExitCode {
     };
 
     match run_format_cli(&args.format, &base_dir) {
-        Ok(has_unformatted) if args.format.check && has_unformatted => ExitCode::from(1),
+        Ok(needs_attention) if needs_attention => ExitCode::from(1),
         Ok(_) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("{error}");
@@ -226,11 +256,40 @@ fn print_diff(path: &Path, original: &str, formatted: &str) {
 /// - **Deterministic**: Same input always produces same output
 /// - **Comment-preserving**: All comments are retained
 pub fn format_source(source: &str) -> String {
-    let tree = parse_main(source).expect("rowan parser should never fail");
+    format_syntax(&parse_file(source).syntax())
+}
 
+/// Render a parsed syntax tree to formatted source.
+fn format_syntax(node: &SyntaxNode) -> String {
     let mut out = Output::new();
-    format::format_node(&tree, &mut out);
+    format::format_node(node, &mut out);
     out.finish()
+}
+
+/// Format Leo source, returning the diagnostics instead of output when the source
+/// fails to lex or parse, so callers never write a partial file that drops content.
+pub fn try_format_source(source: &str) -> Result<String, Vec<ParseError>> {
+    let parse = parse_file(source);
+    if !parse.is_ok() {
+        // Surface lex errors too; a source that only fails lexing has no parse
+        // errors, and returning them would leave the caller with no diagnostics.
+        let mut errors = parse.errors().to_vec();
+        errors.extend(parse.lex_errors().iter().map(lex_error_as_parse_error));
+        return Err(errors);
+    }
+    Ok(format_syntax(&parse.syntax()))
+}
+
+/// Render a lexer error as a [`ParseError`] so it can share the diagnostic path.
+fn lex_error_as_parse_error(error: &LexError) -> ParseError {
+    let message = match &error.kind {
+        LexErrorKind::InvalidDigit { digit, radix, token } => {
+            format!("digit `{digit}` is invalid in radix {radix} (token `{token}`)")
+        }
+        LexErrorKind::CouldNotLex { content } => format!("could not tokenize the following content: `{content}`"),
+        LexErrorKind::BidiOverride => "unicode bidirectional override code point encountered".to_string(),
+    };
+    ParseError { message, range: error.range, found: None, expected: Vec::new() }
 }
 
 /// Check if source code is already formatted.
@@ -249,6 +308,34 @@ mod tests {
     #[test]
     fn valid_code_ok() {
         assert_eq!(format_source(VALID), VALID);
+    }
+
+    #[test]
+    fn try_format_rejects_unparseable_source() {
+        // An invalid program name is unparseable; refuse rather than drop the body (#29583).
+        let source = "program 1num.aleo {\n    function compute() -> u32 {\n        return 42u32;\n    }\n}\n";
+        assert!(try_format_source(source).is_err());
+    }
+
+    #[test]
+    fn try_format_accepts_valid_source() {
+        assert_eq!(try_format_source(VALID).unwrap(), VALID);
+    }
+
+    #[test]
+    fn try_format_reports_lex_only_errors() {
+        // `0b2u8` fails lexing (invalid digit) but parses cleanly, so the error list
+        // must still surface the lex error rather than being empty (#29583).
+        let source = "program test.aleo {\n    fn f() -> u8 {\n        return 0b2u8;\n    }\n}\n";
+        let errors = try_format_source(source).unwrap_err();
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn line_col_counts_characters_not_bytes() {
+        // "é" is two bytes; the caret at byte offset 3 is character column 3.
+        let source = "aé=b\n";
+        assert_eq!(line_col(source, 3), (1, 3));
     }
 
     #[test]

--- a/crates/fmt/tests/harness.rs
+++ b/crates/fmt/tests/harness.rs
@@ -214,6 +214,7 @@ mod validate {
         "wrap_binary_chain",
         // Regression fixtures use undefined symbols to trigger formatter edge cases.
         "comment_path_field_trailing",
+        "comment_path_field_interior",
         "wrap_postfix_method_comma",
         "wrap_single_field_access",
         "wrap_field_access_blank_line",

--- a/crates/fmt/tests/harness.rs
+++ b/crates/fmt/tests/harness.rs
@@ -212,6 +212,11 @@ mod validate {
         "comment_before_program",
         "malformed_missing_program_rbrace",
         "wrap_binary_chain",
+        // Regression fixtures use undefined symbols to trigger formatter edge cases.
+        "comment_path_field_trailing",
+        "wrap_postfix_method_comma",
+        "wrap_single_field_access",
+        "wrap_field_access_blank_line",
     ];
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/fmt/tests/source/comment_path_field_interior.leo
+++ b/crates/fmt/tests/source/comment_path_field_interior.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    struct SwapHop {
+        limit: swap_math:: /* interior */ U256,
+    }
+}

--- a/crates/fmt/tests/source/comment_path_field_trailing.leo
+++ b/crates/fmt/tests/source/comment_path_field_trailing.leo
@@ -1,0 +1,8 @@
+program test.aleo{
+    @noupgrade constructor() {}
+
+    struct SwapHop {
+        pool: field,
+        sqrt_price_limit: swap_math::U256  // price limit for this hop
+    }
+}

--- a/crates/fmt/tests/source/wrap_field_access_blank_line.leo
+++ b/crates/fmt/tests/source/wrap_field_access_blank_line.leo
@@ -1,0 +1,9 @@
+program test.aleo{
+    @noupgrade constructor() {}
+
+    fn choose() -> i32 {
+        let chosen_field: i32 = predicate_flag_a1 && operand_value_lhs == operand_rhs ? record_value_x.next : default_operand_z;
+
+        return chosen_field;
+    }
+}

--- a/crates/fmt/tests/source/wrap_postfix_method_comma.leo
+++ b/crates/fmt/tests/source/wrap_postfix_method_comma.leo
@@ -1,0 +1,7 @@
+program test.aleo{
+    @noupgrade constructor() {}
+
+    fn f() -> bool {
+        return some_long_mapping_name_here.get_or_use(SomeKey { alpha: value_one, beta: value_two }, false);
+    }
+}

--- a/crates/fmt/tests/source/wrap_single_field_access.leo
+++ b/crates/fmt/tests/source/wrap_single_field_access.leo
@@ -1,0 +1,8 @@
+program test.aleo{
+    @noupgrade constructor() {}
+
+    fn compute(use_lower_boundary: bool) -> u128 {
+        let selected_growth_value: u128 = use_lower_boundary ? lower_tick_record.fee_growth_global_value_x : fallback_growth_amount;
+        return selected_growth_value;
+    }
+}

--- a/crates/fmt/tests/target/comment_path_field_interior.leo
+++ b/crates/fmt/tests/target/comment_path_field_interior.leo
@@ -1,0 +1,5 @@
+program test.aleo {
+    struct SwapHop {
+        limit: swap_math::/* interior */U256,
+    }
+}

--- a/crates/fmt/tests/target/comment_path_field_trailing.leo
+++ b/crates/fmt/tests/target/comment_path_field_trailing.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    struct SwapHop {
+        pool: field,
+        sqrt_price_limit: swap_math::U256, // price limit for this hop
+    }
+}

--- a/crates/fmt/tests/target/wrap_field_access_blank_line.leo
+++ b/crates/fmt/tests/target/wrap_field_access_blank_line.leo
@@ -1,0 +1,10 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn choose() -> i32 {
+        let chosen_field: i32 = predicate_flag_a1 && operand_value_lhs == operand_rhs ? record_value_x.next : default_operand_z;
+
+        return chosen_field;
+    }
+}

--- a/crates/fmt/tests/target/wrap_postfix_method_comma.leo
+++ b/crates/fmt/tests/target/wrap_postfix_method_comma.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn f() -> bool {
+        return some_long_mapping_name_here
+            .get_or_use(SomeKey { alpha: value_one, beta: value_two }, false);
+    }
+}

--- a/crates/fmt/tests/target/wrap_single_field_access.leo
+++ b/crates/fmt/tests/target/wrap_single_field_access.leo
@@ -1,0 +1,9 @@
+program test.aleo {
+    @noupgrade
+    constructor() {}
+
+    fn compute(use_lower_boundary: bool) -> u128 {
+        let selected_growth_value: u128 = use_lower_boundary ? lower_tick_record.fee_growth_global_value_x : fallback_growth_amount;
+        return selected_growth_value;
+    }
+}


### PR DESCRIPTION
Fixes five leo-fmt bugs in one pass: closes #29588, closes #29583, closes #29585, closes #29584, closes #29582.

The comment-duplication (#29588), comma-dropping (#29585), and single-field-access orphaning (#29584/#29582) fixes are localized to the type/postfix formatters. For #29583 the formatter now fails closed on parse errors — the CLI reports them and leaves the file untouched rather than emitting a partial file that drops source.
