### PR TITLE
Evaluate storage vector indices once

### DIFF
--- a/crates/passes/src/storage_lowering/ast.rs
+++ b/crates/passes/src/storage_lowering/ast.rs
@@ -380,7 +380,7 @@ impl leo_ast::AstReconstructor for StorageLoweringVisitor<'_> {
                 let key_must_be_evaluated_once = !expression_can_be_discarded(index_expr, self.state);
                 let (reconstructed_key_expr, mut key_stmts) =
                     self.reconstruct_expression(index_expr.clone(), &Default::default());
-                self.state.type_table.insert(reconstructed_key_expr.id(), key_type.clone());
+                self.state.type_table.insert(reconstructed_key_expr.id(), key_type);
                 let reconstructed_key_expr = if key_must_be_evaluated_once {
                     let key_var_sym = self.state.assigner.unique_symbol("$index", "$");
                     let key_var_ident = Identifier {
@@ -508,7 +508,7 @@ impl leo_ast::AstReconstructor for StorageLoweringVisitor<'_> {
                 let index_must_be_evaluated_once = !expression_can_be_discarded(index_expr, self.state);
                 let (reconstructed_index_expr, mut index_stmts) =
                     self.reconstruct_expression(index_expr.clone(), &Default::default());
-                self.state.type_table.insert(reconstructed_index_expr.id(), index_type.clone());
+                self.state.type_table.insert(reconstructed_index_expr.id(), index_type);
                 let reconstructed_index_expr = if index_must_be_evaluated_once {
                     let index_var_sym = self.state.assigner.unique_symbol("$index", "$");
                     let index_var_ident = Identifier {

--- a/crates/passes/src/storage_lowering/ast.rs
+++ b/crates/passes/src/storage_lowering/ast.rs
@@ -371,9 +371,33 @@ impl leo_ast::AstReconstructor for StorageLoweringVisitor<'_> {
                     panic!("Vector::set can only be called with `Expression::Path`");
                 };
 
-                // Reconstruct key/index and value
-                let (reconstructed_key_expr, key_stmts) =
+                // Reconstruct key/index.
+                let key_type = self
+                    .state
+                    .type_table
+                    .get(&index_expr.id())
+                    .expect("type checking should assign a type to the vector index");
+                let key_must_be_evaluated_once = !expression_can_be_discarded(index_expr, self.state);
+                let (reconstructed_key_expr, mut key_stmts) =
                     self.reconstruct_expression(index_expr.clone(), &Default::default());
+                self.state.type_table.insert(reconstructed_key_expr.id(), key_type.clone());
+                let reconstructed_key_expr = if key_must_be_evaluated_once {
+                    let key_var_sym = self.state.assigner.unique_symbol("$index", "$");
+                    let key_var_ident = Identifier {
+                        name: key_var_sym,
+                        span: Default::default(),
+                        id: self.state.node_builder.next_id(),
+                    };
+                    self.state.type_table.insert(key_var_ident.id, key_type);
+                    key_stmts.push(self.state.assigner.simple_definition(
+                        key_var_ident,
+                        reconstructed_key_expr,
+                        self.state.node_builder.next_id(),
+                    ));
+                    key_var_ident.into()
+                } else {
+                    reconstructed_key_expr
+                };
                 let (reconstructed_value_expr, value_stmts) =
                     self.reconstruct_expression(value_expr.clone(), &Default::default());
 
@@ -475,9 +499,33 @@ impl leo_ast::AstReconstructor for StorageLoweringVisitor<'_> {
                     panic!("Vector::swap_remove can only be called with `Expression::Path`");
                 };
 
-                // Reconstruct index
-                let (reconstructed_index_expr, index_stmts) =
+                // Reconstruct index.
+                let index_type = self
+                    .state
+                    .type_table
+                    .get(&index_expr.id())
+                    .expect("type checking should assign a type to the vector index");
+                let index_must_be_evaluated_once = !expression_can_be_discarded(index_expr, self.state);
+                let (reconstructed_index_expr, mut index_stmts) =
                     self.reconstruct_expression(index_expr.clone(), &Default::default());
+                self.state.type_table.insert(reconstructed_index_expr.id(), index_type.clone());
+                let reconstructed_index_expr = if index_must_be_evaluated_once {
+                    let index_var_sym = self.state.assigner.unique_symbol("$index", "$");
+                    let index_var_ident = Identifier {
+                        name: index_var_sym,
+                        span: Default::default(),
+                        id: self.state.node_builder.next_id(),
+                    };
+                    self.state.type_table.insert(index_var_ident.id, index_type);
+                    index_stmts.push(self.state.assigner.simple_definition(
+                        index_var_ident,
+                        reconstructed_index_expr,
+                        self.state.node_builder.next_id(),
+                    ));
+                    index_var_ident.into()
+                } else {
+                    reconstructed_index_expr
+                };
 
                 // Input:
                 //   Vector::swap_remove(v, index)

--- a/tests/expectations/passes/storage_lowering/vector_ops.out
+++ b/tests/expectations/passes/storage_lowering/vector_ops.out
@@ -75,5 +75,24 @@ program singleton_storage.aleo {
             _mapping_set(singleton_storage.aleo::nums__, $len_var$12, $push_value$11);
         };
     }
+    fn set_statement_fallible_index(public x: u32) -> Final<Fn()> {
+        return async {
+            let $index$13 = 1u32 / x;
+            let $len_var$14 = _mapping_get_or_use(singleton_storage.aleo::nums__len__, false, 0u32);
+            assert($index$13 < $len_var$14);
+            _mapping_set(singleton_storage.aleo::nums__, $index$13, 42u32);
+        };
+    }
+    fn swap_remove_fallible_index(public x: u32) -> Final<Fn()> {
+        return async {
+            let $index$15 = 1u32 / x;
+            let $len_var$16 = _mapping_get_or_use(singleton_storage.aleo::nums__len__, false, 0u32);
+            assert($index$15 < $len_var$16);
+            let $removed$17 = _mapping_get(singleton_storage.aleo::nums__, $index$15);
+            _mapping_set(singleton_storage.aleo::nums__, $index$15, _mapping_get(singleton_storage.aleo::nums__, $len_var$16 - 1u32));
+            _mapping_set(singleton_storage.aleo::nums__len__, false, $len_var$16 - 1u32);
+            let $discard$18 = $removed$17;
+        };
+    }
 }
 

--- a/tests/expectations/passes/storage_lowering/vector_ops.out
+++ b/tests/expectations/passes/storage_lowering/vector_ops.out
@@ -2,6 +2,7 @@ program singleton_storage.aleo {
     @noupgrade
     async constructor() {
     }
+    mapping calls: u32 => u32;
     mapping counter__: bool => u8;
     mapping vec__: u32 => u8;
     mapping vec__len__: bool => u32;
@@ -94,5 +95,35 @@ program singleton_storage.aleo {
             let $discard$18 = $removed$17;
         };
     }
+    fn set_effectful_index() -> Final<Fn()> {
+        return async {
+            let $len_var$19 = _mapping_get_or_use(singleton_storage.aleo::nums__len__, false, 0u32);
+            _mapping_set(singleton_storage.aleo::nums__len__, false, $len_var$19 + 1u32);
+            _mapping_set(singleton_storage.aleo::nums__, $len_var$19, 0u32);
+            let $index$20 = singleton_storage.aleo::next_index();
+            let $len_var$21 = _mapping_get_or_use(singleton_storage.aleo::nums__len__, false, 0u32);
+            assert($index$20 < $len_var$21);
+            _mapping_set(singleton_storage.aleo::nums__, $index$20, 42u32);
+        };
+    }
+    fn swap_remove_effectful_index() -> Final<Fn()> {
+        return async {
+            let $len_var$22 = _mapping_get_or_use(singleton_storage.aleo::nums__len__, false, 0u32);
+            _mapping_set(singleton_storage.aleo::nums__len__, false, $len_var$22 + 1u32);
+            _mapping_set(singleton_storage.aleo::nums__, $len_var$22, 0u32);
+            let $index$23 = singleton_storage.aleo::next_index();
+            let $len_var$24 = _mapping_get_or_use(singleton_storage.aleo::nums__len__, false, 0u32);
+            assert($index$23 < $len_var$24);
+            let $removed$25 = _mapping_get(singleton_storage.aleo::nums__, $index$23);
+            _mapping_set(singleton_storage.aleo::nums__, $index$23, _mapping_get(singleton_storage.aleo::nums__, $len_var$24 - 1u32));
+            _mapping_set(singleton_storage.aleo::nums__len__, false, $len_var$24 - 1u32);
+            let $discard$26 = $removed$25;
+        };
+    }
 }
+    final fn next_index() -> u32 {
+        let count: u32 = _mapping_get_or_use(singleton_storage.aleo::calls, 0u32, 0u32);
+        _mapping_set(singleton_storage.aleo::calls, 0u32, count + 1u32);
+        return 0u32;
+    }
 

--- a/tests/tests/passes/storage_lowering/vector_ops.leo
+++ b/tests/tests/passes/storage_lowering/vector_ops.leo
@@ -56,7 +56,7 @@ program singleton_storage.aleo {
         return final { nums.set(1u32 / x, 42u32); };
     }
 
-    fn swap_remove_statement_fallible_index(public x: u32) -> Final {
+    fn swap_remove_fallible_index(public x: u32) -> Final {
         return final { nums.swap_remove(1u32 / x); };
     }
 }

--- a/tests/tests/passes/storage_lowering/vector_ops.leo
+++ b/tests/tests/passes/storage_lowering/vector_ops.leo
@@ -51,4 +51,12 @@ program singleton_storage.aleo {
     fn push_fallible_value(public x: u32) -> Final {
         return final { nums.push(1u32 / x); };
     }
+
+    fn set_statement_fallible_index(public x: u32) -> Final {
+        return final { nums.set(1u32 / x, 42u32); };
+    }
+
+    fn swap_remove_statement_fallible_index(public x: u32) -> Final {
+        return final { nums.swap_remove(1u32 / x); };
+    }
 }

--- a/tests/tests/passes/storage_lowering/vector_ops.leo
+++ b/tests/tests/passes/storage_lowering/vector_ops.leo
@@ -6,6 +6,7 @@ program singleton_storage.aleo {
 
     storage vec: [u8];
     storage nums: [u32];
+    mapping calls: u32 => u32;
 
     fn push() -> Final {
         return final { vec.push(42u8); };
@@ -58,5 +59,26 @@ program singleton_storage.aleo {
 
     fn swap_remove_fallible_index(public x: u32) -> Final {
         return final { nums.swap_remove(1u32 / x); };
+    }
+
+    fn set_effectful_index() -> Final {
+        return final {
+            nums.push(0u32);
+            nums.set(next_index(), 42u32);
+        };
+    }
+
+    fn swap_remove_effectful_index() -> Final {
+        return final {
+            nums.push(0u32);
+            nums.swap_remove(next_index());
+        };
+    }
+
+    // This counter write makes repeated index evaluation observable.
+    final fn next_index() -> u32 {
+        let count: u32 = calls.get_or_use(0u32, 0u32);
+        calls.set(0u32, count + 1u32);
+        return 0u32;
     }
 }


### PR DESCRIPTION
## Motivation

Fixes #29604.

Evaluate non-discardable storage-vector indices exactly once before `set` and `swap_remove` reuse them. Discardable indices remain direct.

## Test Plan

- storage-lowering coverage for fallible and effectful-call `set` and `swap_remove` indices
- fork expectation generation and clean rerun: https://github.com/1sgtpepper/leo/actions/runs/30277104905
- CircleCI

## Related PRs

- #29550
- #29551