### PR TITLE
Fix panic when importing dynamic futures

### DIFF
--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -752,14 +752,19 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
                 .iter()
                 .map(|input| {
                     match &input.type_ {
-                        Type::Future(f) => {
-                            // Since we traverse stubs in post-order, we can assume that the corresponding finalize stub has already been traversed.
-                            Type::Future(FutureType::new(
-                                finalize_input_map.get(f.location.as_ref().unwrap()).unwrap().clone(),
-                                f.location.clone(),
-                                true,
-                            ))
-                        }
+                        Type::Future(f) => match &f.location {
+                            Some(location) => {
+                                // Since we traverse stubs in post-order, the corresponding finalize stub has already
+                                // been traversed.
+                                Type::Future(FutureType::new(
+                                    finalize_input_map.get(location).unwrap().clone(),
+                                    f.location.clone(),
+                                    true,
+                                ))
+                            }
+                            // Dynamic futures do not identify a concrete callee, so their inputs cannot be resolved.
+                            None => input.type_.clone(),
+                        },
                         _ => input.clone().type_,
                     }
                 })

--- a/tests/expectations/compiler/dynamic_call/imported_dynamic_future.out
+++ b/tests/expectations/compiler/dynamic_call/imported_dynamic_future.out
@@ -1,0 +1,95 @@
+program producer.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function route:
+    input r0 as field.private;
+    input r1 as u32.private;
+    call.dynamic r0 'aleo' 'execute' with r1 (as u32.private) into r2 (as dynamic.future);
+    async route r2 into r3;
+    output r3 as producer.aleo/route.future;
+
+finalize route:
+    input r0 as dynamic.future;
+    await r0;
+
+function execute:
+    input r0 as u32.private;
+    async execute r0 into r1;
+    output r1 as producer.aleo/execute.future;
+
+finalize execute:
+    input r0 as u32.public;
+    set r0 into values[r0];
+
+constructor:
+    assert.eq edition 0u16;
+// --- Next Program --- //
+import producer.aleo;
+program consumer.aleo;
+
+function forward:
+    input r0 as field.private;
+    input r1 as u32.private;
+    call producer.aleo/route r0 r1 into r2;
+    async forward r2 into r3;
+    output r3 as consumer.aleo/forward.future;
+
+finalize forward:
+    input r0 as producer.aleo/route.future;
+    await r0;
+
+constructor:
+    assert.eq edition 0u16;
+
+
+---
+Note: Treating dependencies as Aleo produces different results:
+
+program producer.aleo;
+
+mapping values:
+    key as u32.public;
+    value as u32.public;
+
+function execute:
+    input r0 as u32.private;
+    async execute r0 into r1;
+    output r1 as producer.aleo/execute.future;
+
+finalize execute:
+    input r0 as u32.public;
+    set r0 into values[r0];
+
+function route:
+    input r0 as field.private;
+    input r1 as u32.private;
+    call.dynamic r0 'aleo' 'execute' with r1 (as u32.private) into r2 (as dynamic.future);
+    async route r2 into r3;
+    output r3 as producer.aleo/route.future;
+
+finalize route:
+    input r0 as dynamic.future;
+    await r0;
+
+constructor:
+    assert.eq edition 0u16;
+// --- Next Program --- //
+import producer.aleo;
+program consumer.aleo;
+
+function forward:
+    input r0 as field.private;
+    input r1 as u32.private;
+    call producer.aleo/route r0 r1 into r2;
+    async forward r2 into r3;
+    output r3 as consumer.aleo/forward.future;
+
+finalize forward:
+    input r0 as producer.aleo/route.future;
+    await r0;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/tests/compiler/dynamic_call/imported_dynamic_future.leo
+++ b/tests/tests/compiler/dynamic_call/imported_dynamic_future.leo
@@ -1,0 +1,39 @@
+interface AsyncTarget {
+    fn execute(value: u32) -> Final;
+}
+
+program producer.aleo: AsyncTarget {
+    mapping values: u32 => u32;
+
+    fn execute(value: u32) -> Final {
+        return final {
+            Mapping::set(values, value, value);
+        };
+    }
+
+    fn route(target: field, value: u32) -> Final {
+        let future: Final = AsyncTarget@(target)::execute(value);
+        return final {
+            future.run();
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}
+
+// --- Next Program --- //
+
+import producer.aleo;
+
+program consumer.aleo {
+    fn forward(target: field, value: u32) -> Final {
+        let future: Final = producer.aleo::route(target, value);
+        return final {
+            future.run();
+        };
+    }
+
+    @noupgrade
+    constructor() {}
+}


### PR DESCRIPTION
## Motivation

Imported Aleo programs may contain finalize inputs typed as `dynamic.future`. The disassembler represents these as futures without a concrete function location, but stub type checking unconditionally unwrapped that location while resolving finalize inputs. This caused an internal compiler error whenever a Leo package imported such a program.

Preserve location-less dynamic futures as unresolved types while retaining the existing resolution behavior for concrete futures.

## Test Plan

- `cargo check`
- `cargo clippy -- -D warnings`
- `cargo +nightly fmt --all --check`
- `cargo test -p leo-passes`
- `cargo test -p leo-compiler`
- Built Leo 4.3.4 with this patch and verified `leo build` successfully compiles `shield_swap_lp_router.aleo` and generates its ABI

The new compiler regression test builds a producer with a dynamic future, disassembles it to Aleo bytecode, and imports that stub into a consumer program.

## Related PRs

N/A