### PR TITLE
WIP: Add impl blocks

### DIFF
--- a/crates/ast/src/expressions/method_call.rs
+++ b/crates/ast/src/expressions/method_call.rs
@@ -1,0 +1,58 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Expression, Identifier, Node, NodeID};
+use leo_span::Span;
+
+use itertools::Itertools as _;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A method call `receiver.method(arguments)`.
+///
+/// This is a transient node: the parser produces it for every non-operator `.method(..)` call
+/// because the receiver's type (and hence which method is meant) is unknown at parse time. Type
+/// checking resolves it by the receiver's type, and the Disambiguate pass rewrites it into either
+/// an [`crate::IntrinsicExpression`] (built-in methods on `Vector`/`Mapping`/`Optional`/`signature`/
+/// `Future`) or a [`crate::CallExpression`] (a user method on a struct/record). It never survives
+/// past Disambiguate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MethodCall {
+    /// The receiver the method is called on.
+    pub receiver: Expression,
+    /// The method name. Not a path — it is resolved against the receiver's type, not by name.
+    pub method: Identifier,
+    /// The explicit arguments (the receiver is not included here).
+    pub arguments: Vec<Expression>,
+    /// The span covering all of `receiver.method(arguments)`.
+    pub span: Span,
+    /// The ID of the node.
+    pub id: NodeID,
+}
+
+impl fmt::Display for MethodCall {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}.{}({})", self.receiver, self.method, self.arguments.iter().format(", "))
+    }
+}
+
+impl From<MethodCall> for Expression {
+    fn from(value: MethodCall) -> Self {
+        Expression::MethodCall(Box::new(value))
+    }
+}
+
+crate::simple_node_impl!(MethodCall);

--- a/crates/ast/src/expressions/mod.rs
+++ b/crates/ast/src/expressions/mod.rs
@@ -50,6 +50,9 @@ pub use err::*;
 mod member_access;
 pub use member_access::*;
 
+mod method_call;
+pub use method_call::*;
+
 mod intrinsic;
 pub use intrinsic::*;
 
@@ -105,6 +108,8 @@ pub enum Expression {
     Literal(Literal),
     /// An access of a composite member, e.g. `composite.member`.
     MemberAccess(Box<MemberAccess>),
+    /// A method call `receiver.method(args)`, resolved by receiver type and removed by Disambiguate.
+    MethodCall(Box<MethodCall>),
     /// An array expression constructed from one repeated element, e.g., `[1u32; 5]`.
     Repeat(Box<RepeatExpression>),
     /// A ternary conditional expression `cond ? if_expr : else_expr`.
@@ -142,6 +147,7 @@ impl Node for Expression {
             Path(n) => n.span(),
             Literal(n) => n.span(),
             MemberAccess(n) => n.span(),
+            MethodCall(n) => n.span(),
             Repeat(n) => n.span(),
             Ternary(n) => n.span(),
             Tuple(n) => n.span(),
@@ -167,6 +173,7 @@ impl Node for Expression {
             Path(n) => n.set_span(span),
             Literal(n) => n.set_span(span),
             MemberAccess(n) => n.set_span(span),
+            MethodCall(n) => n.set_span(span),
             Repeat(n) => n.set_span(span),
             Ternary(n) => n.set_span(span),
             Tuple(n) => n.set_span(span),
@@ -190,6 +197,7 @@ impl Node for Expression {
             Path(n) => n.id(),
             Literal(n) => n.id(),
             MemberAccess(n) => n.id(),
+            MethodCall(n) => n.id(),
             Repeat(n) => n.id(),
             Err(n) => n.id(),
             Intrinsic(n) => n.id(),
@@ -215,6 +223,7 @@ impl Node for Expression {
             Path(n) => n.set_id(id),
             Literal(n) => n.set_id(id),
             MemberAccess(n) => n.set_id(id),
+            MethodCall(n) => n.set_id(id),
             Repeat(n) => n.set_id(id),
             Err(n) => n.set_id(id),
             Intrinsic(n) => n.set_id(id),
@@ -244,6 +253,7 @@ impl fmt::Display for Expression {
             Path(n) => n.fmt(f),
             Literal(n) => n.fmt(f),
             MemberAccess(n) => n.fmt(f),
+            MethodCall(n) => n.fmt(f),
             Repeat(n) => n.fmt(f),
             Ternary(n) => n.fmt(f),
             Tuple(n) => n.fmt(f),
@@ -269,7 +279,8 @@ impl Expression {
             Cast(_) => 12,
             Ternary(_) => 0,
             Array(_) | ArrayAccess(_) | Async(_) | Call(_) | DynamicOp(_) | Composite(_) | Err(_) | Intrinsic(_)
-            | Path(_) | Literal(_) | MemberAccess(_) | Repeat(_) | Tuple(_) | TupleAccess(_) | Unary(_) | Unit(_) => 20,
+            | Path(_) | Literal(_) | MemberAccess(_) | MethodCall(_) | Repeat(_) | Tuple(_) | TupleAccess(_)
+            | Unary(_) | Unit(_) => 20,
         }
     }
 
@@ -377,6 +388,9 @@ impl Expression {
                 expr.condition.is_pure(get_type) && expr.if_true.is_pure(get_type) && expr.if_false.is_pure(get_type)
             }
             Expression::Tuple(expr) => expr.elements.iter().all(|e| e.is_pure(get_type)),
+
+            // Removed by the Disambiguate pass, long before purity analysis runs.
+            Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
         }
     }
 

--- a/crates/ast/src/functions/intrinsic.rs
+++ b/crates/ast/src/functions/intrinsic.rs
@@ -1218,6 +1218,51 @@ impl Intrinsic {
         })
     }
 
+    /// Resolves a `receiver.method(..)` call against the receiver's TYPE to the concrete low-level
+    /// intrinsic symbol, or `None` if the receiver type has no built-in method by that name.
+    ///
+    /// `None` means "not a built-in" — for a struct/record receiver that is a user method, resolved
+    /// elsewhere. This is the type-directed replacement for the old parse-time name matching, and is
+    /// shared by the type checker (to validate) and the Disambiguate pass (to rewrite), so both agree
+    /// on the target.
+    pub fn builtin_method_symbol(receiver_ty: &Type, method: Symbol) -> Option<Symbol> {
+        match receiver_ty {
+            // `get`/`set` are the only names claimed by both Vector and Mapping. `convert_path_symbols`
+            // maps `(Vector, get/set)` to the *mapping* symbol, so special-case the vector case here.
+            Type::Vector(_) if method == sym::get => Some(sym::_vector_get),
+            Type::Vector(_) if method == sym::set => Some(sym::_vector_set),
+            Type::Vector(_) => Self::convert_path_symbols(sym::Vector, method),
+            Type::Mapping(_) => Self::convert_path_symbols(sym::Mapping, method),
+            Type::Optional(_) => Self::convert_path_symbols(sym::Optional, method),
+            Type::Signature => Self::convert_path_symbols(sym::signature, method),
+            Type::Future(_) => Self::convert_path_symbols(sym::Final, method),
+            _ => None,
+        }
+    }
+
+    /// If `method` is the name of a built-in method, returns a human-readable description of the
+    /// receiver type it expects (for diagnostics when it is called on the wrong type). Returns
+    /// `None` for names that are not built-in methods (candidate user methods).
+    pub fn builtin_method_receiver_hint(method: Symbol) -> Option<&'static str> {
+        // Names owned by more than one built-in type are described with both.
+        if method == sym::get || method == sym::set {
+            return Some("a vector or a mapping");
+        }
+        if Self::convert_path_symbols(sym::Vector, method).is_some() {
+            Some("a vector")
+        } else if Self::convert_path_symbols(sym::Mapping, method).is_some() {
+            Some("a mapping")
+        } else if Self::convert_path_symbols(sym::Optional, method).is_some() {
+            Some("an optional")
+        } else if Self::convert_path_symbols(sym::signature, method).is_some() {
+            Some("a signature")
+        } else if Self::convert_path_symbols(sym::Final, method).is_some() {
+            Some("a future")
+        } else {
+            None
+        }
+    }
+
     /// Returns the number of arguments required by the instruction.
     pub fn num_args(&self) -> usize {
         match self {

--- a/crates/ast/src/impl_block/mod.rs
+++ b/crates/ast/src/impl_block/mod.rs
@@ -1,0 +1,58 @@
+// Copyright (C) 2019-2026 Provable Inc.
+// This file is part of the Leo library.
+
+// The Leo library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// The Leo library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with the Leo library. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Function, Identifier, Indent, Node, NodeID};
+
+use leo_span::{Span, Symbol};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// An `impl` block associating a set of methods with a type.
+///
+/// Methods are ordinary functions namespaced under the target type: a method `m` in
+/// `impl Point { .. }` is registered at the symbol-table location `[Point, m]`, so a static
+/// call `Point::m(..)` resolves through the normal path machinery. An instance method takes a
+/// `self` first parameter and is called as `value.m(..)`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Impl {
+    /// The type this block implements methods for, e.g. `Point` in `impl Point { .. }`.
+    pub type_: Identifier,
+    /// The methods defined in this block. Multiple `impl` blocks for the same type merge.
+    pub functions: Vec<(Symbol, Function)>,
+    /// The entire span of the `impl` block.
+    pub span: Span,
+    /// The ID of the node.
+    pub id: NodeID,
+}
+
+impl Impl {
+    /// The name of the type this block implements.
+    pub fn type_name(&self) -> Symbol {
+        self.type_.name
+    }
+}
+
+impl fmt::Display for Impl {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        writeln!(f, "impl {} {{", self.type_)?;
+        for (_, function) in self.functions.iter() {
+            writeln!(f, "{}", Indent(function))?;
+        }
+        write!(f, "}}")
+    }
+}
+
+crate::simple_node_impl!(Impl);

--- a/crates/ast/src/lib.rs
+++ b/crates/ast/src/lib.rs
@@ -50,6 +50,9 @@ pub use self::expressions::*;
 mod functions;
 pub use self::functions::*;
 
+mod impl_block;
+pub use self::impl_block::*;
+
 mod interface;
 pub use self::interface::*;
 

--- a/crates/ast/src/library.rs
+++ b/crates/ast/src/library.rs
@@ -16,7 +16,7 @@
 
 use leo_span::Symbol;
 
-use crate::{Composite, ConstDeclaration, Function, Indent, Interface, Module, Stub};
+use crate::{Composite, ConstDeclaration, Function, Impl, Indent, Interface, Module, Stub};
 use indexmap::IndexMap;
 use serde::Serialize;
 use std::fmt;
@@ -40,6 +40,8 @@ pub struct Library {
     pub functions: Vec<(Symbol, Function)>,
     /// The interface definitions in this library.
     pub interfaces: Vec<(Symbol, Interface)>,
+    /// A vector of `impl` blocks defining methods on this library's types.
+    pub impls: Vec<Impl>,
     /// Stubs for imported programs/libraries.
     ///
     /// Populated by `Compiler::add_import_stubs`; empty in freshly-parsed libraries.
@@ -68,6 +70,10 @@ impl fmt::Display for Library {
 
         for (_, func) in self.functions.iter() {
             writeln!(f, "{}", Indent(func))?;
+        }
+
+        for impl_ in self.impls.iter() {
+            writeln!(f, "{}", Indent(impl_))?;
         }
 
         for (_, module) in self.modules.iter() {

--- a/crates/ast/src/module/mod.rs
+++ b/crates/ast/src/module/mod.rs
@@ -25,7 +25,7 @@
 //! - A list of function definitions (`functions`)
 //! - A list of interface definitions (`interfaces`)
 
-use crate::{Composite, ConstDeclaration, Function, Indent, Interface};
+use crate::{Composite, ConstDeclaration, Function, Impl, Indent, Interface};
 
 use leo_span::Symbol;
 
@@ -49,6 +49,8 @@ pub struct Module {
     pub functions: Vec<(Symbol, Function)>,
     /// A vector of interface definitions.
     pub interfaces: Vec<(Symbol, Interface)>,
+    /// A vector of `impl` blocks defining methods on this module's types.
+    pub impls: Vec<Impl>,
 }
 
 impl fmt::Display for Module {
@@ -62,6 +64,9 @@ impl fmt::Display for Module {
         }
         for (_, function) in self.functions.iter() {
             writeln!(f, "{}", Indent(function))?;
+        }
+        for impl_ in self.impls.iter() {
+            writeln!(f, "{}", Indent(impl_))?;
         }
         writeln!(f, "}}")
     }

--- a/crates/ast/src/passes/consumer.rs
+++ b/crates/ast/src/passes/consumer.rs
@@ -37,6 +37,7 @@ pub trait ExpressionConsumer {
             Expression::Path(path) => self.consume_path(path),
             Expression::Literal(value) => self.consume_literal(value),
             Expression::MemberAccess(access) => self.consume_member_access(*access),
+            Expression::MethodCall(method_call) => self.consume_method_call(*method_call),
             Expression::Repeat(repeat) => self.consume_repeat(*repeat),
             Expression::Ternary(ternary) => self.consume_ternary(*ternary),
             Expression::Tuple(tuple) => self.consume_tuple(tuple),
@@ -50,6 +51,8 @@ pub trait ExpressionConsumer {
     fn consume_array_access(&mut self, _input: ArrayAccess) -> Self::Output;
 
     fn consume_member_access(&mut self, _input: MemberAccess) -> Self::Output;
+
+    fn consume_method_call(&mut self, _input: MethodCall) -> Self::Output;
 
     fn consume_tuple_access(&mut self, _input: TupleAccess) -> Self::Output;
 

--- a/crates/ast/src/passes/reconstructor.rs
+++ b/crates/ast/src/passes/reconstructor.rs
@@ -148,6 +148,7 @@ pub trait AstReconstructor {
             Expression::Path(path) => self.reconstruct_path(path, additional),
             Expression::Literal(value) => self.reconstruct_literal(value, additional),
             Expression::MemberAccess(access) => self.reconstruct_member_access(*access, additional),
+            Expression::MethodCall(method_call) => self.reconstruct_method_call(*method_call, additional),
             Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, additional),
             Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, additional),
             Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, additional),
@@ -189,6 +190,29 @@ pub trait AstReconstructor {
     ) -> (Expression, Self::AdditionalOutput) {
         (
             MemberAccess { inner: self.reconstruct_expression(input.inner, &Default::default()).0, ..input }.into(),
+            Default::default(),
+        )
+    }
+
+    /// Default: reconstruct the receiver and arguments, leaving `method` untouched (it is resolved
+    /// against the receiver's type, not by name). Passes that resolve method calls (Disambiguate)
+    /// override this.
+    fn reconstruct_method_call(
+        &mut self,
+        input: MethodCall,
+        _additional: &Self::AdditionalInput,
+    ) -> (Expression, Self::AdditionalOutput) {
+        (
+            MethodCall {
+                receiver: self.reconstruct_expression(input.receiver, &Default::default()).0,
+                arguments: input
+                    .arguments
+                    .into_iter()
+                    .map(|arg| self.reconstruct_expression(arg, &Default::default()).0)
+                    .collect(),
+                ..input
+            }
+            .into(),
             Default::default(),
         )
     }
@@ -633,6 +657,7 @@ pub trait UnitReconstructor: AstReconstructor {
             structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             stubs: input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect(),
         }
     }
@@ -670,6 +695,7 @@ pub trait UnitReconstructor: AstReconstructor {
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }
@@ -690,6 +716,16 @@ pub trait UnitReconstructor: AstReconstructor {
             composites: input.composites.into_iter().map(|(i, c)| (i, self.reconstruct_composite(c))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
+        }
+    }
+
+    fn reconstruct_impl(&mut self, input: Impl) -> Impl {
+        Impl {
+            type_: input.type_,
+            functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            span: input.span,
+            id: input.id,
         }
     }
 

--- a/crates/ast/src/passes/visitor.rs
+++ b/crates/ast/src/passes/visitor.rs
@@ -121,6 +121,7 @@ pub trait AstVisitor {
             Expression::Path(path) => self.visit_path(path, additional),
             Expression::Literal(literal) => self.visit_literal(literal, additional),
             Expression::MemberAccess(access) => self.visit_member_access(access, additional),
+            Expression::MethodCall(method_call) => self.visit_method_call(method_call, additional),
             Expression::Repeat(repeat) => self.visit_repeat(repeat, additional),
             Expression::Ternary(ternary) => self.visit_ternary(ternary, additional),
             Expression::Tuple(tuple) => self.visit_tuple(tuple, additional),
@@ -139,6 +140,14 @@ pub trait AstVisitor {
 
     fn visit_member_access(&mut self, input: &MemberAccess, _additional: &Self::AdditionalInput) -> Self::Output {
         self.visit_expression(&input.inner, &Default::default());
+        Default::default()
+    }
+
+    fn visit_method_call(&mut self, input: &MethodCall, _additional: &Self::AdditionalInput) -> Self::Output {
+        self.visit_expression(&input.receiver, &Default::default());
+        input.arguments.iter().for_each(|arg| {
+            self.visit_expression(arg, &Default::default());
+        });
         Default::default()
     }
 
@@ -362,6 +371,7 @@ pub trait UnitVisitor: AstVisitor {
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.functions.iter().for_each(|(_, f)| self.visit_function(f));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         input.modules.values().for_each(|m| self.visit_module(m));
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
     }
@@ -381,6 +391,7 @@ pub trait UnitVisitor: AstVisitor {
         input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
         input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }
@@ -391,6 +402,11 @@ pub trait UnitVisitor: AstVisitor {
         input.composites.iter().for_each(|(_, c)| self.visit_composite(c));
         input.interfaces.iter().for_each(|(_, c)| self.visit_interface(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
+    }
+
+    fn visit_impl(&mut self, input: &Impl) {
+        input.functions.iter().for_each(|(_, f)| self.visit_function(f));
     }
 
     fn visit_composite(&mut self, input: &Composite) {

--- a/crates/ast/src/program/program_scope.rs
+++ b/crates/ast/src/program/program_scope.rs
@@ -21,6 +21,7 @@ use crate::{
     ConstDeclaration,
     Constructor,
     Function,
+    Impl,
     Indent,
     Interface,
     Mapping,
@@ -52,6 +53,8 @@ pub struct ProgramScope {
     pub functions: Vec<(Symbol, Function)>,
     /// A vector of interface definitions.
     pub interfaces: Vec<(Symbol, Interface)>,
+    /// A vector of `impl` blocks defining methods on this program's types.
+    pub impls: Vec<Impl>,
     /// An optional constructor.
     pub constructor: Option<Constructor>,
     /// The span associated with the program scope.
@@ -83,6 +86,9 @@ impl fmt::Display for ProgramScope {
 
         for (_, function) in self.functions.iter().filter(|f| !f.1.variant.is_entry() && !f.1.variant.is_view()) {
             writeln!(f, "{}", Indent(function))?;
+        }
+        for impl_ in self.impls.iter() {
+            writeln!(f, "{impl_}")?;
         }
         Ok(())
     }

--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -42,6 +42,7 @@ pub fn format_node(node: &SyntaxNode, out: &mut Output) {
         FUNCTION_DEF | FINAL_FN_DEF | VIEW_FN_DEF | CONSTRUCTOR_DEF => format_function(node, out),
         STRUCT_DEF | RECORD_DEF => format_composite(node, out),
         INTERFACE_DEF => format_interface(node, out),
+        IMPL_DEF => format_impl(node, out),
         FN_PROTOTYPE_DEF => format_fn_prototype(node, out),
         RECORD_PROTOTYPE_DEF => format_record_prototype(node, out),
         IMPORT => format_import(node, out),
@@ -51,6 +52,7 @@ pub fn format_node(node: &SyntaxNode, out: &mut Output) {
         ANNOTATION => format_annotation(node, out),
         PARAM_LIST => format_parameter_list(node, out),
         PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT => format_parameter(node, out),
+        SELF_PARAM => out.write("self"),
         RETURN_TYPE => format_return_type(node, out),
         CONST_PARAM => format_const_parameter(node, out),
         CONST_PARAM_LIST => format_const_parameter_list(node, out),
@@ -416,6 +418,7 @@ fn is_program_item_non_annotation(kind: SyntaxKind) -> bool {
             | STORAGE_DEF
             | GLOBAL_CONST
             | INTERFACE_DEF
+            | IMPL_DEF
     )
 }
 
@@ -423,7 +426,14 @@ fn is_program_item_non_annotation(kind: SyntaxKind) -> bool {
 fn is_block_item(kind: SyntaxKind) -> bool {
     matches!(
         kind,
-        FUNCTION_DEF | FINAL_FN_DEF | VIEW_FN_DEF | CONSTRUCTOR_DEF | STRUCT_DEF | RECORD_DEF | INTERFACE_DEF
+        FUNCTION_DEF
+            | FINAL_FN_DEF
+            | VIEW_FN_DEF
+            | CONSTRUCTOR_DEF
+            | STRUCT_DEF
+            | RECORD_DEF
+            | INTERFACE_DEF
+            | IMPL_DEF
     )
 }
 
@@ -810,6 +820,89 @@ fn format_interface(node: &SyntaxNode, out: &mut Output) {
                     if n.next_sibling().is_some() {
                         out.newline();
                     }
+                }
+                ERROR => {
+                    let text = n.text().to_string();
+                    let text = text.trim();
+                    if !text.is_empty() {
+                        out.indented(|out| {
+                            out.write(text);
+                            out.newline();
+                        });
+                    }
+                }
+                _ => {}
+            },
+        }
+    }
+
+    if has_token(node, R_BRACE) {
+        out.write("}");
+        if let Some(idx) = rbrace_idx {
+            emit_comments_after(&elems, idx, out);
+        }
+    }
+    if let Some(next) = node.next_sibling() {
+        emit_stolen_trailing_comments(&next, out);
+    }
+    out.set_mark();
+    out.ensure_newline();
+}
+
+fn format_impl(node: &SyntaxNode, out: &mut Output) {
+    let elems = elements(node);
+    let rbrace_idx = find_last_token_index(&elems, R_BRACE);
+
+    emit_leading_comments(node, out);
+
+    let mut after_lbrace = false;
+    let mut first_method = true;
+    for elem in &elems {
+        match elem {
+            SyntaxElement::Token(tok) => match tok.kind() {
+                KW_IMPL => {
+                    out.write("impl");
+                    out.space();
+                }
+                IDENT if !after_lbrace => {
+                    out.write(tok.text());
+                }
+                L_BRACE => {
+                    out.space();
+                    out.write("{");
+                    if let Some(first_item) = node.children().find(|child| matches!(child.kind(), FUNCTION_DEF | ERROR))
+                    {
+                        emit_stolen_trailing_comments(&first_item, out);
+                    }
+                    out.newline();
+                    after_lbrace = true;
+                }
+                R_BRACE => {}
+                COMMENT_LINE if after_lbrace => {
+                    out.indented(|out| {
+                        out.write(tok.text().trim_end());
+                    });
+                    out.newline();
+                }
+                COMMENT_BLOCK if after_lbrace => {
+                    out.indented(|out| {
+                        out.write(tok.text());
+                    });
+                    out.newline();
+                }
+                WHITESPACE | LINEBREAK => {}
+                _ if !after_lbrace => out.write(tok.text()),
+                _ => {}
+            },
+            SyntaxElement::Node(n) => match n.kind() {
+                FUNCTION_DEF => {
+                    // Blank line between methods (inserted at the previous method's mark, before any
+                    // trailing comment), matching how top-level functions are spaced.
+                    if !first_method {
+                        out.insert_newline_at_mark();
+                    }
+                    first_method = false;
+                    out.indented(|out| format_node(n, out));
                 }
                 ERROR => {
                     let text = n.text().to_string();
@@ -1270,7 +1363,9 @@ fn format_parameter_list_with_suffix(node: &SyntaxNode, out: &mut Output, suffix
         SyntaxElement::Token(tok) => {
             !matches!(tok.kind(), L_PAREN | R_PAREN | COMMA | WHITESPACE | LINEBREAK | COMMENT_LINE | COMMENT_BLOCK)
         }
-        SyntaxElement::Node(n) => !matches!(n.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | ERROR),
+        SyntaxElement::Node(n) => {
+            !matches!(n.kind(), SELF_PARAM | PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | ERROR)
+        }
     });
 
     if has_error_descendant(node) || has_direct_non_list_tokens {
@@ -1280,7 +1375,7 @@ fn format_parameter_list_with_suffix(node: &SyntaxNode, out: &mut Output, suffix
 
     let params: Vec<_> = node
         .children()
-        .filter(|c| matches!(c.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | ERROR))
+        .filter(|c| matches!(c.kind(), SELF_PARAM | PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | ERROR))
         .collect();
 
     if params.is_empty() {
@@ -3845,6 +3940,7 @@ fn is_program_item(kind: SyntaxKind) -> bool {
             | STORAGE_DEF
             | GLOBAL_CONST
             | INTERFACE_DEF
+            | IMPL_DEF
             | ANNOTATION
     )
 }

--- a/crates/fmt/tests/source/impl_block.leo
+++ b/crates/fmt/tests/source/impl_block.leo
@@ -1,0 +1,9 @@
+export struct Point{x:u32,y:u32}
+impl Point{
+fn new(x:u32,y:u32)->Point{return Point{x,y};}
+fn sum(self)->u32{return self.x+self.y;}
+}
+program test.aleo{
+fn main(a:u32,b:u32)->u32{let p:Point=Point::new(a,b);return p.sum();}
+@noupgrade constructor(){}
+}

--- a/crates/fmt/tests/target/impl_block.leo
+++ b/crates/fmt/tests/target/impl_block.leo
@@ -1,0 +1,24 @@
+export struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    fn new(x: u32, y: u32) -> Point {
+        return Point { x, y };
+    }
+
+    fn sum(self) -> u32 {
+        return self.x + self.y;
+    }
+}
+
+program test.aleo {
+    fn main(a: u32, b: u32) -> u32 {
+        let p: Point = Point::new(a, b);
+        return p.sum();
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/crates/parser-rowan/src/lexer.rs
+++ b/crates/parser-rowan/src/lexer.rs
@@ -322,6 +322,7 @@ fn ident_to_kind(s: &str) -> SyntaxKind {
         "struct" => KW_STRUCT,
         "constructor" => KW_CONSTRUCTOR,
         "interface" => KW_INTERFACE,
+        "impl" => KW_IMPL,
         // Program structure keywords
         "program" => KW_PROGRAM,
         "import" => KW_IMPORT,

--- a/crates/parser-rowan/src/parser/items.rs
+++ b/crates/parser-rowan/src/parser/items.rs
@@ -31,7 +31,7 @@ impl Parser<'_, '_> {
     /// Recovery set for struct/record fields.
     const FIELD_RECOVERY: &'static [SyntaxKind] = &[COMMA, R_BRACE, KW_PUBLIC, KW_PRIVATE, KW_CONSTANT];
     /// Tokens that can start a module-level item (for error recovery).
-    const MODULE_ITEM_RECOVERY: &'static [SyntaxKind] = &[KW_EXPORT, KW_CONST, KW_STRUCT, KW_FN, KW_FINAL, AT];
+    const MODULE_ITEM_RECOVERY: &'static [SyntaxKind] = &[KW_EXPORT, KW_CONST, KW_STRUCT, KW_FN, KW_FINAL, KW_IMPL, AT];
     /// Expected items within a `program { ... }` block.
     const PROGRAM_ITEM_EXPECTED: &'static [SyntaxKind] = &[
         R_BRACE,
@@ -45,6 +45,7 @@ impl Parser<'_, '_> {
         KW_STORAGE,
         KW_SCRIPT,
         KW_INTERFACE,
+        KW_IMPL,
     ];
     /// Recovery set for return type parsing.
     const RETURN_TYPE_RECOVERY: &'static [SyntaxKind] = &[COMMA, R_PAREN, L_BRACE];
@@ -64,6 +65,7 @@ impl Parser<'_, '_> {
         KW_STORAGE,
         KW_SCRIPT,
         KW_INTERFACE,
+        KW_IMPL,
         AT,
     ];
 
@@ -112,7 +114,7 @@ impl Parser<'_, '_> {
                 }
                 // Module-level items at top level (for module files and
                 // multi-section test files with `// --- Next Module:` separators).
-                KW_EXPORT | KW_CONST | KW_STRUCT | KW_FN | KW_FINAL | AT | KW_INTERFACE | KW_VIEW => {
+                KW_EXPORT | KW_CONST | KW_STRUCT | KW_FN | KW_FINAL | AT | KW_INTERFACE | KW_IMPL | KW_VIEW => {
                     if self.parse_module_item().is_none() {
                         self.error_and_bump("expected module item");
                     }
@@ -129,6 +131,7 @@ impl Parser<'_, '_> {
                         KW_FINAL,
                         KW_VIEW,
                         KW_INTERFACE,
+                        KW_IMPL,
                         AT,
                     ]);
                 }
@@ -168,10 +171,11 @@ impl Parser<'_, '_> {
             KW_CONST => self.parse_global_const(),
             KW_STRUCT => self.parse_composite_def(STRUCT_DEF),
             KW_INTERFACE => self.parse_interface_def(),
+            KW_IMPL => self.parse_impl_def(),
             AT | KW_FN | KW_FINAL | KW_VIEW => self.parse_function_or_constructor(false),
             _ => {
                 if self.at(KW_EXPORT) {
-                    self.error("expected `fn`, `struct`, `const`, or `interface` after `export`");
+                    self.error("expected `fn`, `struct`, `const`, `interface`, or `impl` after `export`");
                     self.bump_any();
                 }
                 None
@@ -270,6 +274,7 @@ impl Parser<'_, '_> {
                 None
             }
             KW_INTERFACE => self.parse_interface_def(),
+            KW_IMPL => self.parse_impl_def(),
             _ => {
                 let expected: Vec<&str> = Self::PROGRAM_ITEM_EXPECTED.iter().map(|k| k.user_friendly_name()).collect();
                 self.error_unexpected(self.current(), &expected);
@@ -380,6 +385,56 @@ impl Parser<'_, '_> {
         self.expect(R_BRACE);
 
         Some(m.complete(self, kind))
+    }
+
+    /// Parse an impl block: `impl Type { <methods> }`.
+    ///
+    /// Methods are plain `fn`s that may take a leading `self` receiver (instance methods) or not
+    /// (static/associated methods). Const generics and `final`/`view` methods are not supported in
+    /// the first version.
+    fn parse_impl_def(&mut self) -> Option<CompletedMarker> {
+        let m = self.start();
+        self.bump_any(); // impl
+
+        // Target type name.
+        self.skip_trivia();
+        if self.at(IDENT) {
+            self.bump_any();
+        } else {
+            self.error("expected type name after `impl`");
+            self.recover(Self::STRUCT_NAME_RECOVERY);
+            return Some(m.complete(self, ERROR));
+        }
+
+        self.expect(L_BRACE);
+        while !self.at(R_BRACE) && !self.at_eof() {
+            // Clear error state so each method gets fresh error reporting.
+            self.erroring = false;
+            if self.parse_impl_method().is_none() {
+                self.recover(ITEM_RECOVERY);
+            }
+        }
+        self.expect(R_BRACE);
+
+        Some(m.complete(self, IMPL_DEF))
+    }
+
+    /// Parse a single method inside an impl block: `[@annotation] fn name(...) -> Type { ... }`.
+    fn parse_impl_method(&mut self) -> Option<CompletedMarker> {
+        let m = self.start();
+
+        while self.at(AT) {
+            self.parse_annotation();
+        }
+
+        if self.at(KW_FN) {
+            self.parse_function_body(true);
+            Some(m.complete(self, FUNCTION_DEF))
+        } else {
+            self.error("expected `fn` in impl block");
+            m.abandon(self);
+            None
+        }
     }
 
     /// Parse struct/record fields.
@@ -557,7 +612,7 @@ impl Parser<'_, '_> {
         // Dispatch based on what follows.
         match self.current() {
             KW_FN => {
-                self.parse_function_body();
+                self.parse_function_body(false);
                 let kind = match (ate_final, ate_view) {
                     (true, _) => FINAL_FN_DEF,
                     (false, true) => VIEW_FN_DEF,
@@ -577,8 +632,11 @@ impl Parser<'_, '_> {
         }
     }
 
-    /// Parse function body (after final/fn keyword marker started)
-    fn parse_function_body(&mut self) {
+    /// Parse function body (after final/fn keyword marker started).
+    ///
+    /// `allow_self` permits a leading `self` receiver parameter, which is only valid for impl
+    /// methods.
+    fn parse_function_body(&mut self, allow_self: bool) {
         // Function keyword
         if !self.eat(KW_FN) {
             self.error("expected 'fn'");
@@ -599,7 +657,7 @@ impl Parser<'_, '_> {
         }
 
         // Parameters
-        self.parse_param_list();
+        self.parse_param_list(allow_self);
 
         // Return type: `-> [visibility] TypeKind` or `-> (vis TypeKind, vis TypeKind)`
         if self.eat(ARROW) {
@@ -653,16 +711,27 @@ impl Parser<'_, '_> {
         self.bump_any(); // constructor
 
         // Parameters
-        self.parse_param_list();
+        self.parse_param_list(false);
 
         // Body
         self.parse_block();
     }
 
-    /// Parse a parameter list: `(a: TypeKind, b: TypeKind)`
-    fn parse_param_list(&mut self) {
+    /// Parse a parameter list: `(a: TypeKind, b: TypeKind)`.
+    ///
+    /// When `allow_self` is set (impl methods), an optional leading `self` receiver is accepted.
+    fn parse_param_list(&mut self, allow_self: bool) {
         let m = self.start();
         self.expect(L_PAREN);
+
+        // Optional leading `self` receiver of an impl instance method.
+        if allow_self && self.at(KW_SELF) {
+            let sm = self.start();
+            self.bump_any(); // self
+            sm.complete(self, SELF_PARAM);
+            // A trailing comma separates `self` from the remaining parameters.
+            self.eat(COMMA);
+        }
 
         while !self.at(R_PAREN) && !self.at_eof() {
             // Clear error state so each parameter gets fresh error reporting.
@@ -809,7 +878,7 @@ impl Parser<'_, '_> {
         }
 
         // Parameters
-        self.parse_param_list();
+        self.parse_param_list(false);
 
         // Return type
         if self.eat(ARROW) {

--- a/crates/parser-rowan/src/syntax_kind.rs
+++ b/crates/parser-rowan/src/syntax_kind.rs
@@ -191,6 +191,8 @@ define_syntax_kinds! {
     KW_CONSTRUCTOR,
     /// `interface`
     KW_INTERFACE,
+    /// `impl`
+    KW_IMPL,
 
     // ==========================================================================
     // Keywords - Program Structure
@@ -411,6 +413,8 @@ define_syntax_kinds! {
     GLOBAL_CONST,
     /// Interface declaration.
     INTERFACE_DEF,
+    /// Impl block: `impl Type { <methods> }`.
+    IMPL_DEF,
     /// Function prototype (in interface).
     FN_PROTOTYPE_DEF,
     /// Record prototype (in interface).
@@ -425,6 +429,8 @@ define_syntax_kinds! {
     ANNOTATION_PAIR,
     /// Parameter in a function signature.
     PARAM,
+    /// The `self` receiver parameter of an impl instance method.
+    SELF_PARAM,
     /// Public parameter: `public name: TypeKind`
     PARAM_PUBLIC,
     /// Private parameter: `private name: TypeKind`
@@ -645,6 +651,7 @@ impl SyntaxKind {
                 | KW_STRUCT
                 | KW_CONSTRUCTOR
                 | KW_INTERFACE
+                | KW_IMPL
                 | KW_PROGRAM
                 | KW_IMPORT
                 | KW_MAPPING
@@ -913,6 +920,7 @@ impl SyntaxKind {
             KW_STRUCT => "'struct'",
             KW_CONSTRUCTOR => "'constructor'",
             KW_INTERFACE => "'interface'",
+            KW_IMPL => "'impl'",
 
             // Program structure keywords
             KW_PROGRAM => "'program'",

--- a/crates/parser/src/errors.rs
+++ b/crates/parser/src/errors.rs
@@ -43,6 +43,9 @@ pub(crate) fn unexpected_str(found: impl Display, expected: impl Display, span: 
         .with_help(format!("Replace `{found}` with `{expected}`."))
 }
 
+// Retained for its error-code slot; user-defined instance-method calls are now deferred to the
+// type checker rather than rejected here (see `method_call_expr_to_expression`).
+#[allow(dead_code)]
 pub(crate) fn invalid_method_call(
     expr: impl Display,
     func: impl Display,

--- a/crates/parser/src/rowan.rs
+++ b/crates/parser/src/rowan.rs
@@ -66,6 +66,13 @@ struct ConversionContext<'a> {
     /// only fails when the CST contains ERROR nodes from parse recovery), so
     /// reporting them would be duplicative.
     suppress_cascade: bool,
+    /// The type name of the impl instance method currently being converted, if any.
+    ///
+    /// `Some(Type)` while converting the body (and `self` parameter) of an instance method in
+    /// `impl Type { .. }`. In that context `self` is a valid local of type `Type` rather than the
+    /// removed execution-context keyword, so `self` and `self.field` are lowered as ordinary
+    /// references instead of migration errors. `None` everywhere else preserves those diagnostics.
+    self_type: std::cell::Cell<Option<Symbol>>,
 }
 
 impl<'a> ConversionContext<'a> {
@@ -77,7 +84,7 @@ impl<'a> ConversionContext<'a> {
         start_pos: u32,
         suppress_cascade: bool,
     ) -> Self {
-        Self { handler, builder, interner, start_pos, suppress_cascade }
+        Self { handler, builder, interner, start_pos, suppress_cascade, self_type: std::cell::Cell::new(None) }
     }
 
     /// Emit an `unexpected_str` error, unless cascade suppression is active.
@@ -573,7 +580,7 @@ impl<'a> ConversionContext<'a> {
             PATH_EXPR => self.path_expr_to_expression(node)?,
             PATH_LOCATOR_EXPR => self.path_locator_expr_to_expression(node)?,
             PROGRAM_REF_EXPR => self.program_ref_expr_to_expression(node)?,
-            SELF_EXPR => self.error_removed_context_keyword(node, sym::SelfLower),
+            SELF_EXPR => self.self_expr_to_expression(node),
             BLOCK_KW_EXPR => self.error_removed_context_keyword(node, sym::block),
             NETWORK_KW_EXPR => self.error_removed_context_keyword(node, sym::network),
             SELF_UPPER_EXPR => {
@@ -1066,7 +1073,8 @@ impl<'a> ConversionContext<'a> {
         // Remaining expression children are the arguments.
         let mut args: Vec<_> = expr_children.map(|n| self.to_expression(&n)).collect::<Result<Vec<_>>>()?;
 
-        // Check for known methods that map to unary/binary operations or intrinsics
+        // Operators are universal and syntactic, so they are desugared here at parse time,
+        // regardless of receiver type. (Operator overloading is planned via traits later.)
         if args.is_empty() {
             if let Some(op) = leo_ast::UnaryOperation::from_symbol(method_name.name) {
                 return Ok(leo_ast::UnaryExpression { span, op, receiver, id }.into());
@@ -1077,45 +1085,11 @@ impl<'a> ConversionContext<'a> {
             return Ok(leo_ast::BinaryExpression { span, op, left: receiver, right: args.pop().unwrap(), id }.into());
         }
 
-        // Check for known intrinsic method calls.
-        // Ordering follows the lossless parser (conversions.rs):
-        // 1. Specific intrinsics (signature, Future, Optional)
-        // 2. Unresolved `.get()`/`.set()` (deferred to type checker)
-        // 3. Vector/Mapping methods
-        let method = method_name.name;
-        let all_args = || std::iter::once(receiver.clone()).chain(args.clone()).collect::<Vec<_>>();
-
-        // Known module-specific intrinsics matched by name and arg count.
-        let intrinsic_name = match args.len() {
-            2 => leo_ast::Intrinsic::convert_path_symbols(sym::signature, method),
-            0 => leo_ast::Intrinsic::convert_path_symbols(sym::Final, method)
-                .or_else(|| leo_ast::Intrinsic::convert_path_symbols(sym::Optional, method)),
-            1 => leo_ast::Intrinsic::convert_path_symbols(sym::Optional, method),
-            _ => None,
-        };
-        if let Some(intrinsic_name) = intrinsic_name {
-            return Ok(self.intrinsic_expression(intrinsic_name, all_args(), span));
-        }
-
-        // Unresolved `.get()` / `.set()` — the receiver type is unknown at
-        // parse time, so defer resolution to the type checker.
-        if method == sym::get && args.len() == 1 {
-            return Ok(self.intrinsic_expression(Symbol::intern("__unresolved_get"), all_args(), span));
-        }
-        if method == sym::set && args.len() == 2 {
-            return Ok(self.intrinsic_expression(Symbol::intern("__unresolved_set"), all_args(), span));
-        }
-
-        // Remaining Vector/Mapping method intrinsics.
-        for module in [sym::Vector, sym::Mapping] {
-            if let Some(intrinsic_name) = leo_ast::Intrinsic::convert_path_symbols(module, method) {
-                return Ok(self.intrinsic_expression(intrinsic_name, all_args(), span));
-            }
-        }
-
-        // Unknown method call - emit error
-        self.handler.emit_err(crate::errors::invalid_method_call(receiver, method_name, args.len(), span));
-        Ok(self.error_expression(span))
+        // Everything else is a method call resolved by the receiver's type. Built-in methods on
+        // `Vector`/`Mapping`/`Optional`/`signature`/`Future` and user methods on structs/records are
+        // all resolved in the type checker (and rewritten by the Disambiguate pass); the receiver
+        // type is unknown here, so we cannot resolve by name.
+        Ok(leo_ast::MethodCall { receiver, method: method_name, arguments: args, span, id }.into())
     }
 
     /// Convert a TUPLE_ACCESS_EXPR node to a TupleAccess expression.
@@ -1160,7 +1134,11 @@ impl<'a> ConversionContext<'a> {
         let (inner, first_child_kind) = match children(node).find(|n| n.kind().is_expression()) {
             Some(n) => {
                 let kind = n.kind();
-                let lowered = if matches!(kind, SELF_EXPR | BLOCK_KW_EXPR | NETWORK_KW_EXPR) {
+                // In an impl instance method, `self.field` is an ordinary member access on the
+                // receiver, so lower `self` to its path rather than an error placeholder.
+                let lowered = if kind == SELF_EXPR && self.self_type.get().is_some() {
+                    self.self_expr_to_expression(&n)
+                } else if matches!(kind, SELF_EXPR | BLOCK_KW_EXPR | NETWORK_KW_EXPR) {
                     self.error_expression(self.trimmed_span(&n))
                 } else {
                     self.to_expression(&n)?
@@ -1200,24 +1178,31 @@ impl<'a> ConversionContext<'a> {
         // through the `std::ctx` module. Emit a targeted migration error that names
         // the replacement.
         let field_name = Symbol::intern(field_token.text());
-        let removed_access = match (first_child_kind, field_name) {
-            (SELF_EXPR, sym::address) => Some(("self.address", "std::ctx::addr()")),
-            (SELF_EXPR, sym::caller) => Some(("self.caller", "std::ctx::caller()")),
-            (SELF_EXPR, sym::checksum) => Some(("self.checksum", "std::ctx::checksum()")),
-            (SELF_EXPR, sym::edition) => Some(("self.edition", "std::ctx::edition()")),
-            (SELF_EXPR, sym::id) => Some(("self.id", "std::ctx::id()")),
-            (SELF_EXPR, sym::program_owner) => Some(("self.program_owner", "std::ctx::program_owner()")),
-            (SELF_EXPR, sym::signer) => Some(("self.signer", "std::ctx::signer()")),
-            (BLOCK_KW_EXPR, sym::height) => Some(("block.height", "std::ctx::block_height()")),
-            (BLOCK_KW_EXPR, sym::timestamp) => Some(("block.timestamp", "std::ctx::block_timestamp()")),
-            (NETWORK_KW_EXPR, sym::id) => Some(("network.id", "std::ctx::network_id()")),
-            _ => None,
+        // Inside an impl instance method, `self.field` is a real field access — skip both the
+        // removed-context-keyword sugar and the migration diagnostic below.
+        let self_field_in_method = first_child_kind == SELF_EXPR && self.self_type.get().is_some();
+        let removed_access = if self_field_in_method {
+            None
+        } else {
+            match (first_child_kind, field_name) {
+                (SELF_EXPR, sym::address) => Some(("self.address", "std::ctx::addr()")),
+                (SELF_EXPR, sym::caller) => Some(("self.caller", "std::ctx::caller()")),
+                (SELF_EXPR, sym::checksum) => Some(("self.checksum", "std::ctx::checksum()")),
+                (SELF_EXPR, sym::edition) => Some(("self.edition", "std::ctx::edition()")),
+                (SELF_EXPR, sym::id) => Some(("self.id", "std::ctx::id()")),
+                (SELF_EXPR, sym::program_owner) => Some(("self.program_owner", "std::ctx::program_owner()")),
+                (SELF_EXPR, sym::signer) => Some(("self.signer", "std::ctx::signer()")),
+                (BLOCK_KW_EXPR, sym::height) => Some(("block.height", "std::ctx::block_height()")),
+                (BLOCK_KW_EXPR, sym::timestamp) => Some(("block.timestamp", "std::ctx::block_timestamp()")),
+                (NETWORK_KW_EXPR, sym::id) => Some(("network.id", "std::ctx::network_id()")),
+                _ => None,
+            }
         };
         if let Some((old, replacement)) = removed_access {
             self.handler.emit_err(crate::errors::obsolete_context_access(old, replacement, span));
             return Ok(self.error_expression(span));
         }
-        if matches!(first_child_kind, SELF_EXPR | BLOCK_KW_EXPR | NETWORK_KW_EXPR) {
+        if !self_field_in_method && matches!(first_child_kind, SELF_EXPR | BLOCK_KW_EXPR | NETWORK_KW_EXPR) {
             let keyword = match first_child_kind {
                 SELF_EXPR => "self",
                 BLOCK_KW_EXPR => "block",
@@ -1589,6 +1574,21 @@ impl<'a> ConversionContext<'a> {
         };
         self.handler.emit_err(crate::errors::obsolete_context_keyword(keyword, span));
         self.error_expression(span)
+    }
+
+    /// Convert a bare `self` expression.
+    ///
+    /// Inside an impl instance method (`self_type` is set), `self` refers to the receiver local,
+    /// so it lowers to an unresolved path that path resolution binds to the `self` parameter.
+    /// Everywhere else `self` is the removed context keyword and produces a migration error.
+    fn self_expr_to_expression(&self, node: &SyntaxNode) -> leo_ast::Expression {
+        if self.self_type.get().is_some() {
+            let span = self.trimmed_span(node);
+            let ident = leo_ast::Identifier { name: sym::SelfLower, span, id: self.builder.next_id() };
+            leo_ast::Path::new(None, Vec::new(), ident, span, self.builder.next_id()).into()
+        } else {
+            self.error_removed_context_keyword(node, sym::SelfLower)
+        }
     }
 
     /// Convert a FINAL_EXPR node to an Expression.
@@ -2015,6 +2015,7 @@ impl<'a> ConversionContext<'a> {
     // =========================================================================
 
     /// Collect a single program item (function, struct/record, const, interface) into the given vectors.
+    #[allow(clippy::too_many_arguments)]
     fn collect_program_item(
         &self,
         item: &SyntaxNode,
@@ -2023,6 +2024,7 @@ impl<'a> ConversionContext<'a> {
         composites: &mut Vec<(Symbol, leo_ast::Composite)>,
         consts: &mut Vec<(Symbol, leo_ast::ConstDeclaration)>,
         interfaces: &mut Vec<(Symbol, leo_ast::Interface)>,
+        impls: &mut Vec<leo_ast::Impl>,
     ) -> Result<()> {
         match item.kind() {
             FUNCTION_DEF | FINAL_FN_DEF | VIEW_FN_DEF => {
@@ -2079,6 +2081,9 @@ impl<'a> ConversionContext<'a> {
                 let interface = self.to_interface(item, is_in_program_block)?;
                 interfaces.push((interface.identifier.name, interface));
             }
+            IMPL_DEF => {
+                impls.push(self.to_impl(item)?);
+            }
             _ => {}
         }
         Ok(())
@@ -2092,6 +2097,7 @@ impl<'a> ConversionContext<'a> {
         structs: &mut Vec<(Symbol, leo_ast::Composite)>,
         functions: &mut Vec<(Symbol, leo_ast::Function)>,
         interfaces: &mut Vec<(Symbol, leo_ast::Interface)>,
+        impls: &mut Vec<leo_ast::Impl>,
     ) -> Result<()> {
         if is_library_item(item.kind()) {
             match item.kind() {
@@ -2111,6 +2117,9 @@ impl<'a> ConversionContext<'a> {
                 INTERFACE_DEF => {
                     let interface = self.to_interface(item, false)?;
                     interfaces.push((interface.identifier.name, interface));
+                }
+                IMPL_DEF => {
+                    impls.push(self.to_impl(item)?);
                 }
                 _ => {}
             }
@@ -2132,6 +2141,60 @@ impl<'a> ConversionContext<'a> {
         Ok(())
     }
 
+    /// Convert an `IMPL_DEF` node to an `Impl`.
+    ///
+    /// Each method is a `Variant::Fn` helper. Instance methods (those with a `self` receiver) are
+    /// converted with `self_type` set so `self`/`self.field` lower as ordinary references.
+    fn to_impl(&self, node: &SyntaxNode) -> Result<leo_ast::Impl> {
+        debug_assert_eq!(node.kind(), IMPL_DEF);
+        let span = self.non_trivia_span(node);
+        let id = self.builder.next_id();
+
+        // The target type is the first direct IDENT token of the impl block.
+        let type_ = self.require_ident(node, "impl target type");
+        self.validate_identifier(&type_);
+
+        let mut functions = Vec::new();
+        for item in children(node).filter(|n| n.kind() == FUNCTION_DEF) {
+            // Enable `self` handling only for instance methods (those with a `self` receiver).
+            let has_self = children(&item)
+                .find(|n| n.kind() == PARAM_LIST)
+                .map(|pl| children(&pl).any(|c| c.kind() == SELF_PARAM))
+                .unwrap_or(false);
+            let prev = self.self_type.replace(if has_self { Some(type_.name) } else { None });
+            // Impl methods are always `Variant::Fn`, never entry points, so pass `false`.
+            let func = self.to_function(&item, false);
+            self.self_type.set(prev);
+            let mut func = func?;
+
+            // An instance method whose name is an operator is unreachable through
+            // `value.method(..)`: operator names are desugared to the operator at parse time, before
+            // any type is known. (Built-in *methods* like `get`/`set`/`unwrap` are fine now — they
+            // are resolved by receiver type, so a struct/record may define them.) Reject only
+            // operator names; the static form `Type::method(..)` remains the escape hatch.
+            let name = func.identifier.name;
+            if has_self
+                && (leo_ast::UnaryOperation::from_symbol(name).is_some()
+                    || leo_ast::BinaryOperation::from_symbol(name).is_some())
+            {
+                self.handler.emit_err(crate::errors::custom(
+                    format!(
+                        "instance method `{name}` collides with a built-in operator; `value.{name}(..)` would apply the operator. Rename it, or call it as `{}::{name}(..)`.",
+                        type_.name
+                    ),
+                    func.identifier.span,
+                ));
+            }
+
+            // Methods form the type's public API, so they are reachable from other modules (e.g. the
+            // program block that uses the type). Mark them exported so accessibility checks pass.
+            func.is_exported = Some(true);
+            functions.push((func.identifier.name, func));
+        }
+
+        Ok(leo_ast::Impl { type_, functions, span, id })
+    }
+
     /// Convert a syntax node to a module.
     fn to_module(&self, node: &SyntaxNode, program_name: Symbol, path: Vec<Symbol>) -> Result<leo_ast::Module> {
         // Module nodes are ROOT nodes containing items (functions, structs, consts, interfaces)
@@ -2139,6 +2202,7 @@ impl<'a> ConversionContext<'a> {
         let mut composites = Vec::new();
         let mut consts = Vec::new();
         let mut interfaces = Vec::new();
+        let mut impls = Vec::new();
 
         for child in children(node) {
             if child.kind() == PROGRAM_DECL {
@@ -2150,6 +2214,7 @@ impl<'a> ConversionContext<'a> {
                         &mut composites,
                         &mut consts,
                         &mut interfaces,
+                        &mut impls,
                     )?;
                 }
             } else {
@@ -2160,6 +2225,7 @@ impl<'a> ConversionContext<'a> {
                     &mut composites,
                     &mut consts,
                     &mut interfaces,
+                    &mut impls,
                 )?;
             }
         }
@@ -2167,7 +2233,7 @@ impl<'a> ConversionContext<'a> {
         // Sort functions: entry points first
         functions.sort_by_key(|func| if func.1.variant.is_entry() { 0u8 } else { 1u8 });
 
-        Ok(leo_ast::Module { unit_name: program_name, path, consts, composites, functions, interfaces })
+        Ok(leo_ast::Module { unit_name: program_name, path, consts, composites, functions, interfaces, impls })
     }
 
     /// Convert a syntax node to a program (main file).
@@ -2181,6 +2247,7 @@ impl<'a> ConversionContext<'a> {
         let mut storage_variables = Vec::new();
         let mut constructors = Vec::new();
         let mut interfaces = Vec::new();
+        let mut impls = Vec::new();
         let mut program_name = None;
         let mut network = None;
         let mut parents = Vec::new();
@@ -2214,6 +2281,7 @@ impl<'a> ConversionContext<'a> {
                             &mut composites,
                             &mut consts,
                             &mut interfaces,
+                            &mut impls,
                         )?;
                         match item.kind() {
                             MAPPING_DEF => {
@@ -2239,6 +2307,7 @@ impl<'a> ConversionContext<'a> {
                         &mut composites,
                         &mut consts,
                         &mut interfaces,
+                        &mut impls,
                     )?;
                 }
             }
@@ -2266,6 +2335,7 @@ impl<'a> ConversionContext<'a> {
             storage_variables,
             functions,
             interfaces,
+            impls,
             constructor: constructors.pop(),
             span,
         };
@@ -2284,9 +2354,10 @@ impl<'a> ConversionContext<'a> {
         let mut structs = Vec::new();
         let mut functions = Vec::new();
         let mut interfaces = Vec::new();
+        let mut impls = Vec::new();
 
         for child in children(node) {
-            self.collect_library_item(&child, &mut consts, &mut structs, &mut functions, &mut interfaces)?;
+            self.collect_library_item(&child, &mut consts, &mut structs, &mut functions, &mut interfaces, &mut impls)?;
         }
 
         Ok(leo_ast::Library {
@@ -2296,6 +2367,7 @@ impl<'a> ConversionContext<'a> {
             structs,
             functions,
             interfaces,
+            impls,
             stubs: indexmap::IndexMap::new(),
         })
     }
@@ -2599,9 +2671,33 @@ impl<'a> ConversionContext<'a> {
         debug_assert_eq!(node.kind(), PARAM_LIST);
 
         children(node)
-            .filter(|n| matches!(n.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT))
-            .map(|n| self.param_to_input(&n))
+            .filter(|n| matches!(n.kind(), PARAM | PARAM_PUBLIC | PARAM_PRIVATE | PARAM_CONSTANT | SELF_PARAM))
+            .map(|n| if n.kind() == SELF_PARAM { self.self_param_to_input(&n) } else { self.param_to_input(&n) })
             .collect()
+    }
+
+    /// Convert a `SELF_PARAM` node to an `Input` named `self` whose type is the enclosing impl
+    /// type. The composite type path is left unresolved for path resolution to bind.
+    fn self_param_to_input(&self, node: &SyntaxNode) -> Result<leo_ast::Input> {
+        debug_assert_eq!(node.kind(), SELF_PARAM);
+        let span = self.non_trivia_span(node);
+        let id = self.builder.next_id();
+
+        let type_ = match self.self_type.get() {
+            Some(type_name) => {
+                let type_ident = leo_ast::Identifier { name: type_name, span, id: self.builder.next_id() };
+                let path = leo_ast::Path::new(None, Vec::new(), type_ident, span, self.builder.next_id());
+                leo_ast::Type::Composite(leo_ast::CompositeType { path, const_arguments: Vec::new() })
+            }
+            None => {
+                // `self` outside an impl method is rejected by the grammar; be defensive.
+                self.emit_unexpected_str("`self` outside an impl method", node.text(), span);
+                leo_ast::Type::Err
+            }
+        };
+
+        let identifier = leo_ast::Identifier { name: sym::SelfLower, span, id: self.builder.next_id() };
+        Ok(leo_ast::Input { identifier, mode: leo_ast::Mode::None, type_, span, id })
     }
 
     /// Convert a PARAM node to an Input.
@@ -3439,7 +3535,7 @@ fn compute_module_key(name: &FileName, root_dir: Option<&std::path::Path>) -> Op
 
 /// Returns `true` for syntax node kinds that are valid inside a library (`lib.leo`).
 fn is_library_item(kind: SyntaxKind) -> bool {
-    matches!(kind, GLOBAL_CONST | STRUCT_DEF | FUNCTION_DEF | INTERFACE_DEF)
+    matches!(kind, GLOBAL_CONST | STRUCT_DEF | FUNCTION_DEF | INTERFACE_DEF | IMPL_DEF)
 }
 
 /// Returns `true` for syntax node kinds that are valid inside a program (`main.leo`).
@@ -3456,6 +3552,7 @@ fn is_program_item(kind: SyntaxKind) -> bool {
             | MAPPING_DEF
             | STORAGE_DEF
             | CONSTRUCTOR_DEF
+            | IMPL_DEF
             | PROGRAM_DECL
             | IMPORT
     )

--- a/crates/passes/src/cei_analysis/cross_layer_taint.rs
+++ b/crates/passes/src/cei_analysis/cross_layer_taint.rs
@@ -179,6 +179,7 @@ impl CrossLayerTaintVisitor<'_> {
             }
             // Leaf / irrelevant nodes.
             Expression::Literal(_) | Expression::Unit(_) | Expression::Err(_) | Expression::Async(_) => {}
+            Expression::MethodCall(_) => unreachable!("MethodCall is removed by the Disambiguate pass"),
         }
     }
 
@@ -274,6 +275,7 @@ impl CrossLayerTaintVisitor<'_> {
             | Expression::Unit(_)
             | Expression::Err(_)
             | Expression::Async(_) => {}
+            Expression::MethodCall(_) => unreachable!("MethodCall is removed by the Disambiguate pass"),
         }
     }
 
@@ -475,6 +477,7 @@ impl CrossLayerTaintVisitor<'_> {
                 }
             }
             Expression::Literal(_) | Expression::Unit(_) | Expression::Err(_) | Expression::Async(_) => {}
+            Expression::MethodCall(_) => unreachable!("MethodCall is removed by the Disambiguate pass"),
         }
     }
 }

--- a/crates/passes/src/cei_analysis/ordering.rs
+++ b/crates/passes/src/cei_analysis/ordering.rs
@@ -297,6 +297,7 @@ impl<'a> Scanner<'a> {
                 }
             }
             Expression::Literal(_) | Expression::Unit(_) | Expression::Err(_) => post,
+            Expression::MethodCall(_) => unreachable!("MethodCall is removed by the Disambiguate pass"),
         }
     }
 

--- a/crates/passes/src/code_generation/expression.rs
+++ b/crates/passes/src/code_generation/expression.rs
@@ -103,6 +103,7 @@ impl CodeGeneratingVisitor<'_> {
             Expression::Err(..) => panic!("`ErrExpression`s should not be in the AST at this phase of compilation."),
             Expression::TupleAccess(..) => panic!("Tuple accesses should not appear in the AST at this point."),
             Expression::Unit(..) => panic!("`UnitExpression`s should not be visited during code generation."),
+            Expression::MethodCall(..) => panic!("Method calls should not appear in the AST at this point."),
         }
     }
 

--- a/crates/passes/src/common/item_walkers.rs
+++ b/crates/passes/src/common/item_walkers.rs
@@ -48,12 +48,14 @@ pub fn items_at_path<'a, V: Clone + 'a>(
     })
 }
 
-/// Yields `(Location, &Function)` for every function defined in `program`, including those in
-/// nested modules. `program.stubs` is not traversed.
+/// Yields `(Location, &Function)` for every function defined in `program`, including impl-block
+/// methods and those in nested modules. `program.stubs` is not traversed.
 pub fn program_functions(program: &Program) -> impl Iterator<Item = (Location, &Function)> {
     let scopes = program.program_scopes.iter().flat_map(|(_, scope)| {
         let prog = scope.program_id.as_symbol();
-        scope.functions.iter().map(move |(name, f)| (Location::new(prog, vec![*name]), f))
+        let functions = scope.functions.iter().map(move |(name, f)| (Location::new(prog, vec![*name]), f));
+        let impls = scope.impls.iter().flat_map(move |imp| impl_functions(prog, &[], imp));
+        functions.chain(impls)
     });
     let modules = program.modules.iter().flat_map(module_functions);
     scopes.chain(modules)
@@ -70,13 +72,14 @@ pub fn program_composites(program: &Program) -> impl Iterator<Item = (Location, 
     scopes.chain(modules)
 }
 
-/// Yields `(Location, &Function)` for every function defined in `library`, including those in
-/// nested modules.
+/// Yields `(Location, &Function)` for every function defined in `library`, including impl-block
+/// methods and those in nested modules.
 pub fn library_functions(library: &Library) -> impl Iterator<Item = (Location, &Function)> {
     let name = library.name;
     let top = library.functions.iter().map(move |(sym, f)| (Location::new(name, vec![*sym]), f));
+    let impls = library.impls.iter().flat_map(move |imp| impl_functions(name, &[], imp));
     let modules = library.modules.iter().flat_map(module_functions);
-    top.chain(modules)
+    top.chain(impls).chain(modules)
 }
 
 /// Yields `(Location, &Composite)` for every composite defined in `library`, including those in
@@ -108,13 +111,29 @@ pub fn stub_composites(stub: &Stub) -> Box<dyn Iterator<Item = (Location, &Compo
     }
 }
 
+/// Yields `(Location, &Function)` for every method in an impl block, keyed at
+/// `module_prefix ++ [Type, method]` within `program`.
+fn impl_functions<'a>(
+    program: Symbol,
+    module_prefix: &'a [Symbol],
+    imp: &'a leo_ast::Impl,
+) -> impl Iterator<Item = (Location, &'a Function)> {
+    let type_name = imp.type_.name;
+    imp.functions.iter().map(move |(name, f)| {
+        let full: Vec<Symbol> = module_prefix.iter().copied().chain([type_name, *name]).collect();
+        (Location::new(program, full), f)
+    })
+}
+
 fn module_functions<'a>(
     (path, m): (&'a Vec<Symbol>, &'a leo_ast::Module),
 ) -> impl Iterator<Item = (Location, &'a Function)> {
-    m.functions.iter().map(move |(name, f)| {
+    let funcs = m.functions.iter().map(move |(name, f)| {
         let full: Vec<Symbol> = path.iter().copied().chain(std::iter::once(*name)).collect();
         (Location::new(m.unit_name, full), f)
-    })
+    });
+    let impls = m.impls.iter().flat_map(move |imp| impl_functions(m.unit_name, path, imp));
+    funcs.chain(impls)
 }
 
 fn module_composites<'a>(

--- a/crates/passes/src/common/mod.rs
+++ b/crates/passes/src/common/mod.rs
@@ -84,6 +84,7 @@ fn contains_non_discardable_operation(expr: &Expression, state: &CompilerState) 
                     .any(|member| contains_non_discardable_operation(member, state))
         }
         Expression::MemberAccess(expr) => contains_non_discardable_operation(&expr.inner, state),
+        Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
         Expression::Repeat(expr) => {
             contains_non_discardable_operation(&expr.expr, state)
                 || contains_non_discardable_operation(&expr.count, state)

--- a/crates/passes/src/common/replacer/mod.rs
+++ b/crates/passes/src/common/replacer/mod.rs
@@ -93,6 +93,9 @@ where
                 Expression::Path(path) => self.reconstruct_path(path, &()),
                 Expression::Literal(value) => self.reconstruct_literal(value, &()),
                 Expression::MemberAccess(access) => self.reconstruct_member_access(*access, &()),
+                // The replacer runs during type checking (via `BlockToFunctionRewriter`), before
+                // Disambiguate, so a `MethodCall` may still be present — recurse into it.
+                Expression::MethodCall(method_call) => self.reconstruct_method_call(*method_call, &()),
                 Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, &()),
                 Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, &()),
                 Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, &()),

--- a/crates/passes/src/common/symbol_table/mod.rs
+++ b/crates/passes/src/common/symbol_table/mod.rs
@@ -510,6 +510,18 @@ impl SymbolTable {
         Ok(())
     }
 
+    /// Replace the stored body of the function at `location` with `function`, preserving the
+    /// entry's `finalizer`/`is_stub` metadata. No-op if no function is registered there.
+    ///
+    /// Used to re-sync the symbol table with the AST after the Disambiguate pass, so analyses that
+    /// read callee bodies from the table (e.g. CEI) see the resolved forms rather than the
+    /// pre-Disambiguate ones registered during global-item collection.
+    pub fn update_function_body(&mut self, location: &Location, function: Function) {
+        if let Some(symbol) = self.functions.get_mut(location) {
+            symbol.function = function;
+        }
+    }
+
     /// Insert an interface at this location.
     pub fn insert_interface(&mut self, location: Location, int: Interface) -> Result<()> {
         self.check_shadow_global(&location, int.identifier.span)?;

--- a/crates/passes/src/common_subexpression_elimination/visitor.rs
+++ b/crates/passes/src/common_subexpression_elimination/visitor.rs
@@ -123,7 +123,8 @@ impl CommonSubexpressionEliminatingVisitor<'_> {
             | Expression::TupleAccess(_)
             | Expression::Unary(_)
             | Expression::Unit(_)
-            | Expression::DynamicOp(_) => return None,
+            | Expression::DynamicOp(_)
+            | Expression::MethodCall(_) => return None,
         };
 
         Some(value)
@@ -244,6 +245,7 @@ impl CommonSubexpressionEliminatingVisitor<'_> {
             }
 
             Expression::TupleAccess(_) => panic!("Tuple access expressions should not exist in this pass."),
+            Expression::MethodCall(_) => unreachable!("MethodCall is removed by the Disambiguate pass"),
 
             Expression::DynamicOp(op) => {
                 self.try_atom(&mut op.target_program)?;

--- a/crates/passes/src/const_propagation/ast.rs
+++ b/crates/passes/src/const_propagation/ast.rs
@@ -67,6 +67,7 @@ impl AstReconstructor for ConstPropagationVisitor<'_> {
             Expression::Path(path) => self.reconstruct_path(path, &()),
             Expression::Literal(value) => self.reconstruct_literal(value, &()),
             Expression::MemberAccess(access) => self.reconstruct_member_access(*access, &()),
+            Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
             Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, &()),
             Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, &()),
             Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, &()),

--- a/crates/passes/src/const_propagation/program.rs
+++ b/crates/passes/src/const_propagation/program.rs
@@ -50,6 +50,7 @@ impl UnitReconstructor for ConstPropagationVisitor<'_> {
             *c = self.reconstruct_constructor(std::mem::take(c));
         }
 
+        input.impls = input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect();
         input.composites = input.composites.into_iter().map(|(i, c)| (i, self.reconstruct_composite(c))).collect();
         input.interfaces = input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect();
         input.mappings =
@@ -86,6 +87,7 @@ impl UnitReconstructor for ConstPropagationVisitor<'_> {
                     .collect(),
                 functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),
                 interfaces: input.interfaces.into_iter().map(|(i, int)| (i, slf.reconstruct_interface(int))).collect(),
+                impls: input.impls.into_iter().map(|i| slf.reconstruct_impl(i)).collect(),
             }
         })
     }
@@ -115,6 +117,8 @@ impl UnitReconstructor for ConstPropagationVisitor<'_> {
             .into_iter()
             .map(|(i, f)| if f.const_parameters.is_empty() { (i, self.reconstruct_function(f)) } else { (i, f) })
             .collect();
+
+        input.impls = input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect();
 
         // Process submodules, applying the same const-propagation logic to their items.
         input.modules = input.modules.into_iter().map(|(id, m)| (id, self.reconstruct_module(m))).collect();

--- a/crates/passes/src/disambiguate.rs
+++ b/crates/passes/src/disambiguate.rs
@@ -18,7 +18,6 @@ use crate::{CompilerState, Pass};
 
 use leo_ast::*;
 use leo_errors::Result;
-use leo_span::{Symbol, sym};
 
 /// Pass that turns ambiguous calls into their proper form after type checking
 /// such as get and set for mappings/vectors
@@ -39,6 +38,33 @@ impl Pass for Disambiguate {
             Ast::Program(program) => Ast::Program(visitor.reconstruct_program(program)),
             Ast::Library(library) => Ast::Library(visitor.reconstruct_library(library)),
         };
+
+        // Re-sync the symbol table's function bodies with the now-disambiguated AST. Bodies were
+        // registered during global-item collection (before method calls were resolved), so passes
+        // that read callee bodies from the table (e.g. CEI analysis) would otherwise see unresolved
+        // `MethodCall` nodes. Refresh them from the reconstructed AST, including import stubs.
+        match &ast {
+            Ast::Program(program) => {
+                let functions: Vec<_> =
+                    crate::common::program_functions(program).map(|(loc, f)| (loc, f.clone())).collect();
+                let stub_functions: Vec<_> = program
+                    .stubs
+                    .values()
+                    .flat_map(crate::common::stub_functions)
+                    .map(|(loc, f)| (loc, f.clone()))
+                    .collect();
+                for (loc, f) in functions.into_iter().chain(stub_functions) {
+                    visitor.state.symbol_table.update_function_body(&loc, f);
+                }
+            }
+            Ast::Library(library) => {
+                let functions: Vec<_> =
+                    crate::common::library_functions(library).map(|(loc, f)| (loc, f.clone())).collect();
+                for (loc, f) in functions {
+                    visitor.state.symbol_table.update_function_body(&loc, f);
+                }
+            }
+        }
 
         visitor.state.handler.last_err()?;
         visitor.state.ast = ast;
@@ -74,32 +100,55 @@ impl AstReconstructor for DisambiguateVisitor<'_> {
             input.return_types.into_iter().map(|(mode, ty, span)| (mode, self.reconstruct_type(ty).0, span)).collect();
         input.arguments = input.arguments.into_iter().map(|arg| self.reconstruct_expression(arg, &()).0).collect();
 
-        if input.name == Symbol::intern("__unresolved_get") {
-            match self.state.type_table.get(&input.arguments[0].id()).map(|t| self.state.types.resolve(t)) {
-                Some(TypeKind::Vector(..)) => {
-                    input.name = sym::_vector_get;
-                }
-                Some(TypeKind::Mapping(..)) => {
-                    input.name = sym::_mapping_get;
-                }
-                _ => {
-                    panic!("type checking should guarantee that no other type is expected here.")
-                }
+        (input.into(), ())
+    }
+
+    /// Rewrite a `MethodCall` (resolved by type checking) into its concrete form. The receiver's
+    /// type — recorded in the type table — selects a built-in intrinsic (`Vector`/`Mapping`/
+    /// `Optional`/`signature`/`Future`) or a user method on a struct/record. `id` is preserved so the
+    /// type recorded for the node stays valid for later passes.
+    fn reconstruct_method_call(
+        &mut self,
+        input: MethodCall,
+        _additional: &Self::AdditionalInput,
+    ) -> (Expression, Self::AdditionalOutput) {
+        let receiver_ty =
+            self.state.type_table.get(&input.receiver.id()).expect("type checking recorded the receiver's type");
+        let span = input.span;
+
+        // `[receiver, ..args]`, reconstructed.
+        let arguments: Vec<Expression> = std::iter::once(input.receiver)
+            .chain(input.arguments)
+            .map(|arg| self.reconstruct_expression(arg, &()).0)
+            .collect();
+
+        match &receiver_ty {
+            Type::Composite(ct) => {
+                // User method: build a resolved call against `[Type, method]`.
+                let base = ct.path.try_global_location().expect("type checking resolved the composite type");
+                let mut path = base.path.clone();
+                path.push(input.method.name);
+                let location = Location::new(base.program, path);
+                let ident = Identifier { name: input.method.name, span, id: self.state.node_builder.next_id() };
+                let function =
+                    Path::new(None, Vec::new(), ident, span, self.state.node_builder.next_id()).to_global(location);
+                (CallExpression { function, const_arguments: Vec::new(), arguments, span, id: input.id }.into(), ())
             }
-        } else if input.name == Symbol::intern("__unresolved_set") {
-            match self.state.type_table.get(&input.arguments[0].id()).map(|t| self.state.types.resolve(t)) {
-                Some(TypeKind::Vector(..)) => {
-                    input.name = sym::_vector_set;
-                }
-                Some(TypeKind::Mapping(..)) => {
-                    input.name = sym::_mapping_set;
-                }
-                _ => {
-                    panic!("type checking should guarantee that no other type is expected here.")
-                }
+            _ => {
+                // Built-in method: pick the concrete intrinsic symbol from the receiver type.
+                let name = Intrinsic::builtin_method_symbol(&receiver_ty, input.method.name)
+                    .expect("type checking guaranteed a built-in method here");
+                let intrinsic = IntrinsicExpression {
+                    name,
+                    type_parameters: Vec::new(),
+                    input_types: Vec::new(),
+                    return_types: Vec::new(),
+                    arguments,
+                    span,
+                    id: input.id,
+                };
+                (intrinsic.into(), ())
             }
         }
-
-        (input.into(), ())
     }
 }

--- a/crates/passes/src/flattening/program.rs
+++ b/crates/passes/src/flattening/program.rs
@@ -39,6 +39,7 @@ impl UnitReconstructor for FlatteningVisitor<'_> {
             structs: input.structs,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces,
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             stubs: input.stubs,
         };
         self.program = prev_program;
@@ -68,6 +69,7 @@ impl UnitReconstructor for FlatteningVisitor<'_> {
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }

--- a/crates/passes/src/function_inlining/transform.rs
+++ b/crates/passes/src/function_inlining/transform.rs
@@ -146,6 +146,9 @@ impl UnitReconstructor for TransformVisitor<'_> {
             constructor,
             functions,
             interfaces: input.interfaces,
+            // Impl methods are non-entry helpers: they were inlined at their call sites (via the
+            // multi-segment paths in `function_map`) and must not appear as standalone items.
+            impls: Vec::new(),
             consts: input.consts,
             span: input.span,
         }
@@ -501,6 +504,7 @@ impl TransformVisitor<'_> {
             storage_variables: input.storage_variables,
             functions,
             interfaces: input.interfaces,
+            impls: Vec::new(),
             constructor: input.constructor,
             consts: input.consts,
             span: input.span,
@@ -511,6 +515,7 @@ impl TransformVisitor<'_> {
     fn assemble_module(&self, input: Module) -> Module {
         Module {
             functions: items_at_path(&self.reconstructed_functions, input.unit_name, &input.path).collect(),
+            impls: Vec::new(),
             ..input
         }
     }

--- a/crates/passes/src/global_items_collection.rs
+++ b/crates/passes/src/global_items_collection.rs
@@ -126,6 +126,7 @@ impl UnitVisitor for GlobalItemsCollectionVisitor<'_> {
         input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
         input.interfaces.iter().for_each(|(_, c)| self.visit_interface(c));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }
@@ -138,7 +139,19 @@ impl UnitVisitor for GlobalItemsCollectionVisitor<'_> {
             input.functions.iter().for_each(|(_, c)| slf.visit_function(c));
             input.consts.iter().for_each(|(_, c)| slf.visit_const(c));
             input.interfaces.iter().for_each(|(_, c)| slf.visit_interface(c));
+            input.impls.iter().for_each(|i| slf.visit_impl(i));
         })
+    }
+
+    /// Registers each impl method under the type's namespace, so a method `m` in `impl Type`
+    /// becomes the symbol-table location `[..module, Type, m]`. This is what makes both static
+    /// (`Type::m`) and instance (`value.m`) calls resolve to the method.
+    fn visit_impl(&mut self, input: &leo_ast::Impl) {
+        let mut path = self.module.clone();
+        path.push(input.type_.name);
+        self.in_module_scope(&path, |slf| {
+            input.functions.iter().for_each(|(_, f)| slf.visit_function(f));
+        });
     }
 
     fn visit_composite(&mut self, input: &Composite) {
@@ -206,6 +219,7 @@ impl UnitVisitor for GlobalItemsCollectionVisitor<'_> {
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.functions.iter().for_each(|(_, f)| self.visit_function(f));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         input.modules.values().for_each(|m| {
             self.visit_module(m);
         });

--- a/crates/passes/src/loop_unrolling/duplicate.rs
+++ b/crates/passes/src/loop_unrolling/duplicate.rs
@@ -75,6 +75,7 @@ impl AstReconstructor for Duplicator<'_> {
             Expression::Intrinsic(e) => self.reconstruct_intrinsic(*e, &()),
             Expression::Literal(e) => self.reconstruct_literal(e, &()),
             Expression::MemberAccess(e) => self.reconstruct_member_access(*e, &()),
+            Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
             Expression::Path(e) => self.reconstruct_path(e, &()),
             Expression::Repeat(e) => self.reconstruct_repeat(*e, &()),
             Expression::Ternary(e) => self.reconstruct_ternary(*e, &()),

--- a/crates/passes/src/loop_unrolling/program.rs
+++ b/crates/passes/src/loop_unrolling/program.rs
@@ -33,6 +33,7 @@ impl UnitReconstructor for UnrollingVisitor<'_> {
         self.program = input.program_id.as_symbol();
         ProgramScope {
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             ..input
         }

--- a/crates/passes/src/monomorphization/ast.rs
+++ b/crates/passes/src/monomorphization/ast.rs
@@ -108,6 +108,7 @@ impl AstReconstructor for MonomorphizationVisitor<'_> {
             Expression::Path(path) => self.reconstruct_path(path, &()),
             Expression::Literal(value) => self.reconstruct_literal(value, &()),
             Expression::MemberAccess(access) => self.reconstruct_member_access(*access, &()),
+            Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
             Expression::Repeat(repeat) => self.reconstruct_repeat(*repeat, &()),
             Expression::Ternary(ternary) => self.reconstruct_ternary(*ternary, &()),
             Expression::Tuple(tuple) => self.reconstruct_tuple(tuple, &()),

--- a/crates/passes/src/monomorphization/program.rs
+++ b/crates/passes/src/monomorphization/program.rs
@@ -38,6 +38,7 @@ impl UnitReconstructor for MonomorphizationVisitor<'_> {
                 .collect(),
             functions: items_at_path(&self.reconstructed_functions, input.name, &[]).collect(),
             interfaces: input.interfaces,
+            impls: self.assemble_impls(input.name, &[], input.impls),
             stubs: input.stubs,
         }
     }
@@ -162,6 +163,7 @@ impl UnitReconstructor for MonomorphizationVisitor<'_> {
             storage_variables,
             functions,
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: self.assemble_impls(self.program, &[], input.impls),
             constructor,
             consts,
             span: input.span,

--- a/crates/passes/src/monomorphization/visitor.rs
+++ b/crates/passes/src/monomorphization/visitor.rs
@@ -159,6 +159,26 @@ impl MonomorphizationVisitor<'_> {
         new_composite_path
     }
 
+    /// Reassembles impl blocks from the already-populated `reconstructed_functions` map. Each
+    /// method was monomorphized under the location `prefix ++ [Type, method]`, mirroring how
+    /// module functions are re-placed. Methods never reached by the DFS are dropped as dead code.
+    pub(super) fn assemble_impls(
+        &self,
+        program: Symbol,
+        prefix: &[Symbol],
+        impls: Vec<leo_ast::Impl>,
+    ) -> Vec<leo_ast::Impl> {
+        impls
+            .into_iter()
+            .map(|imp| {
+                let mut path = prefix.to_vec();
+                path.push(imp.type_.name);
+                let functions = items_at_path(&self.reconstructed_functions, program, &path).collect();
+                leo_ast::Impl { functions, ..imp }
+            })
+            .collect()
+    }
+
     /// Assembles a `Module` from the already-populated `reconstructed_*` maps. Interfaces are
     /// reconstructed because they may reference composites that have been monomorphized.
     /// `input.unit_name` is used (not `self.program`) because a nested `reconstruct_program`
@@ -169,6 +189,7 @@ impl MonomorphizationVisitor<'_> {
             composites: items_at_path(&self.reconstructed_composites, input.unit_name, &input.path).collect(),
             functions: items_at_path(&self.reconstructed_functions, input.unit_name, &input.path).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: self.assemble_impls(input.unit_name, &input.path, input.impls),
             ..input
         }
     }
@@ -219,6 +240,7 @@ impl MonomorphizationVisitor<'_> {
             storage_variables,
             functions,
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: self.assemble_impls(program_name, &[], input.impls),
             constructor,
             consts,
             span: input.span,

--- a/crates/passes/src/name_validation/program.rs
+++ b/crates/passes/src/name_validation/program.rs
@@ -33,12 +33,14 @@ impl UnitVisitor for NameValidationVisitor<'_> {
         input.composites.iter().for_each(|(_, function)| self.visit_composite(function));
         input.interfaces.iter().for_each(|(_, interface)| self.visit_interface(interface));
         input.functions.iter().for_each(|(_, function)| self.visit_function(function));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
     }
 
     fn visit_module(&mut self, input: &Module) {
         input.composites.iter().for_each(|(_, function)| self.visit_composite(function));
         input.interfaces.iter().for_each(|(_, interface)| self.visit_interface(interface));
         input.functions.iter().for_each(|(_, function)| self.visit_function(function));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
     }
 
     fn visit_aleo_program(&mut self, input: &AleoProgram) {

--- a/crates/passes/src/option_lowering/ast.rs
+++ b/crates/passes/src/option_lowering/ast.rs
@@ -105,6 +105,7 @@ impl leo_ast::AstReconstructor for OptionLoweringVisitor<'_> {
             Expression::Path(e) => self.reconstruct_path(e, additional),
             Expression::Literal(e) => self.reconstruct_literal(e, additional),
             Expression::MemberAccess(e) => self.reconstruct_member_access(*e, additional),
+            Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
             Expression::Repeat(e) => self.reconstruct_repeat(*e, additional),
             Expression::Ternary(e) => self.reconstruct_ternary(*e, additional),
             Expression::Tuple(e) => self.reconstruct_tuple(e, additional),

--- a/crates/passes/src/option_lowering/program.rs
+++ b/crates/passes/src/option_lowering/program.rs
@@ -109,10 +109,11 @@ impl UnitReconstructor for OptionLoweringVisitor<'_> {
             })
             .collect();
         let functions = input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect();
+        let impls = input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect();
         let stubs = input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect();
         let structs = items_at_path(&self.composites, input.name, &[]).collect();
 
-        Library { name: input.name, modules, consts, structs, functions, interfaces: input.interfaces, stubs }
+        Library { name: input.name, modules, consts, structs, functions, interfaces: input.interfaces, impls, stubs }
     }
 
     fn reconstruct_program(&mut self, input: Program) -> Program {
@@ -147,10 +148,21 @@ impl UnitReconstructor for OptionLoweringVisitor<'_> {
             input.storage_variables.into_iter().map(|(id, v)| (id, self.reconstruct_storage_variable(v))).collect();
         let functions = input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect();
         let interfaces = input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect();
+        let impls = input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect();
         let constructor = input.constructor.map(|c| self.reconstruct_constructor(c));
         let composites = items_at_path(&self.composites, program_name, &[]).collect();
 
-        ProgramScope { consts, composites, mappings, storage_variables, functions, interfaces, constructor, ..input }
+        ProgramScope {
+            consts,
+            composites,
+            mappings,
+            storage_variables,
+            functions,
+            interfaces,
+            impls,
+            constructor,
+            ..input
+        }
     }
 
     fn reconstruct_module(&mut self, input: Module) -> Module {
@@ -167,6 +179,19 @@ impl UnitReconstructor for OptionLoweringVisitor<'_> {
             composites: items_at_path(&slf.composites, slf.program, &input.path).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, slf.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| slf.reconstruct_impl(i)).collect(),
+            ..input
+        })
+    }
+
+    /// Reconstruct an impl block's methods with the module context extended by the type name, so
+    /// each method's own location reconstructs as `[..module, Type, method]` (matching how it was
+    /// registered). Without this, `reconstruct_return`'s self-location lookup would fail.
+    fn reconstruct_impl(&mut self, input: leo_ast::Impl) -> leo_ast::Impl {
+        let mut module = self.module.clone();
+        module.push(input.type_.name);
+        self.in_module_scope(&module, |slf| leo_ast::Impl {
+            functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),
             ..input
         })
     }

--- a/crates/passes/src/path_resolution/program.rs
+++ b/crates/passes/src/path_resolution/program.rs
@@ -65,6 +65,7 @@ impl UnitReconstructor for PathResolutionVisitor<'_> {
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             stubs: input.stubs.into_iter().map(|(id, stub)| (id, self.reconstruct_stub(stub))).collect(),
         }
     }
@@ -93,6 +94,7 @@ impl UnitReconstructor for PathResolutionVisitor<'_> {
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }
@@ -106,6 +108,7 @@ impl UnitReconstructor for PathResolutionVisitor<'_> {
             composites: input.composites.into_iter().map(|(i, c)| (i, slf.reconstruct_composite(c))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, slf.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, slf.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| slf.reconstruct_impl(i)).collect(),
             consts: input
                 .consts
                 .into_iter()

--- a/crates/passes/src/processing_async/program.rs
+++ b/crates/passes/src/processing_async/program.rs
@@ -61,6 +61,7 @@ impl UnitReconstructor for ProcessingAsyncVisitor<'_> {
                 .collect(),
             functions: reconstructed_functions,
             interfaces: input.interfaces.into_iter().map(|(id, int)| (id, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor,
             consts: input
                 .consts

--- a/crates/passes/src/ssa_const_propagation/program.rs
+++ b/crates/passes/src/ssa_const_propagation/program.rs
@@ -48,6 +48,7 @@ impl UnitReconstructor for SsaConstPropagationVisitor<'_> {
                 .collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }

--- a/crates/passes/src/static_analysis/future_checker.rs
+++ b/crates/passes/src/static_analysis/future_checker.rs
@@ -110,6 +110,7 @@ impl AstVisitor for FutureChecker<'_> {
             Expression::Path(path) => self.visit_path(path, &Position::Misc),
             Expression::Literal(literal) => self.visit_literal(literal, &Position::Misc),
             Expression::MemberAccess(access) => self.visit_member_access(access, &Position::Misc),
+            Expression::MethodCall(..) => unreachable!("MethodCall is removed by the Disambiguate pass"),
             Expression::Repeat(repeat) => self.visit_repeat(repeat, &Position::Misc),
             Expression::Ternary(ternary) => self.visit_ternary(ternary, &Position::Misc),
             Expression::Tuple(tuple) => self.visit_tuple(tuple, additional),

--- a/crates/passes/src/static_analysis/program.rs
+++ b/crates/passes/src/static_analysis/program.rs
@@ -30,6 +30,7 @@ impl UnitVisitor for StaticAnalyzingVisitor<'_> {
         input.mappings.iter().for_each(|(_, c)| self.visit_mapping(c));
         input.storage_variables.iter().for_each(|(_, c)| self.visit_storage_variable(c));
         input.functions.iter().for_each(|(_, c)| self.visit_function(c));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         if let Some(c) = input.constructor.as_ref() {
             self.visit_constructor(c);
         }
@@ -141,6 +142,7 @@ impl UnitVisitor for StaticAnalyzingVisitor<'_> {
         input.structs.iter().for_each(|(_, s)| self.visit_composite(s));
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.functions.iter().for_each(|(_, f)| self.visit_function(f));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         input.modules.values().for_each(|m| self.visit_module(m));
         input.stubs.values().for_each(|stub| self.visit_stub(stub));
     }

--- a/crates/passes/src/static_single_assignment/expression.rs
+++ b/crates/passes/src/static_single_assignment/expression.rs
@@ -71,15 +71,12 @@ impl ExpressionConsumer for SsaFormingVisitor<'_> {
     }
 
     fn consume_member_access(&mut self, input: MemberAccess) -> Self::Output {
-        // If the access expression is of the form `self.<name>`, then don't rename it.
-        if let Expression::Path(path) = &input.inner
-            && path.identifier().name == sym::SelfLower
-        {
-            return (input.into(), Vec::new());
-        }
-
         let (inner, statements) = self.consume_expression_and_define(input.inner);
         (MemberAccess { inner, ..input }.into(), statements)
+    }
+
+    fn consume_method_call(&mut self, _input: leo_ast::MethodCall) -> Self::Output {
+        unreachable!("MethodCall is removed by the Disambiguate pass")
     }
 
     fn consume_tuple_access(&mut self, input: TupleAccess) -> Self::Output {

--- a/crates/passes/src/static_single_assignment/program.rs
+++ b/crates/passes/src/static_single_assignment/program.rs
@@ -140,6 +140,14 @@ impl ProgramScopeConsumer for SsaFormingVisitor<'_> {
             storage_variables: input.storage_variables,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
             interfaces: input.interfaces,
+            impls: input
+                .impls
+                .into_iter()
+                .map(|imp| leo_ast::Impl {
+                    functions: imp.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
+                    ..imp
+                })
+                .collect(),
             constructor: input.constructor.map(|c| self.consume_constructor(c)),
             span: input.span,
         }
@@ -176,6 +184,14 @@ impl LibraryConsumer for SsaFormingVisitor<'_> {
             structs: input.structs,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
             interfaces: input.interfaces,
+            impls: input
+                .impls
+                .into_iter()
+                .map(|imp| leo_ast::Impl {
+                    functions: imp.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
+                    ..imp
+                })
+                .collect(),
             stubs: input.stubs,
         };
         self.program = prev_program;
@@ -208,6 +224,14 @@ impl ModuleConsumer for SsaFormingVisitor<'_> {
             composites: input.composites.into_iter().map(|(i, s)| (i, self.consume_composite(s))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
             interfaces: input.interfaces,
+            impls: input
+                .impls
+                .into_iter()
+                .map(|imp| leo_ast::Impl {
+                    functions: imp.functions.into_iter().map(|(i, f)| (i, self.consume_function(f))).collect(),
+                    ..imp
+                })
+                .collect(),
             consts: input.consts,
         }
     }

--- a/crates/passes/src/storage_lowering/program.rs
+++ b/crates/passes/src/storage_lowering/program.rs
@@ -49,6 +49,7 @@ impl UnitReconstructor for StorageLoweringVisitor<'_> {
             structs: input.structs.into_iter().map(|(i, s)| (i, self.reconstruct_composite(s))).collect(),
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces,
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             stubs: input.stubs,
         };
         self.program = prev_program;
@@ -91,6 +92,7 @@ impl UnitReconstructor for StorageLoweringVisitor<'_> {
             storage_variables,
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
             interfaces: input.interfaces.into_iter().map(|(i, int)| (i, self.reconstruct_interface(int))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             span: input.span,
         }

--- a/crates/passes/src/type_checking/ast.rs
+++ b/crates/passes/src/type_checking/ast.rs
@@ -50,6 +50,114 @@ pub enum AssignTargetKind {
 }
 
 impl TypeCheckingVisitor<'_> {
+    /// Type-check a method call `receiver.method(args)`, resolved by the receiver's type.
+    ///
+    /// - Built-in method on `Vector`/`Mapping`/`Optional`/`signature`/`Future`: synthesize the
+    ///   corresponding `IntrinsicExpression` (receiver prepended to args) and delegate to
+    ///   `visit_intrinsic`, so every existing storage/finalize/path-receiver/arity diagnostic fires
+    ///   unchanged.
+    /// - User method on a struct/record: look up `[Type, method]`, require a `self` receiver, and
+    ///   synthesize a resolved `CallExpression` (receiver as the `self` argument) checked via
+    ///   `visit_call`.
+    ///
+    /// `id` is preserved so the type recorded here stays valid after the Disambiguate pass rewrites
+    /// the node into the concrete form.
+    fn check_method_call(&mut self, input: &MethodCall, expected: &Option<Type>) -> Type {
+        let current_program = self.scope_state.unit_name.unwrap();
+        let span = input.span;
+        let method = input.method.name;
+
+        // Learn the receiver type (this also records it in the type table for the Disambiguate pass).
+        let receiver_ty = self.visit_expression(&input.receiver, &None);
+        if matches!(receiver_ty, Type::Err) {
+            return Type::Err;
+        }
+
+        // `[receiver, ..args]` — the receiver becomes the intrinsic's first operand / the `self` arg.
+        let arguments: Vec<Expression> =
+            std::iter::once(input.receiver.clone()).chain(input.arguments.iter().cloned()).collect();
+
+        // Built-in method on a Vector/Mapping/Optional/signature/Future receiver.
+        if let Some(intrinsic_sym) = Intrinsic::builtin_method_symbol(&receiver_ty, method) {
+            let synth = IntrinsicExpression {
+                name: intrinsic_sym,
+                type_parameters: Vec::new(),
+                input_types: Vec::new(),
+                return_types: Vec::new(),
+                arguments,
+                span,
+                id: input.id,
+            };
+            return self.visit_intrinsic(&synth, expected);
+        }
+
+        // User method on a struct/record, registered at `[Type, method]`.
+        let Type::Composite(ct) = &receiver_ty else {
+            // A built-in method name used on the wrong type: name the type it belongs to. Otherwise
+            // it is an unknown method on a type that can't have methods.
+            let err = match Intrinsic::builtin_method_receiver_hint(method) {
+                Some(hint) => crate::errors::type_checker::custom(
+                    format!("expected {hint}, but type `{receiver_ty}` was found"),
+                    span,
+                )
+                .with_help(format!("`{method}` is a built-in method that can only be called on {hint}.")),
+                None => crate::errors::type_checker::custom(
+                    format!("the type `{receiver_ty}` has no method `{method}`"),
+                    span,
+                )
+                .with_help(
+                    "Methods can only be called on structs, records, and built-in types such as vectors, mappings, and optionals.",
+                ),
+            };
+            self.emit_err(err);
+            return Type::Err;
+        };
+        let Some(base) = ct.path.try_global_location() else {
+            return Type::Err;
+        };
+
+        // Cascade suppression: if the receiver's own type is not a defined struct or record, that
+        // was already reported at its declaration/use site, so don't add a spurious
+        // method-resolution error on top of it (e.g. `f.run()` where `f`'s type is undefined).
+        if self.state.symbol_table.lookup_struct(current_program, base).is_none()
+            && self.state.symbol_table.lookup_record(current_program, base).is_none()
+        {
+            return Type::Err;
+        }
+
+        let mut path = base.path.clone();
+        path.push(method);
+        let location = Location::new(base.program, path);
+
+        // The method must exist and be an instance method (its first parameter is `self`).
+        let type_name = ct.path.identifier();
+        let Some(func_symbol) = self.state.symbol_table.lookup_function(current_program, &location) else {
+            self.emit_err(
+                crate::errors::type_checker::custom(format!("the type `{receiver_ty}` has no method `{method}`"), span)
+                    .with_help(format!(
+                        "Check the method name for typos, or define `{method}` in an `impl {type_name}` block."
+                    )),
+            );
+            return Type::Err;
+        };
+        let is_instance = func_symbol.function.input.first().is_some_and(|p| p.identifier.name == sym::SelfLower);
+        if !is_instance {
+            self.emit_err(
+                crate::errors::type_checker::custom(
+                    format!("`{method}` is a static method on `{type_name}` and cannot be called on a value"),
+                    span,
+                )
+                .with_help(format!("Call it with `::` instead, e.g. `{type_name}::{method}(...)`.")),
+            );
+            return Type::Err;
+        }
+
+        let ident = Identifier { name: method, span, id: self.state.node_builder.next_id() };
+        let function = Path::new(None, Vec::new(), ident, span, self.state.node_builder.next_id()).to_global(location);
+        let call = CallExpression { function, const_arguments: Vec::new(), arguments, span, id: input.id };
+        self.visit_call(&call, expected)
+    }
+
     /// Returns information about an expression when used as the LHS of an assignment.
     ///
     /// Specifically, this function returns an `AssignTargetInfo` containing:
@@ -454,6 +562,7 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
             Expression::Path(path) => self.visit_path(path, additional),
             Expression::Literal(literal) => self.visit_literal(literal, additional),
             Expression::MemberAccess(access) => self.visit_member_access_general(access, false, additional),
+            Expression::MethodCall(method_call) => self.visit_method_call(method_call, additional),
             Expression::Repeat(repeat) => self.visit_repeat(repeat, additional),
             Expression::Ternary(ternary) => self.visit_ternary(ternary, additional),
             Expression::Tuple(tuple) => self.visit_tuple(tuple, additional),
@@ -579,6 +688,10 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
 
         self.maybe_assert_type(&type_, additional, input.span());
         type_
+    }
+
+    fn visit_method_call(&mut self, input: &MethodCall, expected: &Self::AdditionalInput) -> Self::Output {
+        self.check_method_call(input, expected)
     }
 
     fn visit_intrinsic(&mut self, input: &IntrinsicExpression, expected: &Self::AdditionalInput) -> Self::Output {
@@ -2563,10 +2676,15 @@ impl AstVisitor for TypeCheckingVisitor<'_> {
     }
 
     fn visit_expression_statement(&mut self, input: &ExpressionStatement) {
-        // Expression statements can only be function calls.
+        // Expression statements can only be function calls. `MethodCall` is a call form that the
+        // type checker resolves (and Disambiguate rewrites to a `Call`/`Intrinsic`), so allow it too.
         if !matches!(
             input.expression,
-            Expression::Call(_) | Expression::DynamicOp(_) | Expression::Intrinsic(_) | Expression::Unit(_)
+            Expression::Call(_)
+                | Expression::DynamicOp(_)
+                | Expression::Intrinsic(_)
+                | Expression::MethodCall(_)
+                | Expression::Unit(_)
         ) {
             self.emit_err(crate::errors::type_checker::expression_statement_must_be_function_call(input.span()));
         } else {

--- a/crates/passes/src/type_checking/program.rs
+++ b/crates/passes/src/type_checking/program.rs
@@ -170,6 +170,10 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
             }
         }
 
+        // Typecheck each impl block's methods. They resolve at the enclosing (program) scope, so
+        // `module_name` stays cleared; their paths were already resolved to `[Type, method]`.
+        input.impls.iter().for_each(|i| self.visit_impl(i));
+
         if let Some(constructor) = &input.constructor {
             self.visit_constructor(constructor);
         }
@@ -221,6 +225,36 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
             self.visit_function(function);
         }
 
+        input.impls.iter().for_each(|i| self.visit_impl(i));
+
+        self.scope_state.module_name = parent_module;
+    }
+
+    /// Type-check an impl block's methods with `module_name` extended by the type name, so each
+    /// method's own location reconstructs as `[..module, Type, method]` — matching how
+    /// `GlobalItemsCollection` registered it. Reference paths in the body were already resolved by
+    /// path resolution, so this only affects self-location reconstruction, not name lookup.
+    fn visit_impl(&mut self, input: &leo_ast::Impl) {
+        // The impl target must be a struct or record declared in this program.
+        let unit = self.scope_state.unit_name.unwrap();
+        let type_path: Vec<Symbol> =
+            self.scope_state.module_name.iter().cloned().chain(std::iter::once(input.type_.name)).collect();
+        let type_loc = Location::new(unit, type_path);
+        if self.state.symbol_table.lookup_struct(unit, &type_loc).is_none()
+            && self.state.symbol_table.lookup_record(unit, &type_loc).is_none()
+        {
+            self.emit_err(crate::errors::type_checker::custom(
+                format!(
+                    "cannot implement methods for `{}`: no struct or record with that name in this program",
+                    input.type_.name
+                ),
+                input.type_.span,
+            ));
+        }
+
+        let parent_module = self.scope_state.module_name.clone();
+        self.scope_state.module_name.push(input.type_.name);
+        input.functions.iter().for_each(|(_, f)| self.visit_function(f));
         self.scope_state.module_name = parent_module;
     }
 
@@ -234,6 +268,7 @@ impl UnitVisitor for TypeCheckingVisitor<'_> {
         input.consts.iter().for_each(|(_, c)| self.visit_const(c));
         input.interfaces.iter().for_each(|(_, i)| self.visit_interface(i));
         input.functions.iter().for_each(|(_, f)| self.visit_function(f));
+        input.impls.iter().for_each(|i| self.visit_impl(i));
         input.modules.values().for_each(|m| {
             self.visit_module(m);
         });

--- a/crates/passes/src/type_checking/visitor.rs
+++ b/crates/passes/src/type_checking/visitor.rs
@@ -343,24 +343,6 @@ impl TypeCheckingVisitor<'_> {
     pub fn get_intrinsic(&mut self, intrinsic_expr: &IntrinsicExpression) -> Option<Intrinsic> {
         // Lookup core struct
         match Intrinsic::from_symbol(intrinsic_expr.name, &intrinsic_expr.type_parameters) {
-            None if intrinsic_expr.name == Symbol::intern("__unresolved_get") => {
-                let ty = self.visit_expression(&intrinsic_expr.arguments[0], &None);
-                self.assert_vector_or_mapping_type(&ty, intrinsic_expr.arguments[0].span());
-                match ty {
-                    TypeKind::Vector(_) => Some(Intrinsic::VectorGet),
-                    TypeKind::Mapping(_) => Some(Intrinsic::MappingGet),
-                    _ => None,
-                }
-            }
-            None if intrinsic_expr.name == Symbol::intern("__unresolved_set") => {
-                let ty = self.visit_expression(&intrinsic_expr.arguments[0], &None);
-                self.assert_vector_or_mapping_type(&ty, intrinsic_expr.arguments[0].span());
-                match ty {
-                    TypeKind::Vector(_) => Some(Intrinsic::VectorSet),
-                    TypeKind::Mapping(_) => Some(Intrinsic::MappingSet),
-                    _ => None,
-                }
-            }
             None => {
                 // Not a core library struct.
                 self.emit_err(crate::errors::type_checker::invalid_intrinsic(

--- a/crates/passes/src/write_transforming/program.rs
+++ b/crates/passes/src/write_transforming/program.rs
@@ -44,6 +44,7 @@ impl UnitReconstructor for WriteTransformingVisitor<'_> {
         self.program = input.program_id.as_symbol();
         leo_ast::ProgramScope {
             functions: input.functions.into_iter().map(|(i, f)| (i, self.reconstruct_function(f))).collect(),
+            impls: input.impls.into_iter().map(|i| self.reconstruct_impl(i)).collect(),
             constructor: input.constructor.map(|c| self.reconstruct_constructor(c)),
             ..input
         }

--- a/documentation/language/cheatsheet.md
+++ b/documentation/language/cheatsheet.md
@@ -102,6 +102,45 @@ Creating an option type instance of a `struct`
 
 The `address` and `signature` types do not have option variants. Thus, a `struct` that contains these types cannot have an option variant.
 
+### Methods (`impl` blocks)
+
+Methods are associated with a `struct` or `record` in an `impl` block. A method with no `self`
+parameter is a static/associated method, called with `::`. A method whose first parameter is
+`self` is an instance method, called with `.` on a value:
+
+```leo
+struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    // Static method — called as `Point::new(..)`.
+    fn new(x: u32, y: u32) -> Point {
+        return Point { x, y };
+    }
+
+    // Instance method — called as `p.sum()`. `self` is the receiver of type `Point`.
+    fn sum(self) -> u32 {
+        return self.x + self.y;
+    }
+}
+
+// let p = Point::new(1u32, 2u32);
+// let s = p.sum();
+```
+
+Notes and limitations (first version):
+- `impl` blocks are supported for user-defined `struct`s and `record`s in the same program
+  (non-generic).
+- Methods are inlined at their call sites, like other helper `fn`s.
+- Because a method on a `record` would take/return that record, and only entry-point functions may
+  have a record as input or output, instance methods on records are limited; static methods whose
+  signatures avoid the record type work.
+- An instance method may not be named after a built-in operator/intrinsic (e.g. `add`, `sub`,
+  `pow`), because `value.add(..)` desugars to the operator. Use a different name, or the static form
+  `Type::add(..)`.
+
 ## 6. Arrays
 
 Declaring `arrays`:

--- a/tests/expectations/compiler/bugs/b29302_fail.out
+++ b/tests/expectations/compiler/bugs/b29302_fail.out
@@ -1,7 +1,7 @@
-[EPAR0370021] Error: the type of `2u32` has no associated function `exp` that takes 1 argument(s)
+[ETYC0372156] Error: the type `u32` has no method `exp`
    ╭─[ compiler-test:9:20 ]
    │
  9 │     fn main(x: S::[2u32.exp(2u32)]);
    │ 
-   │ Help: Check the method name for typos and confirm the argument count matches the function's signature.
+   │ Help: Methods can only be called on structs, records, and built-in types such as vectors, mappings, and optionals.
 ───╯

--- a/tests/expectations/compiler/impl/basic.out
+++ b/tests/expectations/compiler/impl/basic.out
@@ -1,0 +1,18 @@
+program test.aleo;
+
+struct Point:
+    x as u32;
+    y as u32;
+
+function main:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    cast r0 r1 into r2 as Point;
+    mul r2.x 2u32 into r3;
+    mul r2.y 2u32 into r4;
+    cast r3 r4 into r5 as Point;
+    add r5.x r5.y into r6;
+    output r6 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/impl/no_such_method_fail.out
+++ b/tests/expectations/compiler/impl/no_such_method_fail.out
@@ -1,0 +1,7 @@
+[ETYC0372156] Error: the type `test.aleo::Point` has no method `nonexistent`
+    ╭─[ compiler-test:15:16 ]
+    │
+ 15 │         return p.nonexistent();
+    │ 
+    │ Help: Check the method name for typos, or define `nonexistent` in an `impl Point` block.
+────╯

--- a/tests/expectations/compiler/impl/operator_shadow_fail.out
+++ b/tests/expectations/compiler/impl/operator_shadow_fail.out
@@ -1,0 +1,5 @@
+[EPAR0370047] Error: instance method `add` collides with a built-in operator; `value.add(..)` would apply the operator. Rename it, or call it as `Point::add(..)`.
+   ╭─[ compiler-test:7:8 ]
+   │
+ 7 │     fn add(self, other: Point) -> u32 {
+───╯

--- a/tests/expectations/compiler/impl/record_method.out
+++ b/tests/expectations/compiler/impl/record_method.out
@@ -1,0 +1,13 @@
+program test.aleo;
+
+record Token:
+    owner as address.private;
+    amount as u64.private;
+
+function main:
+    input r0 as u64.private;
+    add r0 1000000u64 into r1;
+    output r1 as u64.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/impl/reserved_method_names.out
+++ b/tests/expectations/compiler/impl/reserved_method_names.out
@@ -1,0 +1,16 @@
+program test.aleo;
+
+struct Bag:
+    items as u32;
+
+function main:
+    input r0 as u32.private;
+    add r0 1u32 into r1;
+    cast r1 into r2 as Bag;
+    is.eq r2.items 3u32 into r3;
+    ternary r3 1u32 0u32 into r4;
+    add r2.items r4 into r5;
+    output r5 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;

--- a/tests/expectations/compiler/impl/static_as_instance_fail.out
+++ b/tests/expectations/compiler/impl/static_as_instance_fail.out
@@ -1,0 +1,7 @@
+[ETYC0372156] Error: `origin` is a static method on `Point` and cannot be called on a value
+    ╭─[ compiler-test:15:16 ]
+    │
+ 15 │         return p.origin().x;
+    │ 
+    │ Help: Call it with `::` instead, e.g. `Point::origin(...)`.
+────╯

--- a/tests/expectations/compiler/impl/undefined_type_fail.out
+++ b/tests/expectations/compiler/impl/undefined_type_fail.out
@@ -1,0 +1,5 @@
+[ETYC0372156] Error: cannot implement methods for `Ghost`: no struct or record with that name in this program
+   ╭─[ compiler-test:1:6 ]
+   │
+ 1 │ impl Ghost {
+───╯

--- a/tests/expectations/compiler/interfaces/optional_in_prototype_fail.out
+++ b/tests/expectations/compiler/interfaces/optional_in_prototype_fail.out
@@ -12,3 +12,10 @@
     │ 
     │ Help: Refactor the shared logic into a regular `fn` and call that from both entry points.
 ────╯
+[ETYC0372043] Error: cannot call a local entry point fn from an entry point fn
+    ╭─[ compiler-test:17:16 ]
+    │
+ 17 │         return find(key).unwrap();
+    │ 
+    │ Help: Refactor the shared logic into a regular `fn` and call that from both entry points.
+────╯

--- a/tests/expectations/compiler/storage/bad_storage_ops_fail.out
+++ b/tests/expectations/compiler/storage/bad_storage_ops_fail.out
@@ -40,73 +40,73 @@
     │ 
     │ Help: Change the expression to produce type `[u32; 2]`.
 ────╯
-[ETYC0372117] Error: expected a vector, but type `field` was found
+[ETYC0372156] Error: expected a vector, but type `field` was found
     ╭─[ compiler-test:31:13 ]
     │
  31 │             x.push(3field); // ❌ not a vector
     │ 
-    │ Help: Change the expression to produce a vector.
+    │ Help: `push` is a built-in method that can only be called on a vector.
 ────╯
-[ETYC0372117] Error: expected a vector, but type `field` was found
+[ETYC0372156] Error: expected a vector, but type `field` was found
     ╭─[ compiler-test:32:13 ]
     │
  32 │             x.pop(); // ❌ not a vector
     │ 
-    │ Help: Change the expression to produce a vector.
+    │ Help: `pop` is a built-in method that can only be called on a vector.
 ────╯
-[ETYC0372117] Error: expected a vector, but type `field` was found
+[ETYC0372156] Error: expected a vector, but type `field` was found
     ╭─[ compiler-test:33:13 ]
     │
  33 │             x.len(); // ❌ not a vector
     │ 
-    │ Help: Change the expression to produce a vector.
+    │ Help: `len` is a built-in method that can only be called on a vector.
 ────╯
-[ETYC0372117] Error: expected a vector, but type `field` was found
+[ETYC0372156] Error: expected a vector, but type `field` was found
     ╭─[ compiler-test:34:13 ]
     │
  34 │             x.swap_remove(0u32); // ❌ not a vector
     │ 
-    │ Help: Change the expression to produce a vector.
+    │ Help: `swap_remove` is a built-in method that can only be called on a vector.
 ────╯
-[ETYC0372117] Error: expected a vector or a mapping, but type `field` was found
+[ETYC0372156] Error: expected a vector or a mapping, but type `field` was found
     ╭─[ compiler-test:35:13 ]
     │
  35 │             x.set(0u32, 1field); // ❌ not a vector
     │ 
-    │ Help: Change the expression to produce a vector or a mapping.
+    │ Help: `set` is a built-in method that can only be called on a vector or a mapping.
 ────╯
-[ETYC0372117] Error: expected a vector or a mapping, but type `field` was found
+[ETYC0372156] Error: expected a vector or a mapping, but type `field` was found
     ╭─[ compiler-test:36:13 ]
     │
  36 │             x.get(0u32); // ❌ not a vector
     │ 
-    │ Help: Change the expression to produce a vector or a mapping.
+    │ Help: `get` is a built-in method that can only be called on a vector or a mapping.
 ────╯
-[ETYC0372117] Error: expected a vector, but type `field?` was found
+[ETYC0372156] Error: expected a vector, but type `field?` was found
     ╭─[ compiler-test:42:13 ]
     │
  42 │             s_field.push(10field); // ❌ cannot push to non-vector storage
     │ 
-    │ Help: Change the expression to produce a vector.
+    │ Help: `push` is a built-in method that can only be called on a vector.
 ────╯
-[ETYC0372117] Error: expected a vector, but type `(u32 => u32)` was found
+[ETYC0372156] Error: expected a vector, but type `(u32 => u32)` was found
     ╭─[ compiler-test:43:13 ]
     │
  43 │             s_map.push(5u32); // ❌ cannot push to mapping
     │ 
-    │ Help: Change the expression to produce a vector.
+    │ Help: `push` is a built-in method that can only be called on a vector.
 ────╯
-[ETYC0372117] Error: expected a vector or a mapping, but type `field?` was found
+[ETYC0372156] Error: expected a vector or a mapping, but type `field?` was found
     ╭─[ compiler-test:49:13 ]
     │
  49 │             s_field.set(0u32, 10field); // ❌ not a vector or mapping
     │ 
-    │ Help: Change the expression to produce a vector or a mapping.
+    │ Help: `set` is a built-in method that can only be called on a vector or a mapping.
 ────╯
-[ETYC0372117] Error: expected a vector or a mapping, but type `field?` was found
+[ETYC0372156] Error: expected a vector or a mapping, but type `field?` was found
     ╭─[ compiler-test:50:13 ]
     │
  50 │             s_field.get(0u32); // ❌ not a vector or mapping
     │ 
-    │ Help: Change the expression to produce a vector or a mapping.
+    │ Help: `get` is a built-in method that can only be called on a vector or a mapping.
 ────╯

--- a/tests/expectations/execution/impl_methods.out
+++ b/tests/expectations/execution/impl_methods.out
@@ -1,0 +1,20 @@
+program impl_demo.aleo;
+
+struct Point:
+    x as u32;
+    y as u32;
+
+function main:
+    input r0 as u32.private;
+    input r1 as u32.private;
+    cast r0 r1 into r2 as Point;
+    mul r2.x 2u32 into r3;
+    mul r2.y 2u32 into r4;
+    cast r3 r4 into r5 as Point;
+    add r5.x r5.y into r6;
+    output r6 as u32.private;
+
+constructor:
+    assert.eq edition 0u16;
+status: success
+output: 14u32

--- a/tests/expectations/parser-expression/expression/optional.out
+++ b/tests/expectations/parser-expression/expression/optional.out
@@ -1,4 +1,4 @@
-_optional_unwrap(x)
+x.unwrap()
 
-_optional_unwrap_or(x, y)
+x.unwrap_or(y)
 

--- a/tests/expectations/parser-expression/expression/storage.out
+++ b/tests/expectations/parser-expression/expression/storage.out
@@ -1,12 +1,12 @@
-_vector_push(v, y)
+v.push(y)
 
-_vector_pop(v)
+v.pop()
 
-__unresolved_get(v, y)
+v.get(y)
 
-__unresolved_set(v, y, z)
+v.set(y, z)
 
-_vector_len(v)
+v.len()
 
-_vector_swap_remove(v, y)
+v.swap_remove(y)
 

--- a/tests/expectations/parser-library/impl_blocks.out
+++ b/tests/expectations/parser-library/impl_blocks.out
@@ -1,0 +1,20 @@
+library test_lib {
+    struct Point {
+        x: u32,
+        y: u32,
+    }
+}
+
+
+library test_lib {
+    impl Point {
+        export fn new(x: u32, y: u32) -> Point {
+            return Point { x, y };
+        }
+        export fn sum(self: Point) -> u32 {
+            return self.x + self.y;
+        }
+    }
+}
+
+

--- a/tests/expectations/parser-module/export_modifier_fail.out
+++ b/tests/expectations/parser-module/export_modifier_fail.out
@@ -1,14 +1,14 @@
-[EPAR0370047] Error: expected `fn`, `struct`, `const`, or `interface` after `export`
+[EPAR0370047] Error: expected `fn`, `struct`, `const`, `interface`, or `impl` after `export`
    ╭─[ test_0:1:1 ]
    │
  1 │ export record Foo {}
 ───╯
-[EPAR0370047] Error: expected `fn`, `struct`, `const`, or `interface` after `export`
+[EPAR0370047] Error: expected `fn`, `struct`, `const`, `interface`, or `impl` after `export`
    ╭─[ test_1:1:1 ]
    │
  1 │ export mapping Map
 ───╯
-[EPAR0370047] Error: expected `fn`, `struct`, `const`, or `interface` after `export`
+[EPAR0370047] Error: expected `fn`, `struct`, `const`, `interface`, or `impl` after `export`
    ╭─[ test_2:1:1 ]
    │
  1 │ export let x = 0;

--- a/tests/expectations/parser/finalize/mapping_fail.out
+++ b/tests/expectations/parser/finalize/mapping_fail.out
@@ -17,7 +17,7 @@
    │ 
    │ Help: Replace the highlighted token with what the parser expects, or insert the missing syntax before it.
 ───╯
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `)`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `)`
    ╭─[ test:6:29 ]
    │
  6 │     mapping foo: (bar => baz);

--- a/tests/expectations/parser/functions/keyword_as_method_name_fail.out
+++ b/tests/expectations/parser/functions/keyword_as_method_name_fail.out
@@ -5,13 +5,6 @@
    │ 
    │ Help: Replace `identifier` with `assert`.
 ───╯
-[EPAR0370021] Error: the type of `x` has no associated function `_error` that takes 0 argument(s)
-   ╭─[ test:1:10 ]
-   │
- 1 │ fn f() { x.assert(); }
-   │ 
-   │ Help: Check the method name for typos and confirm the argument count matches the function's signature.
-───╯
 [EPAR0370027] Error: missing a program scope in a Leo file
    ╭─[ test:1:1 ]
    │

--- a/tests/expectations/parser/future/explicit_future_typing.out
+++ b/tests/expectations/parser/future/explicit_future_typing.out
@@ -9,8 +9,8 @@ program test.aleo {
     }
 }
     final fn finalize_main(a: u32, b: u32, f0: Final<Fn()>, f1: Final<Fn(u32,Final<Fn(u32,u32)>)>) {
-        _final_run(f0);
-        _final_run(f1);
+        f0.run();
+        f1.run();
         assert_eq(a, b);
     }
 

--- a/tests/expectations/parser/program/circuit_deprecated_fail.out
+++ b/tests/expectations/parser/program/circuit_deprecated_fail.out
@@ -1,4 +1,4 @@
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `circuit`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `circuit`
    ╭─[ test:2:5 ]
    │
  2 │     circuit Foo {

--- a/tests/expectations/parser/program/illegal_import_fail.out
+++ b/tests/expectations/parser/program/illegal_import_fail.out
@@ -3,7 +3,7 @@
    │
  1 │ stub credits.aleo {
 ───╯
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `import`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `import`
    ╭─[ test:6:5 ]
    │
  6 │     import hello.aleo;

--- a/tests/expectations/parser/program/mapping_fail.out
+++ b/tests/expectations/parser/program/mapping_fail.out
@@ -1,4 +1,4 @@
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `mappin`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `mappin`
    ╭─[ test:2:5 ]
    │
  2 │     mappin balances: address => u128;

--- a/tests/expectations/parser/program/pipe_eof.out
+++ b/tests/expectations/parser/program/pipe_eof.out
@@ -1,4 +1,4 @@
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `|`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `|`
    ╭─[ test:6:5 ]
    │
  6 │     |

--- a/tests/expectations/parser/type_/signature.out
+++ b/tests/expectations/parser/type_/signature.out
@@ -1,7 +1,7 @@
 program test.aleo {
     fn baz(s: signature, a: address, v: value) {
         let a: bool = _signature_verify(s, a, v);
-        let b: bool = _signature_verify(s, a, v);
+        let b: bool = s.verify(a, v);
         assert_eq(a, b);
     }
     fn bar(x: u8) -> u8 {

--- a/tests/expectations/parser/type_/signature_verify_bad_syntax_fail.out
+++ b/tests/expectations/parser/type_/signature_verify_bad_syntax_fail.out
@@ -24,7 +24,7 @@
     │
  12 │     fn foo(signature: field) -> u8 {
 ────╯
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `:`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `:`
     ╭─[ test:12:21 ]
     │
  12 │     fn foo(signature: field) -> u8 {
@@ -36,17 +36,10 @@
     │
  16 │     fn signature(foo: field) -> u8 {
 ────╯
-[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', found `(`
+[EPAR0370005] Error: expected '}', '@', 'record', 'struct', 'fn', 'final', 'const', 'mapping', 'storage', 'script', 'interface', 'impl', found `(`
     ╭─[ test:16:17 ]
     │
  16 │     fn signature(foo: field) -> u8 {
     │ 
     │ Help: Replace the highlighted token with what the parser expects, or insert the missing syntax before it.
 ────╯
-[EPAR0370021] Error: the type of `s` has no associated function `verify` that takes 3 argument(s)
-   ╭─[ test:8:23 ]
-   │
- 8 │         let b: bool = s.verify(a, a, v);
-   │ 
-   │ Help: Check the method name for typos and confirm the argument count matches the function's signature.
-───╯

--- a/tests/tests/compiler/impl/basic.leo
+++ b/tests/tests/compiler/impl/basic.leo
@@ -1,0 +1,29 @@
+export struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    fn new(x: u32, y: u32) -> Point {
+        return Point { x, y };
+    }
+
+    fn sum(self) -> u32 {
+        return self.x + self.y;
+    }
+
+    fn scaled(self, factor: u32) -> Point {
+        return Point::new(self.x * factor, self.y * factor);
+    }
+}
+
+program test.aleo {
+    fn main(a: u32, b: u32) -> u32 {
+        let p: Point = Point::new(a, b);
+        let q: Point = p.scaled(2u32);
+        return q.sum();
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/impl/no_such_method_fail.leo
+++ b/tests/tests/compiler/impl/no_such_method_fail.leo
@@ -1,0 +1,20 @@
+export struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    fn sum(self) -> u32 {
+        return self.x + self.y;
+    }
+}
+
+program test.aleo {
+    fn main(a: u32) -> u32 {
+        let p: Point = Point { x: a, y: a };
+        return p.nonexistent();
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/impl/operator_shadow_fail.leo
+++ b/tests/tests/compiler/impl/operator_shadow_fail.leo
@@ -1,0 +1,19 @@
+export struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    fn add(self, other: Point) -> u32 {
+        return self.x + other.x;
+    }
+}
+
+program test.aleo {
+    fn main(a: u32) -> u32 {
+        return a;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/impl/record_method.leo
+++ b/tests/tests/compiler/impl/record_method.leo
@@ -1,0 +1,23 @@
+// Records may have `impl` blocks, but a method that takes or returns the record type hits Leo's
+// existing rule that only entry-point fns may have a record as input or output (impl methods are
+// inlined helpers, just like any other helper fn). Static methods whose signatures avoid the
+// record type work fine.
+program test.aleo {
+    record Token {
+        owner: address,
+        amount: u64,
+    }
+
+    impl Token {
+        fn max_supply() -> u64 {
+            return 1_000_000u64;
+        }
+    }
+
+    fn main(a: u64) -> u64 {
+        return a + Token::max_supply();
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/impl/reserved_method_names.leo
+++ b/tests/tests/compiler/impl/reserved_method_names.leo
@@ -1,0 +1,38 @@
+// A struct may now define methods named after built-in collection/optional/signature methods
+// (`get`, `set`, `unwrap`, `verify`, ...). These are resolved by the receiver's type, so on a
+// struct/record they dispatch to the user method rather than a built-in intrinsic.
+export struct Bag {
+    items: u32,
+}
+
+impl Bag {
+    fn get(self) -> u32 {
+        return self.items;
+    }
+
+    fn set(self, v: u32) -> Bag {
+        return Bag { items: v };
+    }
+
+    fn unwrap(self) -> u32 {
+        return self.items;
+    }
+
+    fn verify(self, a: u32, b: u32) -> bool {
+        return self.items == a + b;
+    }
+}
+
+program test.aleo {
+    fn main(a: u32) -> u32 {
+        let b: Bag = Bag { items: a };
+        let g: u32 = b.get();
+        let c: Bag = b.set(g + 1u32);
+        let u: u32 = c.unwrap();
+        let ok: bool = c.verify(1u32, 2u32);
+        return u + (ok ? 1u32 : 0u32);
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/impl/static_as_instance_fail.leo
+++ b/tests/tests/compiler/impl/static_as_instance_fail.leo
@@ -1,0 +1,20 @@
+export struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    fn origin() -> Point {
+        return Point { x: 0u32, y: 0u32 };
+    }
+}
+
+program test.aleo {
+    fn main(a: u32) -> u32 {
+        let p: Point = Point { x: a, y: a };
+        return p.origin().x;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/compiler/impl/undefined_type_fail.leo
+++ b/tests/tests/compiler/impl/undefined_type_fail.leo
@@ -1,0 +1,14 @@
+impl Ghost {
+    fn make() -> u32 {
+        return 1u32;
+    }
+}
+
+program test.aleo {
+    fn main(a: u32) -> u32 {
+        return a;
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/execution/impl_methods.leo
+++ b/tests/tests/execution/impl_methods.leo
@@ -1,0 +1,37 @@
+/*
+seed = 12345
+
+[case]
+program = "impl_demo.aleo"
+function = "main"
+input = ["3u32", "4u32"]
+*/
+
+export struct Point {
+    x: u32,
+    y: u32,
+}
+
+impl Point {
+    fn new(x: u32, y: u32) -> Point {
+        return Point { x, y };
+    }
+
+    fn sum(self) -> u32 {
+        return self.x + self.y;
+    }
+
+    fn scaled(self, factor: u32) -> Point {
+        return Point::new(self.x * factor, self.y * factor);
+    }
+}
+
+program impl_demo.aleo {
+    fn main(a: u32, b: u32) -> u32 {
+        let p: Point = Point::new(a, b);
+        return p.scaled(2u32).sum();
+    }
+
+    @noupgrade
+    constructor() {}
+}

--- a/tests/tests/parser-library/impl_blocks.leo
+++ b/tests/tests/parser-library/impl_blocks.leo
@@ -1,0 +1,7 @@
+
+struct Point { x: u32, y: u32 }
+
+impl Point {
+    fn new(x: u32, y: u32) -> Point { return Point { x, y }; }
+    fn sum(self) -> u32 { return self.x + self.y; }
+}

--- a/tree-sitter/grammar.js
+++ b/tree-sitter/grammar.js
@@ -55,6 +55,7 @@ const ALL_KEYWORDS = [
   'struct',
   'constructor',
   'interface',
+  'impl',
   'program',
   'import',
   'mapping',
@@ -136,6 +137,7 @@ module.exports = grammar({
       $.final_function_definition,
       $.view_function_definition,
       $.constructor_definition,
+      $.impl_definition,
     ),
 
     _file_item: $ => choice(
@@ -147,6 +149,7 @@ module.exports = grammar({
       $.final_function_definition,
       $.view_function_definition,
       $.const_declaration,
+      $.impl_definition,
     ),
 
     _program_item: $ => choice(
@@ -160,6 +163,7 @@ module.exports = grammar({
       $.view_function_definition,
       $.constructor_definition,
       $.interface_declaration,
+      $.impl_definition,
     ),
 
     import_declaration: $ => seq(
@@ -330,6 +334,35 @@ module.exports = grammar({
       field('parameters', $.parameter_list),
       field('body', $.block),
     ),
+
+    impl_definition: $ => seq(
+      'impl',
+      field('type', $.identifier),
+      '{',
+      repeat($.impl_method),
+      '}',
+    ),
+
+    // A method is a `fn` that may take a leading `self` receiver (instance method).
+    impl_method: $ => seq(
+      repeat($.annotation),
+      'fn',
+      field('name', $.identifier),
+      field('parameters', $.method_parameter_list),
+      optional(seq(token(prec(1, '->')), field('return_type', $.return_type))),
+      field('body', $.block),
+    ),
+
+    method_parameter_list: $ => seq(
+      '(',
+      optional(choice(
+        seq($.self_parameter, optional(seq(',', commaSep1($.parameter)))),
+        commaSep1($.parameter),
+      )),
+      ')',
+    ),
+
+    self_parameter: _ => 'self',
 
     const_param_list: $ => seq(
       token(prec(1, '::')),


### PR DESCRIPTION
Introduce Rust-style `impl` blocks so user structs and records can define methods, and make all method-call resolution type-directed.

Method calls are now resolved by receiver type instead of by name at parse time. Every non-operator `.method()` parses to a dedicated `Expression::MethodCall` node; the type checker routes built-in methods on `Vector`/`Mapping`/`Optional`/`signature`/`Future` to the corresponding intrinsic (reusing all storage/finalize/path diagnostics) and struct/record receivers to the user method, and the Disambiguate pass rewrites the node to a concrete `IntrinsicExpression`/`CallExpression`. This unifies the previous per-name desugaring (including the `__unresolved_get`/`_set` sentinels) into one mechanism and lets user types define methods named `get`, `set`, `unwrap`, `verify`, etc. Operators stay parse-time desugared (overloading is left to a future trait mechanism), so operator names remain reserved.
